### PR TITLE
feat: add runtime timeout instrumentation with turn-level tracing (BAT-243)

### DIFF
--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -25,7 +25,7 @@ function httpRequest(options, body = null) {
             });
         });
         req.on('error', reject);
-        req.setTimeout(60000, () => { req.destroy(); reject(new Error('Timeout')); });
+        req.setTimeout(60000, () => { req.destroy(); const err = new Error('Timeout'); err.timeoutSource = 'transport'; reject(err); });
         if (body) req.write(typeof body === 'string' ? body : JSON.stringify(body));
         req.end();
     });


### PR DESCRIPTION
## Summary
- Adds structured `[Trace]` JSON logging on every Claude API call with fields: `turnId`, `chatId`, `iteration`, `attempt`, `apiCallStart`, `apiCallEnd`, `elapsedMs`, `payloadSize`, `toolCount`, `timeoutSource`, `status`
- Generates unique 8-char hex `turnId` per user message to correlate all API calls within a single turn (including tool-use loop iterations and summary calls)
- Tags transport timeout errors with `timeoutSource: 'transport'` in `web.js` so they're distinguishable from HTTP API errors (`api_error`) and network failures (`network_error`)
- Adds correlation logging to `sanitizeConversation`: orphaned tool_use/tool_result blocks now log with `turnId` and tool names, enabling direct mapping from timeout events to sanitizer cleanup

## Before/After Log Samples

**Before (timeout):**
```
ERROR|Claude API error: -1
```

**After (timeout with trace):**
```
WARN|[Trace] {"turnId":"a1b2c3d4","chatId":"123456","iteration":0,"attempt":0,"apiCallStart":"2026-02-21T14:30:00+03:00","apiCallEnd":"2026-02-21T14:31:00+03:00","elapsedMs":60012,"payloadSize":45230,"toolCount":15,"timeoutSource":"transport","status":-1,"error":"Timeout"}
```

**Before (sanitizer):**
```
WARN|[Sanitize] Stripped 2 orphaned tool_use/tool_result block(s) from conversation
```

**After (sanitizer with correlation):**
```
WARN|[Sanitize] {"turnId":"a1b2c3d4","stripped":2,"orphans":[{"type":"tool_use","id":"toolu_01X","tool":"web_fetch"},{"type":"tool_use","id":"toolu_01Y","tool":"js_eval"}]}
```

## Test plan
- [ ] Build app and deploy to device
- [ ] Send a message and verify `[Trace]` log entries appear in `node_debug.log`
- [ ] Trigger a tool-use message and verify iteration counter increments
- [ ] Verify non-traced callers (vision, session summary) still work without errors
- [ ] No regression in normal short chats

Generated with [Claude Code](https://claude.com/claude-code)