### PR TITLE
feat: add API usage analytics to session_status tool (BAT-28)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -2168,10 +2168,10 @@ async function executeTool(name, input) {
                          FROM api_request_log WHERE timestamp LIKE ?`, [today + '%']
                     );
                     if (todayStats.length > 0 && todayStats[0].values.length > 0) {
-                        const [cnt, inp, outp, avgMs, cacheRead, cacheCreate, errors] = todayStats[0].values[0];
+                        const [cnt, inp, outp, avgMs, cacheRead, , errors] = todayStats[0].values[0];
                         const totalTokens = (inp || 0) + (outp || 0);
-                        const cacheHitRate = totalTokens > 0
-                            ? Math.round(((cacheRead || 0) / Math.max(1, (inp || 0))) * 100)
+                        const cacheHitRate = (inp || 0) > 0
+                            ? Math.round(((cacheRead || 0) / (inp || 1)) * 100)
                             : 0;
                         result.apiUsage = {
                             today: {


### PR DESCRIPTION
## Summary
Add API usage analytics to the `session_status` tool by querying the `api_request_log` table.

- **Today's stats:** request count, input/output tokens, avg latency, errors, error rate, cache hit rate
- **Non-fatal:** analytics section omitted silently if DB unavailable
- **Uses existing table** from BAT-15 — no schema changes needed

## Test plan
- [ ] Call session_status → includes `apiUsage.today` section
- [ ] Stats match actual API call count for today
- [ ] Error rate and cache hit rate calculations correct
- [ ] Works with empty table (fresh install, 0 requests)
- [ ] DB unavailable → session_status still works, just no apiUsage section

🤖 Generated with [Claude Code](https://claude.com/claude-code)