### PR TITLE
fix: replace shell_exec ping/curl with js_eval probes in NetWatch (BAT-238)

### DIFF
--- a/app/src/main/assets/default-skills/netwatch/TESTING.md
+++ b/app/src/main/assets/default-skills/netwatch/TESTING.md
@@ -1,4 +1,4 @@
-# NetWatch v2 — Testing Guide
+# NetWatch v2.1 — Testing Guide
 
 ## Test Prompts
 
@@ -6,38 +6,38 @@
 ```
 scan my network
 ```
-**Expected:** Risk score, network summary from Android bridge `/network`, connectivity probes via `ping`, DNS resolution checks, local service port probes via `curl`, recommendations. Telegram-formatted (no ASCII tables). Ends with follow-up CTA. Zero `shell_exec FAIL` for `/proc` or `/sys` paths.
+**Expected:** Risk score, network summary from `android_bridge /network`, connectivity probes via `js_eval` HTTPS fetch with latency timing, DNS resolution via `js_eval dns.resolve()`, local port probes via `js_eval net.createConnection()`, recommendations. Telegram-formatted. Zero `shell_exec` calls. Ends with follow-up CTA.
 
 ### 2. Port Watch
 ```
 check open ports on this device
 ```
-**Expected:** Probes 9 localhost ports via `curl --connect-timeout`. Each port classified as Expected/Unusual/Dangerous. Summary count. Telegram-formatted bullet list (no pipe tables).
+**Expected:** Probes 9 localhost ports via `js_eval` TCP connect. Each port classified as Expected/Unusual/Dangerous. Summary count. Telegram-formatted bullet list. Zero `shell_exec` calls.
 
 ### 3. Connection Status
 ```
 check my connection
 ```
-**Expected:** Latency via `ping -c 3 -W 3` to 5 endpoints (1.1.1.1, 8.8.8.8, api.telegram.org, google.com, api.anthropic.com). DNS resolution status. Network info from Android bridge `/network`. Telegram-formatted.
+**Expected:** Latency via `js_eval` HTTPS fetch + `Date.now()` to 5 endpoints. DNS resolution via `js_eval dns.resolve()`. Network info from `android_bridge /network`. Telegram-formatted. Zero `shell_exec` calls.
 
 ### 4. WiFi Query
 ```
 what's on my wifi
 ```
-**Expected:** Network audit mode. Gets WiFi SSID/signal from Android bridge `/network` (NOT from `/proc/net/wireless`). Probes local services. Full audit with graceful handling of unavailable data.
+**Expected:** Network audit mode. Gets WiFi SSID/signal from `android_bridge /network`. Probes local services via `js_eval`. Full audit with graceful handling of unavailable data.
 
 ### 5. Security Focus
 ```
 run a network security audit
 ```
-**Expected:** Full audit with risk scoring emphasis. Dangerous ports (5555, 4444) probed and flagged if open. Connectivity and DNS validated. Telegram-formatted output.
+**Expected:** Full audit with risk scoring emphasis. Dangerous ports (5555, 4444) probed via `js_eval` TCP connect and flagged if open. Connectivity and DNS validated via `js_eval`. Telegram-formatted output.
 
-## Sample Audit Output (v2 — Telegram-optimized)
+## Sample Audit Output (v2.1 — JS probes)
 
 ```
 🛡️ **NetWatch Audit Report**
-📅 2026-02-21 14:30 UTC • Scan took 12s
-📡 Source: Android APIs + safe network probes
+📅 2026-02-21 14:30 UTC • Scan took 8s
+📡 Source: Android APIs + JS network probes
 
 📊 **Risk Score: 15/100 (LOW)**
 
@@ -52,8 +52,8 @@ run a network security audit
 • IP: `192.168.1.42`
 • Signal: -45 dBm (Good)
 • DNS: ✅ resolving
-• Telegram API: ✅ reachable
-• Anthropic API: ✅ reachable
+• Telegram API: ✅ reachable (45ms)
+• Anthropic API: ✅ reachable (89ms)
 
 🔌 **Local Services**
 • `localhost:8765` (bridge): ✅
@@ -70,7 +70,7 @@ run a network security audit
 👉 What should I look into next?
 ```
 
-## Sample Port Watch Output (v2)
+## Sample Port Watch Output (v2.1)
 
 ```
 🔍 **Port Watch Report**
@@ -86,7 +86,7 @@ run a network security audit
 👉 Want me to investigate any of these?
 ```
 
