### PR TITLE
fix: remove duplicate version field from bundled skill frontmatter (BAT-212)

### DIFF
--- a/app/src/main/assets/nodejs-project/workspace/skills/crypto-prices.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/crypto-prices.md
@@ -2,7 +2,6 @@
 name: crypto-prices
 version: "1.0.0"
 description: "Get real-time cryptocurrency prices and market data from CoinGecko (free, no API key)"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "💰"

--- a/app/src/main/assets/nodejs-project/workspace/skills/device-status.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/device-status.md
@@ -2,7 +2,6 @@
 name: device-status
 version: "1.0.0"
 description: "Check battery level, storage space, and device status"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🔋"

--- a/app/src/main/assets/nodejs-project/workspace/skills/dictionary.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/dictionary.md
@@ -2,7 +2,6 @@
 name: dictionary
 version: "1.0.0"
 description: "Look up word definitions, pronunciation, and etymology using Free Dictionary API"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "📚"

--- a/app/src/main/assets/nodejs-project/workspace/skills/exchange-rates.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/exchange-rates.md
@@ -2,7 +2,6 @@
 name: exchange-rates
 version: "1.0.0"
 description: "Get currency exchange rates and convert between currencies (free API)"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "💱"

--- a/app/src/main/assets/nodejs-project/workspace/skills/github.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/github.md
@@ -2,7 +2,6 @@
 name: github
 version: "1.0.0"
 description: "Search repositories, view issues, check PRs, manage GitHub projects"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🐙"

--- a/app/src/main/assets/nodejs-project/workspace/skills/location.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/location.md
@@ -2,7 +2,6 @@
 name: location
 version: "1.0.0"
 description: "Get current GPS location and find nearby places"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "📍"

--- a/app/src/main/assets/nodejs-project/workspace/skills/movie-tv.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/movie-tv.md
@@ -2,7 +2,6 @@
 name: movie-tv
 version: "1.0.0"
 description: "Search movies and TV shows, get ratings, recommendations using TMDB (free API)"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🎬"

--- a/app/src/main/assets/nodejs-project/workspace/skills/phone-call.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/phone-call.md
@@ -2,7 +2,6 @@
 name: phone-call
 version: "1.0.0"
 description: "Make phone calls to contacts or phone numbers"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "📞"

--- a/app/src/main/assets/nodejs-project/workspace/skills/recipe.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/recipe.md
@@ -2,7 +2,6 @@
 name: recipe
 version: "1.0.0"
 description: "Search recipes, get ingredients and cooking instructions from TheMealDB (free, no API key)"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🍳"

--- a/app/src/main/assets/nodejs-project/workspace/skills/sms.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/sms.md
@@ -2,7 +2,6 @@
 name: sms
 version: "1.0.0"
 description: "Send SMS text messages to contacts or phone numbers"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "💬"

--- a/app/src/main/assets/nodejs-project/workspace/skills/solana-dapp.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/solana-dapp.md
@@ -2,7 +2,6 @@
 name: solana-dapp
 version: "1.0.0"
 description: "Discover, launch, and interact with Solana dApps on the Seeker device via the dApp Store and MWA"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "📱"

--- a/app/src/main/assets/nodejs-project/workspace/skills/solana-wallet.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/solana-wallet.md
@@ -2,7 +2,6 @@
 name: solana-wallet
 version: "1.0.0"
 description: "Check Solana wallet balance, transaction history, and send SOL with wallet approval"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🪙"

--- a/app/src/main/assets/nodejs-project/workspace/skills/speak.md
+++ b/app/src/main/assets/nodejs-project/workspace/skills/speak.md
@@ -2,7 +2,6 @@
 name: speak
 version: "1.0.0"
 description: "Speak text out loud using device text-to-speech"
-version: "1.0.0"
 metadata:
   openclaw:
     emoji: "🔊"


### PR DESCRIPTION
## Summary
- All 13 bundled skill files in `workspace/skills/` had a duplicate `version:` field in their YAML frontmatter — once on line 3 and again on line 5 after `description:`
- Remove the redundant second `version: "1.0.0"` line from each file

## Details

Every file had this structure:
```yaml
---
name: skill-name
version: "1.0.0"        ← keep
description: "..."
version: "1.0.0"        ← remove (duplicate)
metadata:
  openclaw:
    emoji: "..."
---
```

The parser overwrote the key with the same value so there was no runtime bug, but having duplicate keys is non-standard YAML and generated misleading noise when reading the files.

**Affected files:** crypto-prices, device-status, dictionary, exchange-rates, github, location, movie-tv, phone-call, recipe, sms, solana-dapp, solana-wallet, speak

## Test plan
- [ ] Build & run — skills load without warnings for these 13 files
- [ ] Skills screen shows all 13 skills with correct names/emojis/versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)