### PR TITLE
polish: settings order, brave hint text, onboarding color (BAT-214)

### DIFF
--- a/SETTINGS_INFO.md
+++ b/SETTINGS_INFO.md
@@ -10,14 +10,14 @@
 
 | # | Setting | Constant | Status | Text |
 |---|---------|----------|--------|------|
-| 1 | Auth Type | `AUTH_TYPE` | ✅ Good | How your agent talks to the AI. API Key = your own Anthropic key (you're the boss). Setup Token = quick temporary access via Claude Code. Pick whichever works for you. |
-| 2 | API Key | `API_KEY` | ✅ Good | Your Anthropic API key — the magic password that makes your agent smart. Grab one at console.anthropic.com → API Keys → Create Key. Starts with "sk-ant-". Guard it like a seed phrase. |
-| 3 | Setup Token | `SETUP_TOKEN` | ✅ Good | A temporary token for quick setup. Run "claude setup-token" on any machine with Claude Code installed — it'll give you a token to paste here. Great if you don't want to deal with API keys. Temporary = it expires. |
-| 4 | Bot Token | `BOT_TOKEN` | ✅ Good | Your Telegram bot's soul. Get one: open Telegram → @BotFather → /newbot → follow the steps. You'll get something like "123456:ABC-DEF". This is how your agent lives on Telegram. |
-| 5 | Owner ID | `OWNER_ID` | ✅ Good | Your Telegram user ID (a number, not your @username). This is who the agent obeys. Leave blank = first person to message becomes owner. Find yours: message @userinfobot on Telegram. |
-| 6 | Model | `MODEL` | ✅ Good | Your agent's brain. Opus 4.6 — big brain, big bill. Sonnet 4.6 — sweet spot. Sonnet 4.5 — last gen, still solid. Haiku 4.5 — fast & cheap. Pick your fighter. |
+| 1 | Model | `MODEL` | ✅ Good | Your agent's brain. Opus 4.6 — big brain, big bill. Sonnet 4.6 — sweet spot. Sonnet 4.5 — last gen, still solid. Haiku 4.5 — fast & cheap. Pick your fighter. |
+| 2 | Auth Type | `AUTH_TYPE` | ✅ Good | How your agent talks to the AI. API Key = your own Anthropic key (you're the boss). Setup Token = quick temporary access via Claude Code. Pick whichever works for you. |
+| 3 | API Key | `API_KEY` | ✅ Good | Your Anthropic API key — the magic password that makes your agent smart. Grab one at console.anthropic.com → API Keys → Create Key. Starts with "sk-ant-". Guard it like a seed phrase. |
+| 4 | Setup Token | `SETUP_TOKEN` | ✅ Good | A temporary token for quick setup. Run "claude setup-token" on any machine with Claude Code installed — it'll give you a token to paste here. Great if you don't want to deal with API keys. Temporary = it expires. |
+| 5 | Bot Token | `BOT_TOKEN` | ✅ Good | Your Telegram bot's soul. Get one: open Telegram → @BotFather → /newbot → follow the steps. You'll get something like "123456:ABC-DEF". This is how your agent lives on Telegram. |
+| 6 | Owner ID | `OWNER_ID` | ✅ Good | Your Telegram user ID (a number, not your @username). This is who the agent obeys. Leave blank = first person to message becomes owner. Find yours: message @userinfobot on Telegram. |
 | 7 | Agent Name | `AGENT_NAME` | ✅ Good | What should we call your agent? Shows on the dashboard and in its personality. Totally cosmetic — go wild. |
-| 8 | Brave API Key | `BRAVE_API_KEY` | ✅ Good | Optional. Gives your agent Brave Search (better results). Free key at brave.com/search/api. Without it, DuckDuckGo handles search — still works, just less fancy. |
+| 8 | Brave API Key | `BRAVE_API_KEY` | ✅ Good | Optional. Gives your agent Brave Search (better results). Free key at brave.com/search/api. |
 
 ## Preferences
 

--- a/app/src/main/java/com/seekerclaw/app/ui/components/PixelComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/PixelComponents.kt
@@ -86,7 +86,7 @@ fun SetupStepIndicator(
                         .size(circleSize)
                         .background(
                             color = when {
-                                isCompleted -> SeekerClawColors.Accent
+                                isCompleted -> SeekerClawColors.ActionPrimary
                                 isCurrent -> SeekerClawColors.Primary
                                 else -> SeekerClawColors.Surface
                             },

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -54,8 +54,7 @@ object SettingsHelpTexts {
 
     const val BRAVE_API_KEY =
         "Optional. Gives your agent Brave Search (better results). " +
-        "Free key at brave.com/search/api. " +
-        "Without it, DuckDuckGo handles search — still works, just less fancy."
+        "Free key at brave.com/search/api."
 
     // ── Preferences ────────────────────────────────────────────────
 

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -393,6 +393,15 @@ fun SettingsScreen(onRunSetupAgain: () -> Unit = {}) {
                     .background(SeekerClawColors.Surface, shape),
             ) {
                 ConfigField(
+                    label = "Model",
+                    value = availableModels.find { it.id == config?.model }
+                        ?.let { "${it.displayName} (${it.description})" }
+                        ?: config?.model?.ifBlank { "Not set" }
+                        ?: "Not set",
+                    onClick = { showModelPicker = true },
+                    info = SettingsHelpTexts.MODEL,
+                )
+                ConfigField(
                     label = "Auth Type",
                     value = authTypeLabel,
                     onClick = { showAuthTypePicker = true },
@@ -442,15 +451,6 @@ fun SettingsScreen(onRunSetupAgain: () -> Unit = {}) {
                     info = SettingsHelpTexts.OWNER_ID,
                 )
                 ConfigField(
-                    label = "Model",
-                    value = availableModels.find { it.id == config?.model }
-                        ?.let { "${it.displayName} (${it.description})" }
-                        ?: config?.model?.ifBlank { "Not set" }
-                        ?: "Not set",
-                    onClick = { showModelPicker = true },
-                    info = SettingsHelpTexts.MODEL,
-                )
-                ConfigField(
                     label = "Agent Name",
                     value = config?.agentName?.ifBlank { "SeekerClaw" } ?: "SeekerClaw",
                     onClick = {
@@ -463,10 +463,10 @@ fun SettingsScreen(onRunSetupAgain: () -> Unit = {}) {
                 ConfigField(
                     label = "Brave API Key",
                     value = config?.braveApiKey?.let { key ->
-                        if (key.isBlank()) "Not set — using DuckDuckGo"
+                        if (key.isBlank()) "Not set (optional)"
                         else if (key.length > 12) "${key.take(8)}${"*".repeat(8)}${key.takeLast(4)}"
                         else "*".repeat(key.length)
-                    } ?: "Not set — using DuckDuckGo",
+                    } ?: "Not set (optional)",
                     onClick = {
                         editField = "braveApiKey"
                         editLabel = "Brave API Key"

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -1059,13 +1059,13 @@ private fun SetupSuccessStep(
         Box(
             modifier = Modifier
                 .size(80.dp)
-                .background(SeekerClawColors.Accent.copy(alpha = 0.15f), CircleShape),
+                .background(SeekerClawColors.ActionPrimary.copy(alpha = 0.15f), CircleShape),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 Icons.Rounded.Check,
                 contentDescription = "Success",
-                tint = SeekerClawColors.Accent,
+                tint = SeekerClawColors.ActionPrimary,
                 modifier = Modifier.size(40.dp),
             )
         }


### PR DESCRIPTION
## Summary
- Move **Model** to top of Settings Configuration section (most-changed field first)
- Fix **Brave API Key** hint: `"Not set — using DuckDuckGo"` → `"Not set (optional)"`, remove DDG mention from tooltip
- Unify onboarding step indicator completed color with Continue button (`Accent` → `ActionPrimary`)
- Sync `SETTINGS_INFO.md` with new field order and updated text

## Test plan
- [ ] Settings → Configuration section: Model appears first
- [ ] Brave API Key field shows "Not set (optional)" when unset
- [ ] Brave API Key tooltip no longer mentions DuckDuckGo
- [ ] Onboarding stepper: completed step circles match the green of the Next/Continue button
- [ ] Setup success screen: checkmark circle matches the Next button green

🤖 Generated with [Claude Code](https://claude.com/claude-code)