### PR TITLE
feat: add retry with exponential backoff on 429/529 (BAT-17)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -3340,7 +3340,7 @@ async function claudeApiCall(body, chatId) {
     apiCallInFlight = new Promise(r => { resolve = r; });
 
     const startTime = Date.now();
-    const MAX_RETRIES = 3; // max number of retries (not counting initial attempt)
+    const MAX_RETRIES = 3; // 1 initial + up to 3 retries = 4 total attempts max
     try {
         const authHeaders = AUTH_TYPE === 'setup_token'
             ? { 'Authorization': `Bearer ${ANTHROPIC_KEY}` }
@@ -3385,8 +3385,8 @@ async function claudeApiCall(body, chatId) {
                 const retryAfterMs = Math.min(retryAfterRaw * 1000, 30000); // cap at 30s
                 const backoffMs = Math.min(5000 * Math.pow(2, retries), 30000); // 5s, 10s, 20s
                 const waitMs = retryAfterMs > 0 ? retryAfterMs : backoffMs;
+                log(`[Retry] Claude API ${res.status}, retry ${retries + 1}/${MAX_RETRIES}, waiting ${waitMs}ms`);
                 retries++;
-                log(`[Retry] Claude API ${res.status}, retry ${retries}/${MAX_RETRIES}, waiting ${waitMs}ms`);
                 await new Promise(r => setTimeout(r, waitMs));
                 continue;
             }


### PR DESCRIPTION
## Summary
- Add retry loop (max 3 attempts) inside `claudeApiCall()` for HTTP 429 (rate limit) and 529 (overloaded) responses
- Respects `retry-after` header from Anthropic when present
- Falls back to exponential backoff: 5s → 10s → 20s (capped at 30s)
- Logs `[Retry] Claude API 429, attempt 1/3, waiting 5000ms` for visibility
- DB `api_request_log.retry_count` captures how many retries were needed
- Network errors (timeouts) still throw immediately — no retry for those

## Impact
- **Biggest UX improvement**: Rate limit errors are silently retried instead of showing "Error: API error: rate limit exceeded" to the user
- Max additional latency: ~35s (worst case: 5s + 10s + 20s for 3 attempts)
- If all 3 attempts fail, the error surfaces as before — no silent swallowing

## Test plan
- [ ] Deploy to device and send rapid messages to trigger rate limit
- [ ] Check logs for `[Retry]` messages (confirms retry is firing)
- [ ] Verify retry_count > 0 appears in `api_request_log` after rate limit hits
- [ ] Verify normal (non-429) responses work unchanged with retry_count = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)