### PR TITLE
perf: add stable keys to LogsScreen LazyColumn (BAT-100)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
@@ -248,7 +248,7 @@ fun LogsScreen() {
                 ) {
                     items(
                         filteredLogs,
-                        key = { entry -> "${entry.timestamp}_${entry.message.hashCode()}" },
+                        key = { entry -> "${entry.timestamp}_${entry.level.name}_${entry.message.hashCode()}" },
                     ) { entry ->
                         val color = when (entry.level) {
                             LogLevel.INFO -> SeekerClawColors.LogInfo


### PR DESCRIPTION
## Summary
- Add stable `key` to LogsScreen LazyColumn `items()` using `timestamp_messageHashCode` composite
- Enables Compose to efficiently diff log entries and skip recomposition for unchanged items
- Smoother scrolling with large log lists

## Test plan
- [ ] Open Console tab with 100+ log entries
- [ ] Scroll smoothly without jank
- [ ] New logs appear without causing full list recomposition
- [ ] Filter toggles (Info/Warn/Error) still work correctly

Generated with [Claude Code](https://claude.com/claude-code)