### PR TITLE
feat: Message Activity Heatmap on System screen

### DIFF
--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -478,13 +478,15 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // ============================================================================
 
 // Daily message counts for heatmap (last 6 months)
+// Note: counts API requests (api_request_log rows) — each user message = 1+ API calls.
+// UI labels this as "messages" which is close enough for activity visualization.
 function getDailyActivity() {
     if (!db) return [];
     try {
         const rows = db.exec(
             `SELECT DATE(timestamp) AS day, COUNT(*) AS count
              FROM api_request_log
-             WHERE timestamp >= date('now', '-6 months')
+             WHERE timestamp >= date('now', 'localtime', '-6 months')
              GROUP BY DATE(timestamp)
              ORDER BY day ASC`
         );

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -485,11 +485,10 @@ function getDailyActivity() {
     try {
         // SUBSTR extracts the local date portion directly from ISO timestamps
         // (e.g. "2026-03-28T19:17:24+04:00" → "2026-03-28"), avoiding DATE()
-        // timezone interpretation issues.
+        // timezone interpretation issues. No time limit — grid grows with history.
         const rows = db.exec(
             `SELECT SUBSTR(timestamp, 1, 10) AS day, COUNT(*) AS count
              FROM api_request_log
-             WHERE timestamp >= date('now', 'localtime', '-6 months')
              GROUP BY SUBSTR(timestamp, 1, 10)
              ORDER BY day ASC`
         );

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -477,8 +477,26 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // DB SUMMARY & STATS SERVER (BAT-31)
 // ============================================================================
 
+// Daily message counts for heatmap (last 6 months)
+function getDailyActivity() {
+    if (!db) return [];
+    try {
+        const rows = db.exec(
+            `SELECT DATE(timestamp) AS day, COUNT(*) AS count
+             FROM api_request_log
+             WHERE timestamp >= date('now', '-6 months')
+             GROUP BY DATE(timestamp)
+             ORDER BY day ASC`
+        );
+        if (rows.length === 0 || rows[0].values.length === 0) return [];
+        return rows[0].values.map(([day, count]) => ({ day, count }));
+    } catch (e) {
+        return [];
+    }
+}
+
 function getDbSummary() {
-    const summary = { today: null, month: null, memory: null };
+    const summary = { today: null, month: null, memory: null, dailyActivity: [] };
     if (!db) return summary;
 
     try {
@@ -552,6 +570,7 @@ function getDbSummary() {
         }
     } catch (e) { /* non-fatal */ }
 
+    summary.dailyActivity = getDailyActivity();
     return summary;
 }
 

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -489,6 +489,7 @@ function getDailyActivity() {
         const rows = db.exec(
             `SELECT SUBSTR(timestamp, 1, 10) AS day, COUNT(*) AS count
              FROM api_request_log
+             WHERE SUBSTR(timestamp, 1, 10) >= date('now', 'localtime', '-13 months')
              GROUP BY SUBSTR(timestamp, 1, 10)
              ORDER BY day ASC`
         );

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -483,16 +483,20 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 function getDailyActivity() {
     if (!db) return [];
     try {
+        // SUBSTR extracts the local date portion directly from ISO timestamps
+        // (e.g. "2026-03-28T19:17:24+04:00" → "2026-03-28"), avoiding DATE()
+        // timezone interpretation issues.
         const rows = db.exec(
-            `SELECT DATE(timestamp) AS day, COUNT(*) AS count
+            `SELECT SUBSTR(timestamp, 1, 10) AS day, COUNT(*) AS count
              FROM api_request_log
              WHERE timestamp >= date('now', 'localtime', '-6 months')
-             GROUP BY DATE(timestamp)
+             GROUP BY SUBSTR(timestamp, 1, 10)
              ORDER BY day ASC`
         );
         if (rows.length === 0 || rows[0].values.length === 0) return [];
         return rows[0].values.map(([day, count]) => ({ day, count }));
     } catch (e) {
+        log('[DB] getDailyActivity error: ' + e.message, 'WARN');
         return [];
     }
 }

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -477,7 +477,7 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // DB SUMMARY & STATS SERVER (BAT-31)
 // ============================================================================
 
-// Daily message counts for heatmap (last 6 months)
+// Daily message counts for heatmap (up to 13 months of history)
 // Note: counts API requests (api_request_log rows) — each user message = 1+ API calls.
 // UI labels this as "messages" which is close enough for activity visualization.
 function getDailyActivity() {
@@ -485,7 +485,7 @@ function getDailyActivity() {
     try {
         // SUBSTR extracts the local date portion directly from ISO timestamps
         // (e.g. "2026-03-28T19:17:24+04:00" → "2026-03-28"), avoiding DATE()
-        // timezone interpretation issues. No time limit — grid grows with history.
+        // timezone interpretation issues. Capped at 13 months to limit query size.
         const rows = db.exec(
             `SELECT SUBSTR(timestamp, 1, 10) AS day, COUNT(*) AS count
              FROM api_request_log

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -477,9 +477,11 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // DB SUMMARY & STATS SERVER (BAT-31)
 // ============================================================================
 
-// Daily message counts for heatmap (up to 13 months of history)
-// Note: counts API requests (api_request_log rows) — each user message = 1+ API calls.
-// UI labels this as "messages" which is close enough for activity visualization.
+// Daily request counts for the Activity heatmap (up to 13 months of history).
+// Each row in api_request_log is one API call to the model — note that a single
+// user message can produce multiple API calls via tool-use loops, retries, or
+// background session summaries. The UI reflects this accurately: the section is
+// labeled "Activity" and the total reads "X requests" (not "messages").
 function getDailyActivity() {
     if (!db) return [];
     try {

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -180,7 +180,7 @@ fun SystemScreen(onBack: () -> Unit) {
         Spacer(modifier = Modifier.height(24.dp))
 
         // ==================== MESSAGE ACTIVITY ====================
-        SectionLabel("Message Activity")
+        SectionLabel("Activity")
 
         // Preserve last known activity data even when service stops
         val lastKnownActivity = remember { mutableStateOf<List<DayActivity>>(emptyList()) }
@@ -777,7 +777,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 }
                 val rangeLabel = "${halfYearStart.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)}-${halfYearEnd.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} ${halfYearStart.year}"
                 Text(
-                    text = "$countText msgs \u00B7 $rangeLabel",
+                    text = "$countText requests \u00B7 $rangeLabel",
                     fontFamily = FontFamily.Monospace,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -578,13 +578,16 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val cellShape = RoundedCornerShape(2.dp)
 
     val today = LocalDate.now()
-    // 6-month half-year chunks: Jan-Jun or Jul-Dec
-    val halfYearStart = if (today.monthValue <= 6) {
-        LocalDate.of(today.year, 1, 1)
+    // Grid starts from the half-year containing the earliest data (Jan or Jul)
+    // and extends to today. Scroll shows most recent; user can scroll left for history.
+    val earliestDataDate = dailyActivity.firstOrNull()?.let {
+        try { LocalDate.parse(it.day) } catch (_: Exception) { null }
+    } ?: today
+    val halfYearStart = if (earliestDataDate.monthValue <= 6) {
+        LocalDate.of(earliestDataDate.year, 1, 1)
     } else {
-        LocalDate.of(today.year, 7, 1)
+        LocalDate.of(earliestDataDate.year, 7, 1)
     }
-    // Grid starts on Monday of the week containing halfYearStart
     val gridStart = halfYearStart.with(DayOfWeek.MONDAY)
 
     // Build date -> count map
@@ -654,19 +657,32 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 color = SeekerClawColors.TextDim,
             )
         } else {
-            // Use BoxWithConstraints to calculate cell size that fills available width
+            // Cell size fits ~26 weeks (6 months) on screen; scrolls for longer history
             androidx.compose.foundation.layout.BoxWithConstraints(
                 modifier = Modifier.fillMaxWidth()
             ) {
-                val numWeeks = weeks.size
-                // Cell size = (available width - gaps) / number of weeks
+                val visibleWeeks = 26 // 6 months ≈ 26 weeks
                 val availableWidth = maxWidth
-                val totalGaps = cellGap * (numWeeks - 1)
-                val cellSize = ((availableWidth - totalGaps) / numWeeks).coerceIn(6.dp, 16.dp)
+                val totalGaps = cellGap * (visibleWeeks - 1)
+                val cellSize = ((availableWidth - totalGaps) / visibleWeeks).coerceIn(6.dp, 16.dp)
+
+                val numWeeks = weeks.size
+                val scrollState = rememberScrollState()
+                // Auto-scroll to right (most recent) on first render
+                LaunchedEffect(numWeeks) {
+                    scrollState.scrollTo(scrollState.maxValue)
+                }
 
                 Column {
+                    // Month labels + grid in a single scrollable row
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(scrollState),
+                    ) {
+                    Column {
                     // Month labels
-                    Row(modifier = Modifier.fillMaxWidth()) {
+                    Row {
                         var labelIndex = 0
                         for (weekIndex in weeks.indices) {
                             val colWidth = cellSize + if (weekIndex < numWeeks - 1) cellGap else 0.dp
@@ -714,8 +730,10 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                             Spacer(modifier = Modifier.height(cellGap))
                         }
                     }
-                }
-            }
+                } // Column (labels + grid)
+                } // Row (horizontalScroll)
+                } // Column (scroll container)
+            } // BoxWithConstraints
 
             Spacer(modifier = Modifier.height(12.dp))
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,13 +30,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import com.seekerclaw.app.ui.theme.RethinkSans
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,6 +67,7 @@ import java.time.format.TextStyle
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 private val HeatmapColors = listOf(
@@ -179,8 +185,15 @@ fun SystemScreen(onBack: () -> Unit) {
         // ==================== MESSAGE ACTIVITY ====================
         SectionLabel("Message Activity")
 
+        // Preserve last known activity data even when service stops
+        val lastKnownActivity = remember { mutableStateOf<List<DayActivity>>(emptyList()) }
+        val currentActivity = dbSummary?.dailyActivity ?: emptyList()
+        if (currentActivity.isNotEmpty()) {
+            lastKnownActivity.value = currentActivity
+        }
+
         MessageActivityHeatmap(
-            dailyActivity = dbSummary?.dailyActivity ?: emptyList()
+            dailyActivity = lastKnownActivity.value
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -578,15 +591,11 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val cellShape = RoundedCornerShape(2.dp)
 
     val today = LocalDate.now()
-    // Grid starts from the half-year containing the earliest data (Jan or Jul)
-    // and extends to today. Scroll shows most recent; user can scroll left for history.
-    val earliestDataDate = dailyActivity.firstOrNull()?.let {
-        try { LocalDate.parse(it.day) } catch (_: Exception) { null }
-    } ?: today
-    val halfYearStart = if (earliestDataDate.monthValue <= 6) {
-        LocalDate.of(earliestDataDate.year, 1, 1)
+    // Current half-year anchored to today (Jan-Jun or Jul-Dec)
+    val halfYearStart = if (today.monthValue <= 6) {
+        LocalDate.of(today.year, 1, 1)
     } else {
-        LocalDate.of(earliestDataDate.year, 7, 1)
+        LocalDate.of(today.year, 7, 1)
     }
     val gridStart = halfYearStart.with(DayOfWeek.MONDAY)
 
@@ -627,14 +636,23 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val thresholds = remember(dateCountMap) {
         val nonZero = dateCountMap.values.filter { it > 0 }.sorted()
         if (nonZero.isEmpty()) emptyList()
-        else listOf(
-            nonZero[(nonZero.size * 0.25).toInt().coerceAtMost(nonZero.size - 1)],
-            nonZero[(nonZero.size * 0.50).toInt().coerceAtMost(nonZero.size - 1)],
-            nonZero[(nonZero.size * 0.75).toInt().coerceAtMost(nonZero.size - 1)],
-        )
+        else {
+            val pctThresholds = listOf(
+                nonZero[(nonZero.size * 0.25).toInt().coerceAtMost(nonZero.size - 1)],
+                nonZero[(nonZero.size * 0.50).toInt().coerceAtMost(nonZero.size - 1)],
+                nonZero[(nonZero.size * 0.75).toInt().coerceAtMost(nonZero.size - 1)],
+            )
+            // Fallback: if all thresholds are identical, spread evenly across max
+            if (pctThresholds.distinct().size == 1) {
+                val max = nonZero.last()
+                listOf(max / 4, max / 2, (max * 3) / 4).map { it.coerceAtLeast(1) }
+            } else pctThresholds
+        }
     }
 
-    val totalMessages = remember(dateCountMap) { dateCountMap.values.sum() }
+    val totalMessages = remember(dateCountMap, halfYearStart, halfYearEnd) {
+        dateCountMap.filter { (date, _) -> date in halfYearStart..halfYearEnd }.values.sum()
+    }
 
     // Month labels
     val monthLabels = remember(weeks) {
@@ -654,7 +672,8 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         modifier = Modifier
             .fillMaxWidth()
             .background(SeekerClawColors.Surface, shape)
-            .padding(16.dp),
+            .padding(16.dp)
+            .semantics { contentDescription = "Message activity heatmap showing $totalMessages messages" },
     ) {
         if (dailyActivity.isEmpty() || totalMessages == 0) {
             Text(
@@ -665,7 +684,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             )
         } else {
             // Cell size fits ~26 weeks (6 months) on screen; scrolls for longer history
-            androidx.compose.foundation.layout.BoxWithConstraints(
+            BoxWithConstraints(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 val visibleWeeks = 26 // 6 months ≈ 26 weeks
@@ -676,7 +695,10 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 val numWeeks = weeks.size
                 val scrollState = rememberScrollState()
                 // Auto-scroll to right (most recent) on first render
+                // Wait for layout to complete before scrolling (maxValue is 0 before measurement)
                 LaunchedEffect(numWeeks) {
+                    snapshotFlow { scrollState.maxValue }
+                        .first { it > 0 }
                     scrollState.scrollTo(scrollState.maxValue)
                 }
 
@@ -701,7 +723,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                                     color = SeekerClawColors.TextDim,
                                     modifier = Modifier.widthIn(min = colWidth),
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Visible,
+                                    overflow = TextOverflow.Clip,
                                 )
                                 labelIndex++
                             } else {
@@ -751,12 +773,13 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 val countText = when {
-                    totalMessages >= 1_000_000 -> "${totalMessages / 1_000_000}M+"
-                    totalMessages >= 100_000 -> "${totalMessages / 1_000}K+"
+                    totalMessages >= 1_000_000 -> "%.1fM".format(totalMessages / 1_000_000f)
+                    totalMessages >= 10_000 -> "%.0fK".format(totalMessages / 1_000f)
                     else -> "%,d".format(totalMessages)
                 }
+                val rangeLabel = "${halfYearStart.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)}-${halfYearEnd.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} ${halfYearStart.year}"
                 Text(
-                    text = "$countText msgs in last 6 months",
+                    text = "$countText msgs \u00B7 $rangeLabel",
                     fontFamily = FontFamily.Monospace,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -122,7 +122,9 @@ fun SystemScreen(onBack: () -> Unit) {
             delay(60_000)
         }
     }
-    // Fetch DB summary every 30s while running; clear on stop
+    // Fetch DB summary every 30s while running; one-shot read when stopped so the
+    // Activity heatmap keeps showing the last-written snapshot from disk instead
+    // of going blank. workspace/db_summary_state persists across service stops.
     LaunchedEffect(status) {
         if (status == ServiceStatus.RUNNING) {
             while (true) {
@@ -131,7 +133,7 @@ fun SystemScreen(onBack: () -> Unit) {
                 delay(if (result != null) 30_000L else 5_000L)
             }
         } else {
-            dbSummary = null
+            dbSummary = fetchDbSummary()
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -694,13 +694,8 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
 
                 val numWeeks = weeks.size
                 val scrollState = rememberScrollState()
-                // Auto-scroll to right (most recent) on first render
-                // Wait for layout to complete before scrolling (maxValue is 0 before measurement)
-                LaunchedEffect(numWeeks) {
-                    snapshotFlow { scrollState.maxValue }
-                        .first { it > 0 }
-                    scrollState.scrollTo(scrollState.maxValue)
-                }
+                // Left-aligned by default — shows first month of the half-year.
+                // User swipes left to see future months.
 
                 Column {
                     // Month labels + grid in a single scrollable row

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -2,7 +2,6 @@ package com.seekerclaw.app.ui.system
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -38,7 +37,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import com.seekerclaw.app.ui.theme.RethinkSans
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -61,8 +59,6 @@ import com.seekerclaw.app.util.ServiceStatus
 import com.seekerclaw.app.util.fetchDbSummary
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.format.TextStyle
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -181,6 +177,7 @@ fun SystemScreen(onBack: () -> Unit) {
 
         // ==================== MESSAGE ACTIVITY ====================
         SectionLabel("Activity")
+        Spacer(modifier = Modifier.height(8.dp))
 
         // Preserve last known activity data even when service stops
         val lastKnownActivity = remember { mutableStateOf<List<DayActivity>>(emptyList()) }
@@ -585,18 +582,17 @@ private fun StatCard(
 
 @Composable
 private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
-    val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
     val cellGap = 3.dp
     val cellShape = RoundedCornerShape(3.dp)
 
     val today = LocalDate.now()
-    // Current half-year anchored to today (Jan-Jun or Jul-Dec)
-    val halfYearStart = if (today.monthValue <= 6) {
-        LocalDate.of(today.year, 1, 1)
-    } else {
-        LocalDate.of(today.year, 7, 1)
-    }
-    val gridStart = halfYearStart.with(DayOfWeek.MONDAY)
+    // Rolling 26-week window ending with the current week (GitHub-style).
+    // Grid = Mon of 26 weeks ago → Sun of the current week. Today sits wherever
+    // its weekday falls in the rightmost column; later days in that column stay
+    // blank until the week completes.
+    val currentWeekMonday = today.with(DayOfWeek.MONDAY)
+    val gridStart = currentWeekMonday.minusWeeks(25)
+    val gridEnd = currentWeekMonday.plusDays(6) // Sunday of current week
 
     // Build date -> count map
     val dateCountMap = remember(dailyActivity) {
@@ -609,26 +605,12 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }.toMap()
     }
 
-    // End of current half-year (Jun 30 or Dec 31) — show full 6 months including future
-    val halfYearEnd = if (halfYearStart.monthValue == 1) {
-        LocalDate.of(halfYearStart.year, 6, 30)
-    } else {
-        LocalDate.of(halfYearStart.year, 12, 31)
-    }
-
-    // Build weeks grid: each week = 7 days (Mon-Sun), null for out-of-range
-    val weeks = remember(gridStart, halfYearStart, halfYearEnd) {
-        val result = mutableListOf<List<LocalDate?>>()
-        var current = gridStart
-        while (current <= halfYearEnd) {
-            val week = (0 until 7).map { dow ->
-                val day = current.plusDays(dow.toLong())
-                if (day > halfYearEnd || day < halfYearStart) null else day
-            }
-            result.add(week)
-            current = current.plusWeeks(1)
+    // Build weeks grid: 26 weeks × 7 days (Mon-Sun), every cell a real date.
+    val weeks = remember(gridStart) {
+        (0 until 26).map { weekIndex ->
+            val weekStart = gridStart.plusWeeks(weekIndex.toLong())
+            (0 until 7).map { dow -> weekStart.plusDays(dow.toLong()) }
         }
-        result
     }
 
     // Percentile thresholds from non-zero counts
@@ -649,30 +631,16 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }
     }
 
-    val totalMessages = remember(dateCountMap, halfYearStart, halfYearEnd) {
-        dateCountMap.filter { (date, _) -> date in halfYearStart..halfYearEnd }.values.sumOf { it.toLong() }
+    // All-time total across every day the query returned (database.js caps at
+    // 13 months, which comfortably covers SeekerClaw's entire install history).
+    val totalMessages = remember(dailyActivity) {
+        dailyActivity.sumOf { it.count.toLong() }
     }
 
-    // Month labels
-    val monthLabels = remember(weeks) {
-        val labels = mutableListOf<Pair<Int, String>>()
-        var lastMonth = -1
-        weeks.forEachIndexed { weekIndex, week ->
-            val firstDay = week.firstOrNull { it != null }
-            if (firstDay != null && firstDay.monthValue != lastMonth) {
-                lastMonth = firstDay.monthValue
-                labels.add(weekIndex to firstDay.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
-            }
-        }
-        labels
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SeekerClawColors.Surface, shape)
-            .padding(16.dp)
-            .semantics { contentDescription = "Message activity heatmap showing $totalMessages messages" },
+    CardSurface(
+        modifier = Modifier.semantics {
+            contentDescription = "Message activity heatmap showing $totalMessages messages"
+        },
     ) {
         if (dailyActivity.isEmpty() || totalMessages == 0L) {
             Text(
@@ -682,64 +650,25 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 color = SeekerClawColors.TextDim,
             )
         } else {
-            // Cell size fits ~26 weeks (6 months) on screen; scrolls for longer history
-            BoxWithConstraints(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                val visibleWeeks = 22 // Size cells for ~5 months visible; rest scrolls
-                val availableWidth = maxWidth
-                val totalGaps = cellGap * (visibleWeeks - 1)
-                val cellSize = ((availableWidth - totalGaps) / visibleWeeks).coerceIn(6.dp, 16.dp)
-
+            // Fixed 26-week window — no horizontal scroll. Cells size responsively
+            // within a 6–16dp range; at typical phone widths they land around 10–12dp.
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
                 val numWeeks = weeks.size
-                val scrollState = rememberScrollState()
-                // Left-aligned by default — shows first month of the half-year.
-                // User swipes left to see future months.
+                val availableWidth = maxWidth
+                val totalGaps = cellGap * (numWeeks - 1)
+                val cellSize = ((availableWidth - totalGaps) / numWeeks).coerceIn(6.dp, 16.dp)
 
                 Column {
-                    // Month labels + grid in a single scrollable row
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .horizontalScroll(scrollState),
-                    ) {
-                    Column {
-                    // Month labels
-                    Row {
-                        var labelIndex = 0
-                        for (weekIndex in weeks.indices) {
-                            val colWidth = cellSize + if (weekIndex < numWeeks - 1) cellGap else 0.dp
-                            if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
-                                Box(
-                                    modifier = Modifier.width(colWidth),
-                                    contentAlignment = Alignment.CenterStart,
-                                ) {
-                                    Text(
-                                        text = monthLabels[labelIndex].second,
-                                        fontFamily = FontFamily.Monospace,
-                                        fontSize = 9.sp,
-                                        color = SeekerClawColors.TextDim,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Clip,
-                                    )
-                                }
-                                labelIndex++
-                            } else {
-                                Spacer(modifier = Modifier.width(colWidth))
-                            }
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    // Grid: 7 rows x N weeks
+                    // Grid: 7 rows x 26 weeks
                     for (dayOfWeek in 0..6) {
                         Row {
                             for (weekIndex in weeks.indices) {
-                                val date = weeks[weekIndex].getOrNull(dayOfWeek)
-                                val count = if (date != null) dateCountMap[date] ?: 0 else 0
-                                val color = if (date != null) {
-                                    heatmapColorForCount(count, thresholds)
+                                val date = weeks[weekIndex][dayOfWeek]
+                                // Past + today → normal heatmap color; future days in the
+                                // current week stay blank so "today" is visually the last
+                                // filled cell.
+                                val color = if (date <= today) {
+                                    heatmapColorForCount(dateCountMap[date] ?: 0, thresholds)
                                 } else {
                                     Color.Transparent
                                 }
@@ -757,9 +686,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                             Spacer(modifier = Modifier.height(cellGap))
                         }
                     }
-                } // Column (labels + grid)
-                } // Row (horizontalScroll)
-                } // Column (scroll container)
+                }
             } // BoxWithConstraints
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -775,9 +702,8 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                     totalMessages >= 10_000 -> "%.0fK".format(totalMessages / 1_000f)
                     else -> "%,d".format(totalMessages)
                 }
-                val rangeLabel = "${halfYearStart.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)}-${halfYearEnd.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} ${halfYearStart.year}"
                 Text(
-                    text = "$countText requests \u00B7 $rangeLabel",
+                    text = "$countText requests",
                     fontFamily = FontFamily.Monospace,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -177,7 +177,7 @@ fun SystemScreen(onBack: () -> Unit) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // ==================== MESSAGE ACTIVITY ====================
+        // ==================== ACTIVITY ====================
         SectionLabel("Activity")
         Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -677,17 +677,20 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                     Row {
                         var labelIndex = 0
                         for (weekIndex in weeks.indices) {
+                            val colWidth = cellSize + cellGap
                             if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
-                                // Label spans across week columns — no fixed width constraint
                                 Text(
                                     text = monthLabels[labelIndex].second,
                                     fontFamily = FontFamily.Monospace,
                                     fontSize = 9.sp,
                                     color = SeekerClawColors.TextDim,
-                                    modifier = Modifier.padding(end = 2.dp),
+                                    modifier = Modifier.widthIn(min = colWidth),
                                     maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Visible,
                                 )
                                 labelIndex++
+                            } else {
+                                Spacer(modifier = Modifier.width(colWidth))
                             }
                         }
                     }

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -579,13 +579,15 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val cellShape = RoundedCornerShape(2.dp)
 
     val today = LocalDate.now()
-    // Start from first day of the month containing earliest data
-    val earliestData = dailyActivity.firstOrNull()?.let {
-        try { LocalDate.parse(it.day) } catch (_: Exception) { null }
+    // 6-month half-year chunks: Jan-Jun or Jul-Dec
+    // Current half starts at Jan 1 or Jul 1 of current year
+    val halfYearStart = if (today.monthValue <= 6) {
+        LocalDate.of(today.year, 1, 1)
+    } else {
+        LocalDate.of(today.year, 7, 1)
     }
-    val rangeStart = earliestData?.withDayOfMonth(1) ?: today.minusMonths(1).withDayOfMonth(1)
     // Align start to Monday of that week
-    val startDate = rangeStart.with(DayOfWeek.MONDAY)
+    val startDate = halfYearStart.with(DayOfWeek.MONDAY)
 
     // Build date -> count map
     val dateCountMap = remember(dailyActivity) {
@@ -742,14 +744,8 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Left: total count + earliest date
-                val sinceText = if (earliestDate != null) {
-                    val month = earliestDate.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
-                    val year = earliestDate.year
-                    "%,d messages since $month $year".format(totalMessages)
-                } else {
-                    "%,d messages".format(totalMessages)
-                }
+                // Left: total count
+                val sinceText = "%,d msgs in last 6 months".format(totalMessages)
                 Text(
                     text = sinceText,
                     fontFamily = FontFamily.Monospace,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -574,20 +574,18 @@ private fun StatCard(
 @Composable
 private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
-    val cellSize = 10.dp
     val cellGap = 2.dp
     val cellShape = RoundedCornerShape(2.dp)
 
     val today = LocalDate.now()
     // 6-month half-year chunks: Jan-Jun or Jul-Dec
-    // Current half starts at Jan 1 or Jul 1 of current year
     val halfYearStart = if (today.monthValue <= 6) {
         LocalDate.of(today.year, 1, 1)
     } else {
         LocalDate.of(today.year, 7, 1)
     }
-    // Align start to Monday of that week
-    val startDate = halfYearStart.with(DayOfWeek.MONDAY)
+    // Grid starts on Monday of the week containing halfYearStart
+    val gridStart = halfYearStart.with(DayOfWeek.MONDAY)
 
     // Build date -> count map
     val dateCountMap = remember(dailyActivity) {
@@ -600,19 +598,14 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }.toMap()
     }
 
-    // Build weeks grid: list of weeks, each week = list of 7 days (Mon=0 .. Sun=6)
-    val weeks = remember(startDate, today) {
+    // Build weeks grid: each week = 7 days (Mon-Sun), null for out-of-range
+    val weeks = remember(gridStart, today, halfYearStart) {
         val result = mutableListOf<List<LocalDate?>>()
-        var current = startDate
+        var current = gridStart
         while (current <= today) {
-            val week = mutableListOf<LocalDate?>()
-            for (dow in 0..6) {
+            val week = (0 until 7).map { dow ->
                 val day = current.plusDays(dow.toLong())
-                if (day > today || day < startDate) {
-                    week.add(null)
-                } else {
-                    week.add(day)
-                }
+                if (day > today || day < halfYearStart) null else day
             }
             result.add(week)
             current = current.plusWeeks(1)
@@ -620,26 +613,31 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         result
     }
 
-    // Calculate percentile thresholds from non-zero counts
+    // Percentile thresholds from non-zero counts
     val thresholds = remember(dateCountMap) {
         val nonZero = dateCountMap.values.filter { it > 0 }.sorted()
-        if (nonZero.isEmpty()) {
-            emptyList()
-        } else {
-            listOf(
-                nonZero[(nonZero.size * 0.25).toInt().coerceAtMost(nonZero.size - 1)],
-                nonZero[(nonZero.size * 0.50).toInt().coerceAtMost(nonZero.size - 1)],
-                nonZero[(nonZero.size * 0.75).toInt().coerceAtMost(nonZero.size - 1)],
-            )
-        }
+        if (nonZero.isEmpty()) emptyList()
+        else listOf(
+            nonZero[(nonZero.size * 0.25).toInt().coerceAtMost(nonZero.size - 1)],
+            nonZero[(nonZero.size * 0.50).toInt().coerceAtMost(nonZero.size - 1)],
+            nonZero[(nonZero.size * 0.75).toInt().coerceAtMost(nonZero.size - 1)],
+        )
     }
 
-    // Total message count
     val totalMessages = remember(dateCountMap) { dateCountMap.values.sum() }
 
-    // Earliest date with data
-    val earliestDate = remember(dateCountMap) {
-        dateCountMap.keys.minOrNull()
+    // Month labels
+    val monthLabels = remember(weeks) {
+        val labels = mutableListOf<Pair<Int, String>>()
+        var lastMonth = -1
+        weeks.forEachIndexed { weekIndex, week ->
+            val firstDay = week.firstOrNull { it != null }
+            if (firstDay != null && firstDay.monthValue != lastMonth) {
+                lastMonth = firstDay.monthValue
+                labels.add(weekIndex to firstDay.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
+            }
+        }
+        labels
     }
 
     Column(
@@ -649,7 +647,6 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             .padding(16.dp),
     ) {
         if (dailyActivity.isEmpty() || totalMessages == 0) {
-            // Empty state
             Text(
                 text = "No message data yet",
                 fontFamily = FontFamily.Monospace,
@@ -657,38 +654,22 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 color = SeekerClawColors.TextDim,
             )
         } else {
-            // Month labels along the top
-            val scrollState = rememberScrollState()
-            // Auto-scroll to most recent (right side) on first render
-            LaunchedEffect(weeks.size) {
-                scrollState.scrollTo(scrollState.maxValue)
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(scrollState),
+            // Use BoxWithConstraints to calculate cell size that fills available width
+            androidx.compose.foundation.layout.BoxWithConstraints(
+                modifier = Modifier.fillMaxWidth()
             ) {
-                // Build month label positions
-                val monthLabels = remember(weeks) {
-                    val labels = mutableListOf<Pair<Int, String>>()
-                    var lastMonth = -1
-                    weeks.forEachIndexed { weekIndex, week ->
-                        val firstDay = week.firstOrNull { it != null }
-                        if (firstDay != null && firstDay.monthValue != lastMonth) {
-                            lastMonth = firstDay.monthValue
-                            labels.add(weekIndex to firstDay.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
-                        }
-                    }
-                    labels
-                }
+                val numWeeks = weeks.size
+                // Cell size = (available width - gaps) / number of weeks
+                val availableWidth = maxWidth
+                val totalGaps = cellGap * (numWeeks - 1)
+                val cellSize = ((availableWidth - totalGaps) / numWeeks).coerceIn(6.dp, 16.dp)
 
                 Column {
-                    // Month labels row
-                    Row {
+                    // Month labels
+                    Row(modifier = Modifier.fillMaxWidth()) {
                         var labelIndex = 0
                         for (weekIndex in weeks.indices) {
-                            val colWidth = cellSize + cellGap
+                            val colWidth = cellSize + if (weekIndex < numWeeks - 1) cellGap else 0.dp
                             if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
                                 Text(
                                     text = monthLabels[labelIndex].second,
@@ -708,7 +689,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
 
                     Spacer(modifier = Modifier.height(4.dp))
 
-                    // Grid: 7 rows x N columns
+                    // Grid: 7 rows x N weeks
                     for (dayOfWeek in 0..6) {
                         Row {
                             for (weekIndex in weeks.indices) {
@@ -724,7 +705,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                                         .size(cellSize)
                                         .background(color, cellShape),
                                 )
-                                if (weekIndex < weeks.size - 1) {
+                                if (weekIndex < numWeeks - 1) {
                                     Spacer(modifier = Modifier.width(cellGap))
                                 }
                             }
@@ -744,21 +725,19 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Left: total count (compact: 100K+, 1M+ for large numbers)
                 val countText = when {
                     totalMessages >= 1_000_000 -> "${totalMessages / 1_000_000}M+"
                     totalMessages >= 100_000 -> "${totalMessages / 1_000}K+"
                     else -> "%,d".format(totalMessages)
                 }
-                val sinceText = "$countText msgs in last 6 months"
                 Text(
-                    text = sinceText,
+                    text = "$countText msgs in last 6 months",
                     fontFamily = FontFamily.Monospace,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,
                 )
 
-                // Right: legend
+                // Legend
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         text = "Less",
@@ -767,10 +746,11 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                         color = SeekerClawColors.TextDim,
                     )
                     Spacer(modifier = Modifier.width(4.dp))
+                    val legendSize = 8.dp
                     for (i in HeatmapColors.indices) {
                         Box(
                             modifier = Modifier
-                                .size(cellSize)
+                                .size(legendSize)
                                 .background(HeatmapColors[i], cellShape),
                         )
                         if (i < HeatmapColors.size - 1) {

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -651,7 +650,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     }
 
     val totalMessages = remember(dateCountMap, halfYearStart, halfYearEnd) {
-        dateCountMap.filter { (date, _) -> date in halfYearStart..halfYearEnd }.values.sum()
+        dateCountMap.filter { (date, _) -> date in halfYearStart..halfYearEnd }.values.sumOf { it.toLong() }
     }
 
     // Month labels
@@ -675,7 +674,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             .padding(16.dp)
             .semantics { contentDescription = "Message activity heatmap showing $totalMessages messages" },
     ) {
-        if (dailyActivity.isEmpty() || totalMessages == 0) {
+        if (dailyActivity.isEmpty() || totalMessages == 0L) {
             Text(
                 text = "No message data yet",
                 fontFamily = FontFamily.Monospace,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -711,15 +711,19 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                         for (weekIndex in weeks.indices) {
                             val colWidth = cellSize + if (weekIndex < numWeeks - 1) cellGap else 0.dp
                             if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
-                                Text(
-                                    text = monthLabels[labelIndex].second,
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 9.sp,
-                                    color = SeekerClawColors.TextDim,
-                                    modifier = Modifier.widthIn(min = colWidth),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Clip,
-                                )
+                                Box(
+                                    modifier = Modifier.width(colWidth),
+                                    contentAlignment = Alignment.CenterStart,
+                                ) {
+                                    Text(
+                                        text = monthLabels[labelIndex].second,
+                                        fontFamily = FontFamily.Monospace,
+                                        fontSize = 9.sp,
+                                        color = SeekerClawColors.TextDim,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Clip,
+                                    )
+                                }
                                 labelIndex++
                             } else {
                                 Spacer(modifier = Modifier.width(colWidth))

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -601,14 +601,21 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }.toMap()
     }
 
+    // End of current half-year (Jun 30 or Dec 31) — show full 6 months including future
+    val halfYearEnd = if (halfYearStart.monthValue == 1) {
+        LocalDate.of(halfYearStart.year, 6, 30)
+    } else {
+        LocalDate.of(halfYearStart.year, 12, 31)
+    }
+
     // Build weeks grid: each week = 7 days (Mon-Sun), null for out-of-range
-    val weeks = remember(gridStart, today, halfYearStart) {
+    val weeks = remember(gridStart, halfYearStart, halfYearEnd) {
         val result = mutableListOf<List<LocalDate?>>()
         var current = gridStart
-        while (current <= today) {
+        while (current <= halfYearEnd) {
             val week = (0 until 7).map { dow ->
                 val day = current.plusDays(dow.toLong())
-                if (day > today || day < halfYearStart) null else day
+                if (day > halfYearEnd || day < halfYearStart) null else day
             }
             result.add(week)
             current = current.plusWeeks(1)

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -579,9 +579,13 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val cellShape = RoundedCornerShape(2.dp)
 
     val today = LocalDate.now()
-    val sixMonthsAgo = today.minusMonths(6)
-    // Align start to Monday
-    val startDate = sixMonthsAgo.with(DayOfWeek.MONDAY)
+    // Start from first day of the month containing earliest data
+    val earliestData = dailyActivity.firstOrNull()?.let {
+        try { LocalDate.parse(it.day) } catch (_: Exception) { null }
+    }
+    val rangeStart = earliestData?.withDayOfMonth(1) ?: today.minusMonths(1).withDayOfMonth(1)
+    // Align start to Monday of that week
+    val startDate = rangeStart.with(DayOfWeek.MONDAY)
 
     // Build date -> count map
     val dateCountMap = remember(dailyActivity) {
@@ -653,6 +657,10 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         } else {
             // Month labels along the top
             val scrollState = rememberScrollState()
+            // Auto-scroll to most recent (right side) on first render
+            LaunchedEffect(weeks.size) {
+                scrollState.scrollTo(scrollState.maxValue)
+            }
 
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -2,6 +2,7 @@ package com.seekerclaw.app.ui.system
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import com.seekerclaw.app.ui.theme.RethinkSans
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.seekerclaw.app.BuildConfig
@@ -48,13 +50,37 @@ import com.seekerclaw.app.util.AppStorageInfo
 import com.seekerclaw.app.util.DeviceInfo
 import com.seekerclaw.app.util.DeviceInfoProvider
 import com.seekerclaw.app.util.ApiUsageData
+import com.seekerclaw.app.util.DayActivity
 import com.seekerclaw.app.util.DbSummary
 import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
 import com.seekerclaw.app.util.fetchDbSummary
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+
+private val HeatmapColors = listOf(
+    Color(0xFF1A1A24),
+    Color(0xFF3D1117),
+    Color(0xFF6B1D2A),
+    Color(0xFF8B2232),
+    Color(0xFFE41F28),
+)
+
+private fun heatmapColorForCount(count: Int, thresholds: List<Int>): Color {
+    if (count == 0) return HeatmapColors[0]
+    if (thresholds.isEmpty()) return HeatmapColors[4]
+    return when {
+        count <= thresholds.getOrElse(0) { 1 } -> HeatmapColors[1]
+        count <= thresholds.getOrElse(1) { 2 } -> HeatmapColors[2]
+        count <= thresholds.getOrElse(2) { 5 } -> HeatmapColors[3]
+        else -> HeatmapColors[4]
+    }
+}
 
 @Composable
 fun SystemScreen(onBack: () -> Unit) {
@@ -146,6 +172,15 @@ fun SystemScreen(onBack: () -> Unit) {
             InfoRow("Agent", agentName)
             InfoRow("Uptime", formatUptime(uptime), isLast = true)
         }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // ==================== MESSAGE ACTIVITY ====================
+        SectionLabel("Message Activity")
+
+        MessageActivityHeatmap(
+            dailyActivity = dbSummary?.dailyActivity ?: emptyList()
+        )
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -532,6 +567,213 @@ private fun StatCard(
             fontSize = 11.sp,
             color = SeekerClawColors.TextDim,
         )
+    }
+}
+
+@Composable
+private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
+    val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
+    val cellSize = 10.dp
+    val cellGap = 2.dp
+    val cellShape = RoundedCornerShape(2.dp)
+
+    val today = LocalDate.now()
+    val sixMonthsAgo = today.minusMonths(6)
+    // Align start to Monday
+    val startDate = sixMonthsAgo.with(DayOfWeek.MONDAY)
+
+    // Build date -> count map
+    val dateCountMap = remember(dailyActivity) {
+        dailyActivity.associate { activity ->
+            try {
+                LocalDate.parse(activity.day) to activity.count
+            } catch (_: Exception) {
+                null
+            }
+        }.filterKeys { it != null }.mapKeys { it.key!! }
+    }
+
+    // Build weeks grid: list of weeks, each week = list of 7 days (Mon=0 .. Sun=6)
+    val weeks = remember(startDate, today) {
+        val result = mutableListOf<List<LocalDate?>>()
+        var current = startDate
+        while (current <= today) {
+            val week = mutableListOf<LocalDate?>()
+            for (dow in 0..6) {
+                val day = current.plusDays(dow.toLong())
+                if (day > today || day < startDate) {
+                    week.add(null)
+                } else {
+                    week.add(day)
+                }
+            }
+            result.add(week)
+            current = current.plusWeeks(1)
+        }
+        result
+    }
+
+    // Calculate percentile thresholds from non-zero counts
+    val thresholds = remember(dateCountMap) {
+        val nonZero = dateCountMap.values.filter { it > 0 }.sorted()
+        if (nonZero.isEmpty()) {
+            emptyList()
+        } else {
+            listOf(
+                nonZero[(nonZero.size * 0.25).toInt().coerceAtMost(nonZero.size - 1)],
+                nonZero[(nonZero.size * 0.50).toInt().coerceAtMost(nonZero.size - 1)],
+                nonZero[(nonZero.size * 0.75).toInt().coerceAtMost(nonZero.size - 1)],
+            )
+        }
+    }
+
+    // Total message count
+    val totalMessages = remember(dateCountMap) { dateCountMap.values.sum() }
+
+    // Earliest date with data
+    val earliestDate = remember(dateCountMap) {
+        dateCountMap.keys.minOrNull()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(SeekerClawColors.Surface, shape)
+            .padding(16.dp),
+    ) {
+        if (dailyActivity.isEmpty()) {
+            // Empty state
+            Text(
+                text = "No message data yet",
+                fontFamily = FontFamily.Monospace,
+                fontSize = 11.sp,
+                color = SeekerClawColors.TextDim,
+            )
+        } else {
+            // Month labels along the top
+            val scrollState = rememberScrollState()
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(scrollState),
+            ) {
+                // Build month label positions
+                val monthLabels = remember(weeks) {
+                    val labels = mutableListOf<Pair<Int, String>>()
+                    var lastMonth = -1
+                    weeks.forEachIndexed { weekIndex, week ->
+                        val firstDay = week.firstOrNull { it != null }
+                        if (firstDay != null && firstDay.monthValue != lastMonth) {
+                            lastMonth = firstDay.monthValue
+                            labels.add(weekIndex to firstDay.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
+                        }
+                    }
+                    labels
+                }
+
+                Column {
+                    // Month labels row
+                    Row {
+                        var labelIndex = 0
+                        for (weekIndex in weeks.indices) {
+                            if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
+                                Text(
+                                    text = monthLabels[labelIndex].second,
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 9.sp,
+                                    color = SeekerClawColors.TextDim,
+                                    modifier = Modifier.width(cellSize + cellGap),
+                                )
+                                labelIndex++
+                            } else {
+                                Spacer(modifier = Modifier.width(cellSize + cellGap))
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    // Grid: 7 rows x N columns
+                    for (dayOfWeek in 0..6) {
+                        Row {
+                            for (weekIndex in weeks.indices) {
+                                val date = weeks[weekIndex].getOrNull(dayOfWeek)
+                                val count = if (date != null) dateCountMap[date] ?: 0 else 0
+                                val color = if (date != null) {
+                                    heatmapColorForCount(count, thresholds)
+                                } else {
+                                    Color.Transparent
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .size(cellSize)
+                                        .background(color, cellShape),
+                                )
+                                if (weekIndex < weeks.size - 1) {
+                                    Spacer(modifier = Modifier.width(cellGap))
+                                }
+                            }
+                        }
+                        if (dayOfWeek < 6) {
+                            Spacer(modifier = Modifier.height(cellGap))
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Footer
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Left: total count + earliest date
+                val sinceText = if (earliestDate != null) {
+                    val month = earliestDate.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
+                    val year = earliestDate.year
+                    "%,d messages since $month $year".format(totalMessages)
+                } else {
+                    "%,d messages".format(totalMessages)
+                }
+                Text(
+                    text = sinceText,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 11.sp,
+                    color = SeekerClawColors.TextDim,
+                )
+
+                // Right: legend
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Less",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                        color = SeekerClawColors.TextDim,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    for (i in HeatmapColors.indices) {
+                        Box(
+                            modifier = Modifier
+                                .size(cellSize)
+                                .background(HeatmapColors[i], cellShape),
+                        )
+                        if (i < HeatmapColors.size - 1) {
+                            Spacer(modifier = Modifier.width(2.dp))
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "More",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                        color = SeekerClawColors.TextDim,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -584,13 +584,13 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
 
     // Build date -> count map
     val dateCountMap = remember(dailyActivity) {
-        dailyActivity.associate { activity ->
+        dailyActivity.mapNotNull { activity ->
             try {
                 LocalDate.parse(activity.day) to activity.count
             } catch (_: Exception) {
                 null
             }
-        }.filterKeys { it != null }.mapKeys { it.key!! }
+        }.toMap()
     }
 
     // Build weeks grid: list of weeks, each week = list of 7 days (Mon=0 .. Sun=6)
@@ -641,7 +641,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             .background(SeekerClawColors.Surface, shape)
             .padding(16.dp),
     ) {
-        if (dailyActivity.isEmpty()) {
+        if (dailyActivity.isEmpty() || totalMessages == 0) {
             // Empty state
             Text(
                 text = "No message data yet",
@@ -678,16 +678,16 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                         var labelIndex = 0
                         for (weekIndex in weeks.indices) {
                             if (labelIndex < monthLabels.size && monthLabels[labelIndex].first == weekIndex) {
+                                // Label spans across week columns — no fixed width constraint
                                 Text(
                                     text = monthLabels[labelIndex].second,
                                     fontFamily = FontFamily.Monospace,
                                     fontSize = 9.sp,
                                     color = SeekerClawColors.TextDim,
-                                    modifier = Modifier.width(cellSize + cellGap),
+                                    modifier = Modifier.padding(end = 2.dp),
+                                    maxLines = 1,
                                 )
                                 labelIndex++
-                            } else {
-                                Spacer(modifier = Modifier.width(cellSize + cellGap))
                             }
                         }
                     }

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -67,7 +66,6 @@ import java.time.format.TextStyle
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 private val HeatmapColors = listOf(
@@ -188,8 +186,10 @@ fun SystemScreen(onBack: () -> Unit) {
         // Preserve last known activity data even when service stops
         val lastKnownActivity = remember { mutableStateOf<List<DayActivity>>(emptyList()) }
         val currentActivity = dbSummary?.dailyActivity ?: emptyList()
-        if (currentActivity.isNotEmpty()) {
-            lastKnownActivity.value = currentActivity
+        LaunchedEffect(currentActivity) {
+            if (currentActivity.isNotEmpty()) {
+                lastKnownActivity.value = currentActivity
+            }
         }
 
         MessageActivityHeatmap(

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -71,7 +71,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 private val HeatmapColors = listOf(
-    Color(0xFF1A1A24),
+    Color(0xFF252530),  // Level 0: visible empty cell (subtle but clear grid structure)
     Color(0xFF3D1117),
     Color(0xFF6B1D2A),
     Color(0xFF8B2232),
@@ -587,8 +587,8 @@ private fun StatCard(
 @Composable
 private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
-    val cellGap = 2.dp
-    val cellShape = RoundedCornerShape(2.dp)
+    val cellGap = 3.dp
+    val cellShape = RoundedCornerShape(3.dp)
 
     val today = LocalDate.now()
     // Current half-year anchored to today (Jan-Jun or Jul-Dec)
@@ -687,7 +687,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             BoxWithConstraints(
                 modifier = Modifier.fillMaxWidth()
             ) {
-                val visibleWeeks = 26 // 6 months ≈ 26 weeks
+                val visibleWeeks = 22 // Size cells for ~5 months visible; rest scrolls
                 val availableWidth = maxWidth
                 val totalGaps = cellGap * (visibleWeeks - 1)
                 val cellSize = ((availableWidth - totalGaps) / visibleWeeks).coerceIn(6.dp, 16.dp)

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -744,8 +744,13 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Left: total count
-                val sinceText = "%,d msgs in last 6 months".format(totalMessages)
+                // Left: total count (compact: 100K+, 1M+ for large numbers)
+                val countText = when {
+                    totalMessages >= 1_000_000 -> "${totalMessages / 1_000_000}M+"
+                    totalMessages >= 100_000 -> "${totalMessages / 1_000}K+"
+                    else -> "%,d".format(totalMessages)
+                }
+                val sinceText = "$countText msgs in last 6 months"
                 Text(
                     text = sinceText,
                     fontFamily = FontFamily.Monospace,

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -652,42 +651,35 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         } else {
             // Fixed 26-week window — no horizontal scroll. Cells size responsively
             // within a 6–16dp range; at typical phone widths they land around 10–12dp.
-            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                val numWeeks = weeks.size
-                val availableWidth = maxWidth
-                val totalGaps = cellGap * (numWeeks - 1)
-                val cellSize = ((availableWidth - totalGaps) / numWeeks).coerceIn(6.dp, 16.dp)
-
-                Column {
-                    // Grid: 7 rows x 26 weeks
-                    for (dayOfWeek in 0..6) {
-                        Row {
-                            for (weekIndex in weeks.indices) {
-                                val date = weeks[weekIndex][dayOfWeek]
-                                // Past + today → normal heatmap color; future days in the
-                                // current week stay blank so "today" is visually the last
-                                // filled cell.
-                                val color = if (date <= today) {
-                                    heatmapColorForCount(dateCountMap[date] ?: 0, thresholds)
-                                } else {
-                                    Color.Transparent
-                                }
-                                Box(
-                                    modifier = Modifier
-                                        .size(cellSize)
-                                        .background(color, cellShape),
-                                )
-                                if (weekIndex < numWeeks - 1) {
-                                    Spacer(modifier = Modifier.width(cellGap))
-                                }
+            // Grid: 7 rows × 26 weeks. Weighted cells + spacedBy arrangement let
+            // Compose distribute the exact available width — no manual rounding,
+            // no right-edge clipping. aspectRatio(1f) keeps cells square.
+            Column(verticalArrangement = Arrangement.spacedBy(cellGap)) {
+                for (dayOfWeek in 0..6) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(cellGap),
+                    ) {
+                        for (weekIndex in weeks.indices) {
+                            val date = weeks[weekIndex][dayOfWeek]
+                            // Past + today → normal heatmap color; future days in the
+                            // current week stay blank so "today" is visually the last
+                            // filled cell.
+                            val color = if (date <= today) {
+                                heatmapColorForCount(dateCountMap[date] ?: 0, thresholds)
+                            } else {
+                                Color.Transparent
                             }
-                        }
-                        if (dayOfWeek < 6) {
-                            Spacer(modifier = Modifier.height(cellGap))
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .aspectRatio(1f)
+                                    .background(color, cellShape),
+                            )
                         }
                     }
                 }
-            } // BoxWithConstraints
+            }
 
             Spacer(modifier = Modifier.height(12.dp))
 

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -3,6 +3,7 @@ package com.seekerclaw.app.ui.system
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
@@ -49,14 +49,16 @@ suspend fun fetchDbSummary(): DbSummary? = withContext(Dispatchers.IO) {
         val memory = if (json.has("memory") && !json.isNull("memory")) json.getJSONObject("memory") else null
 
         val dailyActivityList = mutableListOf<DayActivity>()
-        if (json.has("dailyActivity") && !json.isNull("dailyActivity")) {
-            val arr = json.getJSONArray("dailyActivity")
-            for (i in 0 until arr.length()) {
-                val item = arr.getJSONObject(i)
-                dailyActivityList.add(DayActivity(
-                    day = item.optString("day", ""),
-                    count = item.optInt("count", 0)
-                ))
+        val dailyArr = json.optJSONArray("dailyActivity")
+        if (dailyArr != null) {
+            for (i in 0 until dailyArr.length()) {
+                try {
+                    val item = dailyArr.getJSONObject(i)
+                    dailyActivityList.add(DayActivity(
+                        day = item.optString("day", ""),
+                        count = item.optInt("count", 0)
+                    ))
+                } catch (_: Exception) { /* skip malformed entries */ }
             }
         }
 

--- a/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
@@ -58,7 +58,7 @@ suspend fun fetchDbSummary(): DbSummary? = withContext(Dispatchers.IO) {
                         day = item.optString("day", ""),
                         count = item.optInt("count", 0)
                     ))
-                } catch (_: Exception) { /* skip malformed entries */ }
+                } catch (_: org.json.JSONException) { /* skip malformed entries */ }
             }
         }
 

--- a/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/StatsClient.kt
@@ -15,6 +15,8 @@ private const val TAG = "StatsClient"
  * Used by DashboardScreen and SystemScreen for API analytics (BAT-32),
  * and by the memory index UI for memory stats (BAT-33).
  */
+data class DayActivity(val day: String, val count: Int)
+
 data class DbSummary(
     val todayRequests: Int = 0,
     val todayInputTokens: Long = 0,
@@ -29,6 +31,7 @@ data class DbSummary(
     val memoryFilesIndexed: Int = 0,
     val memoryChunksCount: Int = 0,
     val memoryLastIndexed: String? = null,
+    val dailyActivity: List<DayActivity> = emptyList(),
 )
 
 suspend fun fetchDbSummary(): DbSummary? = withContext(Dispatchers.IO) {
@@ -45,6 +48,18 @@ suspend fun fetchDbSummary(): DbSummary? = withContext(Dispatchers.IO) {
         val month = if (json.has("month") && !json.isNull("month")) json.getJSONObject("month") else null
         val memory = if (json.has("memory") && !json.isNull("memory")) json.getJSONObject("memory") else null
 
+        val dailyActivityList = mutableListOf<DayActivity>()
+        if (json.has("dailyActivity") && !json.isNull("dailyActivity")) {
+            val arr = json.getJSONArray("dailyActivity")
+            for (i in 0 until arr.length()) {
+                val item = arr.getJSONObject(i)
+                dailyActivityList.add(DayActivity(
+                    day = item.optString("day", ""),
+                    count = item.optInt("count", 0)
+                ))
+            }
+        }
+
         DbSummary(
             todayRequests = today?.optInt("requests", 0) ?: 0,
             todayInputTokens = today?.optLong("input_tokens", 0) ?: 0,
@@ -60,6 +75,7 @@ suspend fun fetchDbSummary(): DbSummary? = withContext(Dispatchers.IO) {
             memoryChunksCount = memory?.optInt("chunks_count", 0) ?: 0,
             memoryLastIndexed = if (memory != null && memory.has("last_indexed") && !memory.isNull("last_indexed"))
                 memory.getString("last_indexed") else null,
+            dailyActivity = dailyActivityList,
         )
     } catch (e: Exception) {
         if (e is kotlinx.coroutines.CancellationException) throw e


### PR DESCRIPTION
## Summary
- GitHub-style contribution heatmap showing messages per day over 6 months
- DarkOps red color scale (5 levels, percentile-based thresholds)
- Located on System screen below Status section
- Total message count + "Less/More" legend
- Piggybacks on existing `db_summary_state` IPC — no new files, no new polling

## Architecture
- **Node.js:** New `getDailyActivity()` SQL query in database.js, result added to `db_summary_state` JSON
- **Kotlin:** `DayActivity` data class + `DbSummary.dailyActivity` field in StatsClient.kt
- **Compose:** `MessageActivityHeatmap` composable in SystemScreen.kt

## Test plan
- [x] JS syntax check passed
- [ ] Build and install on device
- [ ] Open System screen — heatmap visible below Status
- [ ] Verify color scale reflects actual message activity
- [ ] Verify month labels align correctly
- [ ] Verify total count matches expected
- [ ] Verify empty state (new user)

DO NOT MERGE — device test required first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)