### PR TITLE
feat: context-aware /start message + TEMPLATES.md (BAT-104)

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1,0 +1,171 @@
+# SeekerClaw Message Templates
+
+> **Central repository for all user-facing message templates.**
+> Update here first, then sync to code. Keep consistent voice and formatting.
+
+## Telegram Commands
+
+### /start (First-Time Users)
+```
+Hello! I'm {AGENT_NAME}, your AI assistant running on Android via SeekerClaw.
+
+I can:
+- Have conversations and remember context
+- Search the web for current information
+- Save and recall memories
+- Take daily notes
+- Check camera view (vision) and describe what it sees
+- Use specialized skills for specific tasks
+
+Commands:
+/status - Show system status
+/new - Save session summary & start fresh
+/reset - Clear conversation history (no summary)
+/soul - Show my personality
+/memory - Show long-term memory
+/skills - List installed skills
+/help - Show this message
+
+Just send me a message to chat!
+```
+
+### /start (Returning Users)
+```
+Welcome back! I'm {AGENT_NAME}.
+
+Commands:
+/status - Show system status
+/new - Save session summary & start fresh
+/reset - Clear conversation history (no summary)
+/soul - Show my personality
+/memory - Show long-term memory
+/skills - List installed skills
+/help - Show this message
+
+Ready to continue where we left off!
+```
+
+### /status
+```
+🟢 **Status:** Running
+⏱️ **Uptime:** {uptime}
+💬 **Messages:** {messageCount} total, {messagesToday} today
+📊 **Model:** {model}
+🧠 **Memory:** {memoryFiles} files indexed
+
+Last active: {lastActivity}
+```
+
+### /help
+Delegates to `/start`
+
+### /soul
+Shows contents of `SOUL.md`
+
+### /memory
+Shows contents of `MEMORY.md`
+
+### /skills
+Lists all installed skills from workspace
+
+### /new
+```
+Session summary saved. Starting fresh conversation.
+```
+
+### /reset
+```
+Conversation history cleared (no summary saved).
+```
+
+## Error Messages
+
+### API Authentication Failed
+```
+Error: API authentication failed. Please check your API key in Settings.
+```
+
+### Network Offline
+```
+⚠️ No internet connection. Please check your network and try again.
+```
+
+### Rate Limited
+```
+⚠️ API rate limit reached. Retrying in {seconds}s...
+```
+
+### File Too Large
+```
+File too large ({sizeMb}MB). Max is {maxMb}MB.
+```
+
+### Permission Denied
+```
+Permission denied: {permissionName}. Please enable in Android Settings.
+```
+
+## Bootstrap Ritual Messages
+
+### Welcome (BOOTSTRAP.md exists)
+Agent receives bootstrap instructions from system prompt, not a hardcoded template.
+
+### Post-Bootstrap Confirmation
+Agent-generated after completing ritual and deleting BOOTSTRAP.md.
+
+## Setup Flow Messages (Android UI)
+
+### Welcome Screen
+```
+Welcome to SeekerClaw
+
+Turn your Seeker phone into a 24/7 AI assistant.
+```
+
+### QR Scan Prompt
+```
+Scan QR Code
+
+Use the SeekerClaw web setup tool to generate your configuration QR code.
+```
+
+### Manual Entry
+```
+Or enter credentials manually below
+```
+
+### Setup Success
+```
+✅ Configuration saved!
+
+Your AI assistant is ready to deploy.
+```
+
+### Setup Error
+```
+❌ Setup failed: {errorMessage}
+
+Please check your credentials and try again.
+```
+
+## Notification Messages
+
+### Foreground Service
+```
+SeekerClaw is running
+
+Your AI assistant is active and monitoring Telegram.
+```
+
+### Low Battery Warning
+```
+⚠️ Battery below 15%. Agent may stop soon. Please charge your device.
+```
+
+## Notes
+
+- **Variable placeholders:** Use `{variableName}` format for dynamic content
+- **Emoji usage:** Minimal — only for status indicators and critical warnings
+- **Tone:** Professional, helpful, concise
+- **Formatting:** Use bold for emphasis, code blocks for technical terms
+- **Updates:** When updating templates here, sync changes to main.js immediately

