### PR TITLE
chore: use model aliases instead of snapshot IDs

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/config/Models.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Models.kt
@@ -8,8 +8,8 @@ data class ModelInfo(
 
 val availableModels = listOf(
     ModelInfo("claude-opus-4-6", "Opus 4.6", "default"),
-    ModelInfo("claude-sonnet-4-5-20250929", "Sonnet 4.5", "balanced"),
-    ModelInfo("claude-haiku-4-5-20251001", "Haiku 4.5", "fast"),
+    ModelInfo("claude-sonnet-4-5", "Sonnet 4.5", "balanced"),
+    ModelInfo("claude-haiku-4-5", "Haiku 4.5", "fast"),
 )
 
 fun modelDisplayName(modelId: String?): String {


### PR DESCRIPTION
## Summary
- Switch Sonnet and Haiku from full snapshot IDs to API aliases
- `claude-sonnet-4-5-20250929` → `claude-sonnet-4-5`
- `claude-haiku-4-5-20251001` → `claude-haiku-4-5`
- Opus was already using alias format (`claude-opus-4-6`)
- Matches web QR config generator, auto-resolves to latest snapshot

## Test plan
- [ ] Model dropdown shows correct names
- [ ] API calls work with alias IDs

Generated with [Claude Code](https://claude.com/claude-code)