### PR TITLE
feat: tool confirmation gates — YES/NO for dangerous actions (BAT-114)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -7135,9 +7135,11 @@ async function poll() {
                         const msgChatId = update.message.chat.id;
                         const pending = pendingConfirmations.get(msgChatId);
                         const msgText = (update.message.text || '').trim();
-                        if (pending && msgText) {
-                            // Only consume text messages as confirmation replies
-                            // (photos, stickers, etc. are ignored and enqueued normally)
+                        const isPlainText = msgText && !update.message.photo && !update.message.video
+                            && !update.message.document && !update.message.sticker && !update.message.voice;
+                        if (pending && isPlainText) {
+                            // Only consume pure text messages as confirmation replies
+                            // (photos with captions, stickers, etc. are enqueued normally)
                             const confirmed = msgText.toUpperCase() === 'YES';
                             log(`[Confirm] User replied "${msgText}" for ${pending.toolName} → ${confirmed ? 'APPROVED' : 'REJECTED'}`);
                             pending.resolve(confirmed);


### PR DESCRIPTION
## Summary
- Add **programmatic confirmation flow** for 4 high-impact tools: `android_sms`, `android_call`, `jupiter_trigger_create`, `jupiter_dca_create`
- When Claude calls these tools, the system **automatically sends a formatted confirmation message** to the user via Telegram showing what action will be taken
- User must reply **YES** to proceed — anything else (or 60s timeout) cancels the action
- **Rate limiting** as defense-in-depth: SMS/call once per 60s, Jupiter orders once per 30s
- **Poll loop interception**: confirmation replies are caught before normal message handling, preventing deadlock with the chat queue
- System prompt updated so the agent knows confirmation is automatic (no need to double-ask)

## Why this matters
These tools can send real SMS, make phone calls, and create crypto trading orders. A prompt-injected agent (from a malicious web page) could trigger these without the user's knowledge. Tool description prompts say "confirm with user" but that's a soft instruction — this is a hard code-level gate.

## Test plan
- [ ] `android_sms` sends confirmation message, waits for YES, then sends SMS
- [ ] `android_call` sends confirmation message, waits for YES, then makes call
- [ ] `jupiter_trigger_create` sends confirmation message with order details
- [ ] `jupiter_dca_create` sends confirmation message with DCA details
- [ ] Replying anything other than YES cancels the action
- [ ] Not replying for 60s auto-cancels
- [ ] Rate limit blocks rapid successive calls (error returned to Claude)
- [ ] Normal tools (web_search, read, etc.) execute without confirmation
- [ ] No regressions in normal message flow

Generated with [Claude Code](https://claude.com/claude-code)