### PR TITLE
fix: expand info icon touch targets to 48dp (BAT-71)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -1582,10 +1582,7 @@ private fun SettingRow(
                 color = SeekerClawColors.TextPrimary,
             )
             if (info != null) {
-                IconButton(
-                    onClick = { showInfo = true },
-                    modifier = Modifier.size(20.dp),
-                ) {
+                IconButton(onClick = { showInfo = true }) {
                     Icon(
                         Icons.Outlined.Info,
                         contentDescription = "More info about $label",
@@ -1662,10 +1659,7 @@ private fun PermissionRow(
                 color = SeekerClawColors.TextPrimary,
             )
             if (info != null) {
-                IconButton(
-                    onClick = { showInfo = true },
-                    modifier = Modifier.size(20.dp),
-                ) {
+                IconButton(onClick = { showInfo = true }) {
                     Icon(
                         Icons.Outlined.Info,
                         contentDescription = "More info about $label",


### PR DESCRIPTION
## Summary
- Remove `Modifier.size(20.dp)` from `IconButton` in `SettingRow` and `PermissionRow`
- IconButton now uses its default 48dp touch area (Material 3 minimum)
- Icon visual size stays at 14dp — only the touch target expands

Previous PR #51 fixed ConfigField but missed these two composables.

## Test plan
- [ ] Build passes
- [ ] Info icons in Settings are still visually small but easy to tap
- [ ] No layout overflow or overlap with switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)