### PR TITLE
feat: add 200ms fade transition to navigation (BAT-77)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/navigation/NavGraph.kt
@@ -152,14 +152,15 @@ fun SeekerClawNavHost() {
             }
         },
     ) { innerPadding ->
+        val fadeSpec = tween<Float>(durationMillis = 200)
         NavHost(
             navController = navController,
             startDestination = startDestination,
             modifier = Modifier.padding(innerPadding),
-            enterTransition = { fadeIn(animationSpec = tween(200)) },
-            exitTransition = { fadeOut(animationSpec = tween(200)) },
-            popEnterTransition = { fadeIn(animationSpec = tween(200)) },
-            popExitTransition = { fadeOut(animationSpec = tween(200)) },
+            enterTransition = { fadeIn(animationSpec = fadeSpec) },
+            exitTransition = { fadeOut(animationSpec = fadeSpec) },
+            popEnterTransition = { fadeIn(animationSpec = fadeSpec) },
+            popExitTransition = { fadeOut(animationSpec = fadeSpec) },
         ) {
             composable<SetupRoute> {
                 SetupScreen(


### PR DESCRIPTION
## Summary
- Add fadeIn/fadeOut animations (200ms) to all navigation transitions
- Applied at NavHost level so all routes inherit the same smooth fade
- Covers enter, exit, popEnter, and popExit transitions

## Test plan
- [ ] Switch between Home, Console, Settings tabs — verify smooth fade
- [ ] Navigate to System screen and back — verify fade transition
- [ ] Complete Setup → Dashboard transition — verify fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)