### PR TITLE
fix: bootstrap ritual not triggering on first run (BAT-266)

### DIFF
--- a/app/src/main/assets/nodejs-project/memory.js
+++ b/app/src/main/assets/nodejs-project/memory.js
@@ -113,14 +113,20 @@ function loadBootstrap() {
 
 function loadIdentity() {
     if (fs.existsSync(IDENTITY_PATH)) {
-        return fs.readFileSync(IDENTITY_PATH, 'utf8');
+        const content = fs.readFileSync(IDENTITY_PATH, 'utf8');
+        // Kotlin pre-creates template with placeholders — treat as no identity
+        if (content.includes('(not yet named)')) return null;
+        return content;
     }
     return null;
 }
 
 function loadUser() {
     if (fs.existsSync(USER_PATH)) {
-        return fs.readFileSync(USER_PATH, 'utf8');
+        const content = fs.readFileSync(USER_PATH, 'utf8');
+        // Kotlin pre-creates template with placeholders — treat as no user profile
+        if (content.includes('(not yet known)')) return null;
+        return content;
     }
     return null;
 }


### PR DESCRIPTION
## Summary
- **Bug**: Kotlin pre-creates `IDENTITY.md` and `USER.md` with template placeholders on first launch. `loadIdentity()` / `loadUser()` returned this content as truthy, so `claude.js:349` (`bootstrap && !identity`) never activated ritual mode — the agent improvised a generic greeting instead of guiding the user through the bootstrap ritual.
- **Fix**: `loadIdentity()` now detects `(not yet named)` and `loadUser()` detects `(not yet known)` placeholder markers, returning `null` for unfilled templates. This correctly triggers ritual mode in the system prompt and prevents template injection into agent context.
- Fixes all 4 downstream call sites: ritual activation (`claude.js:349`), identity injection (`claude.js:649`), user injection (`claude.js:657`), and `/start` handler (`main.js:162`).

## Test plan
- [ ] Fresh install: `/start` should trigger the 8-question bootstrap ritual, not a generic greeting
- [ ] After ritual completion (IDENTITY.md filled): `/start` shows "Hey, I'm back!" 
- [ ] Crash recovery (BOOTSTRAP.md exists + filled IDENTITY.md): ritual does NOT re-trigger
- [ ] System prompt does not contain template placeholder text during ritual

Generated with [Claude Code](https://claude.com/claude-code)