### PR TITLE
fix: increase log font size from 11sp to 12sp (BAT-81)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
@@ -172,9 +172,9 @@ fun LogsScreen() {
                         Text(
                             text = "[$timeStr] ${entry.message}",
                             color = color,
-                            fontSize = 11.sp,
+                            fontSize = 12.sp,
                             fontFamily = FontFamily.Monospace,
-                            lineHeight = 16.sp,
+                            lineHeight = 18.sp,
                             modifier = Modifier.padding(vertical = 1.dp),
                         )
                     }


### PR DESCRIPTION
## Summary
- Bump log text fontSize from 11sp to 12sp
- Bump lineHeight from 16sp to 18sp for proportional spacing
- Improves readability on phone screens

## Test plan
- [ ] Open Console tab — verify log text is readable
- [ ] Check log entries don't overflow or clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)