### PR TITLE
hotfix: fix Jupiter quote endpoint (quote-api.jup.ag → api.jup.ag/swap/v1)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4193,7 +4193,7 @@ async function resolveToken(input) {
     return null;
 }
 
-// Jupiter Quote API
+// Jupiter Swap API v1 - Quote endpoint (Metis routing)
 async function jupiterQuote(inputMint, outputMint, amountRaw, slippageBps = 100) {
     const params = new URLSearchParams({
         inputMint,
@@ -4203,8 +4203,8 @@ async function jupiterQuote(inputMint, outputMint, amountRaw, slippageBps = 100)
     });
 
     const res = await httpRequest({
-        hostname: 'quote-api.jup.ag',
-        path: `/v6/quote?${params.toString()}`,
+        hostname: 'api.jup.ag',
+        path: `/swap/v1/quote?${params.toString()}`,
         method: 'GET',
         headers: { 'Accept': 'application/json' },
     });


### PR DESCRIPTION
## Critical Hotfix

**Problem:** `solana_quote` tool failing with DNS errors because `quote-api.jup.ag` no longer exists.

**Fix:** Updated `jupiterQuote()` to use correct endpoint:
- Before: `quote-api.jup.ag/v6/quote`
- After: `api.jup.ag/swap/v1/quote`

**Per official docs:** The Swap API v1 quote endpoint is at `https://api.jup.ag/swap/v1/quote`

**Testing:** Build successful, ready for device testing.

🚨 Merging immediately - hotfix for broken quote functionality discovered by agent in production.