### PR TITLE
fix: add UTF-8 encoding to fix emoji in Telegram (BAT-101)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -1213,6 +1213,7 @@ let cachedSkills = [];
 function httpRequest(options, body = null) {
     return new Promise((resolve, reject) => {
         const req = https.request(options, (res) => {
+            res.setEncoding('utf8'); // Handle multi-byte chars (emoji) split across chunks
             let data = '';
             res.on('data', chunk => data += chunk);
             res.on('end', () => {
@@ -3704,6 +3705,7 @@ async function androidBridgeCall(endpoint, data = {}, timeoutMs = 10000) {
             },
             timeout: timeoutMs
         }, (res) => {
+            res.setEncoding('utf8');
             let body = '';
             res.on('data', chunk => body += chunk);
             res.on('end', () => {
@@ -3816,6 +3818,7 @@ async function solanaRpc(method, params = []) {
         };
 
         const req = https.request(options, (res) => {
+            res.setEncoding('utf8');
             let body = '';
             res.on('data', chunk => body += chunk);
             res.on('end', () => {


### PR DESCRIPTION
## Summary
- Multi-byte emoji (4 bytes in UTF-8) split across HTTP response chunks were corrupted into diamond/question mark characters
- Root cause: `data += chunk` implicitly calls `Buffer.toString()` which can't handle partial multi-byte sequences at chunk boundaries
- Fix: `res.setEncoding('utf8')` uses Node.js `StringDecoder` to properly buffer incomplete sequences across chunks
- Applied to 3 HTTP response handlers; file download handler left as raw Buffer (correct for binary)

## Changes
**`app/src/main/assets/nodejs-project/main.js`:**
1. `httpRequest()` — Claude API + Telegram API responses
2. Android Bridge response handler
3. Solana RPC response handler

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Ask agent something that triggers emoji (e.g. "tell me a joke" or "what's the weather") — emoji render correctly in Telegram
- [ ] Regular ASCII/Unicode text still works
- [ ] File downloads (photos, documents) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)