### PR TITLE
feat: add ephemeral session awareness on Node.js restart (BAT-30)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -3139,9 +3139,10 @@ function formatDuration(ms) {
 // CLAUDE API
 // ============================================================================
 
-// Conversation history per chat
+// Conversation history per chat (ephemeral — cleared on every restart, BAT-30)
 const conversations = new Map();
 const MAX_HISTORY = 20;
+let sessionStartedAt = Date.now();
 
 function getConversation(chatId) {
     if (!conversations.has(chatId)) {
@@ -3341,6 +3342,8 @@ function buildSystemBlocks(matchedSkills = []) {
     const now = new Date();
     const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][now.getDay()];
     dynamicLines.push(`Current time: ${weekday} ${localTimestamp(now)} (${now.toLocaleString()})`);
+    const uptimeSec = Math.floor((Date.now() - sessionStartedAt) / 1000);
+    dynamicLines.push(`Session uptime: ${Math.floor(uptimeSec / 60)}m ${uptimeSec % 60}s (conversation context is ephemeral — cleared on each restart)`);
 
     // Active skills for this specific request (varies per message)
     if (matchedSkills.length > 0) {


### PR DESCRIPTION
## Summary
Make the ephemeral session behavior explicit by adding session uptime to the system prompt.

- **`sessionStartedAt`** timestamp tracks when Node.js started
- **System prompt** now includes session uptime and a note that conversation context is cleared on restart
- Conversations were already ephemeral (in-memory `Map`), this makes it visible to the agent

## Test plan
- [ ] Restart Node.js → agent knows context is fresh
- [ ] Session uptime increases correctly between messages
- [ ] No conversation history persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)