-## Sample Connection Status Output (v2)
+## Sample Connection Status Output (v2.1)
 
 ```
 📡 **Connection Status**
@@ -113,28 +113,31 @@ run a network security audit
 
 ## Before/After Comparison
 
-### BEFORE (v1) — Problems
-- Attempts `cat /proc/net/tcp`, `ls /sys/class/net/`, `cat /etc/resolv.conf` → all produce `shell_exec FAIL`
-- ASCII table output with `━━━`, `────`, `| col | col |` → breaks on Telegram mobile
-- No Android bridge integration
-- No scan timestamp or data source line
+### BEFORE (v2.0) — Problems
+- Uses `shell_exec ping` for latency probes → `FAIL` (exit 1) on Android
+- Uses `shell_exec curl` for port/API probes → `FAIL` (exit 127, missing binary) on Android
+- Produces `shell_exec FAIL` lines in logs for every probe
 
-### AFTER (v2) — Fixed
-- Zero `/proc` or `/sys` access attempts
-- Uses Android bridge `/network` + `ping` + `curl` probes
-- Telegram-optimized markdown (bold, bullets, inline code, emojis)
-- Scan timestamp + data source line in every report
-- Graceful "unavailable on Android sandbox" for any probe that fails
+### AFTER (v2.1) — Fixed
+- Zero `shell_exec` calls — entire skill runs in JS + Android bridge
+- Latency via `js_eval` `https.get()` + `Date.now()` timing
+- DNS health via `js_eval` `require('dns').resolve()`
+- Port probing via `js_eval` `require('net').createConnection()`
+- Device/network info via `android_bridge` `/network` + `/battery`
+- No dependency on `ping`, `curl`, or any shell binary
 
 ## Validation Checklist
 - [ ] Skill triggers on all listed phrases
-- [ ] Zero `shell_exec FAIL` for `/proc` or `/sys` paths
-- [ ] Uses `ping` and `curl` for connectivity probes
+- [ ] Zero `shell_exec` calls in entire skill execution
+- [ ] Zero `FAIL` lines in logs during normal NetWatch run
+- [ ] Connectivity probes use `js_eval` with `https.get()`
+- [ ] DNS probes use `js_eval` with `dns.resolve()`
+- [ ] Port probes use `js_eval` with `net.createConnection()`
 - [ ] Uses `android_bridge` for network/battery info
 - [ ] No ASCII tables in output
 - [ ] Output uses **bold**, `code`, • bullets, status emojis
 - [ ] Scan timestamp present in audit report
-- [ ] Data source line present: "Android APIs + safe network probes"
+- [ ] Data source line present: "Android APIs + JS network probes"
 - [ ] Read-only — no system changes made
 - [ ] Report ends with follow-up CTA
 - [ ] Risk score calculated with clear factors


### PR DESCRIPTION
## Summary
- Remove ALL `shell_exec` usage from NetWatch skill (ping, curl both unavailable on Android sandbox)
- Replace with `js_eval` probes using Node.js built-in modules:
  - **Latency:** `https.get()` + `Date.now()` timing with 5s timeout
  - **DNS health:** `require('dns').resolve()` for hostname resolution checks
  - **Port scanning:** `require('net').createConnection()` with 3s timeout for localhost TCP probes
- `android_bridge` `/network` + `/battery` unchanged
- Bump skill version 2.0.0 → 2.1.0

## Before / After

### BEFORE (v2.0) — Problems
- `shell_exec ping -c 3 -W 3 1.1.1.1` → exit 1 (blocked on Android)
- `shell_exec curl -s --connect-timeout 3 http://localhost:8765/ping` → exit 127 (binary not found)
- Every probe produces `shell_exec FAIL` noise in logs

### AFTER (v2.1) — Fixed
- Zero `shell_exec` calls in entire skill execution
- `js_eval` with `https.get()` for latency: returns `{ url, status, latencyMs, ok }`
- `js_eval` with `dns.resolve()` for DNS: returns `{ host, ok, addresses }`
- `js_eval` with `net.createConnection()` for ports: returns `{ port, open, latencyMs }`
- Concrete JS snippets provided in SKILL.md so the agent copies them exactly

## Test plan
- [ ] "scan my network" completes with zero `shell_exec` calls and zero FAIL lines
- [ ] Latency values appear in report (measured via `Date.now()`)
- [ ] DNS resolution status reported for 3 hostnames
- [ ] Port probes detect `localhost:8765` (bridge) as open
- [ ] Risk scoring works with JS probe data
- [ ] Telegram-formatted output unchanged
- [ ] Graceful handling when endpoints are unreachable

Generated with [Claude Code](https://claude.com/claude-code)