### PR TITLE
fix: increase DarkOps TextDim contrast to WCAG AA (BAT-75)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/theme/Theme.kt
@@ -99,7 +99,7 @@ val DarkOpsThemeColors = ThemeColors(
 
     textPrimary = Color(0xF0FFFFFF),   // White ~94%
     textSecondary = Color(0xFF9CA3AF), // Tailwind gray-400
-    textDim = Color(0xFF6B7280),       // Tailwind gray-500
+    textDim = Color(0xFF9CA3AF),       // Tailwind gray-400 (WCAG AA ~5.5:1)
 
     scanline = Color(0x00000000),
     dotMatrix = Color(0x00000000),


### PR DESCRIPTION
## Summary
- Bump DarkOps `textDim` from `#6B7280` (~3.7:1) to `#9CA3AF` (~5.5:1)
- Meets WCAG AA minimum contrast ratio (4.5:1) against background `#0A0A0F`
- Only affects DarkOps theme; Terminal, Pixel, Clean unchanged

## Test plan
- [ ] Open Settings screen — verify dim text (section headers, info icons) is readable
- [ ] Compare with DashboardScreen and LogsScreen dim text
- [ ] Verify other themes still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)