### PR TITLE
feat: close final SAB gaps — PLATFORM.md door and Telegram polling (BAT-234)

### DIFF
--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -402,6 +402,13 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('- For persistent failures, inform the user and suggest manual steps.');
     lines.push('');
 
+    // Telegram polling — how the message loop works (BAT-234)
+    lines.push('**Telegram Polling**');
+    lines.push('You receive messages via long-polling: the bot opens an HTTPS connection to api.telegram.org, the server holds it open until a message arrives or the timeout expires (30s), then you reconnect immediately.');
+    lines.push('This is automatic and self-healing — if a poll fails, it retries. ENOTFOUND errors mean DNS resolution failed on reconnect (network issue, not a bot problem).');
+    lines.push('If messages stop arriving, check node_debug.log for poll errors rather than assuming the bot is broken.');
+    lines.push('');
+
     // Telegram formatting — headers aren't rendered, guide the agent
     lines.push('**Telegram Formatting (for user-visible Telegram replies)**');
     lines.push('- In Telegram replies, do NOT use markdown headers (##, ###) — Telegram doesn\'t render them.');
@@ -479,6 +486,11 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
             platformLoaded = true;
         }
     } catch (e) { /* PLATFORM.md unreadable — fall through to fallback */ }
+    // Explicit door: agent knows PLATFORM.md exists and can re-read it (BAT-234)
+    if (platformLoaded) {
+        lines.push('PLATFORM.md is injected above. When asked about your device, hardware, battery, permissions, or versions, refer to PLATFORM.md. To get fresh data (e.g., current battery level), use the appropriate android_* tool instead.');
+        lines.push('');
+    }
     if (!platformLoaded) {
         lines.push('## Workspace');
         lines.push(`Your working directory is: ${workDir}`);


### PR DESCRIPTION
## Summary
Closes the last 2 SAB audit gaps to reach **60/60** self-knowledge score:

1. **PLATFORM.md explicit door** (+4 lines) — tells the agent that PLATFORM.md is already injected into the prompt and to refer to it for hardware/device/version questions. Also guides it to use `android_*` tools for fresh runtime data (e.g., current battery level vs startup snapshot).

2. **Telegram polling explanation** (+6 lines) — explains how long-polling works: bot opens HTTPS connection to api.telegram.org, server holds until message or 30s timeout, reconnects immediately. ENOTFOUND = DNS failure on reconnect (network issue, not bot problem). Directs agent to check debug log for poll errors.

### SAB audit progress
| PR | What it fixed | Lines |
|----|---------------|-------|
| #156 (BAT-232) | Identity, Architecture, File System Doors, Config, Health, Conversation Limits | +52 |
| #158 (BAT-233) | Self-Diagnosis Playbook (6 scenarios) | +43 |
| This PR (BAT-234) | PLATFORM.md door, Telegram polling | +12 |

## Test plan
- [ ] Build & run — verify Node.js starts without errors
- [ ] Ask "what device am I on?" — agent should reference PLATFORM.md data
- [ ] Ask "what's my battery?" — agent should use android_battery (fresh) not just PLATFORM.md (stale)
- [ ] Ask "how do you get my messages?" — agent should explain long-polling
- [ ] Ask "why did messages stop?" — agent should check debug log for poll errors, mention ENOTFOUND

🤖 Generated with [Claude Code](https://claude.com/claude-code)