### PR TITLE
fix: secrets hardening — 7 surgical security fixes (BAT-305)

### DIFF
--- a/app/src/main/assets/nodejs-project/claude.js
+++ b/app/src/main/assets/nodejs-project/claude.js
@@ -17,6 +17,7 @@ const {
     getOwnerId,
 } = require('./config');
 
+const { redactSecrets } = require('./security');
 const { telegram, sendTyping, sentMessageCache, SENT_CACHE_TTL, deferStatus } = require('./telegram');
 const { httpStreamingRequest } = require('./web');
 const { androidBridgeCall } = require('./bridge');
@@ -313,7 +314,7 @@ async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = 
         // Write the summary file
         const header = `# Session Summary — ${localTimestamp()}\n\n`;
         const meta = `> Trigger: ${trigger} | Exchanges: ${track.messageCount} | Model: ${MODEL}\n\n`;
-        fs.writeFileSync(finalPath, header + meta + summary + '\n', 'utf8');
+        fs.writeFileSync(finalPath, header + meta + redactSecrets(summary) + '\n', 'utf8');
 
         log(`[SessionSummary] Saved: ${path.basename(finalPath)} (trigger: ${trigger})`, 'DEBUG');
 
@@ -510,6 +511,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('1. Use memory_search to find relevant information first (faster, more targeted).');
     lines.push('2. Only use memory_read on specific files if search results are insufficient.');
     lines.push('3. Keep memory entries concise and well-organized when writing.');
+    lines.push('4. **NEVER write API keys, passwords, seed phrases, private keys, or auth tokens to memory files.** Save keys ONLY to agent_settings.json under apiKeys.');
     lines.push('If low confidence after searching, tell the user you checked but found nothing relevant.');
     lines.push('');
 
@@ -564,6 +566,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('');
     lines.push('However, if a user provides a key directly in conversation:');
     lines.push('1. Save it to agent_settings.json under apiKeys.<service> (e.g. apiKeys.perplexity)');
+    lines.push('   IMPORTANT: NEVER save the key to memory files (MEMORY.md, daily notes). Keys go ONLY in agent_settings.json.');
     lines.push('2. Confirm it\'s saved');
     lines.push('3. Built-in tools (web_search, Jupiter, etc.) pick it up immediately — just use them normally');
     lines.push('4. Warn the user:');

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -660,7 +660,7 @@ async function handleMessage(msg) {
                                         await sendMessage(chatId, installResult.result, msg.message_id);
                                     } else if (installResult && installResult.error) {
                                         // Validation failed — tell user why (e.g. missing name, injection blocked)
-                                        await sendMessage(chatId, `Skill install failed: ${installResult.error}`, msg.message_id);
+                                        await sendMessage(chatId, `Skill install failed: ${redactSecrets(installResult.error)}`, msg.message_id);
                                         // Fall through to normal file note so the file is still accessible
                                     }
                                     // Non-skill or failed — fall through to normal file note
@@ -724,7 +724,7 @@ async function handleMessage(msg) {
     } catch (error) {
         log(`Error: ${error.message}`, 'ERROR');
         await statusReaction.setError();
-        await sendMessage(chatId, `Error: ${error.message}`, msg.message_id);
+        await sendMessage(chatId, `Error: ${redactSecrets(error.message)}`, msg.message_id);
     }
 }
 
@@ -920,7 +920,7 @@ async function autoResumeOnStartup() {
                     }
                 } catch (e) {
                     log(`[AutoResume] chat() error: ${e.message}`, 'ERROR');
-                    await sendMessage(chatId, `Auto-resume failed: ${e.message}`).catch(() => {});
+                    await sendMessage(chatId, `Auto-resume failed: ${redactSecrets(e.message)}`).catch(() => {});
                 }
             });
             chatQueues.set(chatId, task);

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -4,11 +4,38 @@
 
 const path = require('path');
 
-const { BRIDGE_TOKEN, log, workDir } = require('./config');
+const { BRIDGE_TOKEN, config, MCP_SERVERS, log, workDir } = require('./config');
 
 // ============================================================================
 // SECRET REDACTION
 // ============================================================================
