### PR TITLE
feat: port OpenClaw parity updates v2026.2.12-2026.2.13 (BAT-63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 | Version | Current | Location |
 |---------|---------|----------|
 | **App** | `1.2.0` (code 3) | `app/build.gradle.kts` → `versionName` / `versionCode` |
-| **OpenClaw** | `2026.2.6` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
+| **OpenClaw** | `2026.2.13` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
 | **Node.js** | `18 LTS` | `app/build.gradle.kts` → `NODEJS_VERSION` buildConfigField |
 
 ## Tech Stack
@@ -392,8 +392,8 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 > **IMPORTANT:** SeekerClaw must stay in sync with OpenClaw updates. See `OPENCLAW_TRACKING.md` for full details.
 
 ### Current Versions
-- **OpenClaw Reference:** 2026.2.2 (commit 1c4db91)
-- **Last Sync Review:** 2026-02-05
+- **OpenClaw Reference:** 2026.2.13 (commit 71f357d)
+- **Last Sync Review:** 2026-02-14
 
 ### Quick Update Check
 ```bash

--- a/OPENCLAW_TRACKING.md
+++ b/OPENCLAW_TRACKING.md
@@ -1,8 +1,8 @@
 # OpenClaw Version Tracking
 
 > **Purpose:** Track OpenClaw releases and identify changes to port to SeekerClaw.
-> **Current OpenClaw Version:** 2026.2.12 (main bdd0c12, 2026-02-12)
-> **Last Sync Review:** 2026-02-12
+> **Current OpenClaw Version:** 2026.2.13 (main 71f357d, 2026-02-14)
+> **Last Sync Review:** 2026-02-14
 > **Parity Plan:** See `PARITY_PLAN.md`
 
 ---
@@ -82,7 +82,28 @@ These files in OpenClaw directly affect SeekerClaw behavior. Changes here requir
 
 ## Version History & Changes
 
-### 2026.2.10-dev (Current - 029b77c)
+### 2026.2.13 (Current - 71f357d)
+- **Release Date:** 2026-02-14
+- **SeekerClaw Sync Status:** Key changes ported
+- **Key Changes Ported:**
+  - [x] web-fetch: Accept header prefers `text/markdown` (Cloudflare Markdown for Agents)
+  - [x] web-fetch: cf-markdown extractor for pre-rendered markdown responses
+  - [x] web-search: Perplexity freshness/recency filter support
+  - [x] Error handling: distinct user messages for rate limit vs overloaded
+- **Skipped (not applicable):**
+  - Memory QMD search mode default change (no QMD in SeekerClaw)
+  - Discord skill rewrite (no Discord channel)
+  - Skills-install archive hardening (no skill install)
+  - Telegram poll support (defer)
+  - Telegram replyToMode default change (SeekerClaw uses direct polling)
+- **Notable upstream:**
+  - 60+ commits, tags v2026.2.12 and v2026.2.13
+  - Many security hardening fixes (channels, browser, media, archives)
+  - New providers: Hugging Face, MiniMax CN, vLLM
+  - Podman container support
+  - Write-ahead delivery queue for crash recovery
+
+### 2026.2.10-dev (029b77c)
 - **Release Date:** 2026-02-11
 - **SeekerClaw Sync Status:** Synced (critical fixes ported)
 - **Key Changes Ported:**
@@ -224,7 +245,7 @@ git pull origin main
 ### Step 2: Generate Diff Report
 ```bash
 # Get the commit range
-OLD_COMMIT="029b77c"  # Previous version
+OLD_COMMIT="71f357d"  # Previous version
 NEW_COMMIT="HEAD"
 
 # Check critical files

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -33,7 +33,7 @@ SeekerClaw is an Android app built for the Solana Seeker phone (also works on an
 | AI Provider | Anthropic Claude API | Sonnet 4.5 default |
 | Messaging | Telegram Bot API (grammy) | — |
 | Database | SQL.js (WASM SQLite) | 1.12.0 |
-| OpenClaw Parity | OpenClaw gateway (ported) | 2026.2.6 |
+| OpenClaw Parity | OpenClaw gateway (ported) | 2026.2.13 |
 | Web Search | Brave Search + Perplexity Sonar | — |
 | Wallet | Solana Web3.js + Jupiter API | — |
 | Build | Gradle (Kotlin DSL) | — |
@@ -216,7 +216,7 @@ User (Telegram) <--HTTPS--> Telegram API <--polling--> Node.js Gateway (on phone
 | "NFT tracking" (JSON-LD, llms.txt) | Not implemented | Remove from website |
 | "DeFi automation" (OG meta, JSON-LD) | Swap tools exist, no automated DeFi | Tone down claim |
 | "Get on dApp Store" button | Link is `href="#"`, not submitted | Fix link or mark "Coming Soon" |
-| "OpenClaw v2026.2.12 parity" (roadmap) | Tracking v2026.2.6 | Update website version |
+| "OpenClaw v2026.2.12 parity" (roadmap) | Tracking v2026.2.13 | Update website version |
 | "150,000+ Seeker Devices" | Market estimate, not users | Fine as-is (addressable market) |
 | "Open-source" (privacy page) | Repo is public | Verify license |
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
         versionName = "1.2.0"
 
         // Keep these in sync when updating OpenClaw or nodejs-mobile
-        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.6\"")
+        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.13\"")
         buildConfigField("String", "NODEJS_VERSION", "\"18 LTS\"")
 
         externalNativeBuild {


### PR DESCRIPTION
## Summary
- **web-fetch**: Prefer `text/markdown` in Accept header to leverage Cloudflare Markdown for Agents — servers that support it return pre-rendered markdown instead of HTML
- **web-fetch**: Add `cf-markdown` extractor that handles `text/markdown` content-type responses directly
- **web-search**: Add Perplexity `search_recency_filter` support — freshness param (day/week/month) now works for both Brave and Perplexity providers
- **error handling**: Rate limit (429) and overloaded (529) errors now show distinct user-facing messages instead of generic fallbacks
- **version tracking**: Update OpenClaw reference from 2026.2.6 to 2026.2.13 (71f357d) across build.gradle.kts, CLAUDE.md, PROJECT.md, OPENCLAW_TRACKING.md

## Parity check notes
60+ upstream commits reviewed. Skipped: memory QMD changes (Node 22+), Discord skill rewrite (no Discord), Telegram poll support (defer), security fixes for channels we don't use.

## Test plan
- [ ] Web fetch returns `cf-markdown` type when server responds with `text/markdown`
- [ ] Perplexity search with freshness param returns recency-filtered results
- [ ] Rate limit error shows "API rate limit reached" (not generic fallback)
- [ ] Overloaded error shows "temporarily overloaded" message
- [ ] App shows OpenClaw version 2026.2.13 in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)