### PR TITLE
fix: correct Jupiter API endpoints (BAT-106)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4374,7 +4374,7 @@ async function jupiterUltraOrder(inputMint, outputMint, amount, taker) {
     });
 
     const res = await httpRequest({
-        hostname: 'lite-api.jup.ag',
+        hostname: 'api.jup.ag',
         path: `/ultra/v1/order?${params.toString()}`,
         method: 'GET',
         headers: { 'Accept': 'application/json' },
@@ -4389,7 +4389,7 @@ async function jupiterUltraOrder(inputMint, outputMint, amount, taker) {
 // Jupiter Ultra API — execute signed transaction (Jupiter broadcasts)
 async function jupiterUltraExecute(signedTransaction, requestId) {
     const res = await httpRequest({
-        hostname: 'lite-api.jup.ag',
+        hostname: 'api.jup.ag',
         path: '/ultra/v1/execute',
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
@@ -4404,12 +4404,12 @@ async function jupiterUltraExecute(signedTransaction, requestId) {
     return res.data;
 }
 
-// Jupiter Price API v2
+// Jupiter Price API v3
 async function jupiterPrice(mintAddresses) {
     const ids = mintAddresses.join(',');
     const res = await httpRequest({
         hostname: 'api.jup.ag',
-        path: `/price/v2?ids=${encodeURIComponent(ids)}`,
+        path: `/price/v3?ids=${encodeURIComponent(ids)}`,
         method: 'GET',
         headers: { 'Accept': 'application/json' },
     });


### PR DESCRIPTION
## Summary

Fixes Jupiter Ultra API integration by correcting hostnames and updating deprecated endpoints based on official documentation at https://dev.jup.ag/llms-full.txt

## Problem

Jupiter swaps not working due to:
- ❌ Wrong hostname: `lite-api.jup.ag` (should be `api.jup.ag`)
- ❌ Deprecated Price API v2 (should be v3)

## Changes

**Ultra API (Swap Execution):**
- `jupiterUltraOrder`: Changed hostname from `lite-api.jup.ag` to `api.jup.ag`
- `jupiterUltraExecute`: Changed hostname from `lite-api.jup.ag` to `api.jup.ag`

**Price API:**
- `jupiterPrice`: Updated from `/price/v2` to `/price/v3` (v2 deprecated)

**Not Changed:**
- `jupiterQuote`: Still using `quote-api.jup.ag` (separate quote endpoint, working as expected)

## Technical Details

Per official docs:
- ✅ Base URL: `https://api.jup.ag/ultra/v1`
- ✅ No API key required (optional for higher rate limits)
- ✅ Gasless swaps for trades ~$10+ minimum
- ✅ Returns base64-encoded unsigned VersionedTransaction
- ✅ `requestId` from `/order` used in `/execute`

## Testing

- ✅ Build successful (Gradle clean build)
- No Kotlin changes (JS only)
- **Just build & run** - no Gradle sync needed
- Ready for testing on device with actual swap

Fixes BAT-106

🤖 Generated with [Claude Code](https://claude.com/claude-code)