### PR TITLE
fix: use Bearer auth for setup tokens (BAT-98)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4717,8 +4717,10 @@ async function claudeApiCall(body, chatId) {
     const startTime = Date.now();
     const MAX_RETRIES = 3; // 1 initial + up to 3 retries = 4 total attempts max
     try {
-        // Setup tokens and API keys both use x-api-key for the Messages API
-        const authHeaders = { 'x-api-key': ANTHROPIC_KEY };
+        // Setup tokens (OAuth) use Bearer auth; regular API keys use x-api-key
+        const authHeaders = AUTH_TYPE === 'setup_token'
+            ? { 'Authorization': `Bearer ${ANTHROPIC_KEY}` }
+            : { 'x-api-key': ANTHROPIC_KEY };
 
         let res;
         let retries = 0;
@@ -4733,7 +4735,9 @@ async function claudeApiCall(body, chatId) {
                     headers: {
                         'Content-Type': 'application/json',
                         'anthropic-version': '2023-06-01',
-                        'anthropic-beta': 'prompt-caching-2024-07-31',
+                        'anthropic-beta': AUTH_TYPE === 'setup_token'
+                            ? 'prompt-caching-2024-07-31,oauth-2025-04-20'
+                            : 'prompt-caching-2024-07-31',
                         ...authHeaders,
                     }
                 }, body);


### PR DESCRIPTION
## Summary
- Setup tokens (`sk-ant-oat01-*`) are OAuth credentials that need `Authorization: Bearer` header, not `x-api-key`
- Previously all auth types sent `x-api-key`, causing 401/403 errors for setup token users
- Also adds `anthropic-beta: oauth-2025-04-20` flag required for OAuth requests
- Regular API key auth (`sk-ant-api03-*`) is unchanged

## Changes
**`app/src/main/assets/nodejs-project/main.js`:**
1. Auth header selection based on `AUTH_TYPE`: Bearer for `setup_token`, x-api-key for `api_key`
2. Conditional `anthropic-beta` header includes `oauth-2025-04-20` for setup tokens

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Setup token auth (`sk-ant-oat01-*`): sends message via Telegram, agent responds (no 401)
- [ ] Regular API key auth (`sk-ant-api03-*`): still works (no regression)
- [ ] Check logs for successful API calls (status 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)