### PR TITLE
fix: navigate to Settings when Config Needed is tapped (BAT-84)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.delay
 import java.util.Date
 
 @Composable
-fun DashboardScreen(onNavigateToSystem: () -> Unit = {}) {
+fun DashboardScreen(onNavigateToSystem: () -> Unit = {}, onNavigateToSettings: () -> Unit = {}) {
     val context = LocalContext.current
     val status by ServiceState.status.collectAsState()
     val uptime by ServiceState.uptime.collectAsState()
@@ -154,12 +154,13 @@ fun DashboardScreen(onNavigateToSystem: () -> Unit = {}) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Status card (tappable → System screen)
+        // Status card (tappable → System screen, or Settings if config needed)
+        val configNeeded = statusText == "Config Needed"
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(SeekerClawColors.Surface, shape)
-                .clickable { onNavigateToSystem() }
+                .clickable { if (configNeeded) onNavigateToSettings() else onNavigateToSystem() }
                 .padding(20.dp),
         ) {
             Row(
@@ -184,7 +185,7 @@ fun DashboardScreen(onNavigateToSystem: () -> Unit = {}) {
                     )
                 }
                 Text(
-                    text = "System >",
+                    text = if (configNeeded) "Settings >" else "System >",
                     fontFamily = FontFamily.Default,
                     fontSize = 12.sp,
                     color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/navigation/NavGraph.kt
@@ -175,7 +175,16 @@ fun SeekerClawNavHost() {
                 DashboardScreen(
                     onNavigateToSystem = {
                         navController.navigate(SystemRoute)
-                    }
+                    },
+                    onNavigateToSettings = {
+                        navController.navigate(SettingsRoute) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
                 )
             }
             composable<SystemRoute> {


### PR DESCRIPTION
## Summary
- Status card on Dashboard now routes to Settings (instead of System) when displaying "Config Needed"
- Hint text changes from "System >" to "Settings >" when config is needed
- Normal status still navigates to System screen as before

## Test plan
- [ ] Build passes
- [ ] With missing config: tapping status card opens Settings
- [ ] With valid config: tapping status card opens System screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)