### PR TITLE
fix: remove node/npm/npx from shell_exec, clean up diagnostics (BAT-58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,8 +338,8 @@ Good: Adding `memory_search` tool with description "Search your SQL.js database 
 
 - **nodejs-mobile:** Community fork at https://github.com/niccolobocook/nodejs-mobile — pin to latest stable release at dev start. Adapt their React Native integration guide for pure Kotlin (no React Native).
 - **nodejs-mobile JNI architecture (IMPORTANT):** Node.js runs as `libnode.so` loaded via `System.loadLibrary("node")` through JNI — there is **NO standalone `node` binary** on the device. Key implications:
-  - `process.execPath` returns `/system/bin/app_process64` (Android's app process launcher), NOT a node path
-  - `process.env.PATH` contains only Android system directories (`/system/bin`, `/vendor/bin`, etc.)
+  - `process.execPath` typically points to Android's app process launcher (e.g., `/system/bin/app_process` or `/system/bin/app_process64`), **not** a Node.js binary path
+  - `process.env.PATH` primarily contains Android system directories (e.g., `/system/bin`, `/vendor/bin`)
   - `node`, `npm`, `npx` commands **cannot** be found or executed via `shell_exec` / `child_process`
   - `shell_exec` uses Android's `/system/bin/sh` (toybox) — completely separate from the Node.js process
   - To run JavaScript code, tools must use `eval()`/`require()` inside the existing Node.js process (see BAT-59: `js_eval` tool)

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -2165,7 +2165,7 @@ const TOOLS = [
         input_schema: {
             type: 'object',
             properties: {
-                command: { type: 'string', description: 'Shell command to execute (e.g., "ls -la", "cat file.txt", "curl https://example.com", "grep pattern *.md")' },
+                command: { type: 'string', description: 'Shell command to execute (e.g., "ls -la", "cat file.txt", "curl https://example.com", "grep pattern README.md")' },
                 cwd: { type: 'string', description: 'Working directory relative to workspace (default: workspace root). Must be within workspace.' },
                 timeout_ms: { type: 'number', description: 'Timeout in milliseconds (default: 30000, max: 30000)' }
             },


### PR DESCRIPTION
## Summary
- Removed `node`, `npm`, `npx` from shell_exec `ALLOWED_CMDS` — they are not available on device (nodejs-mobile runs as `libnode.so` via JNI, no standalone binary)
- Removed temporary `[ENV]` diagnostic logging from main.js (investigation complete)
- Updated shell_exec tool description, system prompt Tooling section, and Runtime Environment section to accurately reflect that node/npm/npx are NOT available
- Updated CLAUDE.md with nodejs-mobile JNI architecture findings and corrected model list to API aliases

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Agent's shell_exec still works for allowed commands (ls, cat, curl, etc.)
- [ ] Agent no longer sees incorrect claims about node/npm/npx availability in its system prompt
- [ ] No `[ENV]` diagnostic lines in logcat output

🤖 Generated with [Claude Code](https://claude.com/claude-code)