### PR TITLE
fix: remove cost metrics from all UI surfaces (BAT-216)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -104,7 +104,7 @@ fun DashboardScreen(onNavigateToSystem: () -> Unit = {}, onNavigateToSettings: (
     // Fetch API stats from bridge (BAT-32)
     var apiRequests by remember { mutableStateOf(0) }
     var apiAvgLatency by remember { mutableStateOf(0) }
-    var monthCost by remember { mutableStateOf(0f) }
+    var apiCacheHits by remember { mutableStateOf(0) }
 
     LaunchedEffect(status) {
         if (status == ServiceStatus.RUNNING) {
@@ -113,18 +113,18 @@ fun DashboardScreen(onNavigateToSystem: () -> Unit = {}, onNavigateToSettings: (
                 if (stats != null) {
                     apiRequests = stats.todayRequests
                     apiAvgLatency = stats.todayAvgLatencyMs
-                    monthCost = stats.monthCostEstimate
+                    apiCacheHits = (stats.todayCacheHitRate * 100).toInt()
                 } else {
                     apiRequests = 0
                     apiAvgLatency = 0
-                    monthCost = 0f
+                    apiCacheHits = 0
                 }
                 delay(if (stats != null) 30_000L else 5_000L)
             }
         } else {
             apiRequests = 0
             apiAvgLatency = 0
-            monthCost = 0f
+            apiCacheHits = 0
         }
     }
 
@@ -558,11 +558,7 @@ fun DashboardScreen(onNavigateToSystem: () -> Unit = {}, onNavigateToSettings: (
             ) {
                 StatMini(small = true, label = "API", value = "$apiRequests req")
                 StatMini(small = true, label = "LATENCY", value = "${apiAvgLatency}ms")
-                StatMini(
-                    small = true,
-                    label = "COST",
-                    value = if (monthCost > 0f) "$${String.format("%.2f", monthCost)}" else "--",
-                )
+                StatMini(small = true, label = "CACHE", value = "${apiCacheHits}%")
             }
         }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -388,20 +388,13 @@ fun SystemScreen(onBack: () -> Unit) {
                     label = "Cache Hits",
                     value = if (stats != null) "${(stats.todayCacheHitRate * 100).toInt()}%" else "--",
                 )
-                if (stats != null && stats.monthCostEstimate > 0f) {
-                    InfoRow(
-                        label = "Est. Cost",
-                        value = "$${String.format("%.2f", stats.monthCostEstimate)} /mo",
-                        isLast = true,
-                    )
-                } else {
-                    InfoRow(label = "Tokens In/Out",
-                        value = if (stats != null)
-                            "${formatTokens(stats.todayInputTokens)} / ${formatTokens(stats.todayOutputTokens)}"
-                        else "--",
-                        isLast = true,
-                    )
-                }
+                InfoRow(
+                    label = "Tokens In/Out",
+                    value = if (stats != null)
+                        "${formatTokens(stats.todayInputTokens)} / ${formatTokens(stats.todayOutputTokens)}"
+                    else "--",
+                    isLast = true,
+                )
             }
 
             // ==================== MEMORY INDEX (BAT-33) ====================


### PR DESCRIPTION
## Summary
- **Dashboard home card**: COST chip removed, replaced with CACHE (today's cache hit rate %)
- **System screen analytics**: "Est. Cost /mo" row removed entirely; "Tokens In/Out" now always renders as the last row (was previously the fallback when cost was zero)
- **No other UI locations** showed cost — confirmed by grep across all Kotlin files
- `monthCostEstimate` field kept in `DbSummary` / `StatsClient.kt` (not rendered, available for future use)

## What changed
| File | Change |
|------|--------|
| `DashboardScreen.kt` | `monthCost` state → `apiCacheHits`; COST `StatMini` → CACHE `StatMini` |
| `SystemScreen.kt` | Removed `if (monthCostEstimate > 0) Est. Cost else Tokens` block; always show Tokens In/Out as `isLast` row |

## Test plan
- [ ] Home screen: confirm 3-chip row shows API / LATENCY / CACHE (no dollar sign anywhere)
- [ ] System screen analytics card: confirm rows are Requests / Avg Latency / Error Rate / Cache Hits / Tokens In/Out — no Est. Cost row
- [ ] Stop and restart service: confirm no cost data reappears
- [ ] Fresh install (no requests yet): card hidden until first request, no cost shown

Generated with [Claude Code](https://claude.com/claude-code)