### PR TITLE
fix: remove updateHeartbeat() — was overwriting agent HEARTBEAT.md (BAT-220)

### DIFF
--- a/app/src/main/assets/nodejs-project/memory.js
+++ b/app/src/main/assets/nodejs-project/memory.js
@@ -297,26 +297,10 @@ function seedHeartbeatMd() {
     }
 }
 
-function updateHeartbeat() {
-    const now = new Date();
-    const uptime = Math.floor(process.uptime());
-    const content = `# Heartbeat
-
-Last updated: ${localTimestamp(now)}
-Uptime: ${Math.floor(uptime / 3600)}h ${Math.floor((uptime % 3600) / 60)}m ${uptime % 60}s
-Memory: ${Math.round(process.memoryUsage().rss / 1024 / 1024)} MB
-Status: Running
-`;
-    try {
-        fs.writeFileSync(HEARTBEAT_PATH, content, 'utf8');
-    } catch (e) {
-        log(`[Heartbeat] Failed to write HEARTBEAT.md: ${e.message}`, 'WARN');
-    }
-}
-
-// Update heartbeat every 5 minutes
-setInterval(updateHeartbeat, 5 * 60 * 1000);
-updateHeartbeat();
+// updateHeartbeat() removed (BAT-220): it was writing system stats (uptime/memory)
+// to HEARTBEAT.md every 5 minutes, overwriting custom tasks the agent stores there.
+// HEARTBEAT.md belongs to the agent as a persistent task checklist — it must not be
+// touched by the runtime. Uptime/memory/status are already reported via agent_health_state.
 
 // ============================================================================
 // EXPORTS


### PR DESCRIPTION
## Summary

**Bug:** `updateHeartbeat()` in `memory.js` wrote system stats (uptime/memory/status) to `HEARTBEAT.md` every 5 minutes via `writeFileSync`, overwriting any custom tasks the agent stored there. When the heartbeat probe fired, `HEARTBEAT.md` only contained the system template — user-added tasks were gone, so the agent replied `HEARTBEAT_OK` (nothing to do) instead of acting on them.

**Root cause:** `updateHeartbeat()` predates the heartbeat probe system (BAT-215). It was originally a "Node.js is alive" signal, but that purpose is now fully covered by `agent_health_state` JSON (written by `claude.js`, polled by `ServiceState.kt`).

**Fix:** Remove `updateHeartbeat()` and its `setInterval` entirely. `HEARTBEAT.md` belongs to the agent as a persistent task checklist — the runtime must not touch it.

## Before / After

**Before:** User asks agent to add a task to HEARTBEAT.md → agent does it → 5 min later `updateHeartbeat()` overwrites file → task gone → agent replies HEARTBEAT_OK

**After:** `HEARTBEAT.md` is write-once (seeded on first launch by `seedHeartbeatMd()`), then owned entirely by the agent

## Test plan

- [ ] Ask agent: "Add a check to HEARTBEAT.md: every heartbeat, remind me to drink water"
- [ ] Wait 5+ minutes — confirm task is still in HEARTBEAT.md (not overwritten)
- [ ] Wait for next heartbeat probe — confirm agent sends the reminder

**Build note:** JS asset only → just build & run (no Gradle sync needed)

Generated with [Claude Code](https://claude.com/claude-code)