### PR TITLE
fix: navigate to Setup after Reset Config (BAT-72)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -1160,6 +1160,7 @@ fun SettingsScreen(onRunSetupAgain: () -> Unit = {}) {
                     ConfigManager.clearConfig(context)
                     Analytics.featureUsed("config_reset")
                     showResetDialog = false
+                    onRunSetupAgain()
                 }) {
                     Text(
                         "Confirm",


### PR DESCRIPTION
## Summary
- Reset Config now navigates user to Setup screen after clearing config
- Previously, user was stuck on stale Settings screen with no config loaded
- Reuses the same `onRunSetupAgain()` callback from BAT-67

## Test plan
- [ ] Open Settings → Danger Zone → Reset Config → Confirm
- [ ] Verify user is navigated to Setup screen after reset
- [ ] Verify config is cleared and setup fields are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)