### PR TITLE
chore: update setup URL from /quick-setup to /setup

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/qr/ScannerOverlay.kt
+++ b/app/src/main/java/com/seekerclaw/app/qr/ScannerOverlay.kt
@@ -265,7 +265,7 @@ private fun ScannerBottomStatus(
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = "seekerclaw.xyz/quick-setup",
+            text = "seekerclaw.xyz/setup",
             fontFamily = FontFamily.Monospace,
             fontSize = 11.sp,
             color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -561,7 +561,7 @@ private fun WelcomeStep(
         Spacer(modifier = Modifier.height(8.dp))
 
         TextButton(
-            onClick = { uriHandler.openUri("https://seekerclaw.xyz/quick-setup.html") },
+            onClick = { uriHandler.openUri("https://seekerclaw.xyz/setup") },
         ) {
             Icon(
                 @Suppress("DEPRECATION") Icons.Default.HelpOutline,


### PR DESCRIPTION
## Summary
- Website URL changed from `seekerclaw.xyz/quick-setup` to `seekerclaw.xyz/setup`
- Updated scanner overlay display text (ScannerOverlay.kt)
- Updated help link URL (SetupScreen.kt)

## Test plan
- [ ] QR scanner page shows `seekerclaw.xyz/setup`
- [ ] "Need help?" link opens correct page

Generated with [Claude Code](https://claude.com/claude-code)