### PR TITLE
feat: add SQL.js memory tables schema — chunks, files, meta (BAT-25)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4026,6 +4026,33 @@ async function initDatabase() {
             duration_ms INTEGER
         )`);
 
+        // Memory indexing tables (BAT-25)
+        db.run(`CREATE TABLE IF NOT EXISTS chunks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT NOT NULL,
+            source TEXT DEFAULT 'memory',
+            start_line INTEGER,
+            end_line INTEGER,
+            hash TEXT,
+            text TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )`);
+        db.run(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path)`);
+        db.run(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source)`);
+
+        db.run(`CREATE TABLE IF NOT EXISTS files (
+            path TEXT PRIMARY KEY,
+            source TEXT DEFAULT 'memory',
+            hash TEXT,
+            mtime TEXT,
+            size INTEGER
+        )`);
+
+        db.run(`CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )`);
+
         // Persist immediately so the file exists on disk right away
         saveDatabase();
 


### PR DESCRIPTION
## Summary
Add 3 new tables to SQL.js database for memory indexing (OpenClaw-compatible schema).

- **`chunks`** — searchable text chunks with path, line range, hash, text content. Indexed by path and source.
- **`files`** — tracks indexed file state (mtime, hash, size) for incremental re-indexing
- **`meta`** — key-value store for indexing metadata (last_indexed, version, etc.)

Tables are created empty alongside existing `api_request_log`. No behavior change — data population comes in BAT-26.

## Test plan
- [ ] App starts without errors
- [ ] All 4 tables exist in SQLite
- [ ] Existing api_request_log still works
- [ ] DB file size unchanged (empty tables add negligible overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)