### PR TITLE
feat: auto session summary — memory before session dies (BAT-57)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4054,7 +4054,11 @@ async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = 
 
     try {
         const summary = await generateSessionSummary(chatId);
-        if (!summary) return; // Debounce stays set — prevents repeated calls for short conversations
+        if (!summary) {
+            // Use shorter backoff (10s) for null — allows retry sooner if messages arrive
+            track.lastSummaryTime = now - 50000;
+            return;
+        }
 
         // Generate descriptive filename: YYYY-MM-DD-slug.md
         const dateStr = localDateStr();


### PR DESCRIPTION
## Summary
- Adds automatic session summaries that trigger on idle (10 min), periodic checkpoint (50 msgs / 30 min), `/new` command, and shutdown (SIGTERM/SIGINT)
- LLM-generated summaries (~500 tokens) saved to `memory/YYYY-MM-DD-slug.md` with OpenClaw-style random slugs
- Immediately indexed into SQL.js chunks for `memory_search` searchability
- Graceful shutdown uses 5s timeout race to avoid hanging on dead API
- Idle timer resets before async save to prevent duplicate triggers (race condition fix)
- System prompt updated so agent knows sessions are auto-captured

## Test plan
- [ ] Deploy to device, send 3+ messages, run `/new` → verify summary file created in `memory/`
- [ ] Verify summary content has 3-5 bullet points with decisions/tasks/info
- [ ] Verify `memory_search` finds content from saved summary
- [ ] Wait 10 min idle → check logcat for `[SessionSummary] Saved: ... (trigger: idle)`
- [ ] Kill service → check if shutdown summary was saved
- [ ] `/reset` still works independently (clears without saving)
- [ ] `/status` still shows correct info

🤖 Generated with [Claude Code](https://claude.com/claude-code)