### PR TITLE
fix: skill_install early-return race and YAML triggers not parsed (BAT-210)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -434,15 +434,11 @@ async function handleMessage(msg) {
                                     // Non-skill or failed — fall through to normal file note
                                 }
                             } catch (e) {
-                                if (skillAutoInstalled) {
-                                    // Install succeeded but confirmation send failed — still don't forward to chat()
-                                    log(`Skill install confirmation send failed: ${e.message}`, 'WARN');
-                                } else {
-                                    log(`Skill auto-detect error: ${e.message}`, 'WARN');
-                                }
+                                // sendMessage() logs internally and does not throw — only readFileSync / executeTool can throw here
+                                log(`Skill auto-detect error: ${e.message}`, 'WARN');
                             }
                         }
-                        // Routing is OUTSIDE the try so it always runs, even if sendMessage threw above
+                        // Routing is OUTSIDE the try so it always runs regardless of install errors
                         if (skillAutoInstalled) {
                             if (!text) {
                                 return; // No caption — nothing more to do


### PR DESCRIPTION
## Summary
- **main.js**: Set `skillAutoInstalled = true` BEFORE `sendMessage` so a Telegram error can't keep the flag false and cause fall-through to `chat()`. Move routing (`if (skillAutoInstalled)`) outside the inner `try` so it always executes. Split catch log to distinguish install failure vs confirmation-send failure.
- **skills.js**: `parseSkillFile` now reads `triggers:` from YAML frontmatter. Uses existing `toArray()` + lowercase normalisation, mirroring the legacy `Trigger:` body line. Skills with frontmatter triggers now match correctly.

## Test plan
- [ ] Send a `.md` skill file with no caption → confirmation sent, no Claude response
- [ ] Send a `.md` skill file with caption → confirmation sent, caption forwarded to Claude
- [ ] (Regression) Break bot token temporarily → skill still installed, error logged, no Claude response
- [ ] Install skill with `triggers: [hello, test]` in frontmatter → send "hello" → skill matches
- [ ] Install skill with `triggers: [hello test]` (multi-word) → send "hello test" → skill matches
- [ ] Install skill with legacy `Trigger: hello` body line → still matches (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)