### PR TITLE
feat: add headers, method, body to web_fetch (BAT-42)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -1548,7 +1548,7 @@ const TOOLS = [
                 url: { type: 'string', description: 'The URL to fetch' },
                 method: { type: 'string', enum: ['GET', 'POST', 'PUT', 'DELETE'], description: 'HTTP method (default: GET)' },
                 headers: { type: 'object', description: 'Custom HTTP headers (e.g. {"Authorization": "Bearer sk-..."})' },
-                body: { description: 'Request body for POST/PUT. String or JSON object.' },
+                body: { type: ['string', 'object'], description: 'Request body for POST/PUT. String or JSON object.' },
                 raw: { type: 'boolean', description: 'If true, return raw text without markdown conversion' }
             },
             required: ['url']


### PR DESCRIPTION
## Summary
- Add `method` param: GET (default), POST, PUT, DELETE
- Add `headers` param: custom HTTP headers (Bearer auth, Content-Type, etc.)
- Add `body` param: request body for POST/PUT (string or JSON object, auto-serialized)
- Auto-set `Content-Type: application/json` for object bodies when not specified
- Downgrade method to GET on redirects (standard HTTP behavior)
- Only cache GET requests (POST/PUT/DELETE skip cache)
- Update system prompt to advertise authenticated API call capabilities

This unlocks the agent's ability to make authenticated API calls — the key blocker shown in the screenshot where the agent said "I can't make authenticated API calls with my current tools".

**Linear:** [BAT-42](https://linear.app/batcave/issue/BAT-42/web-tools-add-headers-method-body-params-to-web-fetch)
**Depends on:** BAT-38 (web_fetch upgrade, merged in PR #23)

## Test plan
- [ ] `web_fetch` with default (GET) still works as before
- [ ] `web_fetch` with `method: "POST"`, `headers: {"Authorization": "Bearer sk-..."}`, `body: {...}` makes authenticated API call
- [ ] `web_fetch` POST returns JSON response with type: "json"
- [ ] Object body auto-sets Content-Type: application/json
- [ ] Custom Content-Type header overrides auto-detection
- [ ] POST/PUT requests are not cached
- [ ] GET requests are still cached
- [ ] Redirects downgrade to GET (no body sent on redirect)
- [ ] System prompt mentions API call capabilities

Generated with Claude Code