### PR TITLE
feat: upgrade web_fetch with markdown, caching, redirects (BAT-38)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -1982,7 +1982,12 @@ async function executeTool(name, input) {
             try {
                 const res = await webFetch(input.url);
                 if (res.status < 200 || res.status >= 300) {
-                    const detail = typeof res.data === 'string' ? res.data.slice(0, 200) : '';
+                    let detail = '';
+                    if (typeof res.data === 'string') {
+                        detail = res.data.slice(0, 200);
+                    } else if (res.data && typeof res.data === 'object') {
+                        detail = (res.data.error && res.data.error.message) || res.data.message || '';
+                    }
                     throw new Error(`HTTP error (${res.status})${detail ? ': ' + detail : ''}`);
                 }
                 let result;


### PR DESCRIPTION
## Summary
- Replace regex HTML strip with `htmlToMarkdown()` — preserves links, headings, lists as clean markdown
- Increase content limit from 8K to 50K chars (6x more content)
- Use `webFetch()` helper for automatic redirect following + SSRF protection
- Add 15-min TTL caching via shared cache from BAT-36
- Handle JSON responses natively (pretty-printed)
- Add `raw` mode option to skip markdown conversion
- Return content type (`markdown`/`json`/`text`) and final URL in response
- Add web search/fetch guidance to agent system prompt

**Linear:** [BAT-38](https://linear.app/batcave/issue/BAT-38/web-tools-upgrade-web-fetch-htmltomarkdown-caching-system-prompt)
**Depends on:** BAT-36 (shared infra, merged in PR #21) + BAT-37 (web_search, merged in PR #22)
**Ref:** WEB_TOOLS_UPGRADE.md Tasks 3+4

## Test plan
- [ ] `web_fetch` on HTML page -> returns markdown with links and headings
- [ ] `web_fetch` on JSON API -> returns pretty-printed JSON with type json
- [ ] `web_fetch` with raw true -> returns stripped text without markdown
- [ ] Same URL twice -> second logs [WebFetch] Cache hit
- [ ] URL that redirects -> follows to final URL, returns content
- [ ] Private IP (127.0.0.1) -> blocked by SSRF guard
- [ ] Large page -> returns up to 50K chars (was 8K)
- [ ] System prompt includes web search/fetch guidance lines

Generated with Claude Code