### PR TITLE
fix: expand info icon touch targets to 48dp minimum (BAT-71)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -1478,7 +1478,6 @@ private fun ConfigField(
                 if (info != null) {
                     IconButton(
                         onClick = { showInfo = true },
-                        modifier = Modifier.size(20.dp),
                     ) {
                         Icon(
                             Icons.Outlined.Info,


### PR DESCRIPTION
## Summary
- Remove `Modifier.size(20.dp)` from all 3 info `IconButton`s (ConfigField, SettingRow, PermissionRow)
- `IconButton` defaults to 48dp minimum touch target per Material 3 guidelines
- Icon stays visually at 14dp, but tap area is now accessible

## Test plan
- [ ] Tap info icons in Settings — verify they're easy to tap
- [ ] Verify layout isn't broken (icon stays small, aligned with labels)
- [ ] Check all three sections: Config fields, toggle settings, permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)