### PR TITLE
feat: add self-diagnosis playbook to system prompt (BAT-233)

### DIFF
--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -586,7 +586,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('2. Auth error (401/403): API key may be invalid — tell user to check Settings');
     lines.push('3. Rate limit (429): slow down — reduce tool calls and response length');
     lines.push('4. Billing error (402): tell user to check their Anthropic billing at console.anthropic.com');
-    lines.push('5. Network error: check connectivity with js_eval using http.get("https://api.anthropic.com") or shell_exec "curl -s https://api.anthropic.com"');
+    lines.push('5. Network error: check connectivity with js_eval using require("https").get("https://api.anthropic.com") or shell_exec "curl -s https://api.anthropic.com"');
     lines.push('');
 
     // Project Context - OpenClaw injects SOUL.md and memory here


### PR DESCRIPTION
## Summary
- Adds a **Self-Diagnosis Playbook** section to the system prompt (`buildSystemBlocks()`) with 6 structured troubleshooting scenarios
- Each scenario gives the agent concrete, actionable steps using real tool commands — no vague advice
- All shell_exec commands are sandbox-safe (no pipes, no blocked operators)

### Playbook scenarios:
| Problem | Key diagnostic steps |
|---------|---------------------|
| Messages stop arriving | grep poll activity in debug log, check health file, check DNS errors |
| Skill won't trigger | ls skills/, read SKILL.md, check triggers + requirements |
| Health keeps going stale | grep errors, check WiFi/DNS, suggest battery optimization |
| Conversation corrupted/loops | /new (safe archive) vs /reset (nuclear), tool-use loop protection |
| Tool fails | 22-cmd allowlist, 10K char js_eval limit, bridge permissions, wallet config |
| API calls failing | read agent_health_state, classify by HTTP code (401/429/402), connectivity check |

## Test plan
- [ ] Build & run — verify Node.js starts without errors
- [ ] Ask "something is wrong, I'm not getting messages" — agent should follow the playbook steps
- [ ] Ask "why won't my skill work?" — agent should check skills/ directory and explain triggers
- [ ] Ask "what happened?" after a restart — agent should check debug log and health file
- [ ] Verify all shell_exec commands in playbook are sandbox-safe (no pipes, no `{}`, no `$()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)