### PR TITLE
docs: bump OpenClaw parity to 2026.2.28, add tool-first guidance (BAT-280)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 | Version | Current | Location |
 |---------|---------|----------|
 | **App** | `1.4.1` (code 6) | `app/build.gradle.kts` → `versionName` / `versionCode` |
-| **OpenClaw** | `2026.2.25` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
+| **OpenClaw** | `2026.2.28` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
 | **Node.js** | `18 LTS` | `app/build.gradle.kts` → `NODEJS_VERSION` buildConfigField |
 
 ## Tech Stack
@@ -472,8 +472,8 @@ git tag v1.x.x && git push origin v1.x.x
 > **IMPORTANT:** SeekerClaw must stay in sync with OpenClaw updates. See `docs/internal/OPENCLAW_TRACKING.md` for full details.
 
 ### Current Versions
-- **OpenClaw Reference:** 2026.2.25
-- **Last Sync Review:** 2026-02-25
+- **OpenClaw Reference:** 2026.2.28
+- **Last Sync Review:** 2026-02-28
 
 ### Quick Update Check
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         versionName = "1.4.1"
 
         // Keep these in sync when updating OpenClaw or nodejs-mobile
-        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.25\"")
+        buildConfigField("String", "OPENCLAW_VERSION", "\"2026.2.28\"")
         buildConfigField("String", "NODEJS_VERSION", "\"18 LTS\"")
 
         externalNativeBuild {

--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -426,6 +426,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.');
     lines.push('Keep narration brief and value-dense; avoid repeating obvious steps.');
     lines.push('Use plain human language for narration unless in a technical context.');
+    lines.push('When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.');
     lines.push('For visual checks ("what do you see", "check my dog", "look at the room"), call android_camera_check.');
     lines.push('For long waits, avoid rapid poll loops: use shell_exec with enough timeout or check status on-demand rather than in a tight loop.');
     lines.push('');

--- a/docs/internal/OPENCLAW_TRACKING.md
+++ b/docs/internal/OPENCLAW_TRACKING.md
@@ -1,8 +1,8 @@
 # OpenClaw Version Tracking
 
 > **Purpose:** Track OpenClaw releases and identify changes to port to SeekerClaw.
-> **Current OpenClaw Version:** 2026.2.25 (main b3f46f0e2, 2026-02-25)
-> **Last Sync Review:** 2026-02-25
+> **Current OpenClaw Version:** 2026.2.28 (main be8a5b9d6, 2026-02-28)
+> **Last Sync Review:** 2026-02-28
 > **Parity Plan:** See `PARITY_PLAN.md`
 
 ---
@@ -82,7 +82,23 @@ These files in OpenClaw directly affect SeekerClaw behavior. Changes here requir
 
 ## Version History & Changes
 
-### 2026.2.25 (Current - b3f46f0e2)
+### 2026.2.28 (Current - be8a5b9d6)
+- **Release Date:** 2026-02-28
+- **SeekerClaw Sync Status:** 1 line ported
+- **652 new commits since last sync (b3f46f0e2)**
+- **Ported:**
+  - [x] System prompt: "tool-first" guidance — use tools directly instead of suggesting CLI/slash commands to user
+- **Skipped (not applicable):**
+  - System prompt: ACP (`acpEnabled`) routing, sessions_spawn ACP harness intent, config.schema for gateway — server-only, no sub-agents/Discord/gateway
+  - Memory: `INDEX_CACHE_PENDING` concurrency guard, SQLite readonly recovery — Node 22+ embedding infrastructure
+  - Skills: coding-agent ACP routing, plugin-skills ACP filter, env-overrides apiKey trim — server-only
+  - Tools/Web: WhatsApp auto-reply refactoring, inbound access-control — server-only
+  - Cron: `isFiniteTimestamp()` guards (our cron.js already guards inputs), `accountId` delivery field, delivery dispatch/session key/thread targeting, timeout policy — server-only or defensive-only
+  - Channels: thread bindings, typing guard, WhatsApp heartbeat, onboarding helpers — server-only
+  - Telegram: version bump only — no functional changes
+  - 700+ lines of test additions — test-only
+
+### 2026.2.25 (b3f46f0e2)
 - **Release Date:** 2026-02-25
 - **SeekerClaw Sync Status:** Reviewed, nothing to port
 - **276 new commits since last sync (4b316c33d)**


### PR DESCRIPTION
## Summary
- Parity check: 652 new OpenClaw commits reviewed (b3f46f0e2 → be8a5b9d6)
- Ported 1 line: "tool-first" guidance in system prompt Tool Call Style section — tells agent to use tools directly instead of suggesting user run CLI/slash commands
- Skipped: ACP routing (server-only), memory readonly recovery (Node 22+), cron accountId/isFiniteTimestamp (server-only/defensive), WhatsApp/Discord changes
- Updated OpenClaw version: 2026.2.25 → 2026.2.28 in build.gradle.kts, CLAUDE.md, OPENCLAW_TRACKING.md

## Test plan
- [ ] Gradle sync (buildConfigField change)
- [ ] Build & run — verify system prompt includes tool-first guidance
- [ ] Verify OpenClaw version shows 2026.2.28 in Settings > About

🤖 Generated with [Claude Code](https://claude.com/claude-code)