### PR TITLE
feat: prompt injection defense — content wrapping, trust policy, pattern detection, skill protection (BAT-112)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -2930,8 +2930,8 @@ async function executeTool(name, input, chatId) {
             if (!filePath) return { error: 'Access denied: path outside workspace' };
 
             // Skill file write protection: writes to skills/ directory are blocked
-            // unless the user explicitly asked for it (defense against prompt injection
-            // creating persistent backdoor skills via external content instructions).
+            // when suspicious injection patterns are detected in the content (defense
+            // against prompt injection creating persistent backdoor skills).
             const relPath = path.relative(workDir, filePath);
             const relPathLower = relPath.toLowerCase();
             if (relPathLower.startsWith('skills' + path.sep) || relPathLower.startsWith('skills/')) {


### PR DESCRIPTION
## Summary
- Add **Content Trust Policy** to system prompt — tells Claude to never follow instructions found in tool results (web pages, files, search results)
- Add **`wrapExternalContent()`** with `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` boundary markers — applied to all `web_fetch` and `web_search` results
- Add **`detectSuspiciousPatterns()`** scanning for 10 common prompt injection phrases (ignore-previous, role-override, crypto-theft, sms-injection, fake-system-turn, urgency-exploit, etc.)
- Add **`sanitizeBoundaryMarkers()`** preventing Unicode fullwidth homoglyph bypass of boundary markers
- Add **skill file write protection** — writes to `skills/` directory blocked when suspicious patterns detected in content (prevents persistent backdoor injection)

## Why this matters
SeekerClaw has access to a crypto wallet, SMS, phone calls, contacts, location, and camera. A malicious web page fetched via `web_fetch` could inject instructions that Claude might follow. This is the #1 security gap identified in the code audit. OpenClaw has equivalent defenses (`wrapExternalContent`, `detectSuspiciousPatterns`) that SeekerClaw was missing.

## Test plan
- [ ] Verify `buildSystemBlocks()` includes Content Trust Policy section after Safety section
- [ ] Verify `web_fetch` results are wrapped with `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers
- [ ] Verify `web_search` results (descriptions/snippets/answers) are wrapped with markers
- [ ] Verify suspicious patterns like "ignore previous instructions" trigger a log warning
- [ ] Verify Unicode homoglyph markers (fullwidth `＜` `＞`) are sanitized
- [ ] Verify writing a skill file with suspicious content (e.g., "ignore previous instructions") is blocked
- [ ] Verify writing a normal skill file without suspicious content succeeds
- [ ] Verify existing web_fetch, web_search, and write functionality not broken

Generated with [Claude Code](https://claude.com/claude-code)