### PR TITLE
feat: add rate-limit-aware request throttling (BAT-18)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -3435,7 +3435,8 @@ async function claudeApiCall(body, chatId) {
         // Capture rate limit headers and update module-level tracking
         if (AUTH_TYPE === 'api_key' && res.headers) {
             const h = res.headers;
-            lastRateLimitTokensRemaining = parseInt(h['anthropic-ratelimit-tokens-remaining']) || Infinity;
+            const parsedRemaining = parseInt(h['anthropic-ratelimit-tokens-remaining'], 10);
+            lastRateLimitTokensRemaining = Number.isFinite(parsedRemaining) ? parsedRemaining : Infinity;
             lastRateLimitTokensReset = h['anthropic-ratelimit-tokens-reset'] || '';
             writeClaudeUsageState({
                 type: 'api_key',


### PR DESCRIPTION
## Summary
- Add proactive rate-limit throttling in `claudeApiCall()` — delay requests when token budget is critically low
- Track `lastRateLimitTokensRemaining` and `lastRateLimitTokensReset` from Anthropic response headers
- Before each request, if remaining tokens < 5,000: wait until the API reset time (capped at 15s)
- Log `[RateLimit] Only X tokens remaining, waiting Yms` for visibility

## Impact
**Two-layer rate limit protection (completes the BAT-13–18 rate limit fix):**
1. **Proactive** (this PR): Detect low budget from headers and pause before making the next call
2. **Reactive** (BAT-17): If a 429 still happens, retry with exponential backoff

Combined with prompt caching (BAT-14), the effective token budget is much higher, so this throttle should rarely trigger. When it does, the user sees a brief delay (3–15s) instead of an error.

## Full rate limit fix summary (BAT-13 through BAT-18)
| PR | Fix | Impact |
|---|---|---|
| BAT-13 | Remove duplicate tool descriptions | -1,500 tokens/call |
| BAT-14 | Prompt caching | Cached tokens use separate, higher-limit bucket |
| BAT-15 | SQL.js database | Foundation for request logging |
| BAT-16 | claudeApiCall wrapper | Mutex serialization + DB logging |
| BAT-17 | Retry on 429/529 | Silent retry instead of user-facing error |
| BAT-18 | Rate-limit throttling | Proactive pause when budget is low |

## Test plan
- [ ] Deploy to device and send messages
- [ ] Send rapid messages to trigger low token budget
- [ ] Check logs for `[RateLimit]` messages (confirms throttle is firing)
- [ ] Verify the "Error: API error: rate limit" from the original bug report no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)