### PR TITLE
fix: Jupiter API hardening — 7 fixes from official skill audit (BAT-151–157)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -4111,7 +4111,8 @@ async function executeTool(name, input, chatId) {
                     wrapAndUnwrapSol: true,
                 };
 
-                const res = await jupiterRequest({
+                // No retry for createOrder — non-idempotent POST could create duplicates
+                const res = await httpRequest({
                     hostname: 'api.jup.ag',
                     path: '/trigger/v1/createOrder',
                     method: 'POST',
@@ -4283,9 +4284,9 @@ async function executeTool(name, input, chatId) {
                     return { error: e.message };
                 }
 
-                // 3. Call Jupiter Trigger API — cancelOrder
+                // 3. Call Jupiter Trigger API — cancelOrder (no retry — non-idempotent POST)
                 log(`[Jupiter Trigger] Cancelling order: ${input.orderId}`);
-                const res = await jupiterRequest({
+                const res = await httpRequest({
                     hostname: 'api.jup.ag',
                     path: '/trigger/v1/cancelOrder',
                     method: 'POST',
@@ -4491,7 +4492,8 @@ async function executeTool(name, input, chatId) {
                     },
                 };
 
-                const res = await jupiterRequest({
+                // No retry for createOrder — non-idempotent POST could create duplicates
+                const res = await httpRequest({
                     hostname: 'api.jup.ag',
                     path: '/recurring/v1/createOrder',
                     method: 'POST',
@@ -4675,9 +4677,9 @@ async function executeTool(name, input, chatId) {
                     return { error: e.message };
                 }
 
-                // 3. Call Jupiter Recurring API — cancelOrder
+                // 3. Call Jupiter Recurring API — cancelOrder (no retry — non-idempotent POST)
                 log(`[Jupiter DCA] Cancelling order: ${input.orderId}`);
-                const res = await jupiterRequest({
+                const res = await httpRequest({
                     hostname: 'api.jup.ag',
                     path: '/recurring/v1/cancelOrder',
                     method: 'POST',


### PR DESCRIPTION
## Summary
Comprehensive Jupiter API hardening based on auditing our integration against the official [jup-ag/agent-skills](https://github.com/jup-ag/agent-skills) SKILL.md specification.

- **BAT-151:** Migrate `fetchJupiterTokenList()` from legacy `token.jup.ag/strict` to `api.jup.ag/tokens/v2/tag?query=verified`
- **BAT-152:** Add `jupiterRequest()` wrapper with 429 rate limit handling — exponential backoff + jitter (2s base, 15s max, 3 retries). Execute endpoints excluded (time-sensitive signed txs)
- **BAT-153:** DCA minimum validation — reject orders below Jupiter minimums ($100 total, $50/order, ≥2 orders) with USD price lookup
- **BAT-154:** Surface `confidenceLevel` from Price v3 in `solana_price`. Block swaps on low confidence
- **BAT-155:** Surface `organicScore` and `audit.isSus` from Tokens v2 in token search and security responses
- **BAT-156:** Ultra swap TTL protection — re-quote + re-sign if MWA approval takes >90s (30s buffer before 2-min TTL expiry)
- **BAT-157:** Token-2022 pre-flight check via Shield API for Trigger and DCA orders — block with clear error

## Changes
| Area | Change |
|------|--------|
| `fetchJupiterTokenList()` | `token.jup.ag/strict` → `api.jup.ag/tokens/v2/tag?query=verified` |
| New: `jupiterRequest()` | Wrapper with 429 backoff for all Jupiter read endpoints |
| `jupiter_dca_create` | Min validation + Token-2022 check |
| `jupiter_trigger_create` | Token-2022 check |
| `solana_price` | `confidenceLevel` + low-confidence warning |
| `solana_swap` | Pre-swap confidence check + TTL re-quote logic |
| `jupiter_token_search` | `organicScore` + `isSus` fields |
| `jupiter_token_security` | Secondary Tokens v2 lookup for `organicScore`/`isSus` |

## Test plan
- [ ] Verify token list loads from v2 API with valid Jupiter API key
- [ ] Verify token list gracefully degrades without API key (falls back to well-known tokens)
- [ ] Verify 429 responses trigger retry with backoff (can test by rapid-firing requests)
- [ ] Verify DCA with <2 orders is rejected
- [ ] Verify DCA with <$50/order or <$100 total is rejected (requires price API)
- [ ] Verify `confidenceLevel` appears in price responses
- [ ] Verify low-confidence tokens block swap flow
- [ ] Verify `organicScore` and `isSus` appear in token search results
- [ ] Verify Token-2022 tokens are blocked for trigger/DCA creation
- [ ] Verify Ultra swap re-quotes when MWA takes >90s (manual test with delayed approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)