### PR TITLE
fix: remove AD_ID permission merged from dependencies (BAT-166)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Core permissions -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -19,6 +20,9 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <!-- Remove AD_ID permission merged from dependencies (app does not use advertising ID) -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
     <application
         android:name=".SeekerClawApplication"


### PR DESCRIPTION
## Summary
- Add `tools:node="remove"` to strip `com.google.android.gms.permission.AD_ID` permission that gets merged from dependencies
- App does not use advertising ID — this prevents potential Google Play rejection

## Changes
- `AndroidManifest.xml`: Added `xmlns:tools` namespace and AD_ID permission removal directive

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Merged manifest no longer contains AD_ID permission (`aapt dump permissions app-debug.apk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)