### PR TITLE
feat: upgrade web_search with multi-provider support (BAT-37)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -1938,7 +1938,7 @@ async function executeTool(name, input) {
         case 'web_search': {
             const provider = (typeof input.provider === 'string' ? input.provider.toLowerCase() : 'brave');
             if (provider !== 'brave' && provider !== 'perplexity') {
-                return { error: `Unknown search provider "${input.provider}". Use "brave" or "perplexity".` };
+                return { error: `Unknown search provider "${provider}". Use "brave" or "perplexity".` };
             }
             const safeCount = Math.min(Math.max(Number(input.count) || 5, 1), 10);
             const safeFreshness = BRAVE_FRESHNESS_VALUES.has(input.freshness) ? input.freshness : '';


### PR DESCRIPTION
## Summary
- Add Brave + Perplexity Sonar as search providers (Brave default, Perplexity for complex questions)
- Perplexity auto-detects API key type: `pplx-` → direct API, `sk-or-` → OpenRouter proxy
- Add `count` (1-10) and `freshness` (day/week/month) filters for Brave
- Cache search results for 15 min using shared cache from BAT-36
- Auto-fallback: if Perplexity fails, transparently retry with Brave
- Redact Brave, Perplexity, and OpenRouter API keys in debug logs

**Linear:** [BAT-37](https://linear.app/batcave/issue/BAT-37/web-tools-upgrade-web-search-multi-provider-caching-filters)
**Depends on:** BAT-36 (merged in PR #21)
**Ref:** WEB_TOOLS_UPGRADE.md Task 2

## Test plan
- [ ] `web_search` with default provider → Brave results with title/url/snippet
- [ ] `web_search` with `provider: "perplexity"` → synthesized answer + citations
- [ ] `web_search` with `count: 3` → only 3 Brave results
- [ ] `web_search` with `freshness: "day"` → recent results only
- [ ] Cache: same query twice → second logs `[WebSearch] Cache hit`
- [ ] Perplexity failure → auto-fallback to Brave with log message
- [ ] API keys in logs → redacted (`pplx-***`, `sk-or-***`, `BSA***`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)