--- a/app/src/main/assets/nodejs-project/TEMPLATES.md
+++ b/app/src/main/assets/nodejs-project/TEMPLATES.md
@@ -1,0 +1,171 @@
+# SeekerClaw Message Templates
+
+> **Central repository for all user-facing message templates.**
+> Update here first, then sync to code. Keep consistent voice and formatting.
+
+## Telegram Commands
+
+### /start (First-Time Users)
+```
+Hello! I'm {AGENT_NAME}, your AI assistant running on Android via SeekerClaw.
+
+I can:
+- Have conversations and remember context
+- Search the web for current information
+- Save and recall memories
+- Take daily notes
+- Check camera view (vision) and describe what it sees
+- Use specialized skills for specific tasks
+
+Commands:
+/status - Show system status
+/new - Save session summary & start fresh
+/reset - Clear conversation history (no summary)
+/soul - Show my personality
+/memory - Show long-term memory
+/skills - List installed skills
+/help - Show this message
+
+Just send me a message to chat!
+```
+
+### /start (Returning Users)
+```
+Welcome back! I'm {AGENT_NAME}.
+
+Commands:
+/status - Show system status
+/new - Save session summary & start fresh
+/reset - Clear conversation history (no summary)
+/soul - Show my personality
+/memory - Show long-term memory
+/skills - List installed skills
+/help - Show this message
+
+Ready to continue where we left off!
+```
+
+### /status
+```
+🟢 **Status:** Running
+⏱️ **Uptime:** {uptime}
+💬 **Messages:** {messageCount} total, {messagesToday} today
+📊 **Model:** {model}
+🧠 **Memory:** {memoryFiles} files indexed
+
+Last active: {lastActivity}
+```
+
+### /help
+Delegates to `/start`
+
+### /soul
+Shows contents of `SOUL.md`
+
+### /memory
+Shows contents of `MEMORY.md`
+
+### /skills
+Lists all installed skills from workspace
+
+### /new
+```
+Session summary saved. Starting fresh conversation.
+```
+
+### /reset
+```
+Conversation history cleared (no summary saved).
+```
+
+## Error Messages
+
+### API Authentication Failed
+```
+Error: API authentication failed. Please check your API key in Settings.
+```
+
+### Network Offline
+```
+⚠️ No internet connection. Please check your network and try again.
+```
+
+### Rate Limited
+```
+⚠️ API rate limit reached. Retrying in {seconds}s...
+```
+
+### File Too Large
+```
+File too large ({sizeMb}MB). Max is {maxMb}MB.
+```
+
+### Permission Denied
+```
+Permission denied: {permissionName}. Please enable in Android Settings.
+```
+
+## Bootstrap Ritual Messages
+
+### Welcome (BOOTSTRAP.md exists)
+Agent receives bootstrap instructions from system prompt, not a hardcoded template.
+
+### Post-Bootstrap Confirmation
+Agent-generated after completing ritual and deleting BOOTSTRAP.md.
+
+## Setup Flow Messages (Android UI)
+
+### Welcome Screen
+```
+Welcome to SeekerClaw
+
+Turn your Seeker phone into a 24/7 AI assistant.
+```
+
+### QR Scan Prompt
+```
+Scan QR Code
+
+Use the SeekerClaw web setup tool to generate your configuration QR code.
+```
+
+### Manual Entry
+```
+Or enter credentials manually below
+```
+
+### Setup Success
+```
+✅ Configuration saved!
+
+Your AI assistant is ready to deploy.
+```
+
+### Setup Error
+```
+❌ Setup failed: {errorMessage}
+
+Please check your credentials and try again.
+```
+
+## Notification Messages
+
+### Foreground Service
+```
+SeekerClaw is running
+
+Your AI assistant is active and monitoring Telegram.
+```
+
+### Low Battery Warning
+```
+⚠️ Battery below 15%. Agent may stop soon. Please charge your device.
+```
+
+## Notes
+
+- **Variable placeholders:** Use `{variableName}` format for dynamic content
+- **Emoji usage:** Minimal — only for status indicators and critical warnings
+- **Tone:** Professional, helpful, concise
+- **Formatting:** Use bold for emphasis, code blocks for technical terms
+- **Updates:** When updating templates here, sync changes to main.js immediately

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -5257,8 +5257,29 @@ async function chat(chatId, userMessage) {
 
 async function handleCommand(chatId, command, args) {
     switch (command) {
-        case '/start':
-            return `Hello! I'm ${AGENT_NAME}, your AI assistant running on Android via SeekerClaw.
+        case '/start': {
+            // Templates defined in TEMPLATES.md — update there first, then sync here
+            const identity = loadIdentity();
+            const isReturningUser = !!identity;
+
+            if (isReturningUser) {
+                // Brief personalized greeting for returning users
+                const agentName = identity.split('\n')[0].replace(/^#\s*/, '').trim() || AGENT_NAME;
+                return `Welcome back! I'm ${agentName}.
+
+Commands:
+/status - Show system status
+/new - Save session summary & start fresh
+/reset - Clear conversation history (no summary)
+/soul - Show my personality
+/memory - Show long-term memory
+/skills - List installed skills
+/help - Show this message
+
+Ready to continue where we left off!`;
+            } else {
+                // Full welcome for first-time users
+                return `Hello! I'm ${AGENT_NAME}, your AI assistant running on Android via SeekerClaw.
 
 I can:
 - Have conversations and remember context
@@ -5278,6 +5299,8 @@ Commands:
 /help - Show this message
 
 Just send me a message to chat!`;
+            }
+        }
 
         case '/help':
             return handleCommand(chatId, '/start', '');


### PR DESCRIPTION
## Summary
- Created **TEMPLATES.md** as central repository for all message templates (Telegram commands, errors, setup flow, notifications)
- Made `/start` command **context-aware**: different messages for first-time vs returning users
- Returning users see personalized greeting with agent's chosen name from IDENTITY.md
- Fixes poor UX when changing bot tokens on existing setups

## Changes

**New file: `TEMPLATES.md`**
- Central template repository with sections for:
  - Telegram commands (/start, /status, /help, etc.)
  - Error messages (auth failed, network offline, rate limited, etc.)
  - Setup flow messages (Android UI)
  - Notification messages (foreground service, low battery)
- Developer guidance: update templates here first, then sync to code
- Variable placeholder format: `{variableName}`

**`main.js` — `/start` handler (lines 5260-5298)**
- Check for IDENTITY.md existence to detect returning users
- Extract agent name from IDENTITY.md first line (`# AgentName`)
- First-time users: full welcome with capabilities list
- Returning users: brief "Welcome back!" with personalized name
- Added comment referencing TEMPLATES.md

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Fresh install, send `/start` → see full welcome
- [ ] Complete bootstrap ritual (IDENTITY.md created)
- [ ] Send `/start` again → see brief personalized greeting with agent's chosen name
- [ ] Change bot token on existing setup → `/start` shows returning user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)