### PR TITLE
Add ClawPump token launchpad skill

### DIFF
--- a/app/src/main/assets/default-skills/clawpump/SKILL.md
+++ b/app/src/main/assets/default-skills/clawpump/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: clawpump
+description: "Launch tokens on Solana via ClawPump (gasless pump.fun launches, earn 65% trading fees). Use when: user wants to launch a token, create a memecoin, check ClawPump earnings, search domains, or get swap quotes. Don't use when: user wants crypto prices (use crypto-prices skill), wants to swap tokens (use solana_swap tool), or wants wallet balance (use solana_balance tool)."
+version: "1.0.0"
+emoji: "\U0001F43E"
+requires:
+  bins: []
+  env: []
+allowed-tools:
+  - web_fetch
+  - solana_address
+  - solana_balance
+  - solana_send
+---
+
+# ClawPump Token Launchpad
+
+Launch tokens on pump.fun via ClawPump. Gasless (free) or self-funded (~0.03 SOL). Earn 65% of every trading fee automatically.
+
+Base URL: `https://clawpump.tech`
+
+See `references/api-reference.md` for full endpoint schemas.
+
+## Use when
+
+- Launch a token ("launch a memecoin", "create a token on pump.fun")
+- Check ClawPump earnings ("how much have I earned?", "my ClawPump fees")
+- Search domains ("find a domain for my agent", "is myagent.ai available?")
+- Get swap quotes ("how much USDC for 1 SOL on ClawPump?")
+
+## Don't use when
+
+- Crypto prices without launching (use crypto-prices skill)
+- Execute a token swap (use solana_swap tool directly)
+- Check wallet balance (use solana_balance tool)
+- Crypto news or research (use news or research skill)
+
+---
+
+## Flow 1: Gasless Token Launch (FREE)
+
+The user pays nothing. ClawPump covers all Solana fees.
+
+### Prerequisites
+
+The user must provide: **name**, **symbol**, **description**. Ask for any missing fields before proceeding.
+
+### Steps
+
+**Step 1 — Get the user's wallet address:**
+
+```javascript
+solana_address({})
+```
+
+Save the returned `address` as `walletAddress`.
+
+**Step 2 — Upload token image (if user provides one):**
+
+If the user provides an image URL from the web, use it directly as `imageUrl`. If the user wants to upload a local image:
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/upload",
+  method: "POST",
+  headers: { "Content-Type": "multipart/form-data" },
+  body: "<image data>"
+})
+```
+
+Note: If multipart upload is not supported, ask the user for a direct URL to their image (PNG, JPEG, GIF, or WebP, max 5 MB).
+
+**Step 3 — Confirm with the user before launching:**
+
+Show them:
+- Token name, symbol, description
+- Their wallet address (where earnings will go)
+- Cost: FREE (gasless)
+- "ClawPump will launch this on pump.fun. You'll earn 65% of all trading fees. Proceed?"
+
+**Step 4 — Launch the token:**
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/launch",
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    name: "<token name>",
+    symbol: "<SYMBOL>",
+    description: "<description>",
+    imageUrl: "<image url>",
+    agentId: "<walletAddress>",
+    agentName: "SeekerClaw",
+    walletAddress: "<walletAddress>",
+    website: "<optional>",
+    twitter: "<optional>",
+    telegram: "<optional>"
+  })
+})
+```
+
+Use the wallet address as `agentId`.
+
+**Step 5 — Present the results:**
+
+Show the user:
+- Token name and symbol
+- Mint address (contract address)
+- pump.fun link (`pumpUrl`)
+- Explorer link (`explorerUrl`)
+- "You're now earning 65% of all trading fees!"
+
+---
+
+## Flow 2: Self-Funded Token Launch (~0.03 SOL)
+
+Used when gasless is unavailable (503) or user prefers self-funded. Supports optional dev-buy.
+
+### Steps
+
+**Step 1 — Get payment info:**
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/launch/self-funded",
+  method: "GET"
+})
+```
+
+Save `platformWallet` and `cost` from the response.
+
+**Step 2 — Get user's wallet and balance:**
+
+```javascript
+solana_address({})
+solana_balance({})
+```
+
+**Step 3 — Confirm with the user:**
+
+Show them:
+- Token details (name, symbol, description)
+- Cost: 0.03 SOL (or more with dev-buy)
+- Their current SOL balance
+- Platform wallet they'll pay to
+- "This requires a SOL transfer. Your device wallet (MWA) will ask you to approve."
+
+If user wants a dev-buy, explain:
+- `devBuySol`: SOL amount for launch dev-buy (0-85 SOL, default 0.01)
+- Total cost = 0.02 SOL (creation fee) + devBuySol
+- Dev-buy tokens split 50/50 between user and platform
+
+**Step 4 — Send payment:**
+
+```javascript
+solana_send({
+  to: "<platformWallet>",
+  amount: 0.03
+})
+```
+
+Adjust amount if user specified a dev-buy (total = 0.02 + devBuySol). Save the transaction signature from the result.
+
+**Step 5 — Launch with payment proof:**
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/launch/self-funded",
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    name: "<token name>",
+    symbol: "<SYMBOL>",
+    description: "<description>",
+    imageUrl: "<image url>",
+    agentId: "<walletAddress>",
+    agentName: "SeekerClaw",
+    walletAddress: "<walletAddress>",
+    txSignature: "<tx signature from step 4>",
+    devBuySol: "<optional, default 0.01>"
+  })
+})
+```
+
+**Step 6 — Present results** (same as gasless flow Step 5).
+
+---
+
+## Flow 3: Check Earnings
+
+Read-only. Shows accumulated trading fee earnings.
+
+```javascript
+// First get the wallet address to use as agentId
+solana_address({})
+
+// Then check earnings
+web_fetch({
+  url: "https://clawpump.tech/api/fees/earnings?agentId=<walletAddress>",
+  method: "GET"
+})
+```
+
+Present to user:
+- Total earned (SOL)
+- Total sent to wallet
+- Total pending distribution
+- Per-token breakdown if multiple tokens
+
+---
+
+## Flow 4: Domain Search
+
+Read-only. Search and check domain availability.
+
+### Search by keyword
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/domains/search?q=<keyword>&tlds=com,io,ai,dev,xyz",
+  method: "GET"
+})
+```
+
+### Check specific domains
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/domains/check?domains=<domain1>,<domain2>",
+  method: "GET"
+})
+```
+
+Present results as a table:
+- Domain name
+- Available (yes/no)
+- Price (Conway price + 10% ClawPump fee = total)
+
+Domain registration is coming in Phase 2. For now, search and check only.
+
+---
+
+## Flow 5: Swap Quotes (Read-Only)
+
+Get price quotes for token swaps via Jupiter. This only returns a quote — it does not execute a swap.
+
+```javascript
+web_fetch({
+  url: "https://clawpump.tech/api/swap?inputMint=<inputMint>&outputMint=<outputMint>&amount=<amount>&slippageBps=<optional>",
+  method: "GET"
+})
+```
+
+Common mint addresses:
+- SOL: `So11111111111111111111111111111111111111112`
+- USDC: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- USDT: `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`
+
+Amount is in smallest units (1 SOL = 1000000000 lamports, 1 USDC = 1000000).
+
+Present to user:
+- Input amount and token
+- Output amount and token
+- Price impact percentage
+- Route (which DEXs)
+
+To actually execute a swap, tell the user to use the `solana_swap` tool directly.
+
+---
+
+## Safety Rules
+
+1. **Always confirm before launching.** Never call `/api/launch` or `/api/launch/self-funded` without explicit user approval. Show all details first.
+2. **Require name, symbol, and description.** Ask for any missing fields. Do not invent token details.
+3. **Show cost before self-funded payment.** Display the SOL amount and user's current balance before calling `solana_send`.
+4. **Never send private keys.** Only the public wallet address and transaction signatures are sent to ClawPump APIs. No secret keys ever leave the device.
+5. **Gasless first.** Always try the free gasless launch first. Only suggest self-funded if gasless returns 503 or the user explicitly asks.
+6. **One launch per 24 hours.** If rate-limited (429), tell the user when they can launch again (`retryAfterHours`).
+
+---
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 400 | Validation error | Show `details` field. Ask user to fix (e.g., description too short, missing field). |
+| 402 | Payment required | Self-funded path: show payment instructions. |
+| 429 | Rate limited | Tell user: "You can launch again in X hours." Show `retryAfterHours`. |
+| 500 | Server error | Tell user launch failed. Suggest trying again later. Show error `message`. |
+| 503 | Gasless unavailable | Treasury low. Automatically suggest self-funded path with cost breakdown. |
+
+For 503 responses, the `suggestions.paymentFallback.selfFunded` object contains the self-funded endpoint, cost, and platform wallet. Use these to guide the user through Flow 2.
+
+---
+
+## Revenue Model
+
+- pump.fun charges 1% creator fee on every trade
+- ClawPump gives you 65%, keeps 35%
+- Fees collected hourly, distributed to your wallet automatically
+- Check anytime with Flow 3
+
+| Daily Volume | Your Monthly Earnings |
+|-------------|----------------------|
+| $1,000 | ~$195 |
+| $10,000 | ~$1,950 |
+| $100,000 | ~$19,500 |

