### PR TITLE
feat: add pre-permission explanation for notifications (BAT-83)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -348,7 +348,7 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                 }
             },
             containerColor = SeekerClawColors.Surface,
-            shape = RoundedCornerShape(SeekerClawColors.CornerRadius),
+            shape = shape,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace immediate notification permission request with explanation dialog
- Dialog explains why notifications matter (background agent status)
- "Enable" button triggers the system permission dialog
- "Not Now" dismisses without requesting permission

## Test plan
- [ ] Fresh install → Setup screen shows notification explanation dialog
- [ ] Tap "Enable" → system permission dialog appears
- [ ] Tap "Not Now" → dialog dismisses, setup continues without permission
- [ ] If permission already granted, dialog does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)