### PR TITLE
fix: include API error reason in user-facing messages (BAT-289)

### DIFF
--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -950,11 +950,13 @@ function classifyApiError(status, data) {
         };
     }
     // BAT-289: Include actual API error reason so users can diagnose without device logs
-    const reason = data?.error?.message || '';
+    // Sanitize reason to prevent markdown injection in Telegram messages
+    const rawReason = data?.error?.message || '';
+    const reason = rawReason.replace(/[*_`\[\]()~>#+\-=|{}.!]/g, '').slice(0, 200);
     return {
         type: 'unknown', retryable: false,
-        userMessage: reason
-            ? `API error (${status}): ${reason}`
+        userMessage: reason.trim()
+            ? `API error (${status}): ${reason.trim()}`
             : `Unexpected API error (${status}). Please try again.`
     };
 }


### PR DESCRIPTION
## Summary
- `classifyApiError()` in claude.js now includes the actual API error message (e.g. `"overloaded"`, `"invalid_api_key"`) in user-facing error text
- Previously showed generic `Unexpected API error (status)` — users had to check device logs to diagnose
- Falls back to the generic message if no reason is available

## Test plan
- [ ] Trigger an API error (e.g. invalid key, overloaded) and verify the error message in Telegram includes the reason
- [ ] Verify normal API calls are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)