### PR TITLE
fix: add Telegram formatting rules to system prompt (BAT-97)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4450,11 +4450,12 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('');
 
     // Telegram formatting — headers aren't rendered, guide the agent
-    lines.push('## Telegram Formatting');
-    lines.push('- Do NOT use markdown headers (##, ###) — Telegram doesn\'t render them.');
+    lines.push('**Telegram Formatting (for user-visible Telegram replies)**');
+    lines.push('- In Telegram replies, do NOT use markdown headers (##, ###) — Telegram doesn\'t render them.');
+    lines.push('- Headers like ## may appear in this system prompt, but must NOT be used in messages you send to users.');
     lines.push('- Use **bold text** for section titles instead.');
     lines.push('- Use emoji + bold for structure: **💰 Prices Right Now**');
-    lines.push('- Telegram supports: **bold**, _italic_, `code`, ```code blocks```, and blockquotes.');
+    lines.push('- Use markdown-style **bold**, _italic_, `code`, ```code blocks``` and blockquotes; these will be converted for Telegram. Do NOT use raw HTML tags in replies.');
     lines.push('- Keep responses scannable with line breaks and emoji, not headers.');
     lines.push('');
 


### PR DESCRIPTION
## Summary
- Telegram doesn't render markdown headers (`##`, `###`) — they show as raw text like `## Prices Right Now`
- Added a "Telegram Formatting" section to the agent's system prompt in `buildSystemBlocks()` 
- Tells the agent to use **bold text** and emoji for structure instead of headers
- Brave API key "Not set" text already updated to "using DuckDuckGo" from BAT-99

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Ask agent a question that would typically produce headers (e.g. "what's the weather like") — response uses bold text, not `##`
- [ ] Verify agent still formats code blocks and bold correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)