+
+// Escape string for use in RegExp constructor
+function _escRx(s) { return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'); }
+
+// Cached dynamic redaction patterns (rebuilt when config changes)
+let _dynamicPatterns = [];
+
+// Rebuild literal-match patterns for secrets without a known prefix (Jupiter, MCP tokens).
+// Called at startup and after syncAgentApiKeys() mutates config.
+function rebuildRedactPatterns() {
+    const patterns = [];
+    // Jupiter API key (no known prefix — literal match)
+    const jk = config.jupiterApiKey;
+    if (jk && jk.length >= 8) {
+        patterns.push({ rx: new RegExp(_escRx(jk), 'g'), replacement: '***jupiter-key***' });
+    }
+    // MCP server auth tokens (literal match per server)
+    for (const server of MCP_SERVERS) {
+        if (server.authToken && server.authToken.length >= 8) {
+            patterns.push({ rx: new RegExp(_escRx(server.authToken), 'g'), replacement: '***mcp-token***' });
+        }
+    }
+    _dynamicPatterns = patterns;
+}
+
+// Build initial patterns (runs once at module load)
+rebuildRedactPatterns();
 
 // Redact sensitive data from log strings (API keys, bot tokens, bridge tokens)
 function redactSecrets(msg) {
@@ -23,9 +50,12 @@ function redactSecrets(msg) {
     msg = msg.replace(/pplx-[a-zA-Z0-9_-]{10,}/g, 'pplx-***');
     // Redact OpenRouter API keys (sk-or-...)
     msg = msg.replace(/sk-or-[a-zA-Z0-9_-]{10,}/g, 'sk-or-***');
-    // Jupiter API keys: no pattern-based redaction (unknown format, optional feature)
     // Redact bridge tokens (UUID format)
-    if (BRIDGE_TOKEN) msg = msg.replace(new RegExp(BRIDGE_TOKEN.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'), '***bridge-token***');
+    if (BRIDGE_TOKEN) msg = msg.replace(new RegExp(_escRx(BRIDGE_TOKEN), 'g'), '***bridge-token***');
+    // Redact Jupiter API key + MCP auth tokens (cached literal patterns)
+    for (const { rx, replacement } of _dynamicPatterns) {
+        msg = msg.replace(rx, replacement);
+    }
     return msg;
 }
 
@@ -162,6 +192,7 @@ function wrapSearchResults(result, provider) {
 
 module.exports = {
     redactSecrets,
+    rebuildRedactPatterns,
     safePath,
     INJECTION_PATTERNS,
     normalizeWhitespace,

--- a/app/src/main/assets/nodejs-project/skills.js
+++ b/app/src/main/assets/nodejs-project/skills.js
@@ -197,7 +197,6 @@ function parseSkillFile(content, skillDir) {
         emoji: '',
         image: '',
         requires: { bins: [], env: [], config: [] },
-        allowedTools: [],
         dir: skillDir
     };
 
@@ -243,10 +242,9 @@ function parseSkillFile(content, skillDir) {
                 skill.requires.config = toArray(reqSource.config);
             }
 
-            // Handle allowed-tools (OpenClaw format)
-            if (frontmatter['allowed-tools']) {
-                skill.allowedTools = toArray(frontmatter['allowed-tools']);
-            }
+            // Note: allowed-tools was previously parsed here but never enforced.
+            // Removed in BAT-305 to avoid false sense of security. If needed,
+            // implement proper per-skill tool restriction in executeTool().
 
             // Body is everything after frontmatter
             body = content.slice(endIndex + 3).trim();

--- a/app/src/main/assets/nodejs-project/task-store.js
+++ b/app/src/main/assets/nodejs-project/task-store.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { TASKS_DIR, log } = require('./config');
+const { redactSecrets } = require('./security');
 
 const MAX_CHECKPOINT_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MAX_CONVERSATION_SLICE = 8; // Keep last 8 messages in checkpoint
@@ -55,6 +56,28 @@ function saveCheckpoint(taskId, state) {
                 }
             }
         }
+
+        // Redact secrets from conversation slice before writing to disk (BAT-305)
+        if (Array.isArray(trimmed.conversationSlice)) {
+            trimmed.conversationSlice = trimmed.conversationSlice.map(msg => {
+                const clone = { ...msg };
+                if (typeof clone.content === 'string') {
+                    clone.content = redactSecrets(clone.content);
+                } else if (Array.isArray(clone.content)) {
+                    clone.content = clone.content.map(block => {
+                        const b = { ...block };
+                        if (typeof b.text === 'string') b.text = redactSecrets(b.text);
+                        if (typeof b.content === 'string') b.content = redactSecrets(b.content);
+                        return b;
+                    });
+                }
+                return clone;
+            });
+        }
+        if (typeof trimmed.originalGoal === 'string') {
+            trimmed.originalGoal = redactSecrets(trimmed.originalGoal);
+        }
+
         trimmed.updatedAt = Date.now();
 
         const json = JSON.stringify(trimmed, null, 2);

--- a/app/src/main/assets/nodejs-project/tools.js
+++ b/app/src/main/assets/nodejs-project/tools.js
@@ -13,7 +13,7 @@ const {
 } = require('./config');
 
 const {
-    safePath, detectSuspiciousPatterns,
+    redactSecrets, rebuildRedactPatterns, safePath, detectSuspiciousPatterns,
     wrapExternalContent, wrapSearchResults,
 } = require('./security');
 
@@ -1005,7 +1005,7 @@ async function executeTool(name, input, chatId) {
 
         case 'memory_save': {
             const currentMemory = loadMemory();
-            const newMemory = currentMemory + '\n\n---\n\n' + input.content;
+            const newMemory = currentMemory + '\n\n---\n\n' + redactSecrets(input.content);
             saveMemory(newMemory.trim());
             return { success: true, message: 'Memory saved' };
         }
@@ -1016,7 +1016,7 @@ async function executeTool(name, input, chatId) {
         }
 
         case 'daily_note': {
-            appendDailyMemory(input.note);
+            appendDailyMemory(redactSecrets(input.note));
             return { success: true, message: 'Note added to daily memory' };
         }
 
@@ -1110,6 +1110,7 @@ async function executeTool(name, input, chatId) {
             // BAT-236: If agent wrote to workspace root agent_settings.json, re-sync API keys
             if (filePath === path.join(workDir, 'agent_settings.json')) {
                 syncAgentApiKeys();
+                rebuildRedactPatterns();
             }
 
             return {
@@ -1162,6 +1163,7 @@ async function executeTool(name, input, chatId) {
             // BAT-236: If agent edited workspace root agent_settings.json, re-sync API keys
             if (filePath === path.join(workDir, 'agent_settings.json')) {
                 syncAgentApiKeys();
+                rebuildRedactPatterns();
             }
 
             return {
@@ -3536,6 +3538,14 @@ async function executeTool(name, input, chatId) {
             const sandboxedRequire = (mod) => {
                 if (BLOCKED_MODULES.has(mod)) {
                     throw new Error(`Module "${mod}" is blocked in js_eval for security. Use shell_exec for command execution.`);
+                }
+                // Block relative requires — prevents access to config.js (secrets), security.js, etc.
+                if (mod.startsWith('./') || mod.startsWith('../') || mod.startsWith('.\\') || mod.startsWith('..\\')) {
+                    throw new Error('Relative module imports are blocked in js_eval for security.');
+                }
+                // Block absolute paths into workspace or source directory
+                if (path.isAbsolute(mod) && (mod.startsWith(workDir) || mod.startsWith(__dirname))) {
+                    throw new Error('Direct module imports from app directories are blocked in js_eval for security.');
                 }
                 if (mod === 'fs') return createGuardedFsProxy(require('fs'), FS_GUARDED, FSP_GUARDED);
                 if (mod === 'fs/promises') return createGuardedFsProxy(require('fs/promises'), FSP_GUARDED);


### PR DESCRIPTION
## Summary

Full security audit of all 15 Node.js modules revealed gaps where secrets could leak. This PR applies 7 surgical fixes:

- **Fix 1** (security.js): Expand `redactSecrets()` with Jupiter API key + MCP auth token redaction using cached compiled regexes
- **Fix 2** (tools.js): Block `require('./config')` in js_eval sandbox — closes sandbox escape that exposed ALL secrets via relative/absolute module imports
- **Fix 3** (main.js): Redact error messages before sending to Telegram (3 locations: main handler, skill install, auto-resume)
- **Fix 4** (task-store.js): Deep-redact conversation slices in task checkpoints before writing to disk
- **Fix 5** (tools.js + claude.js): Filter `memory_save`, `daily_note`, and session summaries through `redactSecrets()` before disk write
- **Fix 6** (claude.js): System prompt guidance — agent instructed to NEVER save secrets to memory files
- **Fix 7** (skills.js): Remove dead `allowedTools` parser (was parsed but never enforced — false sense of security)

**Deferred:** Encrypt apiKeys in agent_settings.json (needs Kotlin), outbound DLP, MCP SSRF protection.

## Test plan

- [ ] Verify `js_eval` with `require('./config')` returns blocked error
- [ ] Verify Jupiter key value appears as `***jupiter-key***` in logs
- [ ] Verify error messages sent to Telegram are redacted
- [ ] Verify task checkpoint JSON files have redacted conversation content
- [ ] Verify `memory_save` with a key pattern produces redacted output in MEMORY.md
- [ ] Verify session summaries are redacted before disk write
- [ ] Verify skills load without `allowedTools` field

Generated with [Claude Code](https://claude.com/claude-code)