### PR TITLE
fix: bootstrap ritual stops after 2 questions (BAT-268)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,14 +724,14 @@ lastDelivered: j.state.lastDelivered,
 lastDelivered: j.state.lastDelivered ?? null,
 ```
 
-### Bootstrap / One-Time Ritual Guards
+### Bootstrap / Multi-Step Ritual Guards
 
-**Gate one-time operations on both trigger AND absence of result.** If a ritual creates `IDENTITY.md` from `BOOTSTRAP.md`, check that identity doesn't already exist — otherwise a crash mid-ritual (before BOOTSTRAP.md cleanup) causes infinite re-triggers.
+**For multi-step rituals, gate on the trigger file only.** The trigger file (BOOTSTRAP.md) is the source of truth for "ritual in progress." The agent deletes it when done. If the result file (IDENTITY.md) already exists alongside the trigger, treat it as crash recovery — inject resume context, don't skip.
 
 ```javascript
-// BAD — re-triggers if BOOTSTRAP.md wasn't cleaned up
-if (bootstrap) { runRitual(); }
-
-// GOOD — skip if ritual already completed
+// BAD — kills multi-step ritual if agent writes partial results mid-way
 if (bootstrap && !identity) { runRitual(); }
+
+// GOOD — trigger file is sole source of truth; add resume note if identity exists
+if (bootstrap) { runRitual(/* resume: !!identity */); }
 ```

--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -344,15 +344,24 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     const lines = [];
 
     // BOOTSTRAP MODE - First run ritual takes priority.
-    // Guard: skip if IDENTITY.md already exists (ritual already completed,
-    // BOOTSTRAP.md just wasn't cleaned up — crash, backup restore, etc.)
-    if (bootstrap && !identity) {
+    // BOOTSTRAP.md existence is the sole source of truth for "ritual in progress."
+    // The agent deletes BOOTSTRAP.md when the ritual is complete.
+    // If identity already exists (crash recovery / partial write), inject a resume note.
+    if (bootstrap) {
         lines.push('# FIRST RUN - BOOTSTRAP MODE');
         lines.push('');
+        if (identity) {
+            lines.push('**NOTE:** IDENTITY.md already has content (from a partial save or restart).');
+            lines.push('Review what is saved, determine which ritual questions were already answered,');
+            lines.push('and continue from where you left off. Do NOT restart from the beginning.');
+            lines.push('');
+        }
         lines.push('**IMPORTANT:** This is your first conversation. BOOTSTRAP.md exists in your workspace.');
         lines.push('You must follow the bootstrap ritual to establish your identity and learn about your human.');
         lines.push('Read BOOTSTRAP.md carefully and guide this conversation through the ritual steps.');
-        lines.push('After completing all steps, use the write tool to delete BOOTSTRAP.md (write empty content to it).');
+        lines.push('**CRITICAL:** Do NOT write to IDENTITY.md, USER.md, or SOUL.md until ALL 8 questions have been asked and answered.');
+        lines.push('Collect all answers in the conversation first, then write everything at the end in one batch.');
+        lines.push('After writing all files, delete BOOTSTRAP.md (write empty content to it).');
         lines.push('');
         lines.push('---');
         lines.push('');


### PR DESCRIPTION
## Summary
- **Bug**: `claude.js:349` gated ritual injection with `if (bootstrap && !identity)`. After the agent wrote partial data to IDENTITY.md (e.g. the name), `loadIdentity()` returned truthy on the next message → `!identity` was false → ritual instructions stopped being injected → agent lost context about remaining 6 questions.
- **Fix**: Changed gate to `if (bootstrap)` — BOOTSTRAP.md existence is the sole source of truth for "ritual in progress." Added crash-recovery resume note when identity already exists alongside bootstrap, and explicit "batch write" instruction to collect all 8 answers before writing files.
- **CLAUDE.md**: Updated pattern guide which previously documented the buggy pattern as "GOOD."

## Test plan
- [ ] Fresh install `/start`: all 8 ritual questions asked one-by-one
- [ ] After ritual: IDENTITY.md + USER.md written, BOOTSTRAP.md deleted
- [ ] Crash mid-ritual: restart → agent resumes with context about what was already answered
- [ ] Post-ritual `/start`: shows "Hey, I'm back!" (no ritual injection)

Generated with [Claude Code](https://claude.com/claude-code)