### PR TITLE
feat: redesign onboarding screens (BAT-65)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/components/PixelComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/PixelComponents.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -222,8 +223,12 @@ fun SetupStepIndicator(
     currentStep: Int,
     labels: List<String>,
     modifier: Modifier = Modifier,
+    circleSize: Dp = 32.dp,
+    stepWidth: Dp = 48.dp,
+    connectorHeight: Dp = 2.dp,
 ) {
     val totalSteps = labels.size
+    val connectorTopPadding = (circleSize.value / 2).dp - (connectorHeight / 2)
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -236,11 +241,11 @@ fun SetupStepIndicator(
             // Step column (circle + label)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.width(48.dp),
+                modifier = Modifier.width(stepWidth),
             ) {
                 Box(
                     modifier = Modifier
-                        .size(32.dp)
+                        .size(circleSize)
                         .background(
                             color = when {
                                 isCompleted -> SeekerClawColors.Accent
@@ -283,6 +288,7 @@ fun SetupStepIndicator(
                             else SeekerClawColors.TextDim,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
 
@@ -291,8 +297,8 @@ fun SetupStepIndicator(
                 Box(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(top = 15.dp) // vertically center with 32dp circles
-                        .height(2.dp)
+                        .padding(top = connectorTopPadding)
+                        .height(connectorHeight)
                         .background(
                             if (i < currentStep) SeekerClawColors.Accent
                             else SeekerClawColors.TextDim.copy(alpha = 0.2f)

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -411,7 +411,9 @@ private fun ClaudeApiStep(
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
     val isToken = authType == "setup_token"
     val uriHandler = LocalUriHandler.current
-    val isValid = apiKey.length >= 20 && apiKeyError == null
+    val isValid = apiKey.trim().isNotBlank() &&
+        ConfigManager.validateCredential(apiKey.trim(), authType) == null &&
+        apiKeyError == null
 
     Column(modifier = Modifier.fillMaxWidth()) {
         SectionLabel("Authentication")
@@ -592,11 +594,14 @@ private fun TelegramStep(
                 supportingText = botTokenError?.let { err ->
                     { Text(err, fontSize = 12.sp) }
                 },
-                trailingIcon = if (botToken.isNotBlank() && botTokenError == null) {
+                trailingIcon = if (
+                    botToken.trim().matches(Regex("^\\d+:[A-Za-z0-9_-]+$")) &&
+                    botTokenError == null
+                ) {
                     {
                         Icon(
                             Icons.Default.CheckCircle,
-                            contentDescription = "Valid",
+                            contentDescription = "Valid format",
                             tint = SeekerClawColors.Accent,
                             modifier = Modifier.size(20.dp),
                         )


### PR DESCRIPTION
## Summary
- Replace plain text setup screens with polished card-based UI matching the main app's dark cyberpunk style
- Add canvas-based SeekerClaw claw logo (56dp) rendered from ic_launcher SVG path data
- Add branded title ("Seeker" + "Claw" in Primary color) with tagline
- Add `SetupStepIndicator` — numbered circles with labels and connecting lines (replaces tiny block dots)
- Wrap all form sections in `SetupCard` composables with proper Surface/border/corner styling
- Add validation icons (green CheckCircle) on API key and bot token fields
- Add "AUTO-DETECT" accent badge on optional User ID field
- Add clickable help links (console.anthropic.com, seekerclaw.xyz/quick-setup.html)
- Switch body text from Monospace to Default font, keeping monospace only for code values
- Add "Initialize Agent" button with PlayArrow icon on final step

## Files changed
- `SetupScreen.kt` — Complete visual redesign of all 4 onboarding steps + header
- `PixelComponents.kt` — Added `SetupStepIndicator` composable

## Test plan
- [ ] Fresh install or clear app data to trigger setup flow
- [ ] Verify claw logo renders correctly at top
- [ ] Verify branded title and tagline display
- [ ] Verify numbered step indicator with labels (Welcome, Claude, Telegram, Options)
- [ ] Welcome step: 3 requirement items with icons, "Get Started" button, help link opens browser
- [ ] Claude Auth step: card wrapper, auth toggle, clickable console link, green check on valid key
- [ ] Telegram step: card wrapper, bot token with validation, auto-detect badge when User ID empty
- [ ] Options step: card wrapper, model dropdown, agent name, "Initialize Agent" with play icon
- [ ] All existing setup logic (save config, navigation, validation) still works
- [ ] Just build & run — no Gradle sync needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)