### PR TITLE
fix: set MWA blockchain to Solana.Mainnet (BAT-269)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
+import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
 
 object SolanaWalletManager {
@@ -16,7 +17,9 @@ object SolanaWalletManager {
             iconUri = Uri.parse("favicon.ico"),
             identityName = "SeekerClaw",
         )
-    )
+    ).apply {
+        blockchain = Solana.Mainnet
+    }
 
     // NOTE: Must be called from Dispatchers.Main — MWA's ActivityResultLauncher
     // requires the main thread. The SDK handles its own IO threading internally.


### PR DESCRIPTION
## Summary
- MobileWalletAdapter (clientlib-ktx 2.0.3) defaults `blockchain` to `Solana.Devnet`
- This caused Phantom on Saga to show a testnet connection prompt
- Set `blockchain = Solana.Mainnet` explicitly to match our mainnet RPC and Jupiter API config

## Test plan
- [ ] Build and install on Solana Saga
- [ ] Connect wallet via MWA — should show mainnet (not testnet/devnet)
- [ ] Verify wallet authorization succeeds
- [ ] Test Jupiter swap executes on mainnet

Generated with [Claude Code](https://claude.com/claude-code)