### PR TITLE
fix: prevent duplicate [Health] logs from multi-process polling (BAT-217)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/util/ServiceState.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/ServiceState.kt
@@ -198,6 +198,14 @@ object ServiceState {
      */
     fun startPolling(context: Context) {
         init(context)
+        // Guard: skip if a polling loop is already running (BAT-217).
+        // Prevents overlapping coroutines that could both detect health transitions
+        // and emit duplicate log entries.
+        if (pollingJob?.isActive == true) {
+            Log.d(TAG, "startPolling: already active, skipping")
+            return
+        }
+        Log.d(TAG, "startPolling: launching polling loop")
         pollingJob?.cancel()
         pollingJob = scope.launch {
             while (isActive) {


### PR DESCRIPTION
## Summary
- **Root cause**: `SeekerClawApplication.onCreate()` runs in both the main UI process and the `:node` process (declared with `android:process=":node"` in manifest). Both processes called `ServiceState.startPolling()`, creating two independent polling loops reading the same `agent_health_state` file and writing duplicate transition entries to the shared `service_logs` file. The `lastLoggedStale` guard only prevents duplicates within a single process since each process has its own `ServiceState` singleton.
- **Primary fix**: Guard polling in `Application.onCreate()` with `getProcessName() == packageName` so only the main UI process polls. The `:node` process writes state files — it has no need to poll them.
- **Belt-and-suspenders**: Added `isActive` guard in `ServiceState.startPolling()` to skip re-launch if a polling loop is already running, plus debug log for call tracing.

## Test plan
- [ ] Deploy to device, start/stop service multiple times
- [ ] Trigger health stale condition (disable network) — verify single `[Health] Agent health file became stale` entry
- [ ] Re-enable network — verify single `[Health] Agent health recovered` entry
- [ ] Check logcat for `startPolling: launching polling loop` — should appear exactly once (main process only)
- [ ] Verify no `startPolling: already active, skipping` in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)