### PR TITLE
fix: write agent health file immediately on startup (BAT-222)

### DIFF
--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -935,7 +935,9 @@ telegram('getMe')
             startDbSummaryInterval();
             startStatsServer();
 
-            // Agent health heartbeat: write every 60s for staleness detection (BAT-134)
+            // Agent health heartbeat: write immediately on startup (prevents false "stale"
+            // when Kotlin reads the old file before the first interval tick), then every 60s.
+            writeAgentHealthFile();
             setInterval(() => writeAgentHealthFile(), 60000);
 
             // Flush old updates to avoid re-processing messages after restart


### PR DESCRIPTION
## Summary
- On restart, Kotlin polls `agent_health_state` every 1s but Node.js only writes it every 60s. The old file from the previous session is stale, triggering a false `[Health] Agent health file became stale` → `[Health] Agent health recovered` cycle on every restart.
- Fix: call `writeAgentHealthFile()` immediately at startup before the 60s `setInterval` begins.

## Test plan
- [ ] Restart agent — verify no false `[Health] Agent health file became stale` log entry
- [ ] Verify health file is written within first few seconds of startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)