### PR TITLE
feat: add DuckDuckGo as zero-config default search (BAT-69)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -65,6 +65,7 @@ const AUTH_TYPE = config.authType || 'api_key';
 const MODEL = config.model || 'claude-opus-4-6';
 const AGENT_NAME = config.agentName || 'SeekerClaw';
 BRIDGE_TOKEN = config.bridgeToken || '';
+const USER_AGENT = 'SeekerClaw/1.0 (Android; +https://seekerclaw.com)';
 
 // Reaction config with validation
 const VALID_REACTION_NOTIFICATIONS = new Set(['off', 'own', 'all']);
@@ -1380,7 +1381,7 @@ async function searchDDG(query, count = 5) {
         path: safePath,
         method: 'GET',
         headers: {
-            'User-Agent': 'SeekerClaw/1.0 (Android; +https://seekerclaw.com)',
+            'User-Agent': USER_AGENT,
             'Accept': 'text/html'
         }
     });
@@ -1393,7 +1394,7 @@ async function searchDDG(query, count = 5) {
     // Parse DDG HTML results — patterns match DDG's current HTML format (double-quoted attributes).
     // May need updating if DDG changes their markup.
     const results = [];
-    const resultBlocks = html.split(/<div[^>]*class="[^"]*result[^"]*"[^>]*>/i);
+    const resultBlocks = html.split(/<div[^>]*class="(?:result\b|results_links\b)[^"]*"[^>]*>/i);
     for (let i = 1; i < resultBlocks.length && results.length < count; i++) {
         const block = resultBlocks[i];
         // Extract URL from <a class="result__a" href="...">
@@ -1457,7 +1458,7 @@ async function webFetch(urlString, options = {}) {
 
         // Strip sensitive headers on cross-origin redirect
         const reqHeaders = {
-            'User-Agent': 'SeekerClaw/1.0 (Android; +https://seekerclaw.com)',
+            'User-Agent': USER_AGENT,
             'Accept': options.accept || 'text/markdown, text/html;q=0.9, */*;q=0.1'
         };
         for (const [k, v] of Object.entries(customHeaders)) {


### PR DESCRIPTION
## Summary
- Adds DuckDuckGo HTML as a zero-config default search provider — web search now works out of the box with no API key
- Brave is auto-used when its API key is configured (better quality)
- Fallback chain: perplexity → brave → ddg, brave → ddg — search never silently fails
- Updated tool schema, system prompt, `/status` output, and features flag

## Test plan
- [ ] Verify `web_search` works with no Brave API key configured (should use DDG)
- [ ] Verify `web_search` auto-uses Brave when key is present
- [ ] Verify `provider=duckduckgo` explicitly returns DDG results
- [ ] Verify fallback: set invalid Brave key, confirm it falls back to DDG
- [ ] Verify `/status` shows "DuckDuckGo" when no Brave key, "Brave" when key present
- [ ] Verify `provider=perplexity` still works with Perplexity key

🤖 Generated with [Claude Code](https://claude.com/claude-code)