### PR TITLE
feat: skill_read returns dir and files for bundled resources (BAT-163)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -3189,7 +3189,7 @@ async function executeTool(name, input, chatId) {
                 instructions: skill.instructions || content,
                 tools: skill.tools,
                 emoji: skill.emoji,
-                dir: skill.dir,
+                dir: isDirectorySkill ? skill.dir : null,
                 files: files
             };
         }
@@ -6254,6 +6254,8 @@ function listFilesRecursive(dir, maxDepth = 3, currentDepth = 0) {
         const entries = fs.readdirSync(dir, { withFileTypes: true });
         for (const entry of entries) {
             const fullPath = path.join(dir, entry.name);
+            // Skip symlinks for security
+            if (entry.isSymbolicLink()) continue;
             if (entry.isFile()) {
                 results.push(fullPath);
             } else if (entry.isDirectory() && !entry.name.startsWith('.')) {


### PR DESCRIPTION
## Summary
- Adds `dir` (absolute path) and `files` (relative paths) to `skill_read` tool response
- Agent can now discover and read supporting files bundled with skills (scripts/, references/, assets/)
- Adds `listFilesRecursive()` helper function (max 3 levels, skips hidden dirs)
- Updates `skill_read` tool description so the agent knows about the new fields (self-awareness rule)

## Test plan
- [ ] Verify skill_read returns dir and files for directory-based skills
- [ ] Verify skill_read still works for flat .md skill files (files should be empty)
- [ ] Build and run on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)