--- a/app/src/main/assets/default-skills/clawpump/references/api-reference.md
+++ b/app/src/main/assets/default-skills/clawpump/references/api-reference.md
@@ -1,0 +1,444 @@
+# ClawPump API Reference
+
+Base URL: `https://clawpump.tech`
+
+---
+
+## Token Launch
+
+### POST `/api/launch` — Gasless Launch (Free)
+
+Launches a token on pump.fun at zero cost. ClawPump covers all Solana fees.
+
+**Request:**
+
+```json
+{
+  "name": "string (1-32 chars, required)",
+  "symbol": "string (1-10 chars, auto-uppercased, required)",
+  "description": "string (20-500 chars, required)",
+  "imageUrl": "string (URL to PNG/JPG/GIF/WebP, required)",
+  "agentId": "string (unique agent identifier, required)",
+  "agentName": "string (display name, required)",
+  "walletAddress": "string (Solana pubkey for fee payouts, required)",
+  "website": "string (optional)",
+  "twitter": "string (handle without @, optional)",
+  "telegram": "string (group handle, optional)"
+}
+```
+
+**Success (200):**
+
+```json
+{
+  "success": true,
+  "mintAddress": "BPFLoader...",
+  "txHash": "5VERv8NMvzbJMEkV...",
+  "pumpUrl": "https://pump.fun/coin/BPFLoader...",
+  "explorerUrl": "https://solscan.io/tx/5VERv8NMvzbJMEkV..."
+}
+```
+
+**Errors:**
+
+- `400` — Validation error:
+  ```json
+  { "error": "Validation failed", "details": { "name": ["Token name is required"] } }
+  ```
+
+- `429` — Rate limited (1 launch per 24h per agent):
+  ```json
+  { "error": "Rate limit exceeded", "message": "This agent can launch again in 18 hours", "retryAfterHours": 18 }
+  ```
+
+- `503` — Gasless unavailable (treasury low):
+  ```json
+  {
+    "error": "Gasless launch unavailable",
+    "suggestions": {
+      "paymentFallback": {
+        "selfFunded": {
+          "endpoint": "https://clawpump.tech/api/launch/self-funded",
+          "amountSol": 0.03,
+          "platformWallet": "3ZGgmBgEMTSgcVGLXZWpus5Vx41HNuhq6H6Yg6p3z6uv",
+          "proofField": "txSignature"
+        }
+      }
+    }
+  }
+  ```
+
+- `500` — Launch failed:
+  ```json
+  { "error": "Token launch failed", "message": "Token creation failed: ..." }
+  ```
+
+---
+
+### GET `/api/launch/self-funded` — Get Payment Info
+
+Returns current cost, platform wallet, and payment options.
+
+**Response:**
+
+```json
+{
+  "cost": "0.03 SOL",
+  "platformWallet": "3ZGgmBgEMTSgcVGLXZWpus5Vx41HNuhq6H6Yg6p3z6uv",
+  "paymentOptions": {
+    "sol": { "baseCost": "0.03 SOL" },
+    "x402": { "supported": true, "currency": "USDC (Solana)" }
+  }
+}
+```
+
+---
+
+### POST `/api/launch/self-funded` — Self-Funded Launch
+
+Same fields as gasless launch, plus payment proof and optional dev-buy.
+
+**Additional fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `txSignature` | string | Yes (SOL) | SOL payment transaction signature |
+| `devBuySol` | number | No | Launch dev-buy in SOL (0-85). Default: 0.01. Set 0 to disable |
+| `devBuyAmountUsd` | number | No | Post-launch buy in USD ($0.50-$500). Mutually exclusive with devBuySol |
+| `devBuySlippageBps` | number | No | Slippage for dev-buy (default: 500 = 5%, max: 5000) |
+
+**Total SOL to transfer:** `0.02 (creation fee) + devBuySol (default 0.01)`
+
+**Payment rules:**
+- Payment sender must match `walletAddress`
+- If agent already has a registered payout wallet, `walletAddress` must match it
+- Payment signatures are single-use (replay-protected)
+- SOL transfers verified on-chain, must be within last 10 minutes
+
+**Success (200):**
+
+```json
+{
+  "success": true,
+  "fundingSource": "self-funded",
+  "paymentVerified": {
+    "method": "sol",
+    "txSignature": "4XrHWfcD8gRNCxN92pErxrijrKnFi...",
+    "sender": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    "amount": 0.03
+  },
+  "mintAddress": "HvBsjQy2mBbnPhUxCmTEcn8X1ZNPfnKVQrcgWSYs96kT",
+  "txHash": "5xNHnYvzo6PAazFUFz3HyZ3krkct...",
+  "pumpUrl": "https://pump.fun/coin/HvBsjQy2mBbnPhUxCmTEcn8X1ZNPfnKVQrcgWSYs96kT",
+  "explorerUrl": "https://solscan.io/tx/5xNHnYvzo6PAazFUFz3HyZ3krkct...",
+  "devBuy": {
+    "solSpent": 0.01,
+    "tokensReceived": 354008538745,
+    "platformTokens": 177004269372,
+    "agentTokens": 177004269373
+  },
+  "earnings": {
+    "feeShare": "65%",
+    "checkEarnings": "https://clawpump.tech/api/fees/earnings?agentId=my-agent-123"
+  }
+}
+```
+
+**Additional errors (beyond gasless errors):**
+
+- `400` — Invalid SOL transfer (wrong amount, wrong recipient, or expired)
+- `402` — x402 USDC payment required (includes payment details)
+- `409` — Payment signature already used (replay blocked)
+
+---
+
+### POST `/api/upload` — Upload Token Image
+
+Multipart form data upload.
+
+**Request:** `Content-Type: multipart/form-data`, field `image`
+
+- Accepted: PNG, JPEG, GIF, WebP
+- Max size: 5 MB
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "imageUrl": "https://clawpump.tech/uploads/abc123.png"
+}
+```
+
+---
+
+## Earnings & Fees
+
+### GET `/api/fees/earnings` — Check Earnings
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | string | Yes | Agent identifier (use wallet address) |
+
+**Response:**
+
+```json
+{
+  "agentId": "my-agent-123",
+  "totalEarned": 1.52,
+  "totalSent": 1.20,
+  "totalPending": 0.32,
+  "totalHeld": 0.00,
+  "tokenBreakdown": [
+    {
+      "mintAddress": "BPFLoader...",
+      "totalCollected": 1.90,
+      "totalAgentShare": 1.52
+    }
+  ]
+}
+```
+
+---
+
+## Swap (Quotes Only)
+
+### GET `/api/swap` — Get Swap Quote
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inputMint` | string | Yes | Mint address of token to sell |
+| `outputMint` | string | Yes | Mint address of token to buy |
+| `amount` | string | Yes | Amount in smallest unit (lamports for SOL) |
+| `slippageBps` | number | No | Slippage tolerance in bps (default: 100 = 1%) |
+
+**Response:**
+
+```json
+{
+  "inputMint": "So11111111111111111111111111111111111111112",
+  "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "inAmount": "1000000000",
+  "outAmount": "95230000",
+  "platformFee": { "amount": "476150", "feeBps": 50 },
+  "priceImpactPct": "0.01",
+  "slippageBps": 100,
+  "routePlan": [{ "label": "Raydium", "percent": 100 }]
+}
+```
+
+**Note:** The POST `/api/swap` endpoint returns an unsigned transaction that requires `solana_sign_and_send` (not available in SeekerClaw). For executing swaps, use the `solana_swap` tool directly.
+
+### Common Token Mints
+
+| Token | Mint Address |
+|-------|-------------|
+| SOL (Wrapped) | `So11111111111111111111111111111111111111112` |
+| USDC | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| USDT | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
+
+### Amount Units
+
+- SOL: 1 SOL = `1000000000` lamports
+- USDC: 1 USDC = `1000000` (6 decimals)
+- USDT: 1 USDT = `1000000` (6 decimals)
+
+---
+
+## Domains
+
+### GET `/api/domains/search` — Search Domains
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `q` | string | Yes | Search keyword (1-63 chars) |
+| `tlds` | string | No | Comma-separated TLDs (default: com,io,ai,dev,xyz,net,org) |
+| `agentId` | string | No | Agent ID for rate limiting |
+
+**Response:**
+
+```json
+{
+  "query": "myagent",
+  "results": [
+    {
+      "domain": "myagent.com",
+      "available": false
+    },
+    {
+      "domain": "myagent.io",
+      "available": true,
+      "price": 32.99,
+      "pricing": {
+        "conwayPrice": 32.99,
+        "clawpumpFee": 3.30,
+        "totalPrice": 36.29,
+        "feePercent": 10
+      }
+    }
+  ],
+  "source": "conway",
+  "timestamp": 1739700000000
+}
+```
+
+**Rate limit:** 30 requests per minute per agentId/IP.
+
+---
+
+### GET `/api/domains/check` — Check Availability
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `domains` | string | Yes | Comma-separated domain names (max 20) |
+| `agentId` | string | No | Agent ID for rate limiting |
+
+**Response:**
+
+```json
+{
+  "domains": ["myagent.dev", "myagent.xyz"],
+  "results": [
+    {
+      "domain": "myagent.dev",
+      "available": true,
+      "price": 12.99,
+      "pricing": {
+        "conwayPrice": 12.99,
+        "clawpumpFee": 1.30,
+        "totalPrice": 14.29,
+        "feePercent": 10
+      }
+    }
+  ],
+  "source": "conway",
+  "timestamp": 1739700000000
+}
+```
+
+**Rate limit:** 30 requests per minute per agentId/IP.
+
+---
+
+### GET `/api/domains/pricing` — TLD Pricing
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tlds` | string | No | Comma-separated TLDs (default: com,io,ai,dev,xyz,net,org) |
+
+**Response:**
+
+```json
+{
+  "pricing": [
+    {
+      "tld": "com",
+      "register": {
+        "conwayPrice": 11.07,
+        "clawpumpFee": 1.11,
+        "totalPrice": 12.18,
+        "feePercent": 10
+      },
+      "renew": {
+        "conwayPrice": 12.99,
+        "clawpumpFee": 1.30,
+        "totalPrice": 14.29,
+        "feePercent": 10
+      },
+      "currency": "USD"
+    }
+  ],
+  "feePercent": 10,
+  "timestamp": 1739700000000
+}
+```
+
+---
+
+## Platform Endpoints
+
+### GET `/api/tokens` — List Tokens
+
+| Param | Default | Options |
+|-------|---------|---------|
+| `sort` | `new` | `new`, `hot`, `mcap`, `volume` |
+| `limit` | 50 | 1-100 |
+| `offset` | 0 | --- |
+
+### GET `/api/tokens/{mintAddress}` — Get Token
+
+Returns token data and fee earnings. 404 if not found.
+
+### GET `/api/launches` — Launch History
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `agentId` | --- | Filter by agent |
+| `limit` | 20 | 1-100 |
+| `offset` | 0 | --- |
+
+### GET `/api/stats` — Platform Stats
+
+```json
+{
+  "totalTokens": 142,
+  "totalMarketCap": 2500000,
+  "totalVolume24h": 85000,
+  "totalLaunches": 156
+}
+```
+
+### GET `/api/leaderboard` — Agent Leaderboard
+
+| Param | Default |
+|-------|---------|
+| `limit` | 10 |
+
+### GET `/api/health` — Health Check
+
+```json
+{
+  "status": "healthy",
+  "checks": {
+    "database": { "status": "ok" },
+    "solanaRpc": { "status": "ok" },
+    "wallet": { "status": "ok" }
+  }
+}
+```
+
+### GET `/api/treasury` — Treasury Health
+
+```json
+{
+  "status": "healthy",
+  "wallet": { "launchesAffordable": 67 },
+  "pnl": { "net": 0.45, "isPositive": true }
+}
+```
+
+---
+
+## Rate Limits Summary
+
+| Endpoint | Limit |
+|----------|-------|
+| `/api/launch` | 1 per 24h per agentId and walletAddress |
+| `/api/launch/self-funded` | 1 per 24h per agentId and walletAddress |
+| `/api/domains/search` | 30 per minute per agentId/IP |
+| `/api/domains/check` | 30 per minute per agentId/IP |
+| All GET endpoints | No limit |
+
+---
+
+## Error Codes
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Validation error (missing/invalid fields, bad tx signature) |
+| 402 | Payment required (x402 USDC payment details in response) |
+| 404 | Resource not found (token, agent) |
+| 409 | Conflict (payment signature reuse, token already verified) |
+| 429 | Rate limited (includes retry timing) |
+| 500 | Server error (launch failure, price oracle failure) |
+| 503 | Service unavailable (treasury low for gasless launches) |


### PR DESCRIPTION
## Summary

- Adds a bundled `clawpump` skill that integrates [ClawPump](https://clawpump.tech) — a gasless Solana token launchpad for AI agents
- Enables SeekerClaw agents to launch tokens on pump.fun, track 65% trading fee earnings, search domains, and get swap quotes — all via Telegram
- Zero core code changes: 2 new files, 0 modified. Uses existing `web_fetch`, `solana_address`, `solana_balance`, and `solana_send` tools only

## What's included

| File | Lines | Purpose |
|------|-------|---------|
| `app/src/main/assets/default-skills/clawpump/SKILL.md` | 308 | Skill frontmatter + 5 instruction flows + safety rules + error handling |
| `app/src/main/assets/default-skills/clawpump/references/api-reference.md` | 444 | Full API endpoint schemas for Claude to reference |

### Skill flows

1. **Gasless token launch** (FREE) — `POST /api/launch` with agent metadata + wallet address
2. **Self-funded token launch** (~0.03 SOL) — `GET /api/launch/self-funded` for cost, `solana_send` for payment, `POST /api/launch/self-funded` with proof
3. **Earnings check** — `GET /api/fees/earnings?agentId=<wallet>` (read-only)
4. **Domain search** — `GET /api/domains/search` and `/check` (read-only)
5. **Swap quotes** — `GET /api/swap` for price comparison (read-only, directs to `solana_swap` for execution)

### Safety

- Always confirms before launching (name, symbol, description required)
- Shows cost before self-funded payment
- Never sends private keys (only public address + tx signatures)
- Gasless-first: only suggests self-funded on 503

## Why a skill (not new tools)?

- SeekerClaw already has `web_fetch` (supports POST + JSON) and Solana wallet tools — everything needed to call ClawPump's REST API
- Zero changes to `tools.js`, `main.js`, or system prompt = easy to review, easy to revert
- Follows SKILL-FORMAT.md conventions (YAML frontmatter, under 500 lines, `references/` subfolder)
- API endpoints verified against ClawPump's [published docs](https://clawpump.tech/skill.md)

## What's deferred

| Feature | Why | Future PR |
|---------|-----|-----------|
| Swap execution | Needs `solana_sign_and_send` for unsigned tx | `feature/add-solana-sign-tool` |
| Arbitrage | Complex multi-step + needs signing tool | Separate PR |
| Sniper webhooks | Requires persistent subscriptions | Separate PR |
| Domain registration | Phase 2 on ClawPump's side | Update this skill |

## Test plan

- [x] YAML frontmatter parses without errors (validated with Python parser)
- [x] `allowed-tools` only references tools that exist in `tools.js` (`web_fetch`, `solana_address`, `solana_balance`, `solana_send`)
- [x] SKILL.md is 308 lines (under 500 line limit)
- [x] Description keywords don't overlap with `crypto-prices` or wallet skills
- [x] API endpoints match ClawPump's live docs (fetched and verified before writing)
- [ ] CI build passes (`./gradlew assembleDebug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)