### PR TITLE
fix: reset isStarting on setup failure (BAT-94)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -3,6 +3,8 @@ package com.seekerclaw.app.ui.setup
 import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import com.seekerclaw.app.util.LogCollector
+import com.seekerclaw.app.util.LogLevel
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -222,6 +224,7 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
             OpenClawService.start(context)
             currentStep = 4
         } catch (e: Exception) {
+            LogCollector.append("[Setup] Failed to start agent: ${e.message}", LogLevel.ERROR)
             isStarting = false
             errorMessage = e.message ?: "Failed to start agent"
         }


### PR DESCRIPTION
## Summary
- Wrap `saveAndStart()` body in try/catch after setting `isStarting = true`
- On exception: reset `isStarting = false` and show `errorMessage`
- Prevents Initialize Agent button from getting permanently stuck in loading state

## Test plan
- [ ] Build passes
- [ ] Normal setup flow still works (config saves, service starts, step 4 shows)
- [ ] If service start fails, button returns to normal and error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)