### PR TITLE
fix: pass Node.js binary dir in shell_exec PATH (BAT-56)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -3112,8 +3112,11 @@ async function executeTool(name, input) {
 
             // Detect shell: Android uses /system/bin/sh, standard Unix uses /bin/sh
             const shellPath = fs.existsSync('/system/bin/sh') ? '/system/bin/sh' : '/bin/sh';
-            // Minimal environment: only PATH and HOME, no inherited secrets
-            const SAFE_PATH = fs.existsSync('/system/bin') ? '/system/bin:/usr/local/bin:/usr/bin:/bin' : '/usr/local/bin:/usr/bin:/bin';
+            // Build PATH: include Node.js binary dir so node/npm/npx resolve,
+            // plus standard system directories. No full process.env inheritance.
+            const nodeBinDir = path.dirname(process.execPath);
+            const systemPaths = fs.existsSync('/system/bin') ? '/system/bin:/usr/local/bin:/usr/bin:/bin' : '/usr/local/bin:/usr/bin:/bin';
+            const SAFE_PATH = `${nodeBinDir}:${systemPaths}`;
 
             // Use async exec to avoid blocking the event loop
             return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- The `shell_exec` tool's hardcoded `SAFE_PATH` only included system directories (`/system/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`)
- Node.js runtime directory was missing, so `node`, `npm`, `npx` commands failed with "not found"
- Fix: prepend `path.dirname(process.execPath)` to `SAFE_PATH` so child processes inherit the Node.js binary location
- Still no full `process.env` inheritance — only PATH, HOME, and TERM are passed

## Test plan
- [ ] Run `shell_exec` with `node --version` — should return Node.js version
- [ ] Run `shell_exec` with `npm --version` — should return npm version
- [ ] Run `shell_exec` with `npx --version` — should return npx version
- [ ] Run `shell_exec` with `npm install <package>` — should succeed
- [ ] Verify `printenv PATH` includes Node.js binary directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)