### PR TITLE
feat: port OpenClaw parity updates v2026.2.14 (BAT-70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 | Version | Current | Location |
 |---------|---------|----------|
 | **App** | `1.2.0` (code 3) | `app/build.gradle.kts` → `versionName` / `versionCode` |
-| **OpenClaw** | `2026.2.13` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
+| **OpenClaw** | `2026.2.14` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
 | **Node.js** | `18 LTS` | `app/build.gradle.kts` → `NODEJS_VERSION` buildConfigField |
 
 ## Tech Stack
@@ -392,8 +392,8 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 > **IMPORTANT:** SeekerClaw must stay in sync with OpenClaw updates. See `OPENCLAW_TRACKING.md` for full details.
 
 ### Current Versions
-- **OpenClaw Reference:** 2026.2.13 (commit 71f357d)
-- **Last Sync Review:** 2026-02-14
+- **OpenClaw Reference:** 2026.2.14 (commit e927fd1)
+- **Last Sync Review:** 2026-02-15
 
 ### Quick Update Check
 ```bash

--- a/OPENCLAW_TRACKING.md
+++ b/OPENCLAW_TRACKING.md
@@ -1,8 +1,8 @@
 # OpenClaw Version Tracking
 
 > **Purpose:** Track OpenClaw releases and identify changes to port to SeekerClaw.
-> **Current OpenClaw Version:** 2026.2.13 (main 71f357d, 2026-02-14)
-> **Last Sync Review:** 2026-02-14
+> **Current OpenClaw Version:** 2026.2.14 (main e927fd1, 2026-02-15)
+> **Last Sync Review:** 2026-02-15
 > **Parity Plan:** See `PARITY_PLAN.md`
 
 ---
@@ -82,7 +82,26 @@ These files in OpenClaw directly affect SeekerClaw behavior. Changes here requir
 
 ## Version History & Changes
 
-### 2026.2.13 (Current - 71f357d)
+### 2026.2.14 (Current - e927fd1)
+- **Release Date:** 2026-02-15
+- **SeekerClaw Sync Status:** Key changes ported
+- **Key Changes Ported:**
+  - [x] System prompt: poll loop avoidance guidance for shell_exec
+- **Skipped (not applicable):**
+  - Sub-agent orchestration (subagents tool, system message handling) — no sub-agents
+  - Sandbox/container workspace path resolution — no Docker on mobile
+  - Memory QMD/embedding refactoring — requires Node 22+ / node:sqlite
+  - Skills refresh watch optimization (SKILL.md glob patterns) — no file watcher
+  - Cron normalize partial agentTurn payloads — SeekerClaw uses reminder-only payloads
+  - Cron sub-agent wait/poll logic — no sub-agent system
+  - Web/auto-reply test infrastructure refactoring — test-only
+- **Notable upstream:**
+  - New `subagents` tool (list/steer/kill sub-agent runs)
+  - Cron jobs now wait for sub-agent completion before delivering
+  - Heavy test refactoring across web, cron, memory subsystems
+  - Skills watcher switched to SKILL.md glob patterns to avoid FD exhaustion
+
+### 2026.2.13 (71f357d)
 - **Release Date:** 2026-02-14
 - **SeekerClaw Sync Status:** Key changes ported
 - **Key Changes Ported:**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
         versionName = "1.2.0"
 
         // Keep these in sync when updating OpenClaw or nodejs-mobile
-        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.13\"")
+        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.14\"")
         buildConfigField("String", "NODEJS_VERSION", "\"18 LTS\"")
 
         externalNativeBuild {

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4293,6 +4293,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('Keep narration brief and value-dense; avoid repeating obvious steps.');
     lines.push('Use plain human language for narration unless in a technical context.');
     lines.push('For visual checks ("what do you see", "check my dog", "look at the room"), call android_camera_check.');
+    lines.push('For long waits, avoid rapid poll loops: use shell_exec with enough timeout or check status on-demand rather than in a tight loop.');
     lines.push('');
 
     // Error recovery guidance — how agent should handle tool failures


### PR DESCRIPTION
## Summary
- Ports system prompt poll loop avoidance guidance from OpenClaw v2026.2.14
- Bumps OPENCLAW_VERSION to 2026.2.14 across all tracking locations
- Comprehensive parity review documented in OPENCLAW_TRACKING.md

**Skipped (not applicable to SeekerClaw):** sub-agent orchestration, sandbox/container paths, memory QMD/embedding (Node 22), cron agentTurn payloads, skills watch optimization, test refactoring.

## Test plan
- [ ] Verify build passes (Gradle sync needed for buildConfigField change)
- [ ] Settings → System shows OpenClaw version "2026.2.14"
- [ ] Agent system prompt includes poll loop avoidance guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)