### PR TITLE
feat: OpenAI Codex OAuth — ChatGPT subscription auth (BAT-485)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         applicationId = "com.seekerclaw.app"
         minSdk = 34
         targetSdk = 35
-        versionCode = 15
+        versionCode = 16
         versionName = "1.8.0"
 
         // Keep these in sync when updating OpenClaw or nodejs-mobile

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,6 +248,9 @@ dependencies {
     // NanoHTTPD for Android Bridge (Node.js <-> Kotlin IPC)
     implementation("org.nanohttpd:nanohttpd:2.3.1")
 
+    // Custom Tabs for OAuth browser flows
+    implementation("androidx.browser:browser:1.8.0")
+
     // Solana Mobile Wallet Adapter
     implementation("com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.0.3")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,11 @@
             android:exported="false" />
 
         <activity
+            android:name=".oauth.OpenAIOAuthActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="false" />
+
+        <activity
             android:name=".camera.CameraCaptureActivity"
             android:theme="@style/Theme.SeekerClaw"
             android:excludeFromRecents="true"

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2001,7 +2001,7 @@ async function chat(chatId, userMessage, options = {}) {
             }
 
             // BAT-315: Parse response through adapter into neutral format
-            log(`[OAuth-Debug] res.status=${res.status}, data keys=${Object.keys(res.data || {}).join(',')}, data.output=${JSON.stringify((res.data?.output || res.data?.response?.output || []).map(i => ({t: i.type, c: !!i.content})).slice(0,3))}`, 'WARN');
+            log(`[OAuth-Debug] res.status=${res.status}, output=${JSON.stringify((res.data?.response?.output || res.data?.output || []).slice(0,2)).slice(0,500)}`, 'WARN');
             const parsed = adapter.fromApiResponse(res.data);
             log(`[OAuth-Debug] parsed: text=${!!parsed.text}, tools=${parsed.toolCalls?.length}, stop=${parsed.stopReason}`, 'WARN');
             // Keep raw response for fallback text extraction later

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2001,7 +2001,9 @@ async function chat(chatId, userMessage, options = {}) {
             }
 
             // BAT-315: Parse response through adapter into neutral format
+            log(`[OAuth-Debug] res.status=${res.status}, data keys=${Object.keys(res.data || {}).join(',')}, data.output=${JSON.stringify((res.data?.output || res.data?.response?.output || []).map(i => ({t: i.type, c: !!i.content})).slice(0,3))}`, 'WARN');
             const parsed = adapter.fromApiResponse(res.data);
+            log(`[OAuth-Debug] parsed: text=${!!parsed.text}, tools=${parsed.toolCalls?.length}, stop=${parsed.stopReason}`, 'WARN');
             // Keep raw response for fallback text extraction later
             response = res.data;
             response._parsed = parsed;

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1193,8 +1193,6 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
                     method: 'POST',
                     headers,
                 }, body);
-
-                // Codex diagnostic: dump raw response shape
             } catch (networkErr) {
                 const attemptEnd = Date.now();
                 timeoutSource = networkErr.timeoutSource || 'network_error';

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1193,6 +1193,8 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
                     method: 'POST',
                     headers,
                 }, body);
+
+                // Codex diagnostic: dump raw response shape
             } catch (networkErr) {
                 const attemptEnd = Date.now();
                 timeoutSource = networkErr.timeoutSource || 'network_error';

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1261,6 +1261,12 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
             if (res.status !== 200) {
                 const errClass = classifyApiError(res.status, res.data);
                 if (errClass.retryable && retries < MAX_RETRIES) {
+                    // OAuth 401: refresh token before retry so the next attempt uses new credentials
+                    if (errClass.type === 'auth' && typeof getAdapter(PROVIDER).handleUnauthorized === 'function') {
+                        try { await getAdapter(PROVIDER).handleUnauthorized(); } catch (e) {
+                            if (!e.retryable) { log(`[Retry] OAuth refresh failed, not retrying: ${e.message}`, 'ERROR'); break; }
+                        }
+                    }
                     const retryAfterRaw = parseInt(res.headers?.['retry-after']) || 0;
                     const retryAfterMs = Math.min(retryAfterRaw * 1000, 30000);
                     // Cloudflare errors use longer backoff (5s, 10s, 20s)

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2001,9 +2001,7 @@ async function chat(chatId, userMessage, options = {}) {
             }
 
             // BAT-315: Parse response through adapter into neutral format
-            log(`[OAuth-Debug] res.status=${res.status}, output=${JSON.stringify((res.data?.response?.output || res.data?.output || []).slice(0,2)).slice(0,500)}`, 'WARN');
             const parsed = adapter.fromApiResponse(res.data);
-            log(`[OAuth-Debug] parsed: text=${!!parsed.text}, tools=${parsed.toolCalls?.length}, stop=${parsed.stopReason}`, 'WARN');
             // Keep raw response for fallback text extraction later
             response = res.data;
             response._parsed = parsed;

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -120,6 +120,7 @@ const OPENAI_KEY = normalizeSecret(config.openaiApiKey || '');
 const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
 const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
 const OPENAI_OAUTH_EMAIL = (config.openaiOAuthEmail || '').trim();
+const AUTH_TYPE = config.authType || 'api_key';
 
 // OpenAI auth type: 'oauth' if OAuth token present and authType matches, else 'api_key'
 const OPENAI_AUTH_TYPE = (AUTH_TYPE === 'oauth' && OPENAI_OAUTH_TOKEN) ? 'oauth' : 'api_key';
@@ -132,7 +133,6 @@ const CUSTOM_FORMAT = (typeof config.customFormat === 'string' ? config.customFo
 const OPENROUTER_FALLBACK_MODEL = (typeof config.openrouterFallbackModel === 'string' ? config.openrouterFallbackModel : '').trim();
 const OPENROUTER_MODEL_CONTEXT = parseInt(config.openrouterModelContext, 10) || 0;
 const OPENROUTER_FALLBACK_CONTEXT = parseInt(config.openrouterFallbackContext, 10) || 0;
-const AUTH_TYPE = config.authType || 'api_key';
 const _defaultModel = PROVIDER === 'openai' ? 'gpt-5.2'
     : PROVIDER === 'openrouter' ? 'anthropic/claude-sonnet-4-6'
     : PROVIDER === 'custom' ? ''
@@ -193,8 +193,8 @@ const MCP_SERVERS = (config.mcpServers || [])
     .filter((server) => server && typeof server === 'object' && server.url);
 
 // Validate: channel token required per channel; API key required for active provider only
-// For OpenAI: OAuth token is a valid alternative to API key
-const _activeKey = PROVIDER === 'openai' ? (OPENAI_KEY || OPENAI_OAUTH_TOKEN)
+// For OpenAI: validate based on effective auth type (api_key needs API key, oauth needs OAuth token)
+const _activeKey = PROVIDER === 'openai' ? (OPENAI_AUTH_TYPE === 'oauth' ? OPENAI_OAUTH_TOKEN : OPENAI_KEY)
     : PROVIDER === 'openrouter' ? OPENROUTER_KEY
     : PROVIDER === 'custom' ? CUSTOM_KEY
     : ANTHROPIC_KEY;

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -119,11 +119,20 @@ const ANTHROPIC_KEY = normalizeSecret(config.anthropicApiKey);
 const OPENAI_KEY = normalizeSecret(config.openaiApiKey || '');
 const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
 const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
-const AUTH_TYPE = config.authType || 'api_key';
 
-// OpenAI auth type strictly follows the configured authType — no silent fallback to api_key
-// when the OAuth token is missing. The credential validation below will fail fast and
-// surface a clear error instead of accidentally charging the user's platform API key.
+// Normalize authType (trim/lowercase) so values like " OAuth\n" don't silently fall
+// through to api_key. For OpenAI, fail fast on unsupported values rather than risking
+// an accidental charge to the user's platform API key.
+const _SUPPORTED_OPENAI_AUTH_TYPES = new Set(['api_key', 'oauth']);
+const _rawAuthType = typeof config.authType === 'string' ? config.authType.trim().toLowerCase() : '';
+const AUTH_TYPE = _rawAuthType || 'api_key';
+
+if (PROVIDER === 'openai' && !_SUPPORTED_OPENAI_AUTH_TYPES.has(AUTH_TYPE)) {
+    throw new Error(`Invalid OpenAI authType: ${JSON.stringify(config.authType)}. Supported values are "api_key" and "oauth".`);
+}
+
+// OpenAI auth type strictly follows the (normalized, validated) authType — no silent
+// fallback. The credential validation below will fail fast on missing OAuth token.
 const OPENAI_AUTH_TYPE = AUTH_TYPE === 'oauth' ? 'oauth' : 'api_key';
 
 const OPENROUTER_KEY = normalizeSecret(config.openrouterApiKey || '');

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -119,7 +119,6 @@ const ANTHROPIC_KEY = normalizeSecret(config.anthropicApiKey);
 const OPENAI_KEY = normalizeSecret(config.openaiApiKey || '');
 const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
 const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
-const OPENAI_OAUTH_EMAIL = (config.openaiOAuthEmail || '').trim();
 const AUTH_TYPE = config.authType || 'api_key';
 
 // OpenAI auth type: 'oauth' if OAuth token present and authType matches, else 'api_key'
@@ -512,7 +511,7 @@ module.exports = {
     PROVIDER,
     ANTHROPIC_KEY,
     OPENAI_KEY,
-    OPENAI_OAUTH_TOKEN, OPENAI_OAUTH_REFRESH, OPENAI_OAUTH_EMAIL, OPENAI_AUTH_TYPE,
+    OPENAI_OAUTH_TOKEN, OPENAI_OAUTH_REFRESH, OPENAI_AUTH_TYPE,
     OPENROUTER_KEY,
     CUSTOM_KEY,
     CUSTOM_BASE_URL,

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -121,8 +121,10 @@ const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
 const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
 const AUTH_TYPE = config.authType || 'api_key';
 
-// OpenAI auth type: 'oauth' if OAuth token present and authType matches, else 'api_key'
-const OPENAI_AUTH_TYPE = (AUTH_TYPE === 'oauth' && OPENAI_OAUTH_TOKEN) ? 'oauth' : 'api_key';
+// OpenAI auth type strictly follows the configured authType — no silent fallback to api_key
+// when the OAuth token is missing. The credential validation below will fail fast and
+// surface a clear error instead of accidentally charging the user's platform API key.
+const OPENAI_AUTH_TYPE = AUTH_TYPE === 'oauth' ? 'oauth' : 'api_key';
 
 const OPENROUTER_KEY = normalizeSecret(config.openrouterApiKey || '');
 const CUSTOM_KEY = normalizeSecret(config.customApiKey || '');

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -121,11 +121,22 @@ const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
 const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
 
 // Normalize authType (trim/lowercase) so values like " OAuth\n" don't silently fall
-// through to api_key. For OpenAI, fail fast on unsupported values rather than risking
-// an accidental charge to the user's platform API key.
+// through to api_key. For OpenAI, alias known legacy values (e.g. "setup_token" left
+// over from when the user was on Anthropic) to "api_key" so older installs don't
+// hard-crash on startup. Truly unknown values still throw to prevent accidentally
+// charging the user's platform API key.
 const _SUPPORTED_OPENAI_AUTH_TYPES = new Set(['api_key', 'oauth']);
+const _LEGACY_OPENAI_AUTH_TYPE_ALIASES = new Map([
+    ['setup_token', 'api_key'],
+]);
 const _rawAuthType = typeof config.authType === 'string' ? config.authType.trim().toLowerCase() : '';
-const AUTH_TYPE = _rawAuthType || 'api_key';
+let AUTH_TYPE = _rawAuthType || 'api_key';
+
+if (PROVIDER === 'openai' && _LEGACY_OPENAI_AUTH_TYPE_ALIASES.has(AUTH_TYPE)) {
+    const aliased = _LEGACY_OPENAI_AUTH_TYPE_ALIASES.get(AUTH_TYPE);
+    log(`[Config] Normalizing legacy OpenAI authType ${JSON.stringify(config.authType)} → ${JSON.stringify(aliased)}`, 'WARN');
+    AUTH_TYPE = aliased;
+}
 
 if (PROVIDER === 'openai' && !_SUPPORTED_OPENAI_AUTH_TYPES.has(AUTH_TYPE)) {
     throw new Error(`Invalid OpenAI authType: ${JSON.stringify(config.authType)}. Supported values are "api_key" and "oauth".`);

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -117,6 +117,13 @@ const _rawProvider = (typeof config.provider === 'string' && config.provider.tri
 const PROVIDER = _SUPPORTED_PROVIDERS.has(_rawProvider) ? _rawProvider : 'claude';
 const ANTHROPIC_KEY = normalizeSecret(config.anthropicApiKey);
 const OPENAI_KEY = normalizeSecret(config.openaiApiKey || '');
+const OPENAI_OAUTH_TOKEN = normalizeSecret(config.openaiOAuthToken || '');
+const OPENAI_OAUTH_REFRESH = normalizeSecret(config.openaiOAuthRefresh || '');
+const OPENAI_OAUTH_EMAIL = (config.openaiOAuthEmail || '').trim();
+
+// OpenAI auth type: 'oauth' if OAuth token present and authType matches, else 'api_key'
+const OPENAI_AUTH_TYPE = (AUTH_TYPE === 'oauth' && OPENAI_OAUTH_TOKEN) ? 'oauth' : 'api_key';
+
 const OPENROUTER_KEY = normalizeSecret(config.openrouterApiKey || '');
 const CUSTOM_KEY = normalizeSecret(config.customApiKey || '');
 const CUSTOM_BASE_URL = (typeof config.customBaseUrl === 'string' ? config.customBaseUrl : '').trim();
@@ -186,7 +193,8 @@ const MCP_SERVERS = (config.mcpServers || [])
     .filter((server) => server && typeof server === 'object' && server.url);
 
 // Validate: channel token required per channel; API key required for active provider only
-const _activeKey = PROVIDER === 'openai' ? OPENAI_KEY
+// For OpenAI: OAuth token is a valid alternative to API key
+const _activeKey = PROVIDER === 'openai' ? (OPENAI_KEY || OPENAI_OAUTH_TOKEN)
     : PROVIDER === 'openrouter' ? OPENROUTER_KEY
     : PROVIDER === 'custom' ? CUSTOM_KEY
     : ANTHROPIC_KEY;
@@ -199,7 +207,7 @@ if (CHANNEL === 'discord' && !DISCORD_TOKEN) {
     process.exit(1);
 }
 if (!_activeKey) {
-    const keyName = PROVIDER === 'openai' ? 'openaiApiKey'
+    const keyName = PROVIDER === 'openai' ? 'openaiApiKey or openaiOAuthToken'
         : PROVIDER === 'openrouter' ? 'openrouterApiKey'
         : PROVIDER === 'custom' ? 'customApiKey'
         : 'anthropicApiKey';
@@ -504,6 +512,7 @@ module.exports = {
     PROVIDER,
     ANTHROPIC_KEY,
     OPENAI_KEY,
+    OPENAI_OAUTH_TOKEN, OPENAI_OAUTH_REFRESH, OPENAI_OAUTH_EMAIL, OPENAI_AUTH_TYPE,
     OPENROUTER_KEY,
     CUSTOM_KEY,
     CUSTOM_BASE_URL,

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -306,6 +306,12 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
 
+                    // Debug: log unhandled SSE event types
+                    const _knownEvents = new Set(['response.output_item.added','response.output_text.delta','response.function_call_arguments.delta','response.completed','response.incomplete','error','response.created','response.in_progress','response.output_item.done','response.content_part.added','response.content_part.done','response.output_text.done','response.function_call_arguments.done','response.refusal.delta','response.refusal.done']);
+                    if (!_knownEvents.has(eventType) && eventType) {
+                        log('[SSE] Unknown event type: ' + eventType + ' data: ' + eventData.slice(0, 200), 'WARN');
+                    }
+
                     switch (eventType) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -376,10 +376,11 @@ function httpOpenAIStreamingRequest(options, body = null) {
                         settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });
                     } else if (parsedEventCount === 0 && sseBuffer.length > 0) {
                         // We assumed SSE (Codex header-less case) but the body never produced
-                        // a single parseable SSE event. Surface a clearer diagnostic so the
-                        // failure mode is obvious instead of a generic transport error.
-                        const preview = sseBuffer.slice(0, 200).replace(/\s+/g, ' ');
-                        const err = new Error(`Expected SSE but no events parsed (body preview: ${preview})`);
+                        // a single parseable SSE event. Keep the error message generic so
+                        // arbitrary response-body content isn't embedded into err.message
+                        // (which ai.js logs verbatim).
+                        console.warn(`[http] Expected SSE but no events parsed (${sseBuffer.length} bytes); body preview: ${sseBuffer.slice(0, 200).replace(/\s+/g, ' ')}`);
+                        const err = new Error('Expected SSE but no events parsed');
                         err.timeoutSource = 'transport';
                         settle(reject, err);
                     } else {

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -235,10 +235,11 @@ function httpOpenAIStreamingRequest(options, body = null) {
         try {
         req = getClient(options).request(options, (res) => {
             const ct = res.headers['content-type'] || '';
-            // Codex endpoint (chatgpt.com) sometimes streams SSE without a Content-Type header.
-            // Only assume SSE-without-header when Content-Type is actually missing/blank — if
-            // Codex ever returns a JSON/HTML body with a real Content-Type, fall through to
-            // the buffered-response branch instead of mis-parsing it as SSE.
+            // Codex endpoint (chatgpt.com) sometimes streams SSE without a Content-Type
+            // header. We treat 200-from-chatgpt.com-without-CT as SSE on faith; if Codex
+            // ever returns a non-SSE 200 with an empty Content-Type, the SSE parser below
+            // tracks parsedEventCount and throws a clear "looked like SSE but no events
+            // parsed" error at end-of-stream rather than the generic "Stream ended" one.
             const isCodexHost = options.hostname === 'chatgpt.com';
             const isSSE = ct.includes('text/event-stream') ||
                 (res.statusCode === 200 && isCodexHost && ct.trim() === '');
@@ -264,6 +265,7 @@ function httpOpenAIStreamingRequest(options, body = null) {
             const funcArgAccum = {}; // output_index → accumulated arguments string
             let accumulatedUsage = null;
             let sseBuffer = '';
+            let parsedEventCount = 0; // tracks successful SSE event parses for end-of-stream diagnostics
 
             // Build response from accumulated deltas (fallback path)
             const buildFromAccum = () => {
@@ -312,6 +314,7 @@ function httpOpenAIStreamingRequest(options, body = null) {
 
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
+                    parsedEventCount++;
 
                     switch (eventType) {
                         case 'response.output_item.added':
@@ -371,6 +374,14 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     // Stream ended without response.completed — build from accumulated deltas
                     if (Object.keys(outputItems).length > 0) {
                         settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });
+                    } else if (parsedEventCount === 0 && sseBuffer.length > 0) {
+                        // We assumed SSE (Codex header-less case) but the body never produced
+                        // a single parseable SSE event. Surface a clearer diagnostic so the
+                        // failure mode is obvious instead of a generic transport error.
+                        const preview = sseBuffer.slice(0, 200).replace(/\s+/g, ' ');
+                        const err = new Error(`Expected SSE but no events parsed (body preview: ${preview})`);
+                        err.timeoutSource = 'transport';
+                        settle(reject, err);
                     } else {
                         const err = new Error('Stream ended before response.completed');
                         err.timeoutSource = 'transport';

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -235,8 +235,13 @@ function httpOpenAIStreamingRequest(options, body = null) {
         try {
         req = getClient(options).request(options, (res) => {
             const ct = res.headers['content-type'] || '';
-            // Codex endpoint (chatgpt.com) doesn't send Content-Type header but streams SSE
-            const isSSE = ct.includes('text/event-stream') || (res.statusCode === 200 && options.hostname === 'chatgpt.com');
+            // Codex endpoint (chatgpt.com) sometimes streams SSE without a Content-Type header.
+            // Only assume SSE-without-header when Content-Type is actually missing/blank — if
+            // Codex ever returns a JSON/HTML body with a real Content-Type, fall through to
+            // the buffered-response branch instead of mis-parsing it as SSE.
+            const isCodexHost = options.hostname === 'chatgpt.com';
+            const isSSE = ct.includes('text/event-stream') ||
+                (res.statusCode === 200 && isCodexHost && ct.trim() === '');
             if (res.statusCode !== 200 || !isSSE) {
                 res.setEncoding('utf8');
                 let data = '';

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -313,7 +313,6 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
 
-
                     switch (eventType) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -250,6 +250,8 @@ function httpOpenAIStreamingRequest(options, body = null) {
                 return;
             }
 
+            log(`[HTTP-SSE] SSE stream opened: ${options.hostname}${options.path} Content-Type: ${ct}`, 'DEBUG');
+
             // Responses API SSE accumulators (fallback if stream disconnects)
             res.setEncoding('utf8');
             const outputItems = {};  // output_index → item skeleton
@@ -367,6 +369,7 @@ function httpOpenAIStreamingRequest(options, body = null) {
             res.on('end', () => {
                 clearTimeout(hardTimer);
                 if (!settled) {
+                    log(`[HTTP-SSE] Stream ended without response.completed. Items: ${Object.keys(outputItems).length}, Text keys: ${Object.keys(textAccum).length}, Accum text: ${JSON.stringify(textAccum).slice(0, 200)}`, 'WARN');
                     // Stream ended without response.completed — build from accumulated deltas
                     if (Object.keys(outputItems).length > 0) {
                         settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -235,7 +235,9 @@ function httpOpenAIStreamingRequest(options, body = null) {
         try {
         req = getClient(options).request(options, (res) => {
             const ct = res.headers['content-type'] || '';
-            if (res.statusCode !== 200 || !ct.includes('text/event-stream')) {
+            // Codex endpoint (chatgpt.com) doesn't send Content-Type header but streams SSE
+            const isSSE = ct.includes('text/event-stream') || (res.statusCode === 200 && options.hostname === 'chatgpt.com');
+            if (res.statusCode !== 200 || !isSSE) {
                 res.setEncoding('utf8');
                 let data = '';
                 res.on('data', chunk => data += chunk);
@@ -305,6 +307,7 @@ function httpOpenAIStreamingRequest(options, body = null) {
 
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
+
 
                     switch (eventType) {
                         case 'response.output_item.added':

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -8,7 +8,7 @@ const https = require('https');
 function getClient(options) {
     return options?.protocol === 'http:' ? http : https;
 }
-const { API_TIMEOUT_MS, log } = require('./config');
+const { API_TIMEOUT_MS } = require('./config');
 
 // BAT-244: timeout is configurable via options.timeout (ms). Defaults to API_TIMEOUT_MS from config.
 function httpRequest(options, body = null) {
@@ -250,8 +250,6 @@ function httpOpenAIStreamingRequest(options, body = null) {
                 return;
             }
 
-            log(`[HTTP-SSE] SSE stream opened: ${options.hostname}${options.path} Content-Type: ${ct}`, 'DEBUG');
-
             // Responses API SSE accumulators (fallback if stream disconnects)
             res.setEncoding('utf8');
             const outputItems = {};  // output_index → item skeleton
@@ -308,12 +306,6 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
 
-                    // Debug: log unhandled SSE event types
-                    const _knownEvents = new Set(['response.output_item.added','response.output_text.delta','response.function_call_arguments.delta','response.completed','response.incomplete','error','response.created','response.in_progress','response.output_item.done','response.content_part.added','response.content_part.done','response.output_text.done','response.function_call_arguments.done','response.refusal.delta','response.refusal.done']);
-                    if (!_knownEvents.has(eventType) && eventType) {
-                        log('[SSE] Unknown event type: ' + eventType + ' data: ' + eventData.slice(0, 200), 'WARN');
-                    }
-
                     switch (eventType) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {
@@ -369,7 +361,6 @@ function httpOpenAIStreamingRequest(options, body = null) {
             res.on('end', () => {
                 clearTimeout(hardTimer);
                 if (!settled) {
-                    log(`[HTTP-SSE] Stream ended without response.completed. Items: ${Object.keys(outputItems).length}, Text keys: ${Object.keys(textAccum).length}, Accum text: ${JSON.stringify(textAccum).slice(0, 200)}`, 'WARN');
                     // Stream ended without response.completed — build from accumulated deltas
                     if (Object.keys(outputItems).length > 0) {
                         settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -8,7 +8,7 @@ const https = require('https');
 function getClient(options) {
     return options?.protocol === 'http:' ? http : https;
 }
-const { API_TIMEOUT_MS } = require('./config');
+const { API_TIMEOUT_MS, log } = require('./config');
 
 // BAT-244: timeout is configurable via options.timeout (ms). Defaults to API_TIMEOUT_MS from config.
 function httpRequest(options, body = null) {

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -214,8 +214,10 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         input,
     };
 
-    // Responses API uses max_tokens (not max_output_tokens)
-    body.max_tokens = maxTokens;
+    // Codex endpoint manages token limits via subscription — don't set max_tokens
+    if (!isOAuth) {
+        body.max_tokens = maxTokens;
+    }
 
     if (tools && tools.length > 0) {
         body.tools = tools;

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -126,6 +126,12 @@ function fromApiResponse(raw) {
     // Handle nested response object (from response.completed event)
     const resp = raw.response || raw;
 
+    // Debug: log raw response structure for troubleshooting
+    if (isOAuth) {
+        log('[OpenAI-OAuth] Response keys: ' + Object.keys(resp).join(', '), 'DEBUG');
+        if (resp.output) log('[OpenAI-OAuth] Output items: ' + JSON.stringify(resp.output.map(i => ({ type: i.type, role: i.role })).slice(0, 5)), 'DEBUG');
+    }
+
     const textParts = [];
     const toolCalls = [];
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -223,10 +223,7 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         body.tools = tools;
     }
 
-    // OAuth (Codex endpoint) requires store: false — conversations cannot be stored
-    if (isOAuth) {
-        body.store = false;
-    }
+    // Codex endpoint: don't set store parameter (let server decide)
 
     // Codex models are reasoning models — they need the reasoning parameter for tool calling.
     if (model && model.includes('codex')) {

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -220,10 +220,7 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         input,
     };
 
-    // Codex endpoint manages token limits via subscription — don't set max_tokens
-    if (!isOAuth) {
-        body.max_tokens = maxTokens;
-    }
+    body.max_output_tokens = maxTokens;
 
     if (tools && tools.length > 0) {
         body.tools = tools;
@@ -258,10 +255,15 @@ let _currentRefreshToken = OPENAI_OAUTH_REFRESH;
 
 function buildHeaders(apiKey) {
     const token = isOAuth ? _currentOAuthToken : apiKey;
-    return {
+    const headers = {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
     };
+    // Codex backend needs Accept header for SSE streaming
+    if (isOAuth) {
+        headers['Accept'] = 'text/event-stream';
+    }
+    return headers;
 }
 
 // ── Streaming ───────────────────────────────────────────────────────────────

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -239,6 +239,7 @@ const endpoint = {
 };
 
 let _currentOAuthToken = OPENAI_OAUTH_TOKEN;
+let _currentRefreshToken = OPENAI_OAUTH_REFRESH;
 
 function buildHeaders(apiKey) {
     const token = isOAuth ? _currentOAuthToken : apiKey;
@@ -263,8 +264,10 @@ function classifyError(status, data) {
     if (status === 401 || status === 403) {
         // OAuth 401s may be retryable after token refresh — caller must call handleUnauthorized()
         return {
-            type: 'auth', retryable: isOAuth && status === 401 && !!OPENAI_OAUTH_REFRESH,
-            userMessage: '🔑 Can\'t reach the AI — OpenAI API key might be wrong. Check Settings?'
+            type: 'auth', retryable: isOAuth && status === 401 && !!_currentRefreshToken,
+            userMessage: isOAuth
+                ? '🔐 Can\'t reach the AI — your OpenAI sign-in may have expired. Please reconnect OpenAI in Settings and try again.'
+                : '🔑 Can\'t reach the AI — OpenAI API key might be wrong. Check Settings?'
         };
     }
     if (status === 402) {
@@ -309,7 +312,7 @@ function classifyError(status, data) {
  * or rethrows non-retryable error on refresh failure.
  */
 async function handleUnauthorized() {
-    if (isOAuth && OPENAI_OAUTH_REFRESH) {
+    if (isOAuth && _currentRefreshToken) {
         log('[OpenAI] OAuth 401 — attempting token refresh...', 'INFO');
         try {
             await refreshOAuthToken();
@@ -404,7 +407,7 @@ async function refreshOAuthToken() {
     const body = new URLSearchParams({
         grant_type: 'refresh_token',
         client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
-        refresh_token: OPENAI_OAUTH_REFRESH,
+        refresh_token: _currentRefreshToken,
     }).toString();
 
     return new Promise((resolve, reject) => {
@@ -425,10 +428,11 @@ async function refreshOAuthToken() {
                     const parsed = JSON.parse(data);
                     if (parsed.access_token) {
                         _currentOAuthToken = parsed.access_token;
+                        if (parsed.refresh_token) _currentRefreshToken = parsed.refresh_token;
                         // Persist via bridge
                         androidBridgeCall('/openai/oauth/save-tokens', {
                             accessToken: parsed.access_token,
-                            refreshToken: parsed.refresh_token || OPENAI_OAUTH_REFRESH,
+                            refreshToken: parsed.refresh_token || _currentRefreshToken,
                             expiresAt: new Date(Date.now() + (parsed.expires_in || 28800) * 1000).toISOString(),
                         }).catch(e => log('[OpenAI] Failed to persist refreshed tokens: ' + e.message, 'WARN'));
                         resolve(true);

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -326,18 +326,21 @@ function classifyError(status, data) {
  * or rethrows non-retryable error on refresh failure.
  */
 async function handleUnauthorized() {
-    if (isOAuth && _currentRefreshToken) {
-        log('[OpenAI] OAuth 401 — attempting token refresh...', 'INFO');
-        try {
-            await refreshOAuthToken();
-            log('[OpenAI] Token refreshed — caller should retry', 'INFO');
-            const retryError = new Error('OAuth token refreshed — retry');
-            retryError.retryable = true;
-            throw retryError;
-        } catch (e) {
-            if (e.retryable) throw e;
-            log('[OpenAI] OAuth refresh failed: ' + e.message, 'ERROR');
-        }
+    if (!(isOAuth && _currentRefreshToken)) return;
+    log('[OpenAI] OAuth 401 — attempting token refresh...', 'INFO');
+    try {
+        await refreshOAuthToken();
+        log('[OpenAI] Token refreshed — caller should retry', 'INFO');
+        const retryError = new Error('OAuth token refreshed — retry');
+        retryError.retryable = true;
+        throw retryError;
+    } catch (e) {
+        if (e.retryable) throw e;
+        // Refresh failed — make sure caller stops retrying with the dead token.
+        log('[OpenAI] OAuth refresh failed: ' + e.message, 'ERROR');
+        const fatal = new Error('OAuth token refresh failed: ' + e.message);
+        fatal.retryable = false;
+        throw fatal;
     }
 }
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -226,7 +226,10 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
     }
 
     if (tools && tools.length > 0) {
-        body.tools = tools;
+        // TEMP: skip tools for OAuth to test if model responds without them
+        if (!isOAuth) {
+            body.tools = tools;
+        }
     }
 
     // OAuth (Codex endpoint) requires store: false — conversations cannot be stored
@@ -235,7 +238,8 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
     }
 
     // Codex models are reasoning models — they need the reasoning parameter for tool calling.
-    if (model && model.includes('codex')) {
+    // Skip for OAuth until we confirm basic responses work
+    if (model && model.includes('codex') && !isOAuth) {
         body.reasoning = { effort: 'medium', summary: 'auto' };
     }
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -220,7 +220,10 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         input,
     };
 
-    body.max_output_tokens = maxTokens;
+    // Codex endpoint rejects max_output_tokens — subscription manages limits
+    if (!isOAuth) {
+        body.max_output_tokens = maxTokens;
+    }
 
     if (tools && tools.length > 0) {
         body.tools = tools;

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -219,6 +219,11 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         body.tools = tools;
     }
 
+    // OAuth (Codex endpoint) requires store: false — conversations cannot be stored
+    if (isOAuth) {
+        body.store = false;
+    }
+
     // Codex models are reasoning models — they need the reasoning parameter for tool calling.
     if (model && model.includes('codex')) {
         body.reasoning = { effort: 'medium', summary: 'auto' };

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -4,7 +4,8 @@
 // All OpenAI models route through the Responses API — future-proof
 // as OpenAI transitions away from Chat Completions.
 
-const { log } = require('../config');
+const { log, OPENAI_OAUTH_TOKEN, OPENAI_OAUTH_REFRESH, OPENAI_AUTH_TYPE } = require('../config');
+const { androidBridgeCall } = require('../bridge');
 
 // ── Neutral ↔ OpenAI Responses API message translation ──────────────────────
 
@@ -228,12 +229,22 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
 
 // ── Connection details ──────────────────────────────────────────────────────
 
-const endpoint = { hostname: 'api.openai.com', path: '/v1/responses' };
+const isOAuth = OPENAI_AUTH_TYPE === 'oauth';
+const CODEX_API_HOST = 'chatgpt.com';
+const CODEX_API_PATH = '/backend-api/codex/responses';
+
+const endpoint = {
+    hostname: isOAuth ? CODEX_API_HOST : 'api.openai.com',
+    path: isOAuth ? CODEX_API_PATH : '/v1/responses',
+};
+
+let _currentOAuthToken = OPENAI_OAUTH_TOKEN;
 
 function buildHeaders(apiKey) {
+    const token = isOAuth ? _currentOAuthToken : apiKey;
     return {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
+        'Authorization': `Bearer ${token}`,
     };
 }
 
@@ -250,8 +261,9 @@ const streamProtocol = 'openai-responses';
 
 function classifyError(status, data) {
     if (status === 401 || status === 403) {
+        // OAuth 401s may be retryable after token refresh — caller must call handleUnauthorized()
         return {
-            type: 'auth', retryable: false,
+            type: 'auth', retryable: isOAuth && status === 401 && !!OPENAI_OAUTH_REFRESH,
             userMessage: '🔑 Can\'t reach the AI — OpenAI API key might be wrong. Check Settings?'
         };
     }
@@ -288,6 +300,28 @@ function classifyError(status, data) {
             ? `API error (${status}): ${reason.trim()}`
             : `Unexpected API error (${status}). Please try again.`
     };
+}
+
+/**
+ * Handle OAuth 401: attempt token refresh and signal retryable.
+ * Call this when classifyError returns { retryable: true } on a 401.
+ * Throws an error with retryable=true on success (caller retries),
+ * or rethrows non-retryable error on refresh failure.
+ */
+async function handleUnauthorized() {
+    if (isOAuth && OPENAI_OAUTH_REFRESH) {
+        log('[OpenAI] OAuth 401 — attempting token refresh...', 'INFO');
+        try {
+            await refreshOAuthToken();
+            log('[OpenAI] Token refreshed — caller should retry', 'INFO');
+            const retryError = new Error('OAuth token refreshed — retry');
+            retryError.retryable = true;
+            throw retryError;
+        } catch (e) {
+            if (e.retryable) throw e;
+            log('[OpenAI] OAuth refresh failed: ' + e.message, 'ERROR');
+        }
+    }
 }
 
 function classifyNetworkError(err) {
@@ -363,6 +397,56 @@ function formatVision(base64, mediaType) {
 
 const testEndpoint = { hostname: 'api.openai.com', path: '/v1/models', method: 'GET' };
 
+// ── OAuth token refresh ─────────────────────────────────────────────────────
+
+async function refreshOAuthToken() {
+    const https = require('https');
+    const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
+        refresh_token: OPENAI_OAUTH_REFRESH,
+    }).toString();
+
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'auth.openai.com',
+            path: '/oauth/token',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Length': Buffer.byteLength(body),
+            },
+            timeout: 15000,
+        }, (res) => {
+            let data = '';
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+                try {
+                    const parsed = JSON.parse(data);
+                    if (parsed.access_token) {
+                        _currentOAuthToken = parsed.access_token;
+                        // Persist via bridge
+                        androidBridgeCall('/openai/oauth/save-tokens', {
+                            accessToken: parsed.access_token,
+                            refreshToken: parsed.refresh_token || OPENAI_OAUTH_REFRESH,
+                            expiresAt: new Date(Date.now() + (parsed.expires_in || 28800) * 1000).toISOString(),
+                        }).catch(e => log('[OpenAI] Failed to persist refreshed tokens: ' + e.message, 'WARN'));
+                        resolve(true);
+                    } else {
+                        reject(new Error(parsed.error_description || parsed.error || 'Token refresh failed'));
+                    }
+                } catch (e) {
+                    reject(new Error('Failed to parse refresh response'));
+                }
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('Refresh timeout')); });
+        req.write(body);
+        req.end();
+    });
+}
+
 // ── Export adapter ──────────────────────────────────────────────────────────
 
 module.exports = {
@@ -386,10 +470,15 @@ module.exports = {
     // Error & usage
     classifyError,
     classifyNetworkError,
+    handleUnauthorized,
     normalizeUsage,
     parseRateLimitHeaders,
 
+    // OAuth
+    refreshOAuthToken,
+    isOAuth,
+
     // Capabilities
     supportsCache: false,
-    authTypes: ['api_key'],
+    authTypes: ['api_key', 'oauth'],
 };

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -447,23 +447,31 @@ async function refreshOAuthToken() {
             let data = '';
             res.on('data', chunk => data += chunk);
             res.on('end', () => {
-                try {
-                    const parsed = JSON.parse(data);
-                    if (parsed.access_token) {
-                        _currentOAuthToken = parsed.access_token;
-                        if (parsed.refresh_token) _currentRefreshToken = parsed.refresh_token;
-                        // Persist via bridge
-                        androidBridgeCall('/openai/oauth/save-tokens', {
-                            accessToken: parsed.access_token,
-                            refreshToken: parsed.refresh_token || _currentRefreshToken,
-                            expiresAt: new Date(Date.now() + (parsed.expires_in || 28800) * 1000).toISOString(),
-                        }).catch(e => log('[OpenAI] Failed to persist refreshed tokens: ' + e.message, 'WARN'));
-                        resolve(true);
-                    } else {
-                        reject(new Error(parsed.error_description || parsed.error || 'Token refresh failed'));
-                    }
-                } catch (e) {
-                    reject(new Error('Failed to parse refresh response'));
+                const status = res.statusCode || 0;
+                let parsed = null;
+                try { parsed = JSON.parse(data); } catch (_) { /* non-JSON body */ }
+
+                if (parsed && parsed.access_token) {
+                    _currentOAuthToken = parsed.access_token;
+                    if (parsed.refresh_token) _currentRefreshToken = parsed.refresh_token;
+                    // Persist via bridge
+                    androidBridgeCall('/openai/oauth/save-tokens', {
+                        accessToken: parsed.access_token,
+                        refreshToken: parsed.refresh_token || _currentRefreshToken,
+                        expiresAt: new Date(Date.now() + (parsed.expires_in || 28800) * 1000).toISOString(),
+                    }).catch(e => log('[OpenAI] Failed to persist refreshed tokens: ' + e.message, 'WARN'));
+                    resolve(true);
+                    return;
+                }
+
+                if (parsed) {
+                    // JSON error response — surface error_description/error verbatim.
+                    reject(new Error(`Token refresh failed (HTTP ${status}): ${parsed.error_description || parsed.error || 'unknown'}`));
+                } else {
+                    // Non-JSON body (HTML/empty/5xx page). Truncate to avoid log spam and
+                    // never include credentials — refresh request body is not echoed back.
+                    const truncated = (data || '').slice(0, 200).replace(/\s+/g, ' ');
+                    reject(new Error(`Token refresh failed (HTTP ${status}): non-JSON response: ${truncated}`));
                 }
             });
         });

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -454,12 +454,17 @@ async function refreshOAuthToken() {
                 if (parsed && parsed.access_token) {
                     _currentOAuthToken = parsed.access_token;
                     if (parsed.refresh_token) _currentRefreshToken = parsed.refresh_token;
-                    // Persist via bridge
+                    // Persist via bridge. androidBridgeCall always resolves — even on
+                    // error — so check the resolved value rather than relying on .catch.
                     androidBridgeCall('/openai/oauth/save-tokens', {
                         accessToken: parsed.access_token,
                         refreshToken: parsed.refresh_token || _currentRefreshToken,
                         expiresAt: new Date(Date.now() + (parsed.expires_in || 28800) * 1000).toISOString(),
-                    }).catch(e => log('[OpenAI] Failed to persist refreshed tokens: ' + e.message, 'WARN'));
+                    }).then(result => {
+                        if (result && result.error) {
+                            log('[OpenAI] Failed to persist refreshed tokens: ' + result.error, 'WARN');
+                        }
+                    });
                     resolve(true);
                     return;
                 }

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -126,12 +126,6 @@ function fromApiResponse(raw) {
     // Handle nested response object (from response.completed event)
     const resp = raw.response || raw;
 
-    // Trace: log response structure (WARN level so it always shows)
-    if (isOAuth) {
-        log('[OpenAI-OAuth] fromApiResponse called. Keys: ' + Object.keys(resp).join(', ') + ', output count: ' + (resp.output?.length || 0), 'WARN');
-        if (resp.output) log('[OpenAI-OAuth] Output types: ' + JSON.stringify(resp.output.map(i => ({ type: i.type, hasContent: !!i.content })).slice(0, 5)), 'WARN');
-    }
-
     const textParts = [];
     const toolCalls = [];
 
@@ -226,10 +220,7 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
     }
 
     if (tools && tools.length > 0) {
-        // TEMP: skip tools for OAuth to test if model responds without them
-        if (!isOAuth) {
-            body.tools = tools;
-        }
+        body.tools = tools;
     }
 
     // OAuth (Codex endpoint) requires store: false — conversations cannot be stored
@@ -238,8 +229,7 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
     }
 
     // Codex models are reasoning models — they need the reasoning parameter for tool calling.
-    // Skip for OAuth until we confirm basic responses work
-    if (model && model.includes('codex') && !isOAuth) {
+    if (model && model.includes('codex')) {
         body.reasoning = { effort: 'medium', summary: 'auto' };
     }
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -7,6 +7,12 @@
 const { log, OPENAI_OAUTH_TOKEN, OPENAI_OAUTH_REFRESH, OPENAI_AUTH_TYPE } = require('../config');
 const { androidBridgeCall } = require('../bridge');
 
+// Codex CLI public OAuth client id. Must stay in sync with
+// app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt:CLIENT_ID
+// (the Node side never initiates an OAuth flow — only refreshes — so duplication
+// is preferable to plumbing the value through the Android bridge.)
+const OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+
 // ── Neutral ↔ OpenAI Responses API message translation ──────────────────────
 
 /**
@@ -423,7 +429,7 @@ async function refreshOAuthToken() {
     const https = require('https');
     const body = new URLSearchParams({
         grant_type: 'refresh_token',
-        client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
+        client_id: OAUTH_CLIENT_ID,
         refresh_token: _currentRefreshToken,
     }).toString();
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -210,10 +210,12 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
     const body = {
         model,
         stream: true,
-        max_output_tokens: maxTokens,
         instructions: typeof instructions === 'string' ? instructions : (instructions?.content || String(instructions)),
         input,
     };
+
+    // Responses API uses max_tokens (not max_output_tokens)
+    body.max_tokens = maxTokens;
 
     if (tools && tools.length > 0) {
         body.tools = tools;

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -126,6 +126,12 @@ function fromApiResponse(raw) {
     // Handle nested response object (from response.completed event)
     const resp = raw.response || raw;
 
+    // Diagnostic: dump raw response shape for Codex debugging
+    if (isOAuth) {
+        const outputSummary = (resp.output || []).map(i => i?.type || 'unknown');
+        log('[Codex] output types: ' + JSON.stringify(outputSummary) + ' | raw keys: ' + Object.keys(resp).join(','), 'WARN');
+    }
+
     const textParts = [];
     const toolCalls = [];
 
@@ -223,7 +229,10 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         body.tools = tools;
     }
 
-    // Codex endpoint: don't set store parameter (let server decide)
+    // Codex endpoint requires store: false
+    if (isOAuth) {
+        body.store = false;
+    }
 
     // Codex models are reasoning models — they need the reasoning parameter for tool calling.
     if (model && model.includes('codex')) {

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -126,10 +126,10 @@ function fromApiResponse(raw) {
     // Handle nested response object (from response.completed event)
     const resp = raw.response || raw;
 
-    // Debug: log raw response structure for troubleshooting
+    // Trace: log response structure (WARN level so it always shows)
     if (isOAuth) {
-        log('[OpenAI-OAuth] Response keys: ' + Object.keys(resp).join(', '), 'DEBUG');
-        if (resp.output) log('[OpenAI-OAuth] Output items: ' + JSON.stringify(resp.output.map(i => ({ type: i.type, role: i.role })).slice(0, 5)), 'DEBUG');
+        log('[OpenAI-OAuth] fromApiResponse called. Keys: ' + Object.keys(resp).join(', ') + ', output count: ' + (resp.output?.length || 0), 'WARN');
+        if (resp.output) log('[OpenAI-OAuth] Output types: ' + JSON.stringify(resp.output.map(i => ({ type: i.type, hasContent: !!i.content })).slice(0, 5)), 'WARN');
     }
 
     const textParts = [];

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -126,12 +126,6 @@ function fromApiResponse(raw) {
     // Handle nested response object (from response.completed event)
     const resp = raw.response || raw;
 
-    // Diagnostic: dump raw response shape for Codex debugging
-    if (isOAuth) {
-        const outputSummary = (resp.output || []).map(i => i?.type || 'unknown');
-        log('[Codex] output types: ' + JSON.stringify(outputSummary) + ' | raw keys: ' + Object.keys(resp).join(','), 'WARN');
-    }
-
     const textParts = [];
     const toolCalls = [];
 
@@ -229,7 +223,7 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         body.tools = tools;
     }
 
-    // Codex endpoint requires store: false
+    // OAuth (Codex endpoint) requires store: false — conversations cannot be stored
     if (isOAuth) {
         body.store = false;
     }

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -169,6 +169,9 @@ function wrapExternalContent(content, source) {
 // Wrap search result text fields with untrusted content markers
 function wrapSearchResults(result, provider) {
     if (!result) return result;
+    // Surface the resolved provider so the agent can tell the user which search
+    // backend actually ran (especially when called with provider:"auto").
+    result.provider = provider;
     const src = `web_search: ${provider}`;
     // Wrap Perplexity answer
     if (typeof result.answer === 'string') {

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -694,7 +694,7 @@ class AndroidBridge(
                 context, config.copy(
                     openaiOAuthToken = accessToken,
                     openaiOAuthRefresh = if (refreshToken.isNotBlank()) refreshToken else config.openaiOAuthRefresh,
-                    openaiOAuthExpiresAt = expiresAt,
+                    openaiOAuthExpiresAt = if (expiresAt.isNotBlank()) expiresAt else config.openaiOAuthExpiresAt,
                 )
             )
             jsonResponse(200, mapOf("success" to true))

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -699,7 +699,13 @@ class AndroidBridge(
             )
             jsonResponse(200, mapOf("success" to true))
         } catch (e: Exception) {
-            jsonResponse(500, mapOf("error" to (e.message ?: "Unknown error")))
+            // Log full details locally; never echo internal exception messages
+            // back across the bridge boundary.
+            Log.w(TAG, "Failed to save OpenAI OAuth tokens", e)
+            jsonResponse(500, mapOf(
+                "error" to "Failed to save OpenAI OAuth tokens",
+                "code" to "OPENAI_OAUTH_SAVE_FAILED",
+            ))
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -58,6 +58,7 @@ class AndroidBridge(
         "/contacts/search" to Pair(20, 60_000L),
         "/contacts/add" to Pair(10, 60_000L),
         "/location" to Pair(10, 60_000L),
+        "/openai/oauth/save-tokens" to Pair(5, 60_000L),
     )
 
     @Synchronized
@@ -143,6 +144,7 @@ class AndroidBridge(
                 "/solana/sign-only" -> handleSolanaSignOnly(params)
                 "/solana/send" -> handleSolanaSend(params)
                 "/config/save-owner" -> handleConfigSaveOwner(params)
+                "/openai/oauth/save-tokens" -> handleOpenAIOAuthSaveTokens(params)
                 "/stats/db-summary" -> proxyToNodeStats()
                 "/ping" -> jsonResponse(200, mapOf("status" to "ok", "bridge" to "AndroidBridge"))
                 else -> jsonResponse(404, mapOf("error" to "Unknown endpoint: $uri"))
@@ -673,6 +675,31 @@ class AndroidBridge(
             jsonResponse(200, mapOf("success" to true))
         } else {
             jsonResponse(500, mapOf("error" to "Failed to persist owner ID"))
+        }
+    }
+
+    // ==================== OpenAI OAuth ====================
+
+    private fun handleOpenAIOAuthSaveTokens(params: JSONObject): Response {
+        val accessToken = params.optString("accessToken", "")
+        val refreshToken = params.optString("refreshToken", "")
+        val expiresAt = params.optString("expiresAt", "")
+        if (accessToken.isBlank()) {
+            return jsonResponse(400, mapOf("error" to "accessToken required"))
+        }
+        return try {
+            val config = ConfigManager.loadConfig(context)
+                ?: return jsonResponse(500, mapOf("error" to "config not loaded"))
+            ConfigManager.saveConfig(
+                context, config.copy(
+                    openaiOAuthToken = accessToken,
+                    openaiOAuthRefresh = if (refreshToken.isNotBlank()) refreshToken else config.openaiOAuthRefresh,
+                    openaiOAuthExpiresAt = expiresAt,
+                )
+            )
+            jsonResponse(200, mapOf("success" to true))
+        } catch (e: Exception) {
+            jsonResponse(500, mapOf("error" to (e.message ?: "Unknown error")))
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -142,24 +142,23 @@ object ConfigManager {
         // doesn't hard-crash on older installs and the UI doesn't drift from persisted
         // state. Rules:
         //  - OpenAI only supports "api_key" or "oauth".
-        //  - OpenAI + "oauth" requires a non-blank token; otherwise normalize to "api_key"
-        //    (Keystore invalidation, data restore, or manual clear leaves a stale state).
         //  - Non-Claude providers can't use "setup_token".
-        // Persistence is gated on `normalized != raw`: in steady state (no drift) this
-        // is a no-op so loadConfig() doesn't write anything. If drift recurs later in
-        // the process (e.g. token decrypt starts failing mid-run), we catch it on the
-        // next load and re-persist — no process-lifetime flag.
+        //
+        // Note: we do NOT flip oauth → api_key just because the token is currently
+        // blank. The "oauth selected, sign-in pending" state is a legitimate UI state
+        // — flipping it on every loadConfig would silently revert the user's choice
+        // when they return from a failed/canceled sign-in. The unstartable
+        // oauth+blank-token combination is instead handled at workspace/config.json
+        // write time (writeConfigJson) so Node never sees it.
         val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
         val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
-        val openaiTokenBlank = openaiOAuthToken.isBlank()
         val normalized = when {
-            provider == "openai" && raw == "oauth" && openaiTokenBlank -> "api_key"
             provider == "openai" && raw != "oauth" && raw != "api_key" -> "api_key"
             provider != "claude" && raw == "setup_token" -> "api_key"
             else -> raw
         }
         if (normalized != raw) {
-            Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider, tokenBlank=$openaiTokenBlank)")
+            Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider)")
             p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
         }
         return normalized
@@ -719,7 +718,16 @@ object ConfigManager {
             put("botToken", config.telegramBotToken)
             put("ownerId", config.telegramOwnerId)
             put("anthropicApiKey", if (config.provider in listOf("openai", "openrouter", "custom")) "" else config.activeCredential)
-            put("authType", config.authType)
+            // For OpenAI: if user has selected oauth but hasn't completed sign-in (token
+            // is blank), write api_key to the workspace JSON so Node's strict validation
+            // doesn't crash on startup. The UI keeps the user's intended "oauth" choice
+            // in SharedPreferences so the OAuth section remains visible.
+            val effectiveAuthType = if (
+                config.provider == "openai" &&
+                config.authType == "oauth" &&
+                config.openaiOAuthToken.isBlank()
+            ) "api_key" else config.authType
+            put("authType", effectiveAuthType)
             put("provider", config.provider)
             put("model", config.model)
             put("agentName", config.agentName)

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -731,7 +731,7 @@ object ConfigManager {
         if (config.channel == "telegram" && config.telegramBotToken.isBlank()) return "missing_bot_token"
         if (config.channel == "discord" && config.discordBotToken.isBlank()) return "missing_discord_token"
         val hasCredential = when (config.provider) {
-            "openai" -> config.openaiApiKey.isNotBlank() || config.openaiOAuthToken.isNotBlank()
+            "openai" -> if (config.authType == "oauth") config.openaiOAuthToken.isNotBlank() else config.openaiApiKey.isNotBlank()
             "openrouter" -> config.openrouterApiKey.isNotBlank()
             "custom" -> config.customApiKey.isNotBlank() && config.customBaseUrl.isNotBlank()
             else -> config.activeCredential.isNotBlank()

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -807,7 +807,14 @@ object ConfigManager {
         if (config.channel == "telegram" && config.telegramBotToken.isBlank()) return "missing_bot_token"
         if (config.channel == "discord" && config.discordBotToken.isBlank()) return "missing_discord_token"
         val hasCredential = when (config.provider) {
-            "openai" -> if (config.authType == "oauth") config.openaiOAuthToken.isNotBlank() else config.openaiApiKey.isNotBlank()
+            "openai" -> {
+                // Match writeConfigJson's effective auth type: oauth requires a token,
+                // but if the user is on oauth without a token AND has a valid API key,
+                // writeConfigJson falls back to api_key for Node — so the agent IS
+                // startable. Validation must align or it would block startup despite
+                // valid credentials.
+                config.openaiOAuthToken.isNotBlank() || config.openaiApiKey.isNotBlank()
+            }
             "openrouter" -> config.openrouterApiKey.isNotBlank()
             "custom" -> config.customApiKey.isNotBlank() && config.customBaseUrl.isNotBlank()
             else -> config.activeCredential.isNotBlank()

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -128,7 +128,7 @@ object ConfigManager {
     private const val KEY_FIRST_DEPLOY_DONE = "first_deploy_done"
     private const val KEY_OPENAI_OAUTH_TOKEN_ENC = "openai_oauth_token_enc"
     private const val KEY_OPENAI_OAUTH_REFRESH_ENC = "openai_oauth_refresh_enc"
-    private const val KEY_OPENAI_OAUTH_EMAIL = "openai_oauth_email"
+    private const val KEY_OPENAI_OAUTH_EMAIL_ENC = "openai_oauth_email_enc"
     private const val KEY_OPENAI_OAUTH_EXPIRES_AT = "openai_oauth_expires_at"
 
     private fun prefs(context: Context): SharedPreferences =
@@ -281,7 +281,13 @@ object ConfigManager {
         } else {
             editor.remove(KEY_OPENAI_OAUTH_REFRESH_ENC)
         }
-        editor.putString(KEY_OPENAI_OAUTH_EMAIL, config.openaiOAuthEmail)
+        if (config.openaiOAuthEmail.isNotBlank()) {
+            // Email is PII — encrypt at rest like other OAuth fields.
+            val encEmail = KeystoreHelper.encrypt(config.openaiOAuthEmail)
+            editor.putString(KEY_OPENAI_OAUTH_EMAIL_ENC, Base64.encodeToString(encEmail, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_EMAIL_ENC)
+        }
         editor.putString(KEY_OPENAI_OAUTH_EXPIRES_AT, config.openaiOAuthExpiresAt)
 
         val persisted = editor.commit()
@@ -448,6 +454,25 @@ object ConfigManager {
             ""
         }
 
+        val openaiOAuthEmail = try {
+            val enc = p.getString(KEY_OPENAI_OAUTH_EMAIL_ENC, null)
+            if (enc != null) {
+                KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP))
+            } else {
+                // One-time migration: pull any legacy plaintext value, then drop the old key
+                // so we don't keep PII unencrypted on disk.
+                val legacy = p.getString("openai_oauth_email", "") ?: ""
+                if (legacy.isNotBlank()) {
+                    p.edit().remove("openai_oauth_email").apply()
+                }
+                legacy
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to decrypt OpenAI OAuth email", e)
+            LogCollector.append("[Config] Failed to decrypt OpenAI OAuth email: ${e.javaClass.simpleName}", LogLevel.ERROR)
+            ""
+        }
+
         return AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
@@ -481,7 +506,7 @@ object ConfigManager {
             discordOwnerId = loadOwnerIdFromFile(context, "discord"),
             openaiOAuthToken = openaiOAuthToken,
             openaiOAuthRefresh = openaiOAuthRefresh,
-            openaiOAuthEmail = p.getString(KEY_OPENAI_OAUTH_EMAIL, "") ?: "",
+            openaiOAuthEmail = openaiOAuthEmail,
             openaiOAuthExpiresAt = p.getString(KEY_OPENAI_OAUTH_EXPIRES_AT, "") ?: "",
         )
     }
@@ -628,7 +653,8 @@ object ConfigManager {
         prefs(context).edit()
             .remove(KEY_OPENAI_OAUTH_TOKEN_ENC)
             .remove(KEY_OPENAI_OAUTH_REFRESH_ENC)
-            .remove(KEY_OPENAI_OAUTH_EMAIL)
+            .remove(KEY_OPENAI_OAUTH_EMAIL_ENC)
+            .remove("openai_oauth_email") // legacy plaintext key — clean up on sign-out
             .remove(KEY_OPENAI_OAUTH_EXPIRES_AT)
             .apply()
         configVersion.intValue++

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -482,7 +482,25 @@ object ConfigManager {
         return AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
-            authType = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key",
+            authType = run {
+                // Migrate legacy/invalid authType combinations so Node's strict validation
+                // doesn't hard-crash on older installs and the UI doesn't drift from
+                // persisted state. OpenAI only supports "api_key" or "oauth"; everything
+                // else (e.g. leftover "setup_token" from when the user was on Anthropic)
+                // is normalized to "api_key" and re-persisted.
+                val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
+                val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
+                val normalized = when {
+                    provider == "openai" && raw != "oauth" && raw != "api_key" -> "api_key"
+                    provider != "claude" && raw == "setup_token" -> "api_key"
+                    else -> raw
+                }
+                if (normalized != raw) {
+                    Log.w(TAG, "Normalizing legacy authType '$raw' → '$normalized' (provider=$provider)")
+                    p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
+                }
+                normalized
+            },
             telegramBotToken = botToken,
             telegramOwnerId = loadOwnerIdFromFile(context, "telegram"),
             model = p.getString(KEY_MODEL, "claude-opus-4-6") ?: "claude-opus-4-6",

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -56,6 +56,10 @@ data class AppConfig(
     val channel: String = "telegram",
     val discordBotToken: String = "",
     val discordOwnerId: String = "",
+    val openaiOAuthToken: String = "",
+    val openaiOAuthRefresh: String = "",
+    val openaiOAuthEmail: String = "",
+    val openaiOAuthExpiresAt: String = "",
 ) {
     /** Anthropic/authType-based credential — used by SetupScreen and legacy flows. */
     val activeCredential: String
@@ -122,6 +126,10 @@ object ConfigManager {
     private const val KEY_DISCORD_BOT_TOKEN_ENC = "discord_bot_token_enc"
     private const val KEY_DISCORD_OWNER_ID = "discord_owner_id"
     private const val KEY_FIRST_DEPLOY_DONE = "first_deploy_done"
+    private const val KEY_OPENAI_OAUTH_TOKEN_ENC = "openai_oauth_token_enc"
+    private const val KEY_OPENAI_OAUTH_REFRESH_ENC = "openai_oauth_refresh_enc"
+    private const val KEY_OPENAI_OAUTH_EMAIL = "openai_oauth_email"
+    private const val KEY_OPENAI_OAUTH_EXPIRES_AT = "openai_oauth_expires_at"
 
     private fun prefs(context: Context): SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -260,6 +268,21 @@ object ConfigManager {
             editor.remove(KEY_DISCORD_BOT_TOKEN_ENC)
         }
         editor.putString(KEY_DISCORD_OWNER_ID, config.discordOwnerId)
+
+        if (config.openaiOAuthToken.isNotBlank()) {
+            val encOAuthToken = KeystoreHelper.encrypt(config.openaiOAuthToken)
+            editor.putString(KEY_OPENAI_OAUTH_TOKEN_ENC, Base64.encodeToString(encOAuthToken, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_TOKEN_ENC)
+        }
+        if (config.openaiOAuthRefresh.isNotBlank()) {
+            val encOAuthRefresh = KeystoreHelper.encrypt(config.openaiOAuthRefresh)
+            editor.putString(KEY_OPENAI_OAUTH_REFRESH_ENC, Base64.encodeToString(encOAuthRefresh, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_REFRESH_ENC)
+        }
+        editor.putString(KEY_OPENAI_OAUTH_EMAIL, config.openaiOAuthEmail)
+        editor.putString(KEY_OPENAI_OAUTH_EXPIRES_AT, config.openaiOAuthExpiresAt)
 
         val persisted = editor.commit()
         if (persisted) {
@@ -407,6 +430,24 @@ object ConfigManager {
             ""
         }
 
+        val openaiOAuthToken = try {
+            val enc = p.getString(KEY_OPENAI_OAUTH_TOKEN_ENC, null)
+            if (enc != null) KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP)) else ""
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to decrypt OpenAI OAuth token", e)
+            LogCollector.append("[Config] Failed to decrypt OpenAI OAuth token: ${e.javaClass.simpleName}", LogLevel.ERROR)
+            ""
+        }
+
+        val openaiOAuthRefresh = try {
+            val enc = p.getString(KEY_OPENAI_OAUTH_REFRESH_ENC, null)
+            if (enc != null) KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP)) else ""
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to decrypt OpenAI OAuth refresh token", e)
+            LogCollector.append("[Config] Failed to decrypt OpenAI OAuth refresh token: ${e.javaClass.simpleName}", LogLevel.ERROR)
+            ""
+        }
+
         return AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
@@ -438,6 +479,10 @@ object ConfigManager {
             channel = p.getString(KEY_CHANNEL, "telegram") ?: "telegram",
             discordBotToken = discordBotToken,
             discordOwnerId = loadOwnerIdFromFile(context, "discord"),
+            openaiOAuthToken = openaiOAuthToken,
+            openaiOAuthRefresh = openaiOAuthRefresh,
+            openaiOAuthEmail = p.getString(KEY_OPENAI_OAUTH_EMAIL, "") ?: "",
+            openaiOAuthExpiresAt = p.getString(KEY_OPENAI_OAUTH_EXPIRES_AT, "") ?: "",
         )
     }
 
@@ -495,6 +540,10 @@ object ConfigManager {
                 saveOwnerIdToFile(context, value, "discord")
                 config.copy(discordOwnerId = value)
             }
+            "openaiOAuthToken" -> config.copy(openaiOAuthToken = value)
+            "openaiOAuthRefresh" -> config.copy(openaiOAuthRefresh = value)
+            "openaiOAuthEmail" -> config.copy(openaiOAuthEmail = value)
+            "openaiOAuthExpiresAt" -> config.copy(openaiOAuthExpiresAt = value)
             else -> return
         }
         saveConfig(context, updated)
@@ -575,6 +624,16 @@ object ConfigManager {
         configVersion.intValue++
     }
 
+    fun clearOpenAIOAuth(context: Context) {
+        prefs(context).edit()
+            .remove(KEY_OPENAI_OAUTH_TOKEN_ENC)
+            .remove(KEY_OPENAI_OAUTH_REFRESH_ENC)
+            .remove(KEY_OPENAI_OAUTH_EMAIL)
+            .remove(KEY_OPENAI_OAUTH_EXPIRES_AT)
+            .apply()
+        configVersion.intValue++
+    }
+
     /**
      * Write ephemeral config.json to workspace for Node.js to read on startup.
      * Includes per-boot bridge auth token. File is deleted after Node.js reads it.
@@ -617,6 +676,10 @@ object ConfigManager {
             put("channel", config.channel)
             if (config.discordBotToken.isNotBlank()) put("discordBotToken", config.discordBotToken)
             if (config.discordOwnerId.isNotBlank()) put("discordOwnerId", config.discordOwnerId)
+            if (config.openaiOAuthToken.isNotBlank()) put("openaiOAuthToken", config.openaiOAuthToken)
+            if (config.openaiOAuthRefresh.isNotBlank()) put("openaiOAuthRefresh", config.openaiOAuthRefresh)
+            if (config.openaiOAuthEmail.isNotBlank()) put("openaiOAuthEmail", config.openaiOAuthEmail)
+            if (config.openaiOAuthExpiresAt.isNotBlank()) put("openaiOAuthExpiresAt", config.openaiOAuthExpiresAt)
             val mcpServers = loadMcpServers(context)
             if (mcpServers.isNotEmpty()) {
                 val arr = JSONArray()
@@ -668,7 +731,7 @@ object ConfigManager {
         if (config.channel == "telegram" && config.telegramBotToken.isBlank()) return "missing_bot_token"
         if (config.channel == "discord" && config.discordBotToken.isBlank()) return "missing_discord_token"
         val hasCredential = when (config.provider) {
-            "openai" -> config.openaiApiKey.isNotBlank()
+            "openai" -> config.openaiApiKey.isNotBlank() || config.openaiOAuthToken.isNotBlank()
             "openrouter" -> config.openrouterApiKey.isNotBlank()
             "custom" -> config.customApiKey.isNotBlank() && config.customBaseUrl.isNotBlank()
             else -> config.activeCredential.isNotBlank()

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -131,13 +131,9 @@ object ConfigManager {
     private const val KEY_OPENAI_OAUTH_REFRESH_ENC = "openai_oauth_refresh_enc"
     private const val KEY_OPENAI_OAUTH_EMAIL_ENC = "openai_oauth_email_enc"
 
-    // Process-lifetime flag so the authType migration write only runs ONCE per process,
-    // making subsequent loadConfig() calls side-effect-free. The migration logic still
-    // returns a normalized value on every call so the in-memory AppConfig is always
-    // consistent — only the persistence write is gated.
-    @Volatile
-    private var authTypeMigrated = false
-
+    // Email migration is a true one-shot: legacy plaintext key is consumed exactly once
+    // and the encrypted form persists thereafter. Process flag avoids re-checking the
+    // legacy key on every loadConfig() call.
     @Volatile
     private var emailMigrated = false
 
@@ -149,6 +145,10 @@ object ConfigManager {
         //  - OpenAI + "oauth" requires a non-blank token; otherwise normalize to "api_key"
         //    (Keystore invalidation, data restore, or manual clear leaves a stale state).
         //  - Non-Claude providers can't use "setup_token".
+        // Persistence is gated on `normalized != raw`: in steady state (no drift) this
+        // is a no-op so loadConfig() doesn't write anything. If drift recurs later in
+        // the process (e.g. token decrypt starts failing mid-run), we catch it on the
+        // next load and re-persist — no process-lifetime flag.
         val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
         val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
         val openaiTokenBlank = openaiOAuthToken.isBlank()
@@ -158,10 +158,9 @@ object ConfigManager {
             provider != "claude" && raw == "setup_token" -> "api_key"
             else -> raw
         }
-        if (normalized != raw && !authTypeMigrated) {
+        if (normalized != raw) {
             Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider, tokenBlank=$openaiTokenBlank)")
             p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
-            authTypeMigrated = true
         }
         return normalized
     }

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -137,7 +137,7 @@ object ConfigManager {
     @Volatile
     private var emailMigrated = false
 
-    private fun resolveAuthType(p: SharedPreferences, openaiOAuthToken: String): String {
+    private fun resolveAuthType(p: SharedPreferences): String {
         // Migrate legacy/invalid authType combinations so Node's strict validation
         // doesn't hard-crash on older installs and the UI doesn't drift from persisted
         // state. Rules:
@@ -518,7 +518,7 @@ object ConfigManager {
         return AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
-            authType = resolveAuthType(p, openaiOAuthToken),
+            authType = resolveAuthType(p),
             telegramBotToken = botToken,
             telegramOwnerId = loadOwnerIdFromFile(context, "telegram"),
             model = p.getString(KEY_MODEL, "claude-opus-4-6") ?: "claude-opus-4-6",

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -459,11 +459,16 @@ object ConfigManager {
             if (enc != null) {
                 KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP))
             } else {
-                // One-time migration: pull any legacy plaintext value, then drop the old key
-                // so we don't keep PII unencrypted on disk.
+                // One-time migration: pull any legacy plaintext value, persist it
+                // encrypted under the new key, then drop the old key so we don't keep
+                // PII unencrypted on disk (and the value survives subsequent launches).
                 val legacy = p.getString("openai_oauth_email", "") ?: ""
                 if (legacy.isNotBlank()) {
-                    p.edit().remove("openai_oauth_email").apply()
+                    val encLegacy = KeystoreHelper.encrypt(legacy)
+                    p.edit()
+                        .putString(KEY_OPENAI_OAUTH_EMAIL_ENC, Base64.encodeToString(encLegacy, Base64.NO_WRAP))
+                        .remove("openai_oauth_email")
+                        .apply()
                 }
                 legacy
             }

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -676,10 +676,9 @@ object ConfigManager {
             put("channel", config.channel)
             if (config.discordBotToken.isNotBlank()) put("discordBotToken", config.discordBotToken)
             if (config.discordOwnerId.isNotBlank()) put("discordOwnerId", config.discordOwnerId)
+            // Only the tokens are needed by Node — email/expiresAt are Android-only metadata.
             if (config.openaiOAuthToken.isNotBlank()) put("openaiOAuthToken", config.openaiOAuthToken)
             if (config.openaiOAuthRefresh.isNotBlank()) put("openaiOAuthRefresh", config.openaiOAuthRefresh)
-            if (config.openaiOAuthEmail.isNotBlank()) put("openaiOAuthEmail", config.openaiOAuthEmail)
-            if (config.openaiOAuthExpiresAt.isNotBlank()) put("openaiOAuthExpiresAt", config.openaiOAuthExpiresAt)
             val mcpServers = loadMcpServers(context)
             if (mcpServers.isNotEmpty()) {
                 val arr = JSONArray()

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -130,6 +130,41 @@ object ConfigManager {
     private const val KEY_OPENAI_OAUTH_TOKEN_ENC = "openai_oauth_token_enc"
     private const val KEY_OPENAI_OAUTH_REFRESH_ENC = "openai_oauth_refresh_enc"
     private const val KEY_OPENAI_OAUTH_EMAIL_ENC = "openai_oauth_email_enc"
+
+    // Process-lifetime flag so the authType migration write only runs ONCE per process,
+    // making subsequent loadConfig() calls side-effect-free. The migration logic still
+    // returns a normalized value on every call so the in-memory AppConfig is always
+    // consistent — only the persistence write is gated.
+    @Volatile
+    private var authTypeMigrated = false
+
+    @Volatile
+    private var emailMigrated = false
+
+    private fun resolveAuthType(p: SharedPreferences, openaiOAuthToken: String): String {
+        // Migrate legacy/invalid authType combinations so Node's strict validation
+        // doesn't hard-crash on older installs and the UI doesn't drift from persisted
+        // state. Rules:
+        //  - OpenAI only supports "api_key" or "oauth".
+        //  - OpenAI + "oauth" requires a non-blank token; otherwise normalize to "api_key"
+        //    (Keystore invalidation, data restore, or manual clear leaves a stale state).
+        //  - Non-Claude providers can't use "setup_token".
+        val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
+        val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
+        val openaiTokenBlank = openaiOAuthToken.isBlank()
+        val normalized = when {
+            provider == "openai" && raw == "oauth" && openaiTokenBlank -> "api_key"
+            provider == "openai" && raw != "oauth" && raw != "api_key" -> "api_key"
+            provider != "claude" && raw == "setup_token" -> "api_key"
+            else -> raw
+        }
+        if (normalized != raw && !authTypeMigrated) {
+            Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider, tokenBlank=$openaiTokenBlank)")
+            p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
+            authTypeMigrated = true
+        }
+        return normalized
+    }
     private const val KEY_OPENAI_OAUTH_EXPIRES_AT = "openai_oauth_expires_at"
 
     private fun prefs(context: Context): SharedPreferences =
@@ -459,10 +494,10 @@ object ConfigManager {
             val enc = p.getString(KEY_OPENAI_OAUTH_EMAIL_ENC, null)
             if (enc != null) {
                 KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP))
-            } else {
-                // One-time migration: pull any legacy plaintext value, persist it
-                // encrypted under the new key, then drop the old key so we don't keep
-                // PII unencrypted on disk (and the value survives subsequent launches).
+            } else if (!emailMigrated) {
+                // One-time per-process migration: pull any legacy plaintext value, persist
+                // it encrypted under the new key, then drop the old key. Gated by the
+                // emailMigrated flag so subsequent loadConfig() calls don't re-touch prefs.
                 val legacy = p.getString("openai_oauth_email", "") ?: ""
                 if (legacy.isNotBlank()) {
                     val encLegacy = KeystoreHelper.encrypt(legacy)
@@ -471,7 +506,10 @@ object ConfigManager {
                         .remove("openai_oauth_email")
                         .apply()
                 }
+                emailMigrated = true
                 legacy
+            } else {
+                ""
             }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to decrypt OpenAI OAuth email", e)
@@ -482,30 +520,7 @@ object ConfigManager {
         return AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
-            authType = run {
-                // Migrate legacy/invalid authType combinations so Node's strict validation
-                // doesn't hard-crash on older installs and the UI doesn't drift from
-                // persisted state. Rules:
-                //  - OpenAI only supports "api_key" or "oauth".
-                //  - OpenAI + "oauth" requires a non-blank token; otherwise normalize to
-                //    "api_key" (Keystore invalidation, data restore, or manual clear can
-                //    leave a stale "oauth" with empty token, which would crash Node).
-                //  - Non-Claude providers can't use "setup_token".
-                val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
-                val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
-                val openaiTokenBlank = openaiOAuthToken.isBlank()
-                val normalized = when {
-                    provider == "openai" && raw == "oauth" && openaiTokenBlank -> "api_key"
-                    provider == "openai" && raw != "oauth" && raw != "api_key" -> "api_key"
-                    provider != "claude" && raw == "setup_token" -> "api_key"
-                    else -> raw
-                }
-                if (normalized != raw) {
-                    Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider, tokenBlank=$openaiTokenBlank)")
-                    p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
-                }
-                normalized
-            },
+            authType = resolveAuthType(p, openaiOAuthToken),
             telegramBotToken = botToken,
             telegramOwnerId = loadOwnerIdFromFile(context, "telegram"),
             model = p.getString(KEY_MODEL, "claude-opus-4-6") ?: "claude-opus-4-6",

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -485,18 +485,23 @@ object ConfigManager {
             authType = run {
                 // Migrate legacy/invalid authType combinations so Node's strict validation
                 // doesn't hard-crash on older installs and the UI doesn't drift from
-                // persisted state. OpenAI only supports "api_key" or "oauth"; everything
-                // else (e.g. leftover "setup_token" from when the user was on Anthropic)
-                // is normalized to "api_key" and re-persisted.
+                // persisted state. Rules:
+                //  - OpenAI only supports "api_key" or "oauth".
+                //  - OpenAI + "oauth" requires a non-blank token; otherwise normalize to
+                //    "api_key" (Keystore invalidation, data restore, or manual clear can
+                //    leave a stale "oauth" with empty token, which would crash Node).
+                //  - Non-Claude providers can't use "setup_token".
                 val raw = p.getString(KEY_AUTH_TYPE, "api_key") ?: "api_key"
                 val provider = p.getString(KEY_PROVIDER, "claude") ?: "claude"
+                val openaiTokenBlank = openaiOAuthToken.isBlank()
                 val normalized = when {
+                    provider == "openai" && raw == "oauth" && openaiTokenBlank -> "api_key"
                     provider == "openai" && raw != "oauth" && raw != "api_key" -> "api_key"
                     provider != "claude" && raw == "setup_token" -> "api_key"
                     else -> raw
                 }
                 if (normalized != raw) {
-                    Log.w(TAG, "Normalizing legacy authType '$raw' → '$normalized' (provider=$provider)")
+                    Log.w(TAG, "Normalizing authType '$raw' → '$normalized' (provider=$provider, tokenBlank=$openaiTokenBlank)")
                     p.edit().putString(KEY_AUTH_TYPE, normalized).apply()
                 }
                 normalized

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -28,7 +28,8 @@ import java.util.zip.ZipOutputStream
 data class AppConfig(
     val anthropicApiKey: String,
     val setupToken: String = "",
-    val authType: String = "api_key", // "api_key" or "setup_token"
+    // "api_key" (all providers), "setup_token" (Anthropic only), or "oauth" (OpenAI Codex only).
+    val authType: String = "api_key",
     val telegramBotToken: String,
     val telegramOwnerId: String,
     val model: String,

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -55,10 +55,10 @@ val openaiModels = listOf(
 )
 
 val openaiOAuthModels = listOf(
-    ModelInfo("gpt-5.4", "GPT-5.4", "frontier"),
-    ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini", "fast"),
-    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
-    ModelInfo("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark", "research"),
+    ModelInfo("openai-codex/gpt-5.4", "GPT-5.4", "frontier"),
+    ModelInfo("openai-codex/gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
+    ModelInfo("openai-codex/gpt-5.3-codex-spark", "GPT-5.3 Codex Spark", "research"),
+    ModelInfo("openai-codex/gpt-5.2-codex", "GPT-5.2 Codex", "legacy"),
 )
 
 /** Default model for freeform providers (OpenRouter) where model list is empty. */

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -55,10 +55,10 @@ val openaiModels = listOf(
 )
 
 val openaiOAuthModels = listOf(
-    ModelInfo("openai-codex/gpt-5.4", "GPT-5.4", "frontier"),
-    ModelInfo("openai-codex/gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
-    ModelInfo("openai-codex/gpt-5.3-codex-spark", "GPT-5.3 Codex Spark", "research"),
-    ModelInfo("openai-codex/gpt-5.2-codex", "GPT-5.2 Codex", "legacy"),
+    ModelInfo("gpt-5.4", "GPT-5.4", "frontier"),
+    ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini", "fast"),
+    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
+    ModelInfo("gpt-5.2", "GPT-5.2", "flagship"),
 )
 
 /** Default model for freeform providers (OpenRouter) where model list is empty. */

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -67,14 +67,18 @@ const val OPENROUTER_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
 /**
  * Resolve the model list for a given provider.
  *
- * `authType` is required (no default) so call sites can't accidentally fall through to
- * the API-key OpenAI list when the user is in OAuth mode. Pass `null` only when the
- * provider is known to be auth-type-agnostic (e.g. Anthropic), or when the call site
- * truly cannot derive an authType yet (initial setup screens before any provider has
- * been selected).
+ * For OpenAI, `authType` MUST be an explicit "oauth" or "api_key" — passing null or
+ * any other value throws so call sites can't accidentally fall through to the API-key
+ * model list while the user is in OAuth mode. For other providers `authType` is
+ * advisory/ignored.
  */
 fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> = when (providerId) {
-    "openai" -> if (authType == "oauth") openaiOAuthModels else openaiModels
+    "openai" -> when (authType) {
+        "oauth" -> openaiOAuthModels
+        "api_key" -> openaiModels
+        null -> throw IllegalArgumentException("authType is required for providerId=openai")
+        else -> throw IllegalArgumentException("Unsupported authType '$authType' for providerId=openai")
+    }
     "openrouter", "custom" -> emptyList() // Freeform: user types model ID
     else -> availableModels
 }

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -25,7 +25,7 @@ val availableProviders = listOf(
     ProviderInfo(
         id = "openai",
         displayName = "OpenAI",
-        authTypes = listOf("api_key"),
+        authTypes = listOf("api_key", "oauth"),
         keyHint = "sk-proj-…",
         consoleUrl = "https://platform.openai.com",
         keysUrl = "https://platform.openai.com/api-keys",
@@ -54,11 +54,18 @@ val openaiModels = listOf(
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
 )
 
+val openaiOAuthModels = listOf(
+    ModelInfo("gpt-5.4", "GPT-5.4", "frontier"),
+    ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini", "fast"),
+    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex", "code agent"),
+    ModelInfo("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark", "research"),
+)
+
 /** Default model for freeform providers (OpenRouter) where model list is empty. */
 const val OPENROUTER_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
 
-fun modelsForProvider(providerId: String): List<ModelInfo> = when (providerId) {
-    "openai" -> openaiModels
+fun modelsForProvider(providerId: String, authType: String? = null): List<ModelInfo> = when (providerId) {
+    "openai" -> if (authType == "oauth") openaiOAuthModels else openaiModels
     "openrouter", "custom" -> emptyList() // Freeform: user types model ID
     else -> availableModels
 }

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -64,7 +64,16 @@ val openaiOAuthModels = listOf(
 /** Default model for freeform providers (OpenRouter) where model list is empty. */
 const val OPENROUTER_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
 
-fun modelsForProvider(providerId: String, authType: String? = null): List<ModelInfo> = when (providerId) {
+/**
+ * Resolve the model list for a given provider.
+ *
+ * `authType` is required (no default) so call sites can't accidentally fall through to
+ * the API-key OpenAI list when the user is in OAuth mode. Pass `null` only when the
+ * provider is known to be auth-type-agnostic (e.g. Anthropic), or when the call site
+ * truly cannot derive an authType yet (initial setup screens before any provider has
+ * been selected).
+ */
+fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> = when (providerId) {
     "openai" -> if (authType == "oauth") openaiOAuthModels else openaiModels
     "openrouter", "custom" -> emptyList() // Freeform: user types model ID
     else -> availableModels

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -26,10 +25,8 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 
 /**
- * Transparent Activity that handles OpenAI OAuth flows.
- * Supports two methods:
- *   - "browser": PKCE authorization code flow via Custom Tabs + local redirect server
- *   - "device_code": Device code flow with polling
+ * Transparent Activity that handles the OpenAI OAuth PKCE flow:
+ * Custom Tabs → user signs in on auth.openai.com → localhost:1455 callback → token exchange.
  *
  * Results are communicated via files (same pattern as SolanaAuthActivity).
  */
@@ -41,8 +38,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
         const val AUTH_URL = "https://auth.openai.com/oauth/authorize"
         const val TOKEN_URL = "https://auth.openai.com/oauth/token"
-        const val DEVICE_URL = "https://auth.openai.com/oauth/device/code"
-        const val DEVICE_VERIFY_URL = "https://auth.openai.com/codex/device"  // User-facing page
         const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
@@ -50,44 +45,25 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
     private var callbackServer: CallbackServer? = null
     private val scope = CoroutineScope(Dispatchers.Main + Job())
-    private var pollingJob: Job? = null
     private var callbackReceived = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val method = intent.getStringExtra("method") ?: run {
-            Log.w(TAG, "No method specified")
-            finish()
-            return
-        }
         val requestId = intent.getStringExtra("requestId") ?: run {
             Log.w(TAG, "No requestId specified")
             finish()
             return
         }
 
-        Log.i(TAG, "Starting OAuth flow: $method (request: $requestId)")
-
-        when (method) {
-            "browser" -> startBrowserFlow(requestId)
-            "device_code" -> startDeviceCodeFlow(requestId)
-            else -> {
-                Log.w(TAG, "Unknown method: $method")
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Unknown method: $method")
-                })
-                finish()
-            }
-        }
+        Log.i(TAG, "Starting OAuth browser flow (request: $requestId)")
+        startBrowserFlow(requestId)
     }
 
     override fun onDestroy() {
         super.onDestroy()
         callbackServer?.stop()
         callbackServer = null
-        pollingJob?.cancel()
         scope.cancel()
     }
 
@@ -254,144 +230,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
             callbackServer?.stop()
             callbackServer = null
             finishOnMain()
-        }
-    }
-
-    // ── Flow B: Device Code ──────────────────────────────────────────────
-
-    private fun startDeviceCodeFlow(requestId: String) {
-        scope.launch {
-            try {
-                val deviceResponse = withContext(Dispatchers.IO) {
-                    val body = buildString {
-                        append("client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
-                        append("&scope=").append(URLEncoder.encode(SCOPES, "UTF-8"))
-                    }
-                    httpPost(DEVICE_URL, body)
-                }
-
-                val json = JSONObject(deviceResponse)
-                val deviceCode = json.getString("device_code")
-                val userCode = json.getString("user_code")
-                val verificationUri = json.getString("verification_uri")
-                val interval = json.optInt("interval", 5)
-                val expiresIn = json.optInt("expires_in", 600)
-
-                // Write pending result so the caller can show the user code
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "pending")
-                    put("userCode", userCode)
-                    put("verificationUri", verificationUri)
-                })
-
-                // Poll for authorization
-                pollForDeviceAuthorization(requestId, deviceCode, interval, expiresIn)
-            } catch (e: Exception) {
-                Log.e(TAG, "Device code request failed", e)
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Device code request failed: ${e.message}")
-                })
-                finish()
-            }
-        }
-    }
-
-    private fun pollForDeviceAuthorization(
-        requestId: String,
-        deviceCode: String,
-        interval: Int,
-        expiresIn: Int
-    ) {
-        val deadline = System.currentTimeMillis() + (expiresIn * 1000L)
-
-        pollingJob = scope.launch {
-            while (isActive && System.currentTimeMillis() < deadline) {
-                delay(interval * 1000L)
-
-                try {
-                    val response = withContext(Dispatchers.IO) {
-                        val body = buildString {
-                            append("grant_type=").append(
-                                URLEncoder.encode(
-                                    "urn:ietf:params:oauth:grant-type:device_code",
-                                    "UTF-8"
-                                )
-                            )
-                            append("&device_code=").append(URLEncoder.encode(deviceCode, "UTF-8"))
-                            append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
-                        }
-                        httpPostRaw(TOKEN_URL, body)
-                    }
-
-                    val statusCode = response.first
-                    val responseBody = response.second
-                    val json = JSONObject(responseBody)
-
-                    if (statusCode in 200..299 && json.has("access_token")) {
-                        // Success
-                        val accessToken = json.getString("access_token")
-                        val refreshToken = json.optString("refresh_token", "")
-                        val tokenExpiresIn = json.optLong("expires_in", 3600)
-                        val expiresAt =
-                            java.time.Instant.now().plusSeconds(tokenExpiresIn).toString()
-                        val email = extractEmailFromJwt(accessToken)
-
-                        writeResultFile(requestId, JSONObject().apply {
-                            put("status", "success")
-                            put("accessToken", accessToken)
-                            put("refreshToken", refreshToken)
-                            put("email", email ?: JSONObject.NULL)
-                            put("expiresAt", expiresAt)
-                        })
-                        Log.i(TAG, "Device code flow completed successfully")
-                        finishOnMain()
-                        return@launch
-                    }
-
-                    val errorCode = json.optString("error", "")
-                    when (errorCode) {
-                        "authorization_pending", "slow_down" -> {
-                            // Continue polling (slow_down: RFC says increase interval,
-                            // but we keep it simple for now)
-                            Log.d(TAG, "Device code polling: $errorCode")
-                        }
-
-                        "expired_token" -> {
-                            writeResultFile(requestId, JSONObject().apply {
-                                put("status", "error")
-                                put("message", "Code expired. Please try again.")
-                            })
-                            finishOnMain()
-                            return@launch
-                        }
-
-                        "access_denied" -> {
-                            writeResultFile(requestId, JSONObject().apply {
-                                put("status", "error")
-                                put("message", "Access denied by user.")
-                            })
-                            finishOnMain()
-                            return@launch
-                        }
-
-                        else -> {
-                            Log.w(TAG, "Unexpected polling error: $errorCode")
-                        }
-                    }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Polling request failed, will retry", e)
-                }
-            }
-
-            // Timeout
-            if (isActive) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Code expired. Please try again.")
-                })
-                finishOnMain()
-            }
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -39,7 +39,9 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
         const val AUTH_URL = "https://auth.openai.com/oauth/authorize"
         const val TOKEN_URL = "https://auth.openai.com/oauth/token"
-        const val REDIRECT_URI = "http://localhost:1455/auth/callback"
+        // Use 127.0.0.1 (not "localhost") so browsers can't resolve the redirect to ::1
+        // and miss the IPv4 NanoHTTPD listener.
+        const val REDIRECT_URI = "http://127.0.0.1:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
     }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -28,10 +28,13 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 
 /**
- * Transparent Activity that handles the OpenAI OAuth PKCE flow:
- * Custom Tabs → user signs in on auth.openai.com → localhost:1455 callback → token exchange.
+ * Activity that handles the OpenAI OAuth PKCE flow:
+ * Custom Tabs → user signs in on auth.openai.com → 127.0.0.1:1455 callback → token exchange.
  *
- * Results are communicated via files (same pattern as SolanaAuthActivity).
+ * Tokens obtained from the flow are persisted directly via [ConfigManager] (encrypted via
+ * Android Keystore). The on-disk result file under `filesDir/oauth_results/` only carries
+ * a status flag (success/error/canceled) — it never contains secrets — and is consumed by
+ * `ProviderConfigScreen`'s polling coroutine to know when to reload config.
  */
 class OpenAIOAuthActivity : ComponentActivity() {
 

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -45,6 +45,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
     private var callbackServer: CallbackServer? = null
     private val scope = CoroutineScope(Dispatchers.Main + Job())
+    // Written from the NanoHTTPD server thread, read from the Main timeout coroutine — needs @Volatile.
+    @Volatile
     private var callbackReceived = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -140,7 +142,19 @@ class OpenAIOAuthActivity : ComponentActivity() {
         expectedState: String,
         codeVerifier: String
     ): String {
-        callbackReceived = true
+        // Idempotency guard: if the user refreshes the browser, NanoHTTPD will fire this
+        // handler multiple times. We only want to run the token exchange once and avoid
+        // racing writes to the same result file.
+        synchronized(this) {
+            if (callbackReceived) {
+                Log.d(TAG, "Duplicate callback ignored")
+                return buildHtmlResponse(
+                    "Completing Sign-In",
+                    "Already processing — please return to SeekerClaw for status."
+                )
+            }
+            callbackReceived = true
+        }
         val code = params["code"]
         val state = params["state"]
         val error = params["error"]

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -160,14 +160,14 @@ class OpenAIOAuthActivity : ComponentActivity() {
         super.onDestroy()
         callbackServer?.stop()
         callbackServer = null
-        // If the activity is dismissed (Back button, system kill, swipe-away) before
-        // any other path has claimed the write slot, leave a canceled result so
-        // ProviderConfigScreen stops polling immediately instead of waiting out the
-        // 10-minute deadline. The file write happens on a fresh background Thread
-        // (not `scope`, which is being canceled, and not Main — file I/O in lifecycle
-        // callbacks risks ANRs on slow storage).
+        // If the activity is dismissed (Back button, system kill, swipe-away) BEFORE a
+        // valid callback has arrived AND no other path has claimed the write slot, leave
+        // a canceled result so ProviderConfigScreen stops polling immediately. We MUST
+        // gate on !callbackReceived — if a callback has already arrived, the GlobalScope
+        // exchange is in flight and writing a synthetic "canceled" here would race a
+        // real sign-in and produce a misleading status.
         val reqId = currentRequestId
-        if (reqId != null && claimWrite()) {
+        if (reqId != null && !callbackReceived && claimWrite()) {
             Thread {
                 try {
                     writeResultFile(reqId, JSONObject().apply {
@@ -509,26 +509,46 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
     private fun writeResultFile(requestId: String, result: JSONObject) {
         try {
-            val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
-            val tmpFile = File(resultDir, "$requestId.tmp")
-            val jsonFile = File(resultDir, "$requestId.json")
-            tmpFile.writeText(result.toString())
-            jsonFile.delete() // renameTo won't overwrite existing file on Android
-            if (!tmpFile.renameTo(jsonFile)) {
-                // Fallback: copy + delete if rename fails on some Android filesystems
-                tmpFile.copyTo(jsonFile, overwrite = true)
-                tmpFile.delete()
-            }
-            Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
+            doWriteResultFile(requestId, result)
         } catch (e: Exception) {
-            // Storage full or filesystem error — log and finish so the UI doesn't hang
-            // polling for a result file that will never appear, and so the callback
-            // server doesn't stay up indefinitely.
+            // Storage full or filesystem error. Try once more in a fresh thread after a
+            // short delay (transient issues like brief storage pressure can self-resolve).
+            // If that also fails, fall back to writing a minimal status file with no JSON
+            // body so the polling UI at least sees *something* and stops spinning.
             Log.e(TAG, "Failed to write OAuth result file for requestId=$requestId", e)
+            Thread {
+                try {
+                    Thread.sleep(500)
+                    doWriteResultFile(requestId, result)
+                    Log.i(TAG, "Result file write succeeded on retry")
+                } catch (retry: Exception) {
+                    Log.e(TAG, "Result file retry also failed", retry)
+                    // Last-ditch: write a minimal status-only file so the UI stops polling.
+                    try {
+                        File(filesDir, RESULTS_DIR).apply { mkdirs() }
+                            .resolve("$requestId.json")
+                            .writeText("""{"status":"error","message":"Failed to persist OAuth result"}""")
+                    } catch (_: Exception) { /* nothing more we can do */ }
+                }
+            }.start()
             try { finishOnMain() } catch (finishEx: Exception) {
                 Log.e(TAG, "Failed to finish activity after writeResultFile error", finishEx)
             }
         }
+    }
+
+    private fun doWriteResultFile(requestId: String, result: JSONObject) {
+        val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
+        val tmpFile = File(resultDir, "$requestId.tmp")
+        val jsonFile = File(resultDir, "$requestId.json")
+        tmpFile.writeText(result.toString())
+        jsonFile.delete() // renameTo won't overwrite existing file on Android
+        if (!tmpFile.renameTo(jsonFile)) {
+            // Fallback: copy + delete if rename fails on some Android filesystems
+            tmpFile.copyTo(jsonFile, overwrite = true)
+            tmpFile.delete()
+        }
+        Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
     }
 
     private fun finishOnMain() {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -536,8 +536,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
         }
 
         return buildHtmlResponse(
-            "Completing Sign-In",
-            "Finishing authentication — please return to SeekerClaw for status."
+            "Signed In",
+            "You can close this tab and return to SeekerClaw."
         )
     }
 
@@ -626,7 +626,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private fun buildHtmlResponse(title: String, message: String): String {
         val safeTitle = escapeHtml(title)
         val safeMessage = escapeHtml(message)
-        val isSuccess = title == "Success" || title == "Completing Sign-In"
+        val isSuccess = title == "Success" || title == "Completing Sign-In" || title == "Signed In"
         val accentColor = if (isSuccess) "#4ADE80" else "#F87171"
         val icon = if (isSuccess) "&#10003;" else "&#10007;"
         return """

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -228,9 +228,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val json = JSONObject(tokenResponse)
             val accessToken = json.optString("access_token", "")
             val refreshToken = json.optString("refresh_token", "")
+            val idToken = json.optString("id_token", "")
             val expiresIn = json.optLong("expires_in", 3600)
             val expiresAt = java.time.Instant.now().plusSeconds(expiresIn).toString()
-            val email = extractEmailFromJwt(accessToken)
+            // Try id_token first (has email), fall back to access_token
+            val email = extractEmailFromJwt(idToken) ?: extractEmailFromJwt(accessToken)
 
             writeResultFile(requestId, JSONObject().apply {
                 put("status", "success")
@@ -489,24 +491,55 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private fun buildHtmlResponse(title: String, message: String): String {
         val safeTitle = escapeHtml(title)
         val safeMessage = escapeHtml(message)
+        val isSuccess = title == "Success"
+        val accentColor = if (isSuccess) "#4ADE80" else "#F87171"
+        val icon = if (isSuccess) "&#10003;" else "&#10007;"
         return """
             <!DOCTYPE html>
             <html>
-            <head><title>$safeTitle</title>
+            <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>SeekerClaw — $safeTitle</title>
             <style>
-                body { font-family: -apple-system, sans-serif; display: flex;
-                       justify-content: center; align-items: center; height: 100vh;
-                       margin: 0; background: #0D0D0D; color: #fff; }
-                .card { text-align: center; padding: 2rem; }
-                h1 { color: ${if (title == "Success") "#00C805" else "#FF4444"}; }
-            </style></head>
-            <script>
-                if ('$safeTitle' === 'Success') {
-                    setTimeout(function() { window.close(); }, 1500);
+                * { margin: 0; padding: 0; box-sizing: border-box; }
+                body {
+                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+                    display: flex; justify-content: center; align-items: center;
+                    height: 100vh; background: #0A0A0F; color: #fff;
                 }
-            </script>
+                .card {
+                    text-align: center; padding: 3rem 2rem;
+                    max-width: 400px; width: 90%;
+                }
+                .icon {
+                    width: 80px; height: 80px; border-radius: 50%;
+                    background: ${accentColor}15;
+                    border: 2px solid ${accentColor};
+                    display: flex; align-items: center; justify-content: center;
+                    margin: 0 auto 1.5rem; font-size: 36px; color: $accentColor;
+                }
+                h1 {
+                    font-size: 24px; font-weight: 700; color: $accentColor;
+                    margin-bottom: 0.75rem; letter-spacing: -0.5px;
+                }
+                .message {
+                    font-size: 15px; color: rgba(255,255,255,0.6);
+                    line-height: 1.5; margin-bottom: 2rem;
+                }
+                .brand {
+                    font-size: 12px; color: rgba(255,255,255,0.25);
+                    letter-spacing: 1px; text-transform: uppercase;
+                }
+            </style>
             </head>
-            <body><div class="card"><h1>$safeTitle</h1><p>$safeMessage</p></div></body>
+            <body>
+                <div class="card">
+                    <div class="icon">$icon</div>
+                    <h1>$safeTitle</h1>
+                    <p class="message">$safeMessage</p>
+                    <p class="brand">SeekerClaw</p>
+                </div>
+            </body>
             </html>
         """.trimIndent()
     }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -328,7 +328,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // lifetime) instead of scope (being cancelled here) so the write actually runs.
         val reqId = currentRequestId
         if (reqId != null && !callbackReceived && claimWrite()) {
+            // Capture only application Context and a local reference to the state
+            // AtomicReference. The launched lambda must NOT call any instance method
+            // (no markWriteCompleted, no writeResultFile, no Log without TAG capture)
+            // so it doesn't pin the Activity beyond destroy.
             val appCtx = applicationContext
+            val stateRef = writeState
             EXCHANGE_SCOPE.launch {
                 try {
                     writeResultFileStatic(appCtx, reqId, JSONObject().apply {
@@ -338,7 +343,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to write canceled result on destroy", e)
                 } finally {
-                    markWriteCompleted()
+                    stateRef.set(WriteState.COMPLETED)
                 }
             }
         }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -286,22 +286,26 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 callbackServer?.stop()
                 callbackServer = null
                 if (claimWrite()) {
-                    // NonCancellable so the result write completes even if the activity is
-                    // finished before the coroutine runs (otherwise writeState would stay
-                    // WRITING and the polling UI would hang for the full 10-min timeout).
-                    scope.launch {
-                        withContext(NonCancellable + Dispatchers.IO) {
-                            writeResultFile(requestId, JSONObject().apply {
+                    // Use EXCHANGE_SCOPE (application-lifetime) so the write completes
+                    // even if the activity is destroyed before scope.launch would have
+                    // started. Capture only locals — no `this` reference inside the
+                    // lambda — and signal completion via the AtomicReference directly.
+                    val appCtx = applicationContext
+                    val stateRef = writeState
+                    EXCHANGE_SCOPE.launch {
+                        try {
+                            writeResultFileStatic(appCtx, requestId, JSONObject().apply {
                                 put("status", "error")
                                 put("message", "Sign-in canceled")
                             })
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to write canceled result", e)
+                        } finally {
+                            stateRef.set(WriteState.COMPLETED)
                         }
-                        markWriteCompleted()
-                        finishOnMain()
                     }
-                } else {
-                    finishOnMain()
                 }
+                finishOnMain()
             }
         }
         root.addView(title)
@@ -368,17 +372,24 @@ class OpenAIOAuthActivity : ComponentActivity() {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start callback server", e)
             if (claimWrite()) {
-                scope.launch {
-                    withContext(NonCancellable + Dispatchers.IO) {
-                        writeResultFile(requestId, JSONObject().apply {
+                // EXCHANGE_SCOPE so the write survives even if the activity is
+                // destroyed before this coroutine starts. No `this` capture.
+                val appCtx = applicationContext
+                val stateRef = writeState
+                EXCHANGE_SCOPE.launch {
+                    try {
+                        writeResultFileStatic(appCtx, requestId, JSONObject().apply {
                             put("status", "error")
                             put("message", "Couldn't start local callback server. Please try again.")
                         })
+                    } catch (writeErr: Exception) {
+                        Log.w(TAG, "Failed to write server-fail result", writeErr)
+                    } finally {
+                        stateRef.set(WriteState.COMPLETED)
                     }
-                    markWriteCompleted()
-                    finishOnMain()
                 }
             }
+            finishOnMain()
             return
         }
 

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -1,0 +1,493 @@
+package com.seekerclaw.app.oauth
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Base64
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import fi.iki.elonen.NanoHTTPD
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * Transparent Activity that handles OpenAI OAuth flows.
+ * Supports two methods:
+ *   - "browser": PKCE authorization code flow via Custom Tabs + local redirect server
+ *   - "device_code": Device code flow with polling
+ *
+ * Results are communicated via files (same pattern as SolanaAuthActivity).
+ */
+class OpenAIOAuthActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "OpenAIOAuth"
+        const val RESULTS_DIR = "oauth_results"
+        const val CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+        const val AUTH_URL = "https://auth.openai.com/oauth/authorize"
+        const val TOKEN_URL = "https://auth.openai.com/oauth/token"
+        const val DEVICE_URL = "https://auth.openai.com/codex/device"
+        const val REDIRECT_URI = "http://localhost:1455/auth/callback"
+        const val SCOPES = "openid profile email offline_access"
+        private const val CALLBACK_PORT = 1455
+    }
+
+    private var callbackServer: CallbackServer? = null
+    private val scope = CoroutineScope(Dispatchers.Main + Job())
+    private var pollingJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val method = intent.getStringExtra("method") ?: run {
+            Log.w(TAG, "No method specified")
+            finish()
+            return
+        }
+        val requestId = intent.getStringExtra("requestId") ?: run {
+            Log.w(TAG, "No requestId specified")
+            finish()
+            return
+        }
+
+        Log.i(TAG, "Starting OAuth flow: $method (request: $requestId)")
+
+        when (method) {
+            "browser" -> startBrowserFlow(requestId)
+            "device_code" -> startDeviceCodeFlow(requestId)
+            else -> {
+                Log.w(TAG, "Unknown method: $method")
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Unknown method: $method")
+                })
+                finish()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        callbackServer?.stop()
+        callbackServer = null
+        pollingJob?.cancel()
+        scope.cancel()
+    }
+
+    // ── Flow A: Browser Redirect (PKCE) ──────────────────────────────────
+
+    private fun startBrowserFlow(requestId: String) {
+        val codeVerifier = generateCodeVerifier()
+        val codeChallenge = generateCodeChallenge(codeVerifier)
+        val state = generateState()
+
+        // Start local callback server
+        val server = CallbackServer(CALLBACK_PORT) { params ->
+            handleCallback(requestId, params, state, codeVerifier)
+        }
+        try {
+            server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false)
+            callbackServer = server
+            Log.i(TAG, "Callback server started on port $CALLBACK_PORT")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start callback server", e)
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "error")
+                put("message", "Failed to start callback server: ${e.message}")
+            })
+            finish()
+            return
+        }
+
+        // Build authorize URL
+        val authorizeUrl = buildString {
+            append(AUTH_URL)
+            append("?response_type=code")
+            append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
+            append("&redirect_uri=").append(URLEncoder.encode(REDIRECT_URI, "UTF-8"))
+            append("&scope=").append(URLEncoder.encode(SCOPES, "UTF-8"))
+            append("&state=").append(URLEncoder.encode(state, "UTF-8"))
+            append("&code_challenge=").append(URLEncoder.encode(codeChallenge, "UTF-8"))
+            append("&code_challenge_method=S256")
+            append("&id_token_add_organizations=true")
+            append("&codex_cli_simplified_flow=true")
+        }
+
+        // Open in Custom Tab or fallback to browser
+        try {
+            val customTabsIntent = CustomTabsIntent.Builder().build()
+            customTabsIntent.launchUrl(this, Uri.parse(authorizeUrl))
+        } catch (e: Exception) {
+            Log.w(TAG, "Custom Tabs unavailable, falling back to ACTION_VIEW", e)
+            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(authorizeUrl))
+            startActivity(browserIntent)
+        }
+    }
+
+    private fun handleCallback(
+        requestId: String,
+        params: Map<String, String>,
+        expectedState: String,
+        codeVerifier: String
+    ): String {
+        val code = params["code"]
+        val state = params["state"]
+        val error = params["error"]
+
+        if (error != null) {
+            Log.e(TAG, "OAuth error: $error")
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "error")
+                put("message", "OAuth error: $error")
+            })
+            finishOnMain()
+            return buildHtmlResponse("Error", "Authentication failed: $error")
+        }
+
+        if (state != expectedState) {
+            Log.e(TAG, "State mismatch")
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "error")
+                put("message", "State mismatch — possible CSRF attack")
+            })
+            finishOnMain()
+            return buildHtmlResponse("Error", "State verification failed. Please try again.")
+        }
+
+        if (code == null) {
+            Log.e(TAG, "No code in callback")
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "error")
+                put("message", "No authorization code received")
+            })
+            finishOnMain()
+            return buildHtmlResponse("Error", "No authorization code received.")
+        }
+
+        // Exchange code for tokens (on IO thread, block the NanoHTTPD thread briefly)
+        scope.launch {
+            exchangeCodeForTokens(requestId, code, codeVerifier)
+        }
+
+        return buildHtmlResponse(
+            "Success",
+            "Authentication successful! You can close this tab and return to SeekerClaw."
+        )
+    }
+
+    private suspend fun exchangeCodeForTokens(
+        requestId: String,
+        code: String,
+        codeVerifier: String
+    ) {
+        try {
+            val tokenResponse = withContext(Dispatchers.IO) {
+                val body = buildString {
+                    append("grant_type=authorization_code")
+                    append("&code=").append(URLEncoder.encode(code, "UTF-8"))
+                    append("&redirect_uri=").append(URLEncoder.encode(REDIRECT_URI, "UTF-8"))
+                    append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
+                    append("&code_verifier=").append(URLEncoder.encode(codeVerifier, "UTF-8"))
+                }
+                httpPost(TOKEN_URL, body)
+            }
+
+            val json = JSONObject(tokenResponse)
+            val accessToken = json.optString("access_token", "")
+            val refreshToken = json.optString("refresh_token", "")
+            val expiresIn = json.optLong("expires_in", 3600)
+            val expiresAt = java.time.Instant.now().plusSeconds(expiresIn).toString()
+            val email = extractEmailFromJwt(accessToken)
+
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "success")
+                put("accessToken", accessToken)
+                put("refreshToken", refreshToken)
+                put("email", email ?: JSONObject.NULL)
+                put("expiresAt", expiresAt)
+            })
+            Log.i(TAG, "Browser flow completed successfully")
+        } catch (e: Exception) {
+            Log.e(TAG, "Token exchange failed", e)
+            writeResultFile(requestId, JSONObject().apply {
+                put("status", "error")
+                put("message", "Token exchange failed: ${e.message}")
+            })
+        } finally {
+            callbackServer?.stop()
+            callbackServer = null
+            finishOnMain()
+        }
+    }
+
+    // ── Flow B: Device Code ──────────────────────────────────────────────
+
+    private fun startDeviceCodeFlow(requestId: String) {
+        scope.launch {
+            try {
+                val deviceResponse = withContext(Dispatchers.IO) {
+                    val body = buildString {
+                        append("client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
+                        append("&scope=").append(URLEncoder.encode(SCOPES, "UTF-8"))
+                    }
+                    httpPost(DEVICE_URL, body)
+                }
+
+                val json = JSONObject(deviceResponse)
+                val deviceCode = json.getString("device_code")
+                val userCode = json.getString("user_code")
+                val verificationUri = json.getString("verification_uri")
+                val interval = json.optInt("interval", 5)
+                val expiresIn = json.optInt("expires_in", 600)
+
+                // Write pending result so the caller can show the user code
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "pending")
+                    put("userCode", userCode)
+                    put("verificationUri", verificationUri)
+                })
+
+                // Poll for authorization
+                pollForDeviceAuthorization(requestId, deviceCode, interval, expiresIn)
+            } catch (e: Exception) {
+                Log.e(TAG, "Device code request failed", e)
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Device code request failed: ${e.message}")
+                })
+                finish()
+            }
+        }
+    }
+
+    private fun pollForDeviceAuthorization(
+        requestId: String,
+        deviceCode: String,
+        interval: Int,
+        expiresIn: Int
+    ) {
+        val deadline = System.currentTimeMillis() + (expiresIn * 1000L)
+
+        pollingJob = scope.launch {
+            while (isActive && System.currentTimeMillis() < deadline) {
+                delay(interval * 1000L)
+
+                try {
+                    val response = withContext(Dispatchers.IO) {
+                        val body = buildString {
+                            append("grant_type=").append(
+                                URLEncoder.encode(
+                                    "urn:ietf:params:oauth:grant-type:device_code",
+                                    "UTF-8"
+                                )
+                            )
+                            append("&device_code=").append(URLEncoder.encode(deviceCode, "UTF-8"))
+                            append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
+                        }
+                        httpPostRaw(TOKEN_URL, body)
+                    }
+
+                    val statusCode = response.first
+                    val responseBody = response.second
+                    val json = JSONObject(responseBody)
+
+                    if (statusCode in 200..299 && json.has("access_token")) {
+                        // Success
+                        val accessToken = json.getString("access_token")
+                        val refreshToken = json.optString("refresh_token", "")
+                        val tokenExpiresIn = json.optLong("expires_in", 3600)
+                        val expiresAt =
+                            java.time.Instant.now().plusSeconds(tokenExpiresIn).toString()
+                        val email = extractEmailFromJwt(accessToken)
+
+                        writeResultFile(requestId, JSONObject().apply {
+                            put("status", "success")
+                            put("accessToken", accessToken)
+                            put("refreshToken", refreshToken)
+                            put("email", email ?: JSONObject.NULL)
+                            put("expiresAt", expiresAt)
+                        })
+                        Log.i(TAG, "Device code flow completed successfully")
+                        finishOnMain()
+                        return@launch
+                    }
+
+                    val errorCode = json.optString("error", "")
+                    when (errorCode) {
+                        "authorization_pending", "slow_down" -> {
+                            // Continue polling (slow_down: RFC says increase interval,
+                            // but we keep it simple for now)
+                            Log.d(TAG, "Device code polling: $errorCode")
+                        }
+
+                        "expired_token" -> {
+                            writeResultFile(requestId, JSONObject().apply {
+                                put("status", "error")
+                                put("message", "Code expired. Please try again.")
+                            })
+                            finishOnMain()
+                            return@launch
+                        }
+
+                        "access_denied" -> {
+                            writeResultFile(requestId, JSONObject().apply {
+                                put("status", "error")
+                                put("message", "Access denied by user.")
+                            })
+                            finishOnMain()
+                            return@launch
+                        }
+
+                        else -> {
+                            Log.w(TAG, "Unexpected polling error: $errorCode")
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "Polling request failed, will retry", e)
+                }
+            }
+
+            // Timeout
+            if (isActive) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Code expired. Please try again.")
+                })
+                finishOnMain()
+            }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private fun generateCodeVerifier(): String {
+        val bytes = ByteArray(64)
+        SecureRandom().nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    private fun generateCodeChallenge(verifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII))
+        return Base64.encodeToString(digest, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    private fun generateState(): String {
+        val bytes = ByteArray(32)
+        SecureRandom().nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    /**
+     * Decode the payload segment of a JWT and extract email (or sub as fallback).
+     */
+    private fun extractEmailFromJwt(jwt: String): String? {
+        return try {
+            val parts = jwt.split(".")
+            if (parts.size < 3) return null
+            val payload = parts[1]
+            // Base64url decode — add padding if needed
+            val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+            val json = JSONObject(String(decoded, Charsets.UTF_8))
+            val email = json.optString("email", "")
+            val sub = json.optString("sub", "")
+            email.ifEmpty { sub.ifEmpty { null } }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract email from JWT", e)
+            null
+        }
+    }
+
+    private fun httpPost(url: String, body: String): String {
+        val result = httpPostRaw(url, body)
+        if (result.first !in 200..299) {
+            throw RuntimeException("HTTP ${result.first}: ${result.second}")
+        }
+        return result.second
+    }
+
+    /**
+     * Returns Pair(statusCode, responseBody).
+     */
+    private fun httpPostRaw(url: String, body: String): Pair<Int, String> {
+        val conn = URL(url).openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+            conn.doOutput = true
+            conn.connectTimeout = 15_000
+            conn.readTimeout = 15_000
+
+            OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(body) }
+
+            val statusCode = conn.responseCode
+            val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
+            val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
+            return Pair(statusCode, responseBody)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun writeResultFile(requestId: String, result: JSONObject) {
+        val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
+        val tmpFile = File(resultDir, "$requestId.tmp")
+        val jsonFile = File(resultDir, "$requestId.json")
+        tmpFile.writeText(result.toString())
+        tmpFile.renameTo(jsonFile)
+        Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
+    }
+
+    private fun finishOnMain() {
+        runOnUiThread { finish() }
+    }
+
+    private fun buildHtmlResponse(title: String, message: String): String {
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head><title>$title</title>
+            <style>
+                body { font-family: -apple-system, sans-serif; display: flex;
+                       justify-content: center; align-items: center; height: 100vh;
+                       margin: 0; background: #0D0D0D; color: #fff; }
+                .card { text-align: center; padding: 2rem; }
+                h1 { color: ${if (title == "Success") "#00C805" else "#FF4444"}; }
+            </style></head>
+            <body><div class="card"><h1>$title</h1><p>$message</p></div></body>
+            </html>
+        """.trimIndent()
+    }
+
+    // ── NanoHTTPD Callback Server ────────────────────────────────────────
+
+    private class CallbackServer(
+        port: Int,
+        private val onCallback: (Map<String, String>) -> String
+    ) : NanoHTTPD("127.0.0.1", port) {
+
+        override fun serve(session: IHTTPSession): Response {
+            if (session.uri == "/auth/callback" && session.method == Method.GET) {
+                @Suppress("DEPRECATION")
+                val params = session.parms ?: emptyMap()
+                val html = onCallback(params)
+                return newFixedLengthResponse(Response.Status.OK, "text/html", html)
+            }
+            return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "Not found")
+        }
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -51,6 +51,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
     // Written from the NanoHTTPD server thread, read from the Main timeout coroutine — needs @Volatile.
     @Volatile
     private var callbackReceived = false
+    // Set to true once exchangeCodeForTokens has finished writing a success/error result file,
+    // so onDestroy doesn't overwrite the real outcome with a "canceled" entry.
+    @Volatile
+    private var resultWritten = false
+    private var currentRequestId: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -60,6 +65,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             finish()
             return
         }
+        currentRequestId = requestId
 
         // Minimal "waiting for sign-in" UI so the user doesn't return from the
         // browser to a blank translucent activity. The Cancel button stops the
@@ -114,10 +120,10 @@ class OpenAIOAuthActivity : ComponentActivity() {
                             put("message", "Sign-in canceled")
                         })
                     }
+                    resultWritten = true
                     finishOnMain()
                 }
             }
-            (layoutParams as? android.widget.LinearLayout.LayoutParams)?.topMargin = dp(24)
         }
         root.addView(title)
         root.addView(subtitle)
@@ -134,6 +140,21 @@ class OpenAIOAuthActivity : ComponentActivity() {
         super.onDestroy()
         callbackServer?.stop()
         callbackServer = null
+        // If the activity is dismissed (Back button, system kill, swipe-away) before any
+        // result has been written, leave a canceled result so ProviderConfigScreen stops
+        // polling immediately instead of waiting out the 10-minute deadline.
+        if (!resultWritten) {
+            currentRequestId?.let { reqId ->
+                try {
+                    writeResultFile(reqId, JSONObject().apply {
+                        put("status", "error")
+                        put("message", "Sign-in canceled")
+                    })
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to write canceled result on destroy", e)
+                }
+            }
+        }
         scope.cancel()
     }
 
@@ -154,11 +175,16 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.i(TAG, "Callback server started on port $CALLBACK_PORT")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start callback server", e)
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "error")
-                put("message", "Failed to start callback server: ${e.message}")
-            })
-            finish()
+            scope.launch {
+                withContext(Dispatchers.IO) {
+                    writeResultFile(requestId, JSONObject().apply {
+                        put("status", "error")
+                        put("message", "Failed to start callback server: ${e.message}")
+                    })
+                }
+                resultWritten = true
+                finishOnMain()
+            }
             return
         }
 
@@ -201,6 +227,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                         put("message", "Browser login timed out. Please try again.")
                     })
                 }
+                resultWritten = true
                 finishOnMain()
             }
         }
@@ -247,6 +274,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 put("status", "error")
                 put("message", "OAuth error: $error")
             })
+            resultWritten = true
             finishOnMain()
             return buildHtmlResponse("Error", "Authentication failed: $error")
         }
@@ -257,6 +285,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 put("status", "error")
                 put("message", "No authorization code received")
             })
+            resultWritten = true
             finishOnMain()
             return buildHtmlResponse("Error", "No authorization code received.")
         }
@@ -332,6 +361,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     put("status", "success")
                 })
             }
+            resultWritten = true
             Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
@@ -341,6 +371,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     put("message", "Token exchange failed: ${e.message}")
                 })
             }
+            resultWritten = true
         } finally {
             callbackServer?.stop()
             callbackServer = null

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -460,19 +460,21 @@ class OpenAIOAuthActivity : ComponentActivity() {
             callbackReceived = true
         }
 
-        // From here on, we know this is the legitimate browser redirect — surface
-        // any OpenAI-side error and tear down the flow.
+        // From here on, we know this is the legitimate browser redirect. Log any
+        // OpenAI-side error for diagnostics, but persist/display only a generic
+        // message — callback query params are untrusted input (any local app can
+        // hit 127.0.0.1:1455) and may contain arbitrary content.
         if (error != null) {
             Log.e(TAG, "OAuth error: $error")
             if (claimWrite()) {
                 writeResultFile(requestId, JSONObject().apply {
                     put("status", "error")
-                    put("message", "OAuth error: $error")
+                    put("message", "Authentication failed. Please try again.")
                 })
                 markWriteCompleted()
             }
             finishOnMain()
-            return buildHtmlResponse("Error", "Authentication failed: $error")
+            return buildHtmlResponse("Error", "Authentication failed. Please try again.")
         }
 
         if (code == null) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -221,7 +221,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
         }
         // Sanitize requestId — even though the activity is exported=false, we want to
         // ensure the value can never escape filesDir/oauth_results via path traversal.
-        // Accept only canonical UUID format (lowercase hex + dashes).
+        // Accept only UUID format (hex digits, either case, separated by dashes).
         if (!UUID_PATTERN.matches(rawRequestId)) {
             Log.w(TAG, "Rejected non-UUID requestId: ${rawRequestId.take(40)}")
             finish()

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -47,9 +47,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
         const val AUTH_URL = "https://auth.openai.com/oauth/authorize"
         const val TOKEN_URL = "https://auth.openai.com/oauth/token"
-        // Use 127.0.0.1 (not "localhost") so browsers can't resolve the redirect to ::1
-        // and miss the IPv4 NanoHTTPD listener.
-        const val REDIRECT_URI = "http://127.0.0.1:1455/auth/callback"
+        // Must be exactly "localhost" — the Codex OAuth client (app_EMoamEEZ...) is
+        // registered with this redirect URI. Using 127.0.0.1 causes OpenAI to reject the
+        // authorize request as a redirect_uri mismatch ("unknown_error" on their side).
+        // The IPv6-resolution risk Copilot flagged is theoretical — Codex CLI itself
+        // uses "localhost" in production and the NanoHTTPD listener resolves correctly.
+        const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
 

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -51,6 +51,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private var callbackServer: CallbackServer? = null
     private val scope = CoroutineScope(Dispatchers.Main + Job())
     private var pollingJob: Job? = null
+    private var browserLaunched = false
+    private var callbackReceived = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,6 +81,15 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 })
                 finish()
             }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // If browser was launched but no callback received, user closed the browser — finish
+        if (browserLaunched && !callbackReceived) {
+            Log.i(TAG, "Browser closed without completing OAuth — finishing")
+            finish()
         }
     }
 
@@ -138,6 +149,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(authorizeUrl))
             startActivity(browserIntent)
         }
+        browserLaunched = true
 
         // Safety timeout: if user abandons browser login, stop server and write error after 10 min
         scope.launch {
@@ -161,6 +173,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
         expectedState: String,
         codeVerifier: String
     ): String {
+        callbackReceived = true
         val code = params["code"]
         val state = params["state"]
         val error = params["error"]

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -229,11 +229,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
             // Try id_token first (has email), fall back to access_token
             val email = extractEmailFromJwt(idToken) ?: extractEmailFromJwt(accessToken)
 
-            // Persist tokens directly to encrypted storage instead of writing them to a
-            // result file. Bearer tokens must never sit on disk in plaintext, even briefly
-            // (RFC 6819 §5.1.4, OWASP MASVS-STORAGE-1). The result file only carries a
-            // status flag — the polling UI reloads config from ConfigManager to pick up
-            // the new tokens.
+            // Persist tokens via ConfigManager rather than echoing them into the transient
+            // OAuth result file. ConfigManager encrypts secrets via Android Keystore for
+            // app-process storage; the workspace/config.json handoff to the embedded Node
+            // runtime is a separate, known constraint (Node can't read Keystore directly).
+            // The result file here only carries a status flag, and the polling UI reloads
+            // config from ConfigManager to pick up the new tokens.
             withContext(Dispatchers.IO) {
                 val current = ConfigManager.loadConfig(this@OpenAIOAuthActivity)
                 if (current == null) {
@@ -345,17 +346,27 @@ class OpenAIOAuthActivity : ComponentActivity() {
     }
 
     private fun writeResultFile(requestId: String, result: JSONObject) {
-        val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
-        val tmpFile = File(resultDir, "$requestId.tmp")
-        val jsonFile = File(resultDir, "$requestId.json")
-        tmpFile.writeText(result.toString())
-        jsonFile.delete() // renameTo won't overwrite existing file on Android
-        if (!tmpFile.renameTo(jsonFile)) {
-            // Fallback: copy + delete if rename fails on some Android filesystems
-            tmpFile.copyTo(jsonFile, overwrite = true)
-            tmpFile.delete()
+        try {
+            val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
+            val tmpFile = File(resultDir, "$requestId.tmp")
+            val jsonFile = File(resultDir, "$requestId.json")
+            tmpFile.writeText(result.toString())
+            jsonFile.delete() // renameTo won't overwrite existing file on Android
+            if (!tmpFile.renameTo(jsonFile)) {
+                // Fallback: copy + delete if rename fails on some Android filesystems
+                tmpFile.copyTo(jsonFile, overwrite = true)
+                tmpFile.delete()
+            }
+            Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
+        } catch (e: Exception) {
+            // Storage full or filesystem error — log and finish so the UI doesn't hang
+            // polling for a result file that will never appear, and so the callback
+            // server doesn't stay up indefinitely.
+            Log.e(TAG, "Failed to write OAuth result file for requestId=$requestId", e)
+            try { finishOnMain() } catch (finishEx: Exception) {
+                Log.e(TAG, "Failed to finish activity after writeResultFile error", finishEx)
+            }
         }
-        Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
     }
 
     private fun finishOnMain() {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -313,14 +313,16 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // If the activity is dismissed (Back button, system kill, swipe-away) BEFORE a
         // valid callback has arrived AND no other path has claimed the write slot, leave
         // a canceled result so ProviderConfigScreen stops polling immediately. We MUST
-        // gate on !callbackReceived — if a callback has already arrived, the GlobalScope
-        // exchange is in flight and writing a synthetic "canceled" here would race a
-        // real sign-in and produce a misleading status.
+        // gate on !callbackReceived — if a callback has already arrived, the EXCHANGE_SCOPE
+        // exchange is in flight and writing a synthetic "canceled" here would race a real
+        // sign-in and produce a misleading status. Use EXCHANGE_SCOPE (application-
+        // lifetime) instead of scope (being cancelled here) so the write actually runs.
         val reqId = currentRequestId
         if (reqId != null && !callbackReceived && claimWrite()) {
-            Thread {
+            val appCtx = applicationContext
+            EXCHANGE_SCOPE.launch {
                 try {
-                    writeResultFile(reqId, JSONObject().apply {
+                    writeResultFileStatic(appCtx, reqId, JSONObject().apply {
                         put("status", "error")
                         put("message", "Sign-in canceled")
                     })
@@ -329,7 +331,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 } finally {
                     markWriteCompleted()
                 }
-            }.start()
+            }
         }
         scope.cancel()
     }
@@ -540,26 +542,25 @@ class OpenAIOAuthActivity : ComponentActivity() {
         try {
             doWriteResultFile(requestId, result)
         } catch (e: Exception) {
-            // Storage full or filesystem error. Try once more in a fresh thread after a
-            // short delay (transient issues like brief storage pressure can self-resolve).
-            // If that also fails, fall back to writing a minimal status file with no JSON
-            // body so the polling UI at least sees *something* and stops spinning.
+            // Storage full or filesystem error. Retry once on EXCHANGE_SCOPE after a
+            // short delay (transient pressure self-resolves). If retry also fails, write
+            // a minimal status-only file so the polling UI sees *something* and stops.
             Log.e(TAG, "Failed to write OAuth result file for requestId=$requestId", e)
-            Thread {
+            val appCtx = applicationContext
+            EXCHANGE_SCOPE.launch {
+                kotlinx.coroutines.delay(500)
                 try {
-                    Thread.sleep(500)
-                    doWriteResultFile(requestId, result)
+                    writeResultFileStatic(appCtx, requestId, result)
                     Log.i(TAG, "Result file write succeeded on retry")
                 } catch (retry: Exception) {
                     Log.e(TAG, "Result file retry also failed", retry)
-                    // Last-ditch: write a minimal status-only file so the UI stops polling.
                     try {
-                        File(filesDir, RESULTS_DIR).apply { mkdirs() }
+                        File(appCtx.filesDir, RESULTS_DIR).apply { mkdirs() }
                             .resolve("$requestId.json")
                             .writeText("""{"status":"error","message":"Failed to persist OAuth result"}""")
                     } catch (_: Exception) { /* nothing more we can do */ }
                 }
-            }.start()
+            }
             try { finishOnMain() } catch (finishEx: Exception) {
                 Log.e(TAG, "Failed to finish activity after writeResultFile error", finishEx)
             }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -448,6 +448,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
         val tmpFile = File(resultDir, "$requestId.tmp")
         val jsonFile = File(resultDir, "$requestId.json")
         tmpFile.writeText(result.toString())
+        jsonFile.delete() // renameTo won't overwrite existing file on Android
         tmpFile.renameTo(jsonFile)
         Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
     }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -684,14 +684,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private class CallbackServer(
         port: Int,
         private val onCallback: (Map<String, String>) -> String
-    ) : NanoHTTPD(port) {
-        // No hostname → NanoHTTPD binds to all loopback interfaces, so a browser that
-        // resolves "localhost" to ::1 (IPv6) still reaches this server. Previously bound
-        // to "127.0.0.1" only, which mismatched the literal "localhost" in REDIRECT_URI
-        // and could fail on dual-stack devices. The redirect URI must stay as "localhost"
-        // because Codex's OAuth client (app_EMoamEEZ...) is registered with that exact
-        // string — switching to 127.0.0.1 causes auth.openai.com to reject the authorize
-        // request as redirect_uri mismatch.
+    ) : NanoHTTPD("localhost", port) {
+        // Bind explicitly to "localhost" so the OAuth callback listener is reachable
+        // only from the local device — never from all network interfaces (NanoHTTPD's
+        // no-hostname constructor binds to 0.0.0.0). The redirect URI must also stay
+        // as "localhost" because Codex's OAuth client (app_EMoamEEZ...) is registered
+        // with that exact string — switching to "127.0.0.1" causes auth.openai.com
+        // to reject the authorize request as redirect_uri mismatch.
 
         override fun serve(session: IHTTPSession): Response {
             if (session.uri == "/auth/callback" && session.method == Method.GET) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -138,6 +138,21 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(authorizeUrl))
             startActivity(browserIntent)
         }
+
+        // Safety timeout: if user abandons browser login, stop server and write error after 10 min
+        scope.launch {
+            delay(600_000)
+            if (callbackServer != null) {
+                Log.w(TAG, "Browser flow timed out after 10 minutes")
+                callbackServer?.stop()
+                callbackServer = null
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Browser login timed out. Please try again.")
+                })
+                finishOnMain()
+            }
+        }
     }
 
     private fun handleCallback(
@@ -401,7 +416,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val parts = jwt.split(".")
             if (parts.size < 3) return null
             val payload = parts[1]
-            // Base64url decode — NO_PADDING flag handles missing '=' padding automatically
+            // Base64url decode — Android's Base64.NO_PADDING flag accepts input without '=' padding
             val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
             val json = JSONObject(String(decoded, Charsets.UTF_8))
             val email = json.optString("email", "")

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -224,6 +224,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
             val json = JSONObject(tokenResponse)
             val accessToken = json.optString("access_token", "")
+            if (accessToken.isBlank()) {
+                // Malformed/error response — don't overwrite existing tokens with "" and
+                // don't signal success to the UI.
+                val errMsg = json.optString("error_description", "")
+                    .ifBlank { json.optString("error", "Token response missing access_token") }
+                throw IllegalStateException(errMsg)
+            }
             val refreshToken = json.optString("refresh_token", "")
             val idToken = json.optString("id_token", "")
             val expiresIn = json.optLong("expires_in", 3600)

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -130,10 +130,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 Log.w(TAG, "Browser flow timed out after 10 minutes")
                 callbackServer?.stop()
                 callbackServer = null
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Browser login timed out. Please try again.")
-                })
+                withContext(Dispatchers.IO) {
+                    writeResultFile(requestId, JSONObject().apply {
+                        put("status", "error")
+                        put("message", "Browser login timed out. Please try again.")
+                    })
+                }
                 finishOnMain()
             }
         }
@@ -260,16 +262,20 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 )
             }
 
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "success")
-            })
+            withContext(Dispatchers.IO) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "success")
+                })
+            }
             Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "error")
-                put("message", "Token exchange failed: ${e.message}")
-            })
+            withContext(Dispatchers.IO) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Token exchange failed: ${e.message}")
+                })
+            }
         } finally {
             callbackServer?.stop()
             callbackServer = null

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -51,9 +51,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private var callbackServer: CallbackServer? = null
     private val scope = CoroutineScope(Dispatchers.Main + Job())
     private var pollingJob: Job? = null
-    private var browserLaunched = false
     private var callbackReceived = false
-    private var resumeCount = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -80,19 +78,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     put("status", "error")
                     put("message", "Unknown method: $method")
                 })
-                finish()
-            }
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (browserLaunched && !callbackReceived) {
-            resumeCount++
-            // Skip first resume (Custom Tab opening triggers it).
-            // Second resume = user actually came back without completing auth.
-            if (resumeCount > 1) {
-                Log.i(TAG, "Browser closed without completing OAuth — finishing")
                 finish()
             }
         }
@@ -154,7 +139,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(authorizeUrl))
             startActivity(browserIntent)
         }
-        browserLaunched = true
 
         // Safety timeout: if user abandons browser login, stop server and write error after 10 min
         scope.launch {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -400,7 +400,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val parts = jwt.split(".")
             if (parts.size < 3) return null
             val payload = parts[1]
-            // Base64url decode — add padding if needed
+            // Base64url decode — NO_PADDING flag handles missing '=' padding automatically
             val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
             val json = JSONObject(String(decoded, Charsets.UTF_8))
             val email = json.optString("email", "")
@@ -449,7 +449,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
         val jsonFile = File(resultDir, "$requestId.json")
         tmpFile.writeText(result.toString())
         jsonFile.delete() // renameTo won't overwrite existing file on Android
-        tmpFile.renameTo(jsonFile)
+        if (!tmpFile.renameTo(jsonFile)) {
+            // Fallback: copy + delete if rename fails on some Android filesystems
+            tmpFile.copyTo(jsonFile, overwrite = true)
+            tmpFile.delete()
+        }
         Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
     }
 
@@ -457,11 +461,17 @@ class OpenAIOAuthActivity : ComponentActivity() {
         runOnUiThread { finish() }
     }
 
+    private fun escapeHtml(text: String): String = text
+        .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        .replace("\"", "&quot;").replace("'", "&#39;")
+
     private fun buildHtmlResponse(title: String, message: String): String {
+        val safeTitle = escapeHtml(title)
+        val safeMessage = escapeHtml(message)
         return """
             <!DOCTYPE html>
             <html>
-            <head><title>$title</title>
+            <head><title>$safeTitle</title>
             <style>
                 body { font-family: -apple-system, sans-serif; display: flex;
                        justify-content: center; align-items: center; height: 100vh;
@@ -469,7 +479,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 .card { text-align: center; padding: 2rem; }
                 h1 { color: ${if (title == "Success") "#00C805" else "#FF4444"}; }
             </style></head>
-            <body><div class="card"><h1>$title</h1><p>$message</p></div></body>
+            <body><div class="card"><h1>$safeTitle</h1><p>$safeMessage</p></div></body>
             </html>
         """.trimIndent()
     }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -11,6 +11,7 @@ import com.seekerclaw.app.config.ConfigManager
 import fi.iki.elonen.NanoHTTPD
 import java.util.concurrent.atomic.AtomicReference
 import android.content.Context
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -57,6 +58,137 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // always completes its persist + result-write, regardless of UI lifecycle.
         // SupervisorJob means a single failed exchange doesn't cancel sibling jobs.
         private val EXCHANGE_SCOPE = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+        /**
+         * Static token-exchange entry point. Pure function — takes only Application
+         * Context + the OAuth params + a cleanup callback. Does NOT capture an Activity
+         * instance, so launching this on EXCHANGE_SCOPE cannot leak the Activity.
+         *
+         * Persists tokens via ConfigManager (encrypted via Keystore) and writes the
+         * status result file directly to filesDir. Calls [onComplete] on the same
+         * thread when done so the caller can do whatever cleanup it likes (typically
+         * via a WeakReference back to the Activity).
+         */
+        suspend fun exchangeCodeForTokensStatic(
+            appCtx: Context,
+            requestId: String,
+            code: String,
+            codeVerifier: String,
+            onComplete: () -> Unit,
+        ) {
+            try {
+                val tokenResponse = withContext(NonCancellable + Dispatchers.IO) {
+                    val body = buildString {
+                        append("grant_type=authorization_code")
+                        append("&code=").append(URLEncoder.encode(code, "UTF-8"))
+                        append("&redirect_uri=").append(URLEncoder.encode(REDIRECT_URI, "UTF-8"))
+                        append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
+                        append("&code_verifier=").append(URLEncoder.encode(codeVerifier, "UTF-8"))
+                    }
+                    httpPostStatic(TOKEN_URL, body)
+                }
+                val json = JSONObject(tokenResponse)
+                val accessToken = json.optString("access_token", "")
+                if (accessToken.isBlank()) {
+                    val errMsg = json.optString("error_description", "")
+                        .ifBlank { json.optString("error", "Token response missing access_token") }
+                    throw IllegalStateException(errMsg)
+                }
+                val refreshToken = json.optString("refresh_token", "")
+                val idToken = json.optString("id_token", "")
+                val expiresIn = json.optLong("expires_in", 3600)
+                val expiresAt = java.time.Instant.now().plusSeconds(expiresIn).toString()
+                val email = extractEmailFromJwtStatic(idToken) ?: extractEmailFromJwtStatic(accessToken)
+
+                withContext(NonCancellable + Dispatchers.IO) {
+                    val current = ConfigManager.loadConfig(appCtx)
+                        ?: throw IllegalStateException("Config not loaded — cannot persist OAuth tokens")
+                    ConfigManager.saveConfig(
+                        appCtx,
+                        current.copy(
+                            openaiOAuthToken = accessToken,
+                            openaiOAuthRefresh = refreshToken.ifBlank { current.openaiOAuthRefresh },
+                            openaiOAuthEmail = email ?: current.openaiOAuthEmail,
+                            openaiOAuthExpiresAt = expiresAt,
+                        )
+                    )
+                    writeResultFileStatic(appCtx, requestId, JSONObject().apply {
+                        put("status", "success")
+                    })
+                }
+                Log.i(TAG, "Browser flow completed successfully")
+            } catch (e: Exception) {
+                Log.e(TAG, "Token exchange failed", e)
+                try {
+                    withContext(NonCancellable + Dispatchers.IO) {
+                        writeResultFileStatic(appCtx, requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "Token exchange failed: ${e.message}")
+                        })
+                    }
+                } catch (writeErr: Exception) {
+                    Log.e(TAG, "Failed to write OAuth error result", writeErr)
+                }
+            } finally {
+                onComplete()
+            }
+        }
+
+        /** Static HTTP POST helper — used by both the companion exchange and the instance flow. */
+        private fun httpPostStatic(url: String, body: String): String {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            try {
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+                conn.doOutput = true
+                conn.connectTimeout = 15_000
+                conn.readTimeout = 15_000
+                OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(body) }
+                val statusCode = conn.responseCode
+                val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
+                val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
+                if (statusCode !in 200..299) throw RuntimeException("HTTP $statusCode: $responseBody")
+                return responseBody
+            } finally {
+                conn.disconnect()
+            }
+        }
+
+        /** Static result-file writer using only application Context — no Activity capture. */
+        private fun writeResultFileStatic(appCtx: Context, requestId: String, result: JSONObject) {
+            val resultDir = File(appCtx.filesDir, RESULTS_DIR).apply { mkdirs() }
+            val tmpFile = File(resultDir, "$requestId.tmp")
+            val jsonFile = File(resultDir, "$requestId.json")
+            tmpFile.writeText(result.toString())
+            jsonFile.delete()
+            if (!tmpFile.renameTo(jsonFile)) {
+                tmpFile.copyTo(jsonFile, overwrite = true)
+                tmpFile.delete()
+            }
+            Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
+        }
+
+        /** Static JWT email extractor — no Activity dependency. */
+        private fun extractEmailFromJwtStatic(jwt: String): String? {
+            return try {
+                val parts = jwt.split(".")
+                if (parts.size < 3) return null
+                val payload = parts[1]
+                val normalized = when (payload.length % 4) {
+                    0 -> payload
+                    else -> payload.padEnd(payload.length + (4 - (payload.length % 4)), '=')
+                }
+                val decoded = Base64.decode(normalized, Base64.URL_SAFE or Base64.NO_WRAP)
+                val json = JSONObject(String(decoded, Charsets.UTF_8))
+                val email = json.optString("email", "")
+                val name = json.optString("name", "")
+                val preferredUsername = json.optString("preferred_username", "")
+                val sub = json.optString("sub", "")
+                email.ifEmpty { preferredUsername.ifEmpty { name.ifEmpty { sub.ifEmpty { null } } } }
+            } catch (_: Exception) {
+                null
+            }
+        }
     }
 
     private var callbackServer: CallbackServer? = null
@@ -339,13 +471,21 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return buildHtmlResponse("Error", "Sign-in already completed in another tab.")
         }
 
-        // Run the exchange on the application-lifetime EXCHANGE_SCOPE (not the activity
-        // scope) so it survives activity destruction. We pass applicationContext explicitly
-        // so the exchange path doesn't pin the Activity instance through ConfigManager /
-        // file I/O — only the application Context, which is process-lifetime anyway.
+        // Run the exchange on the application-lifetime EXCHANGE_SCOPE via a companion
+        // function that takes only appCtx + a WeakReference for cleanup. The launched
+        // coroutine therefore does NOT capture the Activity instance — it survives
+        // destruction without leaking, and the cleanup callback is a no-op if the
+        // activity is already gone.
         val appCtx = applicationContext
+        val activityRef = WeakReference(this)
         EXCHANGE_SCOPE.launch {
-            exchangeCodeForTokens(appCtx, requestId, code, codeVerifier)
+            exchangeCodeForTokensStatic(
+                appCtx = appCtx,
+                requestId = requestId,
+                code = code,
+                codeVerifier = codeVerifier,
+                onComplete = { activityRef.get()?.onExchangeComplete() },
+            )
         }
 
         return buildHtmlResponse(
@@ -354,88 +494,16 @@ class OpenAIOAuthActivity : ComponentActivity() {
         )
     }
 
-    private suspend fun exchangeCodeForTokens(
-        appCtx: Context,
-        requestId: String,
-        code: String,
-        codeVerifier: String
-    ) {
-        // The write slot was claimed by handleCallback() before this coroutine was
-        // launched, so we can proceed straight to the exchange. We just need to make
-        // sure markWriteCompleted() is called on every exit path.
-        try {
-            val tokenResponse = withContext(Dispatchers.IO) {
-                val body = buildString {
-                    append("grant_type=authorization_code")
-                    append("&code=").append(URLEncoder.encode(code, "UTF-8"))
-                    append("&redirect_uri=").append(URLEncoder.encode(REDIRECT_URI, "UTF-8"))
-                    append("&client_id=").append(URLEncoder.encode(CLIENT_ID, "UTF-8"))
-                    append("&code_verifier=").append(URLEncoder.encode(codeVerifier, "UTF-8"))
-                }
-                httpPost(TOKEN_URL, body)
-            }
-
-            val json = JSONObject(tokenResponse)
-            val accessToken = json.optString("access_token", "")
-            if (accessToken.isBlank()) {
-                // Malformed/error response — don't overwrite existing tokens with "" and
-                // don't signal success to the UI.
-                val errMsg = json.optString("error_description", "")
-                    .ifBlank { json.optString("error", "Token response missing access_token") }
-                throw IllegalStateException(errMsg)
-            }
-            val refreshToken = json.optString("refresh_token", "")
-            val idToken = json.optString("id_token", "")
-            val expiresIn = json.optLong("expires_in", 3600)
-            val expiresAt = java.time.Instant.now().plusSeconds(expiresIn).toString()
-            // Try id_token first (has email), fall back to access_token
-            val email = extractEmailFromJwt(idToken) ?: extractEmailFromJwt(accessToken)
-
-            // Persist tokens via ConfigManager rather than echoing them into the transient
-            // OAuth result file. ConfigManager encrypts secrets via Android Keystore for
-            // app-process storage; the workspace/config.json handoff to the embedded Node
-            // runtime is a separate, known constraint (Node can't read Keystore directly).
-            // The result file here only carries a status flag, and the polling UI reloads
-            // config from ConfigManager to pick up the new tokens.
-            withContext(Dispatchers.IO) {
-                val current = ConfigManager.loadConfig(appCtx)
-                if (current == null) {
-                    throw IllegalStateException("Config not loaded — cannot persist OAuth tokens")
-                }
-                ConfigManager.saveConfig(
-                    appCtx,
-                    current.copy(
-                        openaiOAuthToken = accessToken,
-                        openaiOAuthRefresh = refreshToken.ifBlank { current.openaiOAuthRefresh },
-                        openaiOAuthEmail = email ?: current.openaiOAuthEmail,
-                        openaiOAuthExpiresAt = expiresAt,
-                    )
-                )
-            }
-
-            // We already claimed the write slot at the top of this function.
-            // NonCancellable so a quick onDestroy can't cancel us mid-write.
-            withContext(NonCancellable + Dispatchers.IO) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "success")
-                })
-            }
-            markWriteCompleted()
-            Log.i(TAG, "Browser flow completed successfully")
-        } catch (e: Exception) {
-            Log.e(TAG, "Token exchange failed", e)
-            withContext(NonCancellable + Dispatchers.IO) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Token exchange failed: ${e.message}")
-                })
-            }
-            markWriteCompleted()
-        } finally {
-            callbackServer?.stop()
-            callbackServer = null
-            finishOnMain()
-        }
+    /**
+     * Called by the companion-object exchange when it completes (success or failure).
+     * Runs on whatever thread the companion finishes on; hops to Main for UI work.
+     * No-op if the activity is already gone (the WeakReference returns null).
+     */
+    private fun onExchangeComplete() {
+        callbackServer?.stop()
+        callbackServer = null
+        markWriteCompleted()
+        finishOnMain()
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -113,6 +113,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 Log.i(TAG, "User canceled OAuth flow")
                 callbackServer?.stop()
                 callbackServer = null
+                resultWritten = true
                 scope.launch {
                     withContext(Dispatchers.IO) {
                         writeResultFile(requestId, JSONObject().apply {
@@ -120,7 +121,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
                             put("message", "Sign-in canceled")
                         })
                     }
-                    resultWritten = true
                     finishOnMain()
                 }
             }
@@ -175,6 +175,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.i(TAG, "Callback server started on port $CALLBACK_PORT")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start callback server", e)
+            resultWritten = true
             scope.launch {
                 withContext(Dispatchers.IO) {
                     writeResultFile(requestId, JSONObject().apply {
@@ -182,7 +183,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
                         put("message", "Failed to start callback server: ${e.message}")
                     })
                 }
-                resultWritten = true
                 finishOnMain()
             }
             return
@@ -221,13 +221,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 Log.w(TAG, "Browser flow timed out after 10 minutes")
                 callbackServer?.stop()
                 callbackServer = null
+                resultWritten = true
                 withContext(Dispatchers.IO) {
                     writeResultFile(requestId, JSONObject().apply {
                         put("status", "error")
                         put("message", "Browser login timed out. Please try again.")
                     })
                 }
-                resultWritten = true
                 finishOnMain()
             }
         }
@@ -270,22 +270,22 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // any OpenAI-side error and tear down the flow.
         if (error != null) {
             Log.e(TAG, "OAuth error: $error")
+            resultWritten = true
             writeResultFile(requestId, JSONObject().apply {
                 put("status", "error")
                 put("message", "OAuth error: $error")
             })
-            resultWritten = true
             finishOnMain()
             return buildHtmlResponse("Error", "Authentication failed: $error")
         }
 
         if (code == null) {
             Log.e(TAG, "No code in callback")
+            resultWritten = true
             writeResultFile(requestId, JSONObject().apply {
                 put("status", "error")
                 put("message", "No authorization code received")
             })
-            resultWritten = true
             finishOnMain()
             return buildHtmlResponse("Error", "No authorization code received.")
         }
@@ -356,22 +356,25 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 )
             }
 
+            // Set the guard BEFORE the file write so onDestroy() can't race in
+            // between write completion and the flag flip and emit a conflicting
+            // "canceled" result on top of the legitimate outcome.
+            resultWritten = true
             withContext(Dispatchers.IO) {
                 writeResultFile(requestId, JSONObject().apply {
                     put("status", "success")
                 })
             }
-            resultWritten = true
             Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
+            resultWritten = true
             withContext(Dispatchers.IO) {
                 writeResultFile(requestId, JSONObject().apply {
                     put("status", "error")
                     put("message", "Token exchange failed: ${e.message}")
                 })
             }
-            resultWritten = true
         } finally {
             callbackServer?.stop()
             callbackServer = null

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -53,6 +53,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private var pollingJob: Job? = null
     private var browserLaunched = false
     private var callbackReceived = false
+    private var resumeCount = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,10 +87,14 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        // If browser was launched but no callback received, user closed the browser — finish
         if (browserLaunched && !callbackReceived) {
-            Log.i(TAG, "Browser closed without completing OAuth — finishing")
-            finish()
+            resumeCount++
+            // Skip first resume (Custom Tab opening triggers it).
+            // Second resume = user actually came back without completing auth.
+            if (resumeCount > 1) {
+                Log.i(TAG, "Browser closed without completing OAuth — finishing")
+                finish()
+            }
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -53,6 +53,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
 
+        private val UUID_PATTERN = Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
         // Application-lifetime scope for the token exchange. Survives Activity destruction
         // (rotation, system reclaim, fast back-press) so a successful browser redirect
         // always completes its persist + result-write, regardless of UI lifecycle.
@@ -212,11 +214,20 @@ class OpenAIOAuthActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val requestId = intent.getStringExtra("requestId") ?: run {
+        val rawRequestId = intent.getStringExtra("requestId") ?: run {
             Log.w(TAG, "No requestId specified")
             finish()
             return
         }
+        // Sanitize requestId — even though the activity is exported=false, we want to
+        // ensure the value can never escape filesDir/oauth_results via path traversal.
+        // Accept only canonical UUID format (lowercase hex + dashes).
+        if (!UUID_PATTERN.matches(rawRequestId)) {
+            Log.w(TAG, "Rejected non-UUID requestId: ${rawRequestId.take(40)}")
+            finish()
+            return
+        }
+        val requestId = rawRequestId
         currentRequestId = requestId
 
         // Minimal "waiting for sign-in" UI so the user doesn't return from the
@@ -523,64 +534,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
         val bytes = ByteArray(32)
         SecureRandom().nextBytes(bytes)
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-    }
-
-    /**
-     * Decode the payload segment of a JWT and extract email (or sub as fallback).
-     */
-    private fun extractEmailFromJwt(jwt: String): String? {
-        return try {
-            val parts = jwt.split(".")
-            if (parts.size < 3) return null
-            val payload = parts[1]
-            // Base64url decode — normalize padding to avoid edge cases on some Android versions
-            val normalizedPayload = when (payload.length % 4) {
-                0 -> payload
-                else -> payload.padEnd(payload.length + (4 - (payload.length % 4)), '=')
-            }
-            val decoded = Base64.decode(normalizedPayload, Base64.URL_SAFE or Base64.NO_WRAP)
-            val json = JSONObject(String(decoded, Charsets.UTF_8))
-            // Try multiple claim names — OpenAI JWT varies by auth method
-            val email = json.optString("email", "")
-            val name = json.optString("name", "")
-            val preferredUsername = json.optString("preferred_username", "")
-            val sub = json.optString("sub", "")
-            email.ifEmpty { preferredUsername.ifEmpty { name.ifEmpty { sub.ifEmpty { null } } } }
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to extract email from JWT", e)
-            null
-        }
-    }
-
-    private fun httpPost(url: String, body: String): String {
-        val result = httpPostRaw(url, body)
-        if (result.first !in 200..299) {
-            throw RuntimeException("HTTP ${result.first}: ${result.second}")
-        }
-        return result.second
-    }
-
-    /**
-     * Returns Pair(statusCode, responseBody).
-     */
-    private fun httpPostRaw(url: String, body: String): Pair<Int, String> {
-        val conn = URL(url).openConnection() as HttpURLConnection
-        try {
-            conn.requestMethod = "POST"
-            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
-            conn.doOutput = true
-            conn.connectTimeout = 15_000
-            conn.readTimeout = 15_000
-
-            OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(body) }
-
-            val statusCode = conn.responseCode
-            val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
-            val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
-            return Pair(statusCode, responseBody)
-        } finally {
-            conn.disconnect()
-        }
     }
 
     private fun writeResultFile(requestId: String, result: JSONObject) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -10,11 +10,12 @@ import androidx.browser.customtabs.CustomTabsIntent
 import com.seekerclaw.app.config.ConfigManager
 import fi.iki.elonen.NanoHTTPD
 import java.util.concurrent.atomic.AtomicReference
+import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -50,6 +51,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val REDIRECT_URI = "http://127.0.0.1:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
+
+        // Application-lifetime scope for the token exchange. Survives Activity destruction
+        // (rotation, system reclaim, fast back-press) so a successful browser redirect
+        // always completes its persist + result-write, regardless of UI lifecycle.
+        // SupervisorJob means a single failed exchange doesn't cancel sibling jobs.
+        private val EXCHANGE_SCOPE = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 
     private var callbackServer: CallbackServer? = null
@@ -332,13 +339,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return buildHtmlResponse("Error", "Sign-in already completed in another tab.")
         }
 
-        // Run the exchange on GlobalScope (not the activity scope) so it survives activity
-        // destruction (rotation, system reclaim, fast back-press). The exchange persists
-        // tokens via ConfigManager and writes the result file — both are application-level
-        // side effects that must complete regardless of UI lifecycle.
-        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-        GlobalScope.launch(Dispatchers.IO) {
-            exchangeCodeForTokens(requestId, code, codeVerifier)
+        // Run the exchange on the application-lifetime EXCHANGE_SCOPE (not the activity
+        // scope) so it survives activity destruction. We pass applicationContext explicitly
+        // so the exchange path doesn't pin the Activity instance through ConfigManager /
+        // file I/O — only the application Context, which is process-lifetime anyway.
+        val appCtx = applicationContext
+        EXCHANGE_SCOPE.launch {
+            exchangeCodeForTokens(appCtx, requestId, code, codeVerifier)
         }
 
         return buildHtmlResponse(
@@ -348,6 +355,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
     }
 
     private suspend fun exchangeCodeForTokens(
+        appCtx: Context,
         requestId: String,
         code: String,
         codeVerifier: String
@@ -390,12 +398,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
             // The result file here only carries a status flag, and the polling UI reloads
             // config from ConfigManager to pick up the new tokens.
             withContext(Dispatchers.IO) {
-                val current = ConfigManager.loadConfig(this@OpenAIOAuthActivity)
+                val current = ConfigManager.loadConfig(appCtx)
                 if (current == null) {
                     throw IllegalStateException("Config not loaded — cannot persist OAuth tokens")
                 }
                 ConfigManager.saveConfig(
-                    this@OpenAIOAuthActivity,
+                    appCtx,
                     current.copy(
                         openaiOAuthToken = accessToken,
                         openaiOAuthRefresh = refreshToken.ifBlank { current.openaiOAuthRefresh },

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import com.seekerclaw.app.config.ConfigManager
 import fi.iki.elonen.NanoHTTPD
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -51,11 +52,18 @@ class OpenAIOAuthActivity : ComponentActivity() {
     // Written from the NanoHTTPD server thread, read from the Main timeout coroutine — needs @Volatile.
     @Volatile
     private var callbackReceived = false
-    // Set to true once exchangeCodeForTokens has finished writing a success/error result file,
-    // so onDestroy doesn't overwrite the real outcome with a "canceled" entry.
-    @Volatile
-    private var resultWritten = false
+    // Three-state machine so onDestroy() never races with an in-flight result write
+    // AND a write that fails mid-way still falls back to a canceled result on destroy.
+    //   IDLE      — no write attempted yet; onDestroy may take over
+    //   WRITING   — a write is in progress; onDestroy must NOT also write
+    //   COMPLETED — write finished; onDestroy must NOT write
+    private enum class WriteState { IDLE, WRITING, COMPLETED }
+    private val writeState = AtomicReference(WriteState.IDLE)
     private var currentRequestId: String? = null
+
+    /** Atomically claim the write slot. Returns true if the caller may proceed to write. */
+    private fun claimWrite(): Boolean = writeState.compareAndSet(WriteState.IDLE, WriteState.WRITING)
+    private fun markWriteCompleted() { writeState.set(WriteState.COMPLETED) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -113,14 +121,18 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 Log.i(TAG, "User canceled OAuth flow")
                 callbackServer?.stop()
                 callbackServer = null
-                resultWritten = true
-                scope.launch {
-                    withContext(Dispatchers.IO) {
-                        writeResultFile(requestId, JSONObject().apply {
-                            put("status", "error")
-                            put("message", "Sign-in canceled")
-                        })
+                if (claimWrite()) {
+                    scope.launch {
+                        withContext(Dispatchers.IO) {
+                            writeResultFile(requestId, JSONObject().apply {
+                                put("status", "error")
+                                put("message", "Sign-in canceled")
+                            })
+                        }
+                        markWriteCompleted()
+                        finishOnMain()
                     }
+                } else {
                     finishOnMain()
                 }
             }
@@ -140,11 +152,15 @@ class OpenAIOAuthActivity : ComponentActivity() {
         super.onDestroy()
         callbackServer?.stop()
         callbackServer = null
-        // If the activity is dismissed (Back button, system kill, swipe-away) before any
-        // result has been written, leave a canceled result so ProviderConfigScreen stops
-        // polling immediately instead of waiting out the 10-minute deadline.
-        if (!resultWritten) {
-            currentRequestId?.let { reqId ->
+        // If the activity is dismissed (Back button, system kill, swipe-away) before
+        // any other path has claimed the write slot, leave a canceled result so
+        // ProviderConfigScreen stops polling immediately instead of waiting out the
+        // 10-minute deadline. The file write happens on a fresh background Thread
+        // (not `scope`, which is being canceled, and not Main — file I/O in lifecycle
+        // callbacks risks ANRs on slow storage).
+        val reqId = currentRequestId
+        if (reqId != null && claimWrite()) {
+            Thread {
                 try {
                     writeResultFile(reqId, JSONObject().apply {
                         put("status", "error")
@@ -152,8 +168,10 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     })
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to write canceled result on destroy", e)
+                } finally {
+                    markWriteCompleted()
                 }
-            }
+            }.start()
         }
         scope.cancel()
     }
@@ -175,15 +193,17 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.i(TAG, "Callback server started on port $CALLBACK_PORT")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start callback server", e)
-            resultWritten = true
-            scope.launch {
-                withContext(Dispatchers.IO) {
-                    writeResultFile(requestId, JSONObject().apply {
-                        put("status", "error")
-                        put("message", "Failed to start callback server: ${e.message}")
-                    })
+            if (claimWrite()) {
+                scope.launch {
+                    withContext(Dispatchers.IO) {
+                        writeResultFile(requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "Failed to start callback server: ${e.message}")
+                        })
+                    }
+                    markWriteCompleted()
+                    finishOnMain()
                 }
-                finishOnMain()
             }
             return
         }
@@ -217,17 +237,17 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // by a timeout error written over its eventual success/error result.
         scope.launch {
             delay(600_000)
-            if (!callbackReceived && callbackServer != null) {
+            if (!callbackReceived && callbackServer != null && claimWrite()) {
                 Log.w(TAG, "Browser flow timed out after 10 minutes")
                 callbackServer?.stop()
                 callbackServer = null
-                resultWritten = true
                 withContext(Dispatchers.IO) {
                     writeResultFile(requestId, JSONObject().apply {
                         put("status", "error")
                         put("message", "Browser login timed out. Please try again.")
                     })
                 }
+                markWriteCompleted()
                 finishOnMain()
             }
         }
@@ -270,22 +290,26 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // any OpenAI-side error and tear down the flow.
         if (error != null) {
             Log.e(TAG, "OAuth error: $error")
-            resultWritten = true
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "error")
-                put("message", "OAuth error: $error")
-            })
+            if (claimWrite()) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "OAuth error: $error")
+                })
+                markWriteCompleted()
+            }
             finishOnMain()
             return buildHtmlResponse("Error", "Authentication failed: $error")
         }
 
         if (code == null) {
             Log.e(TAG, "No code in callback")
-            resultWritten = true
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "error")
-                put("message", "No authorization code received")
-            })
+            if (claimWrite()) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "No authorization code received")
+                })
+                markWriteCompleted()
+            }
             finishOnMain()
             return buildHtmlResponse("Error", "No authorization code received.")
         }
@@ -356,24 +380,30 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 )
             }
 
-            // Set the guard BEFORE the file write so onDestroy() can't race in
-            // between write completion and the flag flip and emit a conflicting
-            // "canceled" result on top of the legitimate outcome.
-            resultWritten = true
-            withContext(Dispatchers.IO) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "success")
-                })
+            // Claim the write slot BEFORE the file write so onDestroy() can't race
+            // and emit a conflicting "canceled" result. If we fail to claim, another
+            // path (likely cancel/timeout) is already handling termination.
+            if (claimWrite()) {
+                withContext(Dispatchers.IO) {
+                    writeResultFile(requestId, JSONObject().apply {
+                        put("status", "success")
+                    })
+                }
+                markWriteCompleted()
+                Log.i(TAG, "Browser flow completed successfully")
+            } else {
+                Log.w(TAG, "Token exchange completed but another path already wrote a result")
             }
-            Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
-            resultWritten = true
-            withContext(Dispatchers.IO) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Token exchange failed: ${e.message}")
-                })
+            if (claimWrite()) {
+                withContext(Dispatchers.IO) {
+                    writeResultFile(requestId, JSONObject().apply {
+                        put("status", "error")
+                        put("message", "Token exchange failed: ${e.message}")
+                    })
+                }
+                markWriteCompleted()
             }
         } finally {
             callbackServer?.stop()

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -41,7 +41,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
         const val CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
         const val AUTH_URL = "https://auth.openai.com/oauth/authorize"
         const val TOKEN_URL = "https://auth.openai.com/oauth/token"
-        const val DEVICE_URL = "https://auth.openai.com/codex/device"
+        const val DEVICE_URL = "https://auth.openai.com/oauth/device/code"
+        const val DEVICE_VERIFY_URL = "https://auth.openai.com/codex/device"  // User-facing page
         const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -197,14 +197,14 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return buildHtmlResponse("Error", "No authorization code received.")
         }
 
-        // Exchange code for tokens asynchronously — respond to browser immediately
+        // Exchange code for tokens asynchronously in a coroutine after returning the NanoHTTPD response.
         scope.launch {
             exchangeCodeForTokens(requestId, code, codeVerifier)
         }
 
         return buildHtmlResponse(
-            "Success",
-            "Authentication successful! You can close this tab and return to SeekerClaw."
+            "Completing Sign-In",
+            "Finishing authentication — please return to SeekerClaw for status."
         )
     }
 
@@ -420,8 +420,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
             val parts = jwt.split(".")
             if (parts.size < 3) return null
             val payload = parts[1]
-            // Base64url decode — Android's Base64.NO_PADDING flag accepts input without '=' padding
-            val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+            // Base64url decode — normalize padding to avoid edge cases on some Android versions
+            val normalizedPayload = when (payload.length % 4) {
+                0 -> payload
+                else -> payload.padEnd(payload.length + (4 - (payload.length % 4)), '=')
+            }
+            val decoded = Base64.decode(normalizedPayload, Base64.URL_SAFE or Base64.NO_WRAP)
             val json = JSONObject(String(decoded, Charsets.UTF_8))
             // Try multiple claim names — OpenAI JWT varies by auth method
             val email = json.optString("email", "")
@@ -491,7 +495,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private fun buildHtmlResponse(title: String, message: String): String {
         val safeTitle = escapeHtml(title)
         val safeMessage = escapeHtml(message)
-        val isSuccess = title == "Success"
+        val isSuccess = title == "Success" || title == "Completing Sign-In"
         val accentColor = if (isSuccess) "#4ADE80" else "#F87171"
         val icon = if (isSuccess) "&#10003;" else "&#10007;"
         return """

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -145,12 +145,25 @@ class OpenAIOAuthActivity : ComponentActivity() {
         expectedState: String,
         codeVerifier: String
     ): String {
-        // Idempotency guard: if the user refreshes the browser, NanoHTTPD will fire this
-        // handler multiple times. We only want to run the token exchange once and avoid
-        // racing writes to the same result file.
+        val code = params["code"]
+        val state = params["state"]
+        val error = params["error"]
+
+        // Reject stray/hostile requests BEFORE flipping the idempotency guard.
+        // Otherwise an attacker (or buggy client) hitting 127.0.0.1:1455/auth/callback
+        // with the wrong state could permanently lock out the real browser redirect
+        // and DoS the sign-in flow.
+        if (state != expectedState) {
+            Log.w(TAG, "State mismatch — ignoring stray callback (not flipping guard)")
+            return buildHtmlResponse("Error", "State verification failed. Please try again.")
+        }
+
+        // Idempotency guard: flip only after state is validated. Browser refresh on a
+        // valid redirect would otherwise launch multiple token exchanges that race
+        // on the same result file.
         synchronized(this) {
             if (callbackReceived) {
-                Log.d(TAG, "Duplicate callback ignored")
+                Log.d(TAG, "Duplicate valid callback ignored")
                 return buildHtmlResponse(
                     "Completing Sign-In",
                     "Already processing — please return to SeekerClaw for status."
@@ -158,10 +171,9 @@ class OpenAIOAuthActivity : ComponentActivity() {
             }
             callbackReceived = true
         }
-        val code = params["code"]
-        val state = params["state"]
-        val error = params["error"]
 
+        // From here on, we know this is the legitimate browser redirect — surface
+        // any OpenAI-side error and tear down the flow.
         if (error != null) {
             Log.e(TAG, "OAuth error: $error")
             writeResultFile(requestId, JSONObject().apply {
@@ -170,16 +182,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
             })
             finishOnMain()
             return buildHtmlResponse("Error", "Authentication failed: $error")
-        }
-
-        if (state != expectedState) {
-            Log.e(TAG, "State mismatch")
-            writeResultFile(requestId, JSONObject().apply {
-                put("status", "error")
-                put("message", "State mismatch — possible CSRF attack")
-            })
-            finishOnMain()
-            return buildHtmlResponse("Error", "State verification failed. Please try again.")
         }
 
         if (code == null) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -61,8 +61,73 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return
         }
 
+        // Minimal "waiting for sign-in" UI so the user doesn't return from the
+        // browser to a blank translucent activity. The Cancel button stops the
+        // local callback server, writes a canceled result, and finishes.
+        setContentView(buildWaitingView(requestId))
+
         Log.i(TAG, "Starting OAuth browser flow (request: $requestId)")
         startBrowserFlow(requestId)
+    }
+
+    private fun buildWaitingView(requestId: String): android.view.View {
+        val ctx = this
+        val density = resources.displayMetrics.density
+        fun dp(v: Int) = (v * density).toInt()
+
+        val root = android.widget.LinearLayout(ctx).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            gravity = android.view.Gravity.CENTER
+            setBackgroundColor(0xFF0A0A0F.toInt())
+            setPadding(dp(32), dp(32), dp(32), dp(32))
+            layoutParams = android.view.ViewGroup.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+        }
+        val title = android.widget.TextView(ctx).apply {
+            text = "Waiting for OpenAI sign-in"
+            textSize = 20f
+            setTextColor(0xFFFFFFFF.toInt())
+            gravity = android.view.Gravity.CENTER
+        }
+        val subtitle = android.widget.TextView(ctx).apply {
+            text = "Complete sign-in in your browser, then return to SeekerClaw."
+            textSize = 14f
+            setTextColor(0xCCFFFFFF.toInt())
+            gravity = android.view.Gravity.CENTER
+            setPadding(0, dp(12), 0, dp(24))
+        }
+        val progress = android.widget.ProgressBar(ctx).apply {
+            isIndeterminate = true
+        }
+        val cancel = android.widget.Button(ctx).apply {
+            text = "Cancel"
+            setOnClickListener {
+                Log.i(TAG, "User canceled OAuth flow")
+                callbackServer?.stop()
+                callbackServer = null
+                scope.launch {
+                    withContext(Dispatchers.IO) {
+                        writeResultFile(requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "Sign-in canceled")
+                        })
+                    }
+                    finishOnMain()
+                }
+            }
+            (layoutParams as? android.widget.LinearLayout.LayoutParams)?.topMargin = dp(24)
+        }
+        root.addView(title)
+        root.addView(subtitle)
+        root.addView(progress)
+        val cancelParams = android.widget.LinearLayout.LayoutParams(
+            android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply { topMargin = dp(24) }
+        root.addView(cancel, cancelParams)
+        return root
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -120,12 +120,15 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 }
                 Log.i(TAG, "Browser flow completed successfully")
             } catch (e: Exception) {
+                // Log the full exception (including any details) only to Logcat. The
+                // result file gets a generic user-safe message — `e.message` can
+                // contain raw HTTP response bodies that may include tokens or PII.
                 Log.e(TAG, "Token exchange failed", e)
                 try {
                     withContext(NonCancellable + Dispatchers.IO) {
                         writeResultFileStatic(appCtx, requestId, JSONObject().apply {
                             put("status", "error")
-                            put("message", "Token exchange failed: ${e.message}")
+                            put("message", "Sign-in failed. Please try again.")
                         })
                     }
                 } catch (writeErr: Exception) {
@@ -149,7 +152,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val statusCode = conn.responseCode
                 val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
                 val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
-                if (statusCode !in 200..299) throw RuntimeException("HTTP $statusCode: $responseBody")
+                if (statusCode !in 200..299) {
+                    // Don't put the response body into the exception message — it can
+                    // surface in result files / UI / logs and may contain secrets or
+                    // untrusted HTML. Body is logged separately at debug level only.
+                    Log.d(TAG, "httpPostStatic non-2xx body (truncated): ${responseBody.take(200)}")
+                    throw RuntimeException("HTTP $statusCode")
+                }
                 return responseBody
             } finally {
                 conn.disconnect()

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -140,10 +140,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
             startActivity(browserIntent)
         }
 
-        // Safety timeout: if user abandons browser login, stop server and write error after 10 min
+        // Safety timeout: if user abandons browser login, stop server and write error after 10 min.
+        // Gate on !callbackReceived so a slow token exchange (already in progress) isn't clobbered
+        // by a timeout error written over its eventual success/error result.
         scope.launch {
             delay(600_000)
-            if (callbackServer != null) {
+            if (!callbackReceived && callbackServer != null) {
                 Log.w(TAG, "Browser flow timed out after 10 minutes")
                 callbackServer?.stop()
                 callbackServer = null

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -330,6 +330,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
         code: String,
         codeVerifier: String
     ) {
+        // Claim the write slot at the very start of the exchange so onDestroy() can't
+        // emit a "canceled" result over an in-flight token persistence. If we can't
+        // claim, another path (cancel/timeout) is already terminating — bail out.
+        if (!claimWrite()) {
+            Log.w(TAG, "Token exchange skipped — write slot already claimed by another path")
+            return
+        }
         try {
             val tokenResponse = withContext(Dispatchers.IO) {
                 val body = buildString {
@@ -380,31 +387,23 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 )
             }
 
-            // Claim the write slot BEFORE the file write so onDestroy() can't race
-            // and emit a conflicting "canceled" result. If we fail to claim, another
-            // path (likely cancel/timeout) is already handling termination.
-            if (claimWrite()) {
-                withContext(Dispatchers.IO) {
-                    writeResultFile(requestId, JSONObject().apply {
-                        put("status", "success")
-                    })
-                }
-                markWriteCompleted()
-                Log.i(TAG, "Browser flow completed successfully")
-            } else {
-                Log.w(TAG, "Token exchange completed but another path already wrote a result")
+            // We already claimed the write slot at the top of this function.
+            withContext(Dispatchers.IO) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "success")
+                })
             }
+            markWriteCompleted()
+            Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
-            if (claimWrite()) {
-                withContext(Dispatchers.IO) {
-                    writeResultFile(requestId, JSONObject().apply {
-                        put("status", "error")
-                        put("message", "Token exchange failed: ${e.message}")
-                    })
-                }
-                markWriteCompleted()
+            withContext(Dispatchers.IO) {
+                writeResultFile(requestId, JSONObject().apply {
+                    put("status", "error")
+                    put("message", "Token exchange failed: ${e.message}")
+                })
             }
+            markWriteCompleted()
         } finally {
             callbackServer?.stop()
             callbackServer = null

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -195,7 +195,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return buildHtmlResponse("Error", "No authorization code received.")
         }
 
-        // Exchange code for tokens (on IO thread, block the NanoHTTPD thread briefly)
+        // Exchange code for tokens asynchronously — respond to browser immediately
         scope.launch {
             exchangeCodeForTokens(requestId, code, codeVerifier)
         }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -156,10 +156,10 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
                 val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
                 if (statusCode !in 200..299) {
-                    // Don't put the response body into the exception message — it can
-                    // surface in result files / UI / logs and may contain secrets or
-                    // untrusted HTML. Body is logged separately at debug level only.
-                    Log.d(TAG, "httpPostStatic non-2xx body (truncated): ${responseBody.take(200)}")
+                    // Don't put the response body into logs OR the exception message —
+                    // OAuth/token endpoints can return content that includes secrets or
+                    // untrusted HTML. Status code is enough for diagnostics.
+                    Log.d(TAG, "httpPostStatic non-2xx response: HTTP $statusCode")
                     throw RuntimeException("HTTP $statusCode")
                 }
                 return responseBody
@@ -684,7 +684,14 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private class CallbackServer(
         port: Int,
         private val onCallback: (Map<String, String>) -> String
-    ) : NanoHTTPD("127.0.0.1", port) {
+    ) : NanoHTTPD(port) {
+        // No hostname → NanoHTTPD binds to all loopback interfaces, so a browser that
+        // resolves "localhost" to ::1 (IPv6) still reaches this server. Previously bound
+        // to "127.0.0.1" only, which mismatched the literal "localhost" in REDIRECT_URI
+        // and could fail on dual-stack devices. The redirect URI must stay as "localhost"
+        // because Codex's OAuth client (app_EMoamEEZ...) is registered with that exact
+        // string — switching to 127.0.0.1 causes auth.openai.com to reject the authorize
+        // request as redirect_uri mismatch.
 
         override fun serve(session: IHTTPSession): Response {
             if (session.uri == "/auth/callback" && session.method == Method.GET) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -122,8 +123,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 callbackServer?.stop()
                 callbackServer = null
                 if (claimWrite()) {
+                    // NonCancellable so the result write completes even if the activity is
+                    // finished before the coroutine runs (otherwise writeState would stay
+                    // WRITING and the polling UI would hang for the full 10-min timeout).
                     scope.launch {
-                        withContext(Dispatchers.IO) {
+                        withContext(NonCancellable + Dispatchers.IO) {
                             writeResultFile(requestId, JSONObject().apply {
                                 put("status", "error")
                                 put("message", "Sign-in canceled")
@@ -195,7 +199,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.e(TAG, "Failed to start callback server", e)
             if (claimWrite()) {
                 scope.launch {
-                    withContext(Dispatchers.IO) {
+                    withContext(NonCancellable + Dispatchers.IO) {
                         writeResultFile(requestId, JSONObject().apply {
                             put("status", "error")
                             put("message", "Failed to start callback server: ${e.message}")
@@ -241,7 +245,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 Log.w(TAG, "Browser flow timed out after 10 minutes")
                 callbackServer?.stop()
                 callbackServer = null
-                withContext(Dispatchers.IO) {
+                withContext(NonCancellable + Dispatchers.IO) {
                     writeResultFile(requestId, JSONObject().apply {
                         put("status", "error")
                         put("message", "Browser login timed out. Please try again.")
@@ -388,7 +392,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
             }
 
             // We already claimed the write slot at the top of this function.
-            withContext(Dispatchers.IO) {
+            // NonCancellable so a quick onDestroy can't cancel us mid-write.
+            withContext(NonCancellable + Dispatchers.IO) {
                 writeResultFile(requestId, JSONObject().apply {
                     put("status", "success")
                 })
@@ -397,7 +402,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Token exchange failed", e)
-            withContext(Dispatchers.IO) {
+            withContext(NonCancellable + Dispatchers.IO) {
                 writeResultFile(requestId, JSONObject().apply {
                     put("status", "error")
                     put("message", "Token exchange failed: ${e.message}")

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -7,6 +7,7 @@ import android.util.Base64
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.browser.customtabs.CustomTabsIntent
+import com.seekerclaw.app.config.ConfigManager
 import fi.iki.elonen.NanoHTTPD
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -226,12 +227,29 @@ class OpenAIOAuthActivity : ComponentActivity() {
             // Try id_token first (has email), fall back to access_token
             val email = extractEmailFromJwt(idToken) ?: extractEmailFromJwt(accessToken)
 
+            // Persist tokens directly to encrypted storage instead of writing them to a
+            // result file. Bearer tokens must never sit on disk in plaintext, even briefly
+            // (RFC 6819 §5.1.4, OWASP MASVS-STORAGE-1). The result file only carries a
+            // status flag — the polling UI reloads config from ConfigManager to pick up
+            // the new tokens.
+            withContext(Dispatchers.IO) {
+                val current = ConfigManager.loadConfig(this@OpenAIOAuthActivity)
+                if (current == null) {
+                    throw IllegalStateException("Config not loaded — cannot persist OAuth tokens")
+                }
+                ConfigManager.saveConfig(
+                    this@OpenAIOAuthActivity,
+                    current.copy(
+                        openaiOAuthToken = accessToken,
+                        openaiOAuthRefresh = refreshToken.ifBlank { current.openaiOAuthRefresh },
+                        openaiOAuthEmail = email ?: current.openaiOAuthEmail,
+                        openaiOAuthExpiresAt = expiresAt,
+                    )
+                )
+            }
+
             writeResultFile(requestId, JSONObject().apply {
                 put("status", "success")
-                put("accessToken", accessToken)
-                put("refreshToken", refreshToken)
-                put("email", email ?: JSONObject.NULL)
-                put("expiresAt", expiresAt)
             })
             Log.i(TAG, "Browser flow completed successfully")
         } catch (e: Exception) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -372,7 +372,7 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     withContext(NonCancellable + Dispatchers.IO) {
                         writeResultFile(requestId, JSONObject().apply {
                             put("status", "error")
-                            put("message", "Failed to start callback server: ${e.message}")
+                            put("message", "Couldn't start local callback server. Please try again.")
                         })
                     }
                     markWriteCompleted()
@@ -443,7 +443,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // and DoS the sign-in flow.
         if (state != expectedState) {
             Log.w(TAG, "State mismatch — ignoring stray callback (not flipping guard)")
-            return buildHtmlResponse("Error", "State verification failed. Please try again.")
+            return buildHtmlResponse(
+                "Ignored Redirect",
+                "This sign-in redirect was ignored because it did not match the active request. " +
+                    "Return to SeekerClaw to retry or cancel the sign-in."
+            )
         }
 
         // Idempotency guard: flip only after state is validated. Browser refresh on a

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -12,6 +12,7 @@ import fi.iki.elonen.NanoHTTPD
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
@@ -321,8 +322,22 @@ class OpenAIOAuthActivity : ComponentActivity() {
             return buildHtmlResponse("Error", "No authorization code received.")
         }
 
-        // Exchange code for tokens asynchronously in a coroutine after returning the NanoHTTPD response.
-        scope.launch {
+        // Claim the write slot HERE, before launching the exchange. This closes the race
+        // window where onDestroy() (e.g. user kills the activity right after the redirect)
+        // could otherwise sneak in and write a "canceled" result before the exchange
+        // coroutine even starts. The exchange will see the slot already claimed and just
+        // markWriteCompleted() when done.
+        if (!claimWrite()) {
+            Log.w(TAG, "Write slot already claimed before exchange could start")
+            return buildHtmlResponse("Error", "Sign-in already completed in another tab.")
+        }
+
+        // Run the exchange on GlobalScope (not the activity scope) so it survives activity
+        // destruction (rotation, system reclaim, fast back-press). The exchange persists
+        // tokens via ConfigManager and writes the result file — both are application-level
+        // side effects that must complete regardless of UI lifecycle.
+        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+        GlobalScope.launch(Dispatchers.IO) {
             exchangeCodeForTokens(requestId, code, codeVerifier)
         }
 
@@ -337,13 +352,9 @@ class OpenAIOAuthActivity : ComponentActivity() {
         code: String,
         codeVerifier: String
     ) {
-        // Claim the write slot at the very start of the exchange so onDestroy() can't
-        // emit a "canceled" result over an in-flight token persistence. If we can't
-        // claim, another path (cancel/timeout) is already terminating — bail out.
-        if (!claimWrite()) {
-            Log.w(TAG, "Token exchange skipped — write slot already claimed by another path")
-            return
-        }
+        // The write slot was claimed by handleCallback() before this coroutine was
+        // launched, so we can proceed straight to the exchange. We just need to make
+        // sure markWriteCompleted() is called on every exit path.
         try {
             val tokenResponse = withContext(Dispatchers.IO) {
                 val body = buildString {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -419,9 +419,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
             // Base64url decode — Android's Base64.NO_PADDING flag accepts input without '=' padding
             val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
             val json = JSONObject(String(decoded, Charsets.UTF_8))
+            // Try multiple claim names — OpenAI JWT varies by auth method
             val email = json.optString("email", "")
+            val name = json.optString("name", "")
+            val preferredUsername = json.optString("preferred_username", "")
             val sub = json.optString("sub", "")
-            email.ifEmpty { sub.ifEmpty { null } }
+            email.ifEmpty { preferredUsername.ifEmpty { name.ifEmpty { sub.ifEmpty { null } } } }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to extract email from JWT", e)
             null
@@ -495,6 +498,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 .card { text-align: center; padding: 2rem; }
                 h1 { color: ${if (title == "Success") "#00C805" else "#FF4444"}; }
             </style></head>
+            <script>
+                if ('$safeTitle' === 'Success') {
+                    setTimeout(function() { window.close(); }, 1500);
+                }
+            </script>
+            </head>
             <body><div class="card"><h1>$safeTitle</h1><p>$safeMessage</p></div></body>
             </html>
         """.trimIndent()

--- a/app/src/main/java/com/seekerclaw/app/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/seekerclaw/app/receiver/BootReceiver.kt
@@ -32,7 +32,7 @@ class BootReceiver : BroadcastReceiver() {
             return
         }
 
-        LogCollector.append("[Boot] Auto-starting OpenClaw service...")
+        LogCollector.append("[Boot] Auto-starting Claw Engine...")
         OpenClawService.start(context)
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/service/NodeBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/NodeBridge.kt
@@ -59,7 +59,7 @@ object NodeBridge {
      * Only re-copies when APK is updated (new install or app update).
      */
     fun extractBundle(context: Context) {
-        LogCollector.append("[Service] Extracting OpenClaw bundle...")
+        LogCollector.append("[Service] Extracting Claw Engine bundle...")
 
         val nodeDir = context.filesDir.absolutePath + "/" + NODE_DIR_NAME
         val entryFile = File(nodeDir, "main.js")
@@ -76,7 +76,7 @@ object NodeBridge {
             saveLastUpdateTime(context)
 
             val fileCount = File(nodeDir).walk().count { it.isFile }
-            LogCollector.append("[Service] OpenClaw bundle extracted ($fileCount files)")
+            LogCollector.append("[Service] Claw Engine bundle extracted ($fileCount files)")
 
             if (!entryFile.isFile) {
                 LogCollector.append("[Service] WARNING: main.js still missing after extraction!", LogLevel.ERROR)

--- a/app/src/main/java/com/seekerclaw/app/service/OpenClawService.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/OpenClawService.kt
@@ -96,7 +96,7 @@ class OpenClawService : Service() {
         val newCrashCount = if (now - lastStart < 30_000) crashCount + 1 else 0
         prefs.edit().putLong("last_start", now).putInt("crash_count", newCrashCount).apply()
 
-        LogCollector.append("[Service] Starting OpenClaw service... (attempt ${newCrashCount + 1})")
+        LogCollector.append("[Service] Starting Claw Engine... (attempt ${newCrashCount + 1})")
         ServiceState.updateStatus(ServiceStatus.STARTING)
 
         // Generate per-boot auth token for bridge security
@@ -166,7 +166,7 @@ class OpenClawService : Service() {
 
         // Mark as running
         ServiceState.updateStatus(ServiceStatus.RUNNING)
-        LogCollector.append("[Service] OpenClaw service is now RUNNING")
+        LogCollector.append("[Service] Claw Engine is now RUNNING")
 
         // Start watchdog
         // Note: Node.js can only start once per process. If it dies,
@@ -230,13 +230,13 @@ class OpenClawService : Service() {
             }
         }
 
-        LogCollector.append("[Service] OpenClaw service started")
+        LogCollector.append("[Service] Claw Engine started")
 
         return START_STICKY
     }
 
     override fun onDestroy() {
-        LogCollector.append("[Service] Stopping OpenClaw service...")
+        LogCollector.append("[Service] Stopping Claw Engine...")
         nodeDebugJob?.cancel()
         uptimeJob?.cancel()
         Watchdog.stop()
@@ -262,7 +262,7 @@ class OpenClawService : Service() {
             .putInt("crash_count", 0)
             .apply()
 
-        LogCollector.append("[Service] OpenClaw service stopped")
+        LogCollector.append("[Service] Claw Engine stopped")
         super.onDestroy()
 
         // Service is isolated in :node process. Kill process so Node runtime cannot linger.

--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -108,7 +108,11 @@ fun DashboardScreen(
     }
     val hasCredential = remember(config) {
         when (config?.provider) {
-            "openai" -> config?.openaiApiKey?.isNotBlank() == true
+            "openai" -> if (config?.authType == "oauth") {
+                config?.openaiOAuthToken?.isNotBlank() == true
+            } else {
+                config?.openaiApiKey?.isNotBlank() == true
+            }
             "openrouter" -> config?.openrouterApiKey?.isNotBlank() == true
             "custom" -> config?.customApiKey?.isNotBlank() == true && config?.customBaseUrl?.isNotBlank() == true
             else -> config?.activeCredential?.isNotBlank() == true

--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -108,11 +108,11 @@ fun DashboardScreen(
     }
     val hasCredential = remember(config) {
         when (config?.provider) {
-            "openai" -> if (config?.authType == "oauth") {
-                config?.openaiOAuthToken?.isNotBlank() == true
-            } else {
+            // OpenAI is valid if EITHER credential is present — writeConfigJson falls
+            // back to api_key when oauth is selected without a token, so the agent is
+            // startable as long as one of the two is non-blank.
+            "openai" -> config?.openaiOAuthToken?.isNotBlank() == true ||
                 config?.openaiApiKey?.isNotBlank() == true
-            }
             "openrouter" -> config?.openrouterApiKey?.isNotBlank() == true
             "custom" -> config?.customApiKey?.isNotBlank() == true && config?.customBaseUrl?.isNotBlank() == true
             else -> config?.activeCredential?.isNotBlank() == true

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -186,43 +186,39 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     }
 
     fun switchProvider(newProviderId: String) {
-        val oldProviderId = config?.provider ?: "claude"
-        val currentModel = config?.model ?: ""
-        // Capture authType BEFORE saveField("provider", ...) — saveField triggers a config
-        // reload that may normalize/mutate authType, which would otherwise corrupt the
-        // lastAuthType_<oldProvider> we're about to save.
-        val oldAuthType = config?.authType
+        // `switchProvider` is conceptually ONE user action — it should persist atomically.
+        // Batching the 2-3 field mutations (provider + authType + possibly model) into a
+        // single `saveConfig` avoids: (a) 3x disk writes on slow storage, (b) 3x
+        // configVersion bumps re-rendering every observer, (c) observers briefly seeing
+        // an inconsistent intermediate state like "OpenAI + setup_token + claude-opus".
+        val current = config ?: return
+        val oldProviderId = current.provider
+        val oldAuthType = current.authType
+        val currentModel = current.model
+
         // Cancel any in-progress OAuth polling — leaving it running across a provider
-        // switch would let a stale callback flip authType back or pop a restart dialog
-        // for a provider the user already left.
+        // switch would let a stale callback flip authType or pop a restart dialog for
+        // a provider the user already left.
         if (oldProviderId == "openai" && newProviderId != "openai") {
             oauthPolling = false
             oauthRequestId = null
             oauthError = null
         }
 
-        // Remember the current model for the old provider before switching
+        // Remember per-provider last-used model and authType (similar to lastModel_*)
+        // so explicit choices survive a round-trip through another provider. These are
+        // cheap prefs-only writes, not full config saves.
         val prefs = context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
-        prefs.edit().putString("lastModel_$oldProviderId", currentModel).apply()
+        prefs.edit()
+            .putString("lastModel_$oldProviderId", currentModel)
+            .putString("lastAuthType_$oldProviderId", oldAuthType)
+            .apply()
 
-        saveField("provider", newProviderId, needsRestart = true)
-
-        // Normalize auth type on EVERY provider switch so provider, auth mode,
-        // validation, and the model list stay in a consistent persisted state.
-        // We also remember the user's last-used authType per provider (similar to
-        // lastModel_*) so an explicit "api_key" choice for OpenAI survives a round-trip
-        // through another provider, while a fresh switch-in still defaults to OAuth.
-        val oldProviderAuthKey = "lastAuthType_$oldProviderId"
-        if (oldAuthType != null) {
-            prefs.edit().putString(oldProviderAuthKey, oldAuthType).apply()
-        }
-        val currentAuthType = oldAuthType
+        // Resolve the effective authType for the new provider. OpenAI defaults to OAuth
+        // (ChatGPT subscription) on first switch-in — the OAuth section shows a Sign In
+        // button and writeConfigJson translates oauth+blank → api_key for Node so the
+        // agent stays startable. Explicit picker choice is remembered per-provider.
         val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
-        // Resolve authType for the new provider. OpenAI defaults to OAuth (ChatGPT
-        // subscription) on first switch-in, even without a token yet — the OAuth section
-        // shows a Sign In button and writeConfigJson translates oauth+blank → api_key
-        // for Node so the agent stays startable. The user's explicit picker choice is
-        // remembered per-provider via lastAuthType_<id>.
         val effectiveAuthType = when (newProviderId) {
             "openai" -> when (savedNewAuthType) {
                 "oauth", "api_key" -> savedNewAuthType
@@ -230,34 +226,44 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             }
             "claude" -> when (savedNewAuthType) {
                 "api_key", "setup_token" -> savedNewAuthType
-                else -> if (currentAuthType == "setup_token") "setup_token" else "api_key"
+                else -> if (oldAuthType == "setup_token") "setup_token" else "api_key"
             }
             else -> "api_key"
         }
-        saveField("authType", effectiveAuthType)
 
-        // Restore last-used model for new provider, or fall back to first model.
+        // Resolve the effective model for the new provider.
         val modelsForNew = modelsForProvider(newProviderId, effectiveAuthType)
-        if (modelsForNew.isEmpty()) {
+        val savedModel = prefs.getString("lastModel_$newProviderId", null)
+        val effectiveModel: String = if (modelsForNew.isEmpty()) {
             // Freeform provider (e.g. OpenRouter) — restore last-used or set default
-            val savedModel = prefs.getString("lastModel_$newProviderId", null)
             val defaultModel = when (newProviderId) {
                 "openrouter" -> "anthropic/claude-sonnet-4-6"
                 "custom" -> ""
                 else -> ""
             }
-            saveField("model", savedModel?.takeIf { it.isNotBlank() } ?: defaultModel)
+            savedModel?.takeIf { it.isNotBlank() } ?: defaultModel
         } else {
-            val savedModel = prefs.getString("lastModel_$newProviderId", null)
-            val restoredModel = if (savedModel != null && modelsForNew.any { it.id == savedModel }) {
+            if (modelsForNew.any { it.id == currentModel }) {
+                // Current model is still valid — keep it.
+                currentModel
+            } else if (savedModel != null && modelsForNew.any { it.id == savedModel }) {
                 savedModel
             } else {
                 modelsForNew.firstOrNull()?.id ?: ""
             }
-            if (modelsForNew.none { it.id == currentModel }) {
-                saveField("model", restoredModel)
-            }
         }
+
+        // Single atomic save.
+        ConfigManager.saveConfig(
+            context,
+            current.copy(
+                provider = newProviderId,
+                authType = effectiveAuthType,
+                model = effectiveModel,
+            )
+        )
+        config = ConfigManager.loadConfig(context)
+        showRestartDialog = true
     }
 
     SeekerClawScaffold(title = "AI Provider", onBack = onBack) { padding ->

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -141,22 +141,31 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 when (json.optString("status")) {
                     "success" -> {
                         // Tokens were persisted directly by OpenAIOAuthActivity via
-                        // ConfigManager.saveConfig. Now that we have a valid token, also
-                        // flip authType=oauth (the picker intentionally deferred this
-                        // until token-present so a canceled sign-in couldn't strand the
-                        // agent in an unstartable state).
-                        withContext(Dispatchers.IO) {
+                        // ConfigManager.saveConfig. Only apply OpenAI-specific auth state
+                        // changes if OpenAI is still the active provider — the user may
+                        // have switched providers while polling was in progress.
+                        val shouldApply = withContext(Dispatchers.IO) {
                             val current = ConfigManager.loadConfig(context)
-                            if (current != null && !current.openaiOAuthToken.isBlank() && current.authType != "oauth") {
-                                ConfigManager.saveConfig(context, current.copy(authType = "oauth"))
+                            if (current != null &&
+                                current.provider == "openai" &&
+                                current.openaiOAuthToken.isNotBlank()
+                            ) {
+                                if (current.authType != "oauth") {
+                                    ConfigManager.saveConfig(context, current.copy(authType = "oauth"))
+                                }
+                                true
+                            } else {
+                                false
                             }
                         }
-                        context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
-                            .edit()
-                            .putString("lastAuthType_openai", "oauth")
-                            .apply()
-                        config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
-                        showRestartDialog = true
+                        if (shouldApply) {
+                            context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
+                                .edit()
+                                .putString("lastAuthType_openai", "oauth")
+                                .apply()
+                            config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
+                            showRestartDialog = true
+                        }
                         oauthPolling = false
                     }
                     "error" -> {
@@ -203,6 +212,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         // reload that may normalize/mutate authType, which would otherwise corrupt the
         // lastAuthType_<oldProvider> we're about to save.
         val oldAuthType = config?.authType
+        // Cancel any in-progress OAuth polling — leaving it running across a provider
+        // switch would let a stale callback flip authType back or pop a restart dialog
+        // for a provider the user already left.
+        if (oldProviderId == "openai" && newProviderId != "openai") {
+            oauthPolling = false
+            oauthRequestId = null
+            oauthError = null
+        }
 
         // Remember the current model for the old provider before switching
         val prefs = context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -106,7 +106,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         if (!oauthPolling) return@LaunchedEffect
         val resultsDir = File(context.filesDir, OpenAIOAuthActivity.RESULTS_DIR)
         val resultFile = File(resultsDir, "$reqId.json")
-        val deadline = System.currentTimeMillis() + 600_000 // 10 min timeout (device-code flows can take a while)
+        val deadline = System.currentTimeMillis() + 600_000 // 10 min timeout — browser PKCE sign-in/consent can take a while
         while (oauthPolling && System.currentTimeMillis() < deadline) {
             delay(1000)
             val exists = withContext(Dispatchers.IO) { resultFile.exists() }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -112,7 +112,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         val deadline = System.currentTimeMillis() + 600_000 // 10 min timeout (device-code flows can take a while)
         while (oauthPolling && System.currentTimeMillis() < deadline) {
             delay(1000)
-            if (!resultFile.exists()) continue
+            val exists = withContext(Dispatchers.IO) { resultFile.exists() }
+            if (!exists) continue
             try {
                 val json = withContext(Dispatchers.IO) {
                     val text = resultFile.readText()

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -177,17 +177,20 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
 
         saveField("provider", newProviderId, needsRestart = true)
 
-        // OpenAI defaults to OAuth (ChatGPT subscription) when switching INTO the provider.
-        // The previous authType comes from another provider (e.g. Anthropic's default
-        // "api_key", or "setup_token"), which should not silently carry over. Users who
-        // prefer API key can change it via the auth-type picker after the switch.
-        // We persist the resolved value so UI, Node config, and validation all agree.
-        val effectiveAuthType: String? = if (newProviderId == "openai") {
-            saveField("authType", "oauth")
-            "oauth"
-        } else {
-            config?.authType
+        // Normalize auth type on EVERY provider switch so provider, auth mode,
+        // validation, and the model list stay in a consistent persisted state.
+        // - OpenAI defaults to OAuth (ChatGPT subscription); user can change later.
+        // - Anthropic accepts api_key or setup_token; everything else falls back to api_key.
+        // - OpenRouter / custom only support api_key.
+        // Without this, switching openai → claude would leave authType="oauth", which
+        // Claude doesn't support and which silently breaks credential validation.
+        val currentAuthType = config?.authType
+        val effectiveAuthType = when (newProviderId) {
+            "openai" -> "oauth"
+            "claude" -> if (currentAuthType == "setup_token") "setup_token" else "api_key"
+            else -> "api_key"
         }
+        saveField("authType", effectiveAuthType)
 
         // Restore last-used model for new provider, or fall back to first model.
         val modelsForNew = modelsForProvider(newProviderId, effectiveAuthType)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -358,7 +358,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
                                         putExtra("method", "browser")
                                         putExtra("requestId", requestId)
-                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                     }
                                     context.startActivity(intent)
                                     oauthRequestId = requestId

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -179,15 +179,24 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
 
         // Normalize auth type on EVERY provider switch so provider, auth mode,
         // validation, and the model list stay in a consistent persisted state.
-        // - OpenAI defaults to OAuth (ChatGPT subscription); user can change later.
-        // - Anthropic accepts api_key or setup_token; everything else falls back to api_key.
-        // - OpenRouter / custom only support api_key.
-        // Without this, switching openai → claude would leave authType="oauth", which
-        // Claude doesn't support and which silently breaks credential validation.
+        // We also remember the user's last-used authType per provider (similar to
+        // lastModel_*) so an explicit "api_key" choice for OpenAI survives a round-trip
+        // through another provider, while a fresh switch-in still defaults to OAuth.
         val currentAuthType = config?.authType
+        val oldProviderAuthKey = "lastAuthType_$oldProviderId"
+        if (currentAuthType != null) {
+            prefs.edit().putString(oldProviderAuthKey, currentAuthType).apply()
+        }
+        val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
         val effectiveAuthType = when (newProviderId) {
-            "openai" -> "oauth"
-            "claude" -> if (currentAuthType == "setup_token") "setup_token" else "api_key"
+            "openai" -> when (savedNewAuthType) {
+                "oauth", "api_key" -> savedNewAuthType
+                else -> "oauth" // default for first-time switch into OpenAI
+            }
+            "claude" -> when (savedNewAuthType) {
+                "api_key", "setup_token" -> savedNewAuthType
+                else -> if (currentAuthType == "setup_token") "setup_token" else "api_key"
+            }
             else -> "api_key"
         }
         saveField("authType", effectiveAuthType)
@@ -840,6 +849,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 TextButton(
                     onClick = {
                         saveField("authType", selectedAuth, needsRestart = true)
+                        // Remember per-provider so a round-trip through another provider preserves it.
+                        context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
+                            .edit()
+                            .putString("lastAuthType_$activeProvider", selectedAuth)
+                            .apply()
                         // Ensure the selected model is valid for the chosen OpenAI auth type.
                         // OAuth and API-key model lists differ — fall back to a default if not.
                         if (activeProvider == "openai") {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -126,11 +126,12 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         showRestartDialog = true
                         oauthPolling = false
                     }
-                    "pending" -> {
-                        // Continue polling — the file will be overwritten with success/error
-                    }
                     "error" -> {
                         oauthError = json.optString("message", "Unknown error")
+                        oauthPolling = false
+                    }
+                    else -> {
+                        oauthError = "Unexpected OAuth result status: ${json.optString("status")}"
                         oauthPolling = false
                     }
                 }
@@ -172,18 +173,19 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
 
         saveField("provider", newProviderId, needsRestart = true)
 
-        // Normalize authType when switching to OpenAI: only "oauth" and "api_key" are valid.
-        // Default to "oauth" (ChatGPT subscription) — leftover values from other providers
-        // (e.g. "setup_token" from Anthropic) would otherwise desync UI vs Node.
-        if (newProviderId == "openai" && config?.authType !in listOf("oauth", "api_key")) {
+        // OpenAI defaults to OAuth (ChatGPT subscription) when switching INTO the provider.
+        // The previous authType comes from another provider (e.g. Anthropic's default
+        // "api_key", or "setup_token"), which should not silently carry over. Users who
+        // prefer API key can change it via the auth-type picker after the switch.
+        // We persist the resolved value so UI, Node config, and validation all agree.
+        val effectiveAuthType: String? = if (newProviderId == "openai") {
             saveField("authType", "oauth")
+            "oauth"
+        } else {
+            config?.authType
         }
 
         // Restore last-used model for new provider, or fall back to first model.
-        // Pass the (possibly just-updated) authType so OpenAI gets the OAuth model list when applicable.
-        val effectiveAuthType = if (newProviderId == "openai") {
-            if (config?.authType == "api_key") "api_key" else "oauth"
-        } else config?.authType
         val modelsForNew = modelsForProvider(newProviderId, effectiveAuthType)
         if (modelsForNew.isEmpty()) {
             // Freeform provider (e.g. OpenRouter) — restore last-used or set default
@@ -361,7 +363,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 onSignInBrowser = {
                                     val requestId = UUID.randomUUID().toString()
                                     val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
-                                        putExtra("method", "browser")
                                         putExtra("requestId", requestId)
                                     }
                                     context.startActivity(intent)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -369,20 +369,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     oauthRequestId = requestId
                                     oauthPolling = true
                                     oauthError = null
-                                    oauthDeviceCode = null
-                                },
-                                onSignInDeviceCode = {
-                                    val requestId = UUID.randomUUID().toString()
-                                    val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
-                                        putExtra("method", "device_code")
-                                        putExtra("requestId", requestId)
-                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                    }
-                                    context.startActivity(intent)
-                                    oauthRequestId = requestId
-                                    oauthPolling = true
-                                    oauthError = null
-                                    oauthDeviceCode = null
                                 },
                                 onSignOut = {
                                     ConfigManager.clearOpenAIOAuth(context)
@@ -391,8 +377,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 },
                                 oauthPolling = oauthPolling,
                                 oauthError = oauthError,
-                                oauthDeviceCode = oauthDeviceCode,
-                                oauthVerificationUri = oauthVerificationUri,
                             )
                         }
                     }
@@ -841,14 +825,10 @@ private fun OpenAIOAuthSection(
     isConnected: Boolean,
     email: String,
     onSignInBrowser: () -> Unit,
-    onSignInDeviceCode: () -> Unit,
     onSignOut: () -> Unit,
     oauthPolling: Boolean,
     oauthError: String?,
-    oauthDeviceCode: String?,
-    oauthVerificationUri: String?,
 ) {
-    val clipboardManager = LocalClipboardManager.current
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
     Column(modifier = Modifier.padding(16.dp)) {
@@ -898,66 +878,24 @@ private fun OpenAIOAuthSection(
                 Text("Sign Out", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, fontSize = 14.sp)
             }
         } else if (oauthPolling) {
-            // Polling state
-            if (oauthDeviceCode != null) {
-                // Device code flow — show code
+            // Waiting for browser authentication
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = SeekerClawColors.ActionPrimary,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "Go to:",
+                    text = "Waiting for authentication...",
                     fontFamily = RethinkSans,
-                    fontSize = 12.sp,
+                    fontSize = 13.sp,
                     color = SeekerClawColors.TextDim,
                 )
-                Text(
-                    text = oauthVerificationUri ?: "auth.openai.com/codex/device",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = SeekerClawColors.TextInteractive,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    text = "Enter code:",
-                    fontFamily = RethinkSans,
-                    fontSize = 12.sp,
-                    color = SeekerClawColors.TextDim,
-                )
-                Text(
-                    text = oauthDeviceCode,
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = SeekerClawColors.TextPrimary,
-                    letterSpacing = 4.sp,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                OutlinedButton(
-                    onClick = { clipboardManager.setText(AnnotatedString(oauthDeviceCode)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = shape,
-                    border = BorderStroke(1.dp, SeekerClawColors.TextDim),
-                ) {
-                    Text("Copy Code", fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
-                }
-            } else {
-                // Browser flow — waiting
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 2.dp,
-                        color = SeekerClawColors.ActionPrimary,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "Waiting for authentication...",
-                        fontFamily = RethinkSans,
-                        fontSize = 13.sp,
-                        color = SeekerClawColors.TextDim,
-                    )
-                }
             }
         } else {
             // Not connected — show sign in buttons
@@ -970,16 +908,7 @@ private fun OpenAIOAuthSection(
                     contentColor = Color.White,
                 ),
             ) {
-                Text("Sign in with Browser", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, fontSize = 14.sp)
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            OutlinedButton(
-                onClick = onSignInDeviceCode,
-                modifier = Modifier.fillMaxWidth(),
-                shape = shape,
-                border = BorderStroke(1.dp, SeekerClawColors.TextDim),
-            ) {
-                Text("Sign in with Code", fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
+                Text("Sign in with ChatGPT", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, fontSize = 14.sp)
             }
         }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -47,7 +47,6 @@ import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.availableModels
 import com.seekerclaw.app.config.availableProviders
 import com.seekerclaw.app.config.modelsForProvider
-import com.seekerclaw.app.config.openaiModels
 import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.oauth.OpenAIOAuthActivity
 import com.seekerclaw.app.util.Analytics
@@ -61,7 +60,6 @@ import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -49,19 +49,31 @@ import com.seekerclaw.app.config.availableProviders
 import com.seekerclaw.app.config.modelsForProvider
 import com.seekerclaw.app.config.openaiModels
 import com.seekerclaw.app.config.providerById
+import com.seekerclaw.app.oauth.OpenAIOAuthActivity
 import com.seekerclaw.app.util.Analytics
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.content.Intent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import org.json.JSONObject
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.UUID
 
 @Composable
 fun ProviderConfigScreen(onBack: () -> Unit) {
@@ -84,8 +96,67 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     var testStatus by remember { mutableStateOf("Idle") }
     var testMessage by remember { mutableStateOf("") }
     var showRestartDialog by remember { mutableStateOf(false) }
+    // OpenAI OAuth state
+    var oauthRequestId by remember { mutableStateOf<String?>(null) }
+    var oauthPolling by remember { mutableStateOf(false) }
+    var oauthError by remember { mutableStateOf<String?>(null) }
+    var oauthDeviceCode by remember { mutableStateOf<String?>(null) }
+    var oauthVerificationUri by remember { mutableStateOf<String?>(null) }
 
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
+
+    // OAuth result file polling
+    LaunchedEffect(oauthRequestId, oauthPolling) {
+        val reqId = oauthRequestId ?: return@LaunchedEffect
+        if (!oauthPolling) return@LaunchedEffect
+        val resultsDir = File(context.filesDir, OpenAIOAuthActivity.RESULTS_DIR)
+        val resultFile = File(resultsDir, "$reqId.json")
+        val deadline = System.currentTimeMillis() + 120_000 // 2 min timeout
+        while (oauthPolling && System.currentTimeMillis() < deadline) {
+            delay(1000)
+            if (!resultFile.exists()) continue
+            try {
+                val json = JSONObject(resultFile.readText())
+                resultFile.delete()
+                when (json.optString("status")) {
+                    "success" -> {
+                        val accessToken = json.optString("accessToken", "")
+                        val refreshToken = json.optString("refreshToken", "")
+                        val email = json.optString("email", "")
+                        val expiresAt = json.optString("expiresAt", "")
+                        if (accessToken.isNotBlank()) {
+                            ConfigManager.updateConfigField(context, "openaiOAuthToken", accessToken)
+                            if (refreshToken.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthRefresh", refreshToken)
+                            if (email.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthEmail", email)
+                            if (expiresAt.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthExpiresAt", expiresAt)
+                            config = ConfigManager.loadConfig(context)
+                            showRestartDialog = true
+                        }
+                        oauthPolling = false
+                        oauthDeviceCode = null
+                    }
+                    "pending" -> {
+                        // Device code flow — show user code
+                        oauthDeviceCode = json.optString("userCode", "")
+                        oauthVerificationUri = json.optString("verificationUri", "")
+                        // Continue polling — the file will be overwritten with success/error
+                    }
+                    "error" -> {
+                        oauthError = json.optString("message", "Unknown error")
+                        oauthPolling = false
+                        oauthDeviceCode = null
+                    }
+                }
+            } catch (e: Exception) {
+                oauthError = "Failed to read OAuth result: ${e.message}"
+                oauthPolling = false
+            }
+        }
+        if (oauthPolling) {
+            oauthError = "OAuth timed out. Please try again."
+            oauthPolling = false
+        }
+    }
 
     fun saveField(field: String, value: String, needsRestart: Boolean = false) {
         ConfigManager.updateConfigField(context, field, value)
@@ -245,26 +316,82 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         )
                     }
                     "openai" -> {
+                        val openaiAuthType = config?.authType ?: "api_key"
+                        val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         ConfigField(
                             label = "Model",
-                            value = openaiModels.find { it.id == config?.model }
+                            value = openaiModelList.find { it.id == config?.model }
                                 ?.let { "${it.displayName} (${it.description})" }
                                 ?: config?.model?.ifBlank { "Not set" } ?: "Not set",
                             onClick = { showModelPicker = true },
                             info = SettingsHelpTexts.MODEL,
                         )
+                        val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth (experimental)" else "API Key"
                         ConfigField(
-                            label = "API Key",
-                            value = maskKey(config?.openaiApiKey),
-                            onClick = {
-                                editField = "openaiApiKey"
-                                editLabel = "OpenAI API Key"
-                                editValue = config?.openaiApiKey ?: ""
-                            },
-                            info = SettingsHelpTexts.OPENAI_API_KEY,
-                            isRequired = true,
-                            showDivider = false,
+                            label = "Auth Type",
+                            value = openaiAuthLabel,
+                            onClick = { showAuthTypePicker = true },
+                            info = "API Key uses your OpenAI platform key. OAuth uses your ChatGPT subscription via Codex OAuth.",
                         )
+                        if (openaiAuthType == "api_key") {
+                            ConfigField(
+                                label = "API Key",
+                                value = maskKey(config?.openaiApiKey),
+                                onClick = {
+                                    editField = "openaiApiKey"
+                                    editLabel = "OpenAI API Key"
+                                    editValue = config?.openaiApiKey ?: ""
+                                },
+                                info = SettingsHelpTexts.OPENAI_API_KEY,
+                                isRequired = true,
+                                showDivider = false,
+                            )
+                        } else {
+                            // OAuth section
+                            HorizontalDivider(
+                                color = SeekerClawColors.CardBorder,
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                            )
+                            OpenAIOAuthSection(
+                                isConnected = !config?.openaiOAuthToken.isNullOrBlank(),
+                                email = config?.openaiOAuthEmail ?: "",
+                                onSignInBrowser = {
+                                    val requestId = UUID.randomUUID().toString()
+                                    val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
+                                        putExtra("method", "browser")
+                                        putExtra("requestId", requestId)
+                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    }
+                                    context.startActivity(intent)
+                                    oauthRequestId = requestId
+                                    oauthPolling = true
+                                    oauthError = null
+                                    oauthDeviceCode = null
+                                },
+                                onSignInDeviceCode = {
+                                    val requestId = UUID.randomUUID().toString()
+                                    val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
+                                        putExtra("method", "device_code")
+                                        putExtra("requestId", requestId)
+                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    }
+                                    context.startActivity(intent)
+                                    oauthRequestId = requestId
+                                    oauthPolling = true
+                                    oauthError = null
+                                    oauthDeviceCode = null
+                                },
+                                onSignOut = {
+                                    ConfigManager.clearOpenAIOAuth(context)
+                                    config = ConfigManager.loadConfig(context)
+                                    showRestartDialog = true
+                                },
+                                oauthPolling = oauthPolling,
+                                oauthError = oauthError,
+                                oauthDeviceCode = oauthDeviceCode,
+                                oauthVerificationUri = oauthVerificationUri,
+                            )
+                        }
                     }
                     "openrouter" -> {
                         val modelCtxDisplay = config?.openrouterModelContext?.ifBlank { null }
@@ -374,7 +501,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         scope.launch {
                             val result = when (activeProvider) {
                                 "openrouter" -> testOpenRouterConnection(config?.openrouterApiKey ?: "")
-                                "openai" -> testOpenAIConnection(config?.openaiApiKey ?: "")
+                                "openai" -> {
+                                    val authType = config?.authType ?: "api_key"
+                                    if (authType == "oauth") {
+                                        testOpenAIConnection(config?.openaiOAuthToken ?: "")
+                                    } else {
+                                        testOpenAIConnection(config?.openaiApiKey ?: "")
+                                    }
+                                }
                                 "custom" -> testCustomConnection(
                                     endpointUrl = config?.customBaseUrl ?: "",
                                     apiKey = config?.customApiKey ?: "",
@@ -509,8 +643,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     }
 
     // Model picker dialog — shows models for active provider only (skip for freeform providers)
-    if (showModelPicker && modelsForProvider(activeProvider).isNotEmpty()) {
-        val models = modelsForProvider(activeProvider)
+    if (showModelPicker && modelsForProvider(activeProvider, config?.authType).isNotEmpty()) {
+        val models = modelsForProvider(activeProvider, config?.authType)
         var selectedModel by remember {
             mutableStateOf(models.firstOrNull { it.id == config?.model }?.id ?: models.firstOrNull()?.id ?: "")
         }
@@ -582,9 +716,12 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         )
     }
 
-    // Auth type picker (Claude only)
+    // Auth type picker (Claude + OpenAI)
     if (showAuthTypePicker) {
-        val authOptions = listOf("api_key" to "API Key", "setup_token" to "Pro/Max Setup Token")
+        val authOptions = when (activeProvider) {
+            "openai" -> listOf("api_key" to "API Key", "oauth" to "ChatGPT OAuth (experimental)")
+            else -> listOf("api_key" to "API Key", "setup_token" to "Pro/Max Setup Token")
+        }
         var selectedAuth by remember { mutableStateOf(config?.authType ?: "api_key") }
 
         AlertDialog(
@@ -621,7 +758,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "Both credentials are stored. Switching just changes which one is used.",
+                        text = if (activeProvider == "openai") "Switching auth type changes how you authenticate with OpenAI."
+                               else "Both credentials are stored. Switching just changes which one is used.",
                         fontFamily = RethinkSans,
                         fontSize = 12.sp,
                         color = SeekerClawColors.TextDim,
@@ -692,6 +830,166 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             context = context,
             onDismiss = { showRestartDialog = false },
         )
+    }
+}
+
+@Composable
+private fun OpenAIOAuthSection(
+    isConnected: Boolean,
+    email: String,
+    onSignInBrowser: () -> Unit,
+    onSignInDeviceCode: () -> Unit,
+    onSignOut: () -> Unit,
+    oauthPolling: Boolean,
+    oauthError: String?,
+    oauthDeviceCode: String?,
+    oauthVerificationUri: String?,
+) {
+    val clipboardManager = LocalClipboardManager.current
+    val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        // Warning card
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SeekerClawColors.Warning.copy(alpha = 0.1f), shape)
+                .padding(12.dp),
+        ) {
+            Text(
+                text = "Experimental: uses OpenAI's Codex OAuth. Not officially supported for third-party apps. Subscription rate limits apply.",
+                fontFamily = RethinkSans,
+                fontSize = 13.sp,
+                color = SeekerClawColors.Warning,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (isConnected) {
+            // Connected state
+            Text(
+                text = "Connected as:",
+                fontFamily = RethinkSans,
+                fontSize = 12.sp,
+                color = SeekerClawColors.TextDim,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = email.ifBlank { "Unknown account" },
+                fontFamily = RethinkSans,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = SeekerClawColors.ActionPrimary,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = onSignOut,
+                modifier = Modifier.fillMaxWidth(),
+                shape = shape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = SeekerClawColors.Error,
+                    contentColor = Color.White,
+                ),
+            ) {
+                Text("Sign Out", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+            }
+        } else if (oauthPolling) {
+            // Polling state
+            if (oauthDeviceCode != null) {
+                // Device code flow — show code
+                Text(
+                    text = "Go to:",
+                    fontFamily = RethinkSans,
+                    fontSize = 12.sp,
+                    color = SeekerClawColors.TextDim,
+                )
+                Text(
+                    text = oauthVerificationUri ?: "auth.openai.com/codex/device",
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = SeekerClawColors.TextInteractive,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Enter code:",
+                    fontFamily = RethinkSans,
+                    fontSize = 12.sp,
+                    color = SeekerClawColors.TextDim,
+                )
+                Text(
+                    text = oauthDeviceCode,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = SeekerClawColors.TextPrimary,
+                    letterSpacing = 4.sp,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = { clipboardManager.setText(AnnotatedString(oauthDeviceCode)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = shape,
+                    border = BorderStroke(1.dp, SeekerClawColors.TextDim),
+                ) {
+                    Text("Copy Code", fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
+                }
+            } else {
+                // Browser flow — waiting
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = SeekerClawColors.ActionPrimary,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Waiting for authentication...",
+                        fontFamily = RethinkSans,
+                        fontSize = 13.sp,
+                        color = SeekerClawColors.TextDim,
+                    )
+                }
+            }
+        } else {
+            // Not connected — show sign in buttons
+            Button(
+                onClick = onSignInBrowser,
+                modifier = Modifier.fillMaxWidth(),
+                shape = shape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = SeekerClawColors.ActionPrimary,
+                    contentColor = Color.White,
+                ),
+            ) {
+                Text("Sign in with Browser", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onSignInDeviceCode,
+                modifier = Modifier.fillMaxWidth(),
+                shape = shape,
+                border = BorderStroke(1.dp, SeekerClawColors.TextDim),
+            ) {
+                Text("Sign in with Code", fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
+            }
+        }
+
+        // Error message
+        if (oauthError != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = oauthError,
+                fontFamily = RethinkSans,
+                fontSize = 13.sp,
+                color = SeekerClawColors.Error,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -119,8 +119,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     "success" -> {
                         val accessToken = json.optString("accessToken", "")
                         val refreshToken = json.optString("refreshToken", "")
-                        val email = json.optString("email", "")
-                        val expiresAt = json.optString("expiresAt", "")
+                        // Guard against JSONObject.NULL which optString renders as "null"
+                        val email = json.optString("email", "").takeIf { it != "null" } ?: ""
+                        val expiresAt = json.optString("expiresAt", "").takeIf { it != "null" } ?: ""
                         if (accessToken.isNotBlank()) {
                             ConfigManager.updateConfigField(context, "openaiOAuthToken", accessToken)
                             if (refreshToken.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthRefresh", refreshToken)
@@ -701,7 +702,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             "openai" -> listOf("api_key" to "API Key", "oauth" to "ChatGPT OAuth (experimental)")
             else -> listOf("api_key" to "API Key", "setup_token" to "Pro/Max Setup Token")
         }
-        var selectedAuth by remember { mutableStateOf(config?.authType ?: "api_key") }
+        // Normalize: ensure selectedAuth is a valid option for the current provider
+        val validAuthTypes = authOptions.map { it.first }.toSet()
+        var selectedAuth by remember {
+            mutableStateOf((config?.authType ?: "api_key").let { if (it in validAuthTypes) it else "api_key" })
+        }
 
         AlertDialog(
             onDismissRequest = { showAuthTypePicker = false },

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -125,11 +125,21 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         val email = json.optString("email", "").takeIf { it != "null" } ?: ""
                         val expiresAt = json.optString("expiresAt", "").takeIf { it != "null" } ?: ""
                         if (accessToken.isNotBlank()) {
-                            ConfigManager.updateConfigField(context, "openaiOAuthToken", accessToken)
-                            if (refreshToken.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthRefresh", refreshToken)
-                            if (email.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthEmail", email)
-                            if (expiresAt.isNotBlank()) ConfigManager.updateConfigField(context, "openaiOAuthExpiresAt", expiresAt)
-                            config = ConfigManager.loadConfig(context)
+                            // Batch into a single saveConfig to avoid 4× SharedPreferences commits
+                            // and 4× workspace config writes / configVersion bumps.
+                            val current = config ?: ConfigManager.loadConfig(context)
+                            if (current != null) {
+                                val updated = current.copy(
+                                    openaiOAuthToken = accessToken,
+                                    openaiOAuthRefresh = if (refreshToken.isNotBlank()) refreshToken else current.openaiOAuthRefresh,
+                                    openaiOAuthEmail = if (email.isNotBlank()) email else current.openaiOAuthEmail,
+                                    openaiOAuthExpiresAt = if (expiresAt.isNotBlank()) expiresAt else current.openaiOAuthExpiresAt,
+                                )
+                                withContext(Dispatchers.IO) { ConfigManager.saveConfig(context, updated) }
+                                config = updated
+                            } else {
+                                config = ConfigManager.loadConfig(context)
+                            }
                             showRestartDialog = true
                         }
                         oauthPolling = false

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -734,7 +734,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 value = customModelId,
                                 onValueChange = {
                                     customModelId = it
-                                    if (it.isNotBlank()) selectedModel = it
+                                    // Update selectedModel even when blank — point at the sentinel
+                                    // so canSave (which excludes the sentinel) disables Save.
+                                    selectedModel = it.ifBlank { CUSTOM_MODEL_SENTINEL }
                                 },
                                 placeholder = { Text("e.g. gpt-5.4-pro", fontSize = 12.sp) },
                                 textStyle = androidx.compose.ui.text.TextStyle(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -730,14 +730,19 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
             },
             confirmButton = {
+                val canSave = selectedModel.isNotBlank() && selectedModel != "custom"
                 TextButton(
                     onClick = {
-                        saveField("model", selectedModel, needsRestart = true)
-                        Analytics.modelSelected(selectedModel)
-                        showModelPicker = false
+                        if (canSave) {
+                            saveField("model", selectedModel, needsRestart = true)
+                            Analytics.modelSelected(selectedModel)
+                            showModelPicker = false
+                        }
                     },
+                    enabled = canSave,
                 ) {
-                    Text("Save", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, color = SeekerClawColors.ActionPrimary)
+                    Text("Save", fontFamily = RethinkSans, fontWeight = FontWeight.Bold,
+                        color = if (canSave) SeekerClawColors.ActionPrimary else SeekerClawColors.TextDim)
                 }
             },
             dismissButton = {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -808,6 +808,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 TextButton(
                     onClick = {
                         saveField("authType", selectedAuth, needsRestart = true)
+                        // Set default model when switching to OAuth (Codex models differ)
+                        if (selectedAuth == "oauth" && activeProvider == "openai") {
+                            val currentModel = config?.model ?: ""
+                            val oauthModels = modelsForProvider("openai", "oauth")
+                            if (oauthModels.none { it.id == currentModel }) {
+                                saveField("model", "gpt-5.4", needsRestart = false)
+                            }
+                        }
                         Analytics.authTypeChanged(selectedAuth)
                         showAuthTypePicker = false
                     },

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.CircularProgressIndicator
 import com.seekerclaw.app.ui.components.SeekerClawScaffold
 import androidx.compose.material3.HorizontalDivider
@@ -666,7 +668,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             )
                             Column(modifier = Modifier.padding(start = 8.dp)) {
                                 Text(
-                                    text = "${model.displayName} (${model.description})",
+                                    text = model.displayName,
                                     fontFamily = RethinkSans,
                                     fontSize = 14.sp,
                                     color = SeekerClawColors.TextPrimary,
@@ -947,9 +949,14 @@ private fun OpenAIOAuthSection(
                     color = SeekerClawColors.TextDim,
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            TextButton(onClick = onCancelPolling) {
-                Text("Cancel", fontFamily = RethinkSans, fontSize = 13.sp, color = SeekerClawColors.TextDim)
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedButton(
+                onClick = onCancelPolling,
+                modifier = Modifier.fillMaxWidth(),
+                shape = shape,
+                border = BorderStroke(1.dp, SeekerClawColors.TextDim),
+            ) {
+                Text("Cancel", fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
             }
         } else {
             // Not connected — show sign in buttons

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -428,15 +428,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     oauthError = null
                                 },
                                 onSignOut = {
+                                    // Clear tokens but keep authType=oauth so the OAuth
+                                    // section stays visible with the Sign In button — the
+                                    // user just signed out, they probably want to sign
+                                    // back in (or pick API Key explicitly via the picker).
+                                    // writeConfigJson will translate oauth+blank → api_key
+                                    // for Node so the agent stays startable in the meantime.
                                     ConfigManager.clearOpenAIOAuth(context)
-                                    // Flip authType to api_key so the next Node startup
-                                    // doesn't trip the strict validation (oauth without
-                                    // a token would otherwise hard-crash on launch).
-                                    saveField("authType", "api_key", needsRestart = true)
-                                    context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
-                                        .edit()
-                                        .putString("lastAuthType_openai", "api_key")
-                                        .apply()
                                     config = ConfigManager.loadConfig(context)
                                     showRestartDialog = true
                                 },

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -636,7 +636,15 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     if (showModelPicker && modelsForProvider(activeProvider, config?.authType).isNotEmpty()) {
         val models = modelsForProvider(activeProvider, config?.authType)
         var selectedModel by remember {
-            mutableStateOf(models.firstOrNull { it.id == config?.model }?.id ?: models.firstOrNull()?.id ?: "")
+            // Preserve the user's current model even when it's not in the known list —
+            // otherwise opening the picker would silently overwrite a custom model ID.
+            val current = config?.model.orEmpty()
+            mutableStateOf(
+                when {
+                    current.isNotBlank() -> current
+                    else -> models.firstOrNull()?.id ?: ""
+                }
+            )
         }
 
         AlertDialog(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -57,15 +57,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.content.Intent
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import org.json.JSONObject
 import java.io.File
@@ -98,8 +94,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     var oauthRequestId by remember { mutableStateOf<String?>(null) }
     var oauthPolling by remember { mutableStateOf(false) }
     var oauthError by remember { mutableStateOf<String?>(null) }
-    var oauthDeviceCode by remember { mutableStateOf<String?>(null) }
-    var oauthVerificationUri by remember { mutableStateOf<String?>(null) }
+    // Note: device code UI removed — only browser flow used for now
 
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
@@ -135,18 +130,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             showRestartDialog = true
                         }
                         oauthPolling = false
-                        oauthDeviceCode = null
                     }
                     "pending" -> {
-                        // Device code flow — show user code (treat blank as null)
-                        oauthDeviceCode = json.optString("userCode", "").takeIf { it.isNotBlank() }
-                        oauthVerificationUri = json.optString("verificationUri", "").takeIf { it.isNotBlank() }
                         // Continue polling — the file will be overwritten with success/error
                     }
                     "error" -> {
                         oauthError = json.optString("message", "Unknown error")
                         oauthPolling = false
-                        oauthDeviceCode = null
                     }
                 }
             } catch (e: Exception) {
@@ -318,7 +308,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         )
                     }
                     "openai" -> {
-                        val openaiAuthType = config?.authType ?: "api_key"
+                        // Normalize: only "api_key" and "oauth" are valid for OpenAI;
+                        // other values (e.g. "setup_token" from Claude) fall back to "api_key"
+                        val openaiAuthType = if (config?.authType == "oauth") "oauth" else "api_key"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         // Auth Type first (determines model list + credential UI)
                         val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth (experimental)" else "API Key"
@@ -1007,7 +999,7 @@ private suspend fun testOpenAIOAuthConnection(accessToken: String): Result<Unit>
     runCatching {
         if (accessToken.isBlank()) error("OAuth token is empty — please sign in first")
         // OAuth tokens use the Codex endpoint; /v1/models won't work.
-        // Use a lightweight HEAD to chatgpt.com to verify the token is still valid.
+        // Use a lightweight GET to chatgpt.com/backend-api/me to verify the token is still valid.
         val url = URL("https://chatgpt.com/backend-api/me")
         val conn = url.openConnection() as HttpURLConnection
         conn.requestMethod = "GET"

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -388,6 +388,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 },
                                 onSignOut = {
                                     ConfigManager.clearOpenAIOAuth(context)
+                                    // Flip authType to api_key so the next Node startup
+                                    // doesn't trip the strict validation (oauth without
+                                    // a token would otherwise hard-crash on launch).
+                                    saveField("authType", "api_key", needsRestart = true)
+                                    context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
+                                        .edit()
+                                        .putString("lastAuthType_openai", "api_key")
+                                        .apply()
                                     config = ConfigManager.loadConfig(context)
                                     showRestartDialog = true
                                 },
@@ -855,13 +863,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             .putString("lastAuthType_$activeProvider", selectedAuth)
                             .apply()
                         // Ensure the selected model is valid for the chosen OpenAI auth type.
-                        // OAuth and API-key model lists differ — fall back to a default if not.
+                        // OAuth and API-key model lists differ — derive the fallback from the
+                        // available models so a model list change doesn't silently leave a
+                        // hardcoded ID that no longer exists.
                         if (activeProvider == "openai") {
                             val currentModel = config?.model ?: ""
                             val allowedModels = modelsForProvider("openai", selectedAuth)
                             if (allowedModels.none { it.id == currentModel }) {
-                                val fallback = if (selectedAuth == "oauth") "gpt-5.4"
-                                               else allowedModels.firstOrNull()?.id ?: "gpt-5.4"
+                                val fallback = allowedModels.firstOrNull()?.id ?: "gpt-5.4"
                                 saveField("model", fallback, needsRestart = false)
                             }
                         }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -71,6 +71,10 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
 
+// Sentinel for the "Custom model" radio in the model picker. Must NOT be a valid model id —
+// using "__custom__" so a real model literally named "custom" can still be entered freely.
+private const val CUSTOM_MODEL_SENTINEL = "__custom__"
+
 @Composable
 fun ProviderConfigScreen(onBack: () -> Unit) {
     val context = LocalContext.current
@@ -660,12 +664,12 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             },
             text = {
                 Column {
-                    // "custom" is a sentinel for "user wants to type a model ID" — never display
+                    // CUSTOM_MODEL_SENTINEL is a sentinel for "user wants to type a model ID" — never display
                     // it as the model ID itself, and don't treat it as a real selection.
-                    val isCustomSelected = selectedModel == "custom" ||
+                    val isCustomSelected = selectedModel == CUSTOM_MODEL_SENTINEL ||
                         (models.none { it.id == selectedModel } && selectedModel.isNotBlank())
                     var customModelId by remember {
-                        mutableStateOf(if (isCustomSelected && selectedModel != "custom") selectedModel else "")
+                        mutableStateOf(if (isCustomSelected && selectedModel != CUSTOM_MODEL_SENTINEL) selectedModel else "")
                     }
 
                     models.forEach { model ->
@@ -704,13 +708,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { selectedModel = customModelId.ifBlank { "custom" } }
+                            .clickable { selectedModel = customModelId.ifBlank { CUSTOM_MODEL_SENTINEL } }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
-                            selected = isCustomSelected || selectedModel == "custom",
-                            onClick = { selectedModel = customModelId.ifBlank { "custom" } },
+                            selected = isCustomSelected || selectedModel == CUSTOM_MODEL_SENTINEL,
+                            onClick = { selectedModel = customModelId.ifBlank { CUSTOM_MODEL_SENTINEL } },
                             colors = RadioButtonDefaults.colors(
                                 selectedColor = SeekerClawColors.Primary,
                                 unselectedColor = SeekerClawColors.TextDim,
@@ -748,7 +752,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
             },
             confirmButton = {
-                val canSave = selectedModel.isNotBlank() && selectedModel != "custom"
+                val canSave = selectedModel.isNotBlank() && selectedModel != CUSTOM_MODEL_SENTINEL
                 TextButton(
                     onClick = {
                         if (canSave) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -1052,7 +1052,9 @@ private fun OpenAIOAuthSection(
                 modifier = Modifier.fillMaxWidth(),
                 shape = shape,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = SeekerClawColors.Error,
+                    // Use the same destructive-action red as Reset/Wipe buttons elsewhere
+                    // for visual consistency across the app's destructive surfaces.
+                    containerColor = SeekerClawColors.ActionDanger,
                     contentColor = Color.White,
                 ),
             ) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -390,9 +390,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     }
                     "openai" -> {
                         // Match Node's view: only "oauth" is OAuth; everything else is API key.
-                        // switchProvider() persists "oauth" as the default when entering OpenAI,
-                        // so this branch normally renders the user's actual choice — this guard
-                        // just protects against any remaining drift.
+                        // switchProvider() persists "api_key" when entering OpenAI unless an
+                        // OAuth token already exists, so this branch normally reflects the
+                        // user's actual saved choice. The guard protects against any drift.
                         val openaiAuthType = if (config?.authType == "oauth") "oauth" else "api_key"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         // Auth Type first (determines model list + credential UI)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -394,7 +394,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             onClick = { showModelPicker = true },
                             info = SettingsHelpTexts.MODEL,
                         )
-                        if (openaiAuthType == "api_key") {
+                        // Show the OAuth section whenever an OAuth flow is in progress or has
+                        // produced an error, even if persisted authType is still "api_key".
+                        // This is the case during a first-time sign-in launched from the auth
+                        // picker — we deferred persisting authType=oauth until the token
+                        // arrives, so without this guard the polling/error UI would be invisible.
+                        val showOAuthSection = openaiAuthType == "oauth" || oauthPolling || oauthError != null
+                        if (!showOAuthSection) {
                             ConfigField(
                                 label = "API Key",
                                 value = maskKey(config?.openaiApiKey),

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -141,31 +141,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 when (json.optString("status")) {
                     "success" -> {
                         // Tokens were persisted directly by OpenAIOAuthActivity via
-                        // ConfigManager.saveConfig. Only apply OpenAI-specific auth state
-                        // changes if OpenAI is still the active provider — the user may
-                        // have switched providers while polling was in progress.
-                        val shouldApply = withContext(Dispatchers.IO) {
-                            val current = ConfigManager.loadConfig(context)
-                            if (current != null &&
-                                current.provider == "openai" &&
-                                current.openaiOAuthToken.isNotBlank()
-                            ) {
-                                if (current.authType != "oauth") {
-                                    ConfigManager.saveConfig(context, current.copy(authType = "oauth"))
-                                }
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        if (shouldApply) {
-                            context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
-                                .edit()
-                                .putString("lastAuthType_openai", "oauth")
-                                .apply()
-                            config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
-                            showRestartDialog = true
-                        }
+                        // ConfigManager.saveConfig. authType is already "oauth" (the
+                        // picker saves it on selection), so we just reload to pick up
+                        // the new token and pop the restart dialog.
+                        config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
+                        showRestartDialog = true
                         oauthPolling = false
                     }
                     "error" -> {
@@ -917,34 +897,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
             },
             confirmButton = {
-                // If switching to OpenAI OAuth without a token, the Save button becomes
-                // "Sign in with OpenAI" — it launches the browser flow directly and only
-                // persists authType=oauth after the OAuth section flow completes (the
-                // OAuth section will be rendered as soon as the picker closes because
-                // the OAuth UI is gated on the presence of the token, not the picker).
-                val oauthMissingToken = activeProvider == "openai" &&
-                    selectedAuth == "oauth" &&
-                    config?.openaiOAuthToken.isNullOrBlank()
                 TextButton(
                     onClick = {
-                        if (oauthMissingToken) {
-                            // Don't persist oauth yet — only after sign-in succeeds, the
-                            // OAuth result handler will set authType=oauth alongside the
-                            // token save. Persisting here would leave the agent unstartable
-                            // (oauth + blank token) if the user dismisses the restart dialog
-                            // or sign-in fails.
-                            Analytics.authTypeChanged(selectedAuth)
-                            showAuthTypePicker = false
-                            val requestId = UUID.randomUUID().toString()
-                            val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
-                                putExtra("requestId", requestId)
-                            }
-                            context.startActivity(intent)
-                            oauthRequestId = requestId
-                            oauthPolling = true
-                            oauthError = null
-                            return@TextButton
-                        }
+                        // Persist the user's selection immediately. If they pick "oauth"
+                        // without a token yet, that's fine — the OAuth section will render
+                        // with a Sign In button and ConfigManager.loadConfig() will
+                        // normalize oauth+blank back to api_key on the next load if they
+                        // never complete sign-in.
                         saveField("authType", selectedAuth, needsRestart = true)
                         context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
                             .edit()
@@ -963,7 +922,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     },
                 ) {
                     Text(
-                        if (oauthMissingToken) "Sign in with OpenAI" else "Save",
+                        "Save",
                         fontFamily = RethinkSans,
                         fontWeight = FontWeight.Bold,
                         color = SeekerClawColors.ActionPrimary,

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -320,6 +320,14 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     "openai" -> {
                         val openaiAuthType = config?.authType ?: "api_key"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
+                        // Auth Type first (determines model list + credential UI)
+                        val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth (experimental)" else "API Key"
+                        ConfigField(
+                            label = "Auth Type",
+                            value = openaiAuthLabel,
+                            onClick = { showAuthTypePicker = true },
+                            info = "API Key uses your OpenAI platform key. OAuth uses your ChatGPT subscription via Codex OAuth.",
+                        )
                         ConfigField(
                             label = "Model",
                             value = openaiModelList.find { it.id == config?.model }
@@ -327,13 +335,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 ?: config?.model?.ifBlank { "Not set" } ?: "Not set",
                             onClick = { showModelPicker = true },
                             info = SettingsHelpTexts.MODEL,
-                        )
-                        val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth (experimental)" else "API Key"
-                        ConfigField(
-                            label = "Auth Type",
-                            value = openaiAuthLabel,
-                            onClick = { showAuthTypePicker = true },
-                            info = "API Key uses your OpenAI platform key. OAuth uses your ChatGPT subscription via Codex OAuth.",
                         )
                         if (openaiAuthType == "api_key") {
                             ConfigField(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -368,6 +368,10 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     config = ConfigManager.loadConfig(context)
                                     showRestartDialog = true
                                 },
+                                onCancelPolling = {
+                                    oauthPolling = false
+                                    oauthError = null
+                                },
                                 oauthPolling = oauthPolling,
                                 oauthError = oauthError,
                             )
@@ -871,6 +875,7 @@ private fun OpenAIOAuthSection(
     email: String,
     onSignInBrowser: () -> Unit,
     onSignOut: () -> Unit,
+    onCancelPolling: () -> Unit,
     oauthPolling: Boolean,
     oauthError: String?,
 ) {
@@ -941,6 +946,10 @@ private fun OpenAIOAuthSection(
                     fontSize = 13.sp,
                     color = SeekerClawColors.TextDim,
                 )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(onClick = onCancelPolling) {
+                Text("Cancel", fontFamily = RethinkSans, fontSize = 13.sp, color = SeekerClawColors.TextDim)
             }
         } else {
             // Not connected — show sign in buttons

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -48,6 +48,7 @@ import com.seekerclaw.app.ui.components.ConfigField
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.availableModels
 import com.seekerclaw.app.config.availableProviders
+import com.seekerclaw.app.config.OPENROUTER_DEFAULT_MODEL
 import com.seekerclaw.app.config.modelsForProvider
 import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.oauth.OpenAIOAuthActivity
@@ -239,7 +240,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         val effectiveModel: String = if (modelsForNew.isEmpty()) {
             // Freeform provider (e.g. OpenRouter) — restore last-used or set default
             val defaultModel = when (newProviderId) {
-                "openrouter" -> "anthropic/claude-sonnet-4-6"
+                "openrouter" -> OPENROUTER_DEFAULT_MODEL
                 "custom" -> ""
                 else -> ""
             }
@@ -905,9 +906,10 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     onClick = {
                         // Persist the user's selection immediately. If they pick "oauth"
                         // without a token yet, that's fine — the OAuth section will render
-                        // with a Sign In button and ConfigManager.loadConfig() will
-                        // normalize oauth+blank back to api_key on the next load if they
-                        // never complete sign-in.
+                        // with a Sign In button. resolveAuthType() preserves the
+                        // "oauth selected, sign-in pending" state in SharedPreferences;
+                        // the oauth+blank → api_key fallback only happens at writeConfigJson
+                        // time so Node never sees an unstartable combination.
                         saveField("authType", selectedAuth, needsRestart = true)
                         context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
                             .edit()

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -218,17 +218,15 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         }
         val currentAuthType = oldAuthType
         val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
-        // Resolve authType for the new provider with a strict safety rule for OpenAI:
-        // never persist "oauth" unless an OAuth token is already present, otherwise the
-        // strict Node validation would hard-crash on the next restart with an unsignable
-        // state. The OAuth section UI will still let the user start sign-in from here.
-        val openaiHasToken = !config?.openaiOAuthToken.isNullOrBlank()
+        // Resolve authType for the new provider. OpenAI defaults to OAuth (ChatGPT
+        // subscription) on first switch-in, even without a token yet — the OAuth section
+        // shows a Sign In button and writeConfigJson translates oauth+blank → api_key
+        // for Node so the agent stays startable. The user's explicit picker choice is
+        // remembered per-provider via lastAuthType_<id>.
         val effectiveAuthType = when (newProviderId) {
-            "openai" -> when {
-                savedNewAuthType == "oauth" && openaiHasToken -> "oauth"
-                savedNewAuthType == "api_key" -> "api_key"
-                openaiHasToken -> "oauth"
-                else -> "api_key"
+            "openai" -> when (savedNewAuthType) {
+                "oauth", "api_key" -> savedNewAuthType
+                else -> "oauth" // first-time switch-in default
             }
             "claude" -> when (savedNewAuthType) {
                 "api_key", "setup_token" -> savedNewAuthType

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -119,29 +119,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
                 when (json.optString("status")) {
                     "success" -> {
-                        val accessToken = json.optString("accessToken", "")
-                        val refreshToken = json.optString("refreshToken", "")
-                        // Guard against JSONObject.NULL which optString renders as "null"
-                        val email = json.optString("email", "").takeIf { it != "null" } ?: ""
-                        val expiresAt = json.optString("expiresAt", "").takeIf { it != "null" } ?: ""
-                        if (accessToken.isNotBlank()) {
-                            // Batch into a single saveConfig to avoid 4× SharedPreferences commits
-                            // and 4× workspace config writes / configVersion bumps.
-                            val current = config ?: ConfigManager.loadConfig(context)
-                            if (current != null) {
-                                val updated = current.copy(
-                                    openaiOAuthToken = accessToken,
-                                    openaiOAuthRefresh = if (refreshToken.isNotBlank()) refreshToken else current.openaiOAuthRefresh,
-                                    openaiOAuthEmail = if (email.isNotBlank()) email else current.openaiOAuthEmail,
-                                    openaiOAuthExpiresAt = if (expiresAt.isNotBlank()) expiresAt else current.openaiOAuthExpiresAt,
-                                )
-                                withContext(Dispatchers.IO) { ConfigManager.saveConfig(context, updated) }
-                                config = updated
-                            } else {
-                                config = ConfigManager.loadConfig(context)
-                            }
-                            showRestartDialog = true
-                        }
+                        // Tokens were persisted directly by OpenAIOAuthActivity via
+                        // ConfigManager.saveConfig — they never touch the result file.
+                        // We just reload to pick up the encrypted values.
+                        config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
+                        showRestartDialog = true
                         oauthPolling = false
                     }
                     "pending" -> {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -190,8 +190,19 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
 
         saveField("provider", newProviderId, needsRestart = true)
 
-        // Restore last-used model for new provider, or fall back to first model
-        val modelsForNew = modelsForProvider(newProviderId)
+        // Normalize authType when switching to OpenAI: only "oauth" and "api_key" are valid.
+        // Default to "oauth" (ChatGPT subscription) — leftover values from other providers
+        // (e.g. "setup_token" from Anthropic) would otherwise desync UI vs Node.
+        if (newProviderId == "openai" && config?.authType !in listOf("oauth", "api_key")) {
+            saveField("authType", "oauth")
+        }
+
+        // Restore last-used model for new provider, or fall back to first model.
+        // Pass the (possibly just-updated) authType so OpenAI gets the OAuth model list when applicable.
+        val effectiveAuthType = if (newProviderId == "openai") {
+            if (config?.authType == "api_key") "api_key" else "oauth"
+        } else config?.authType
+        val modelsForNew = modelsForProvider(newProviderId, effectiveAuthType)
         if (modelsForNew.isEmpty()) {
             // Freeform provider (e.g. OpenRouter) — restore last-used or set default
             val savedModel = prefs.getString("lastModel_$newProviderId", null)
@@ -321,9 +332,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         )
                     }
                     "openai" -> {
-                        // Normalize: only "oauth" and "api_key" are valid for OpenAI;
-                        // other values (e.g. "setup_token" from Claude) default to "oauth"
-                        val openaiAuthType = if (config?.authType == "api_key") "api_key" else "oauth"
+                        // Match Node's view: only "oauth" is OAuth; everything else is API key.
+                        // switchProvider() persists "oauth" as the default when entering OpenAI,
+                        // so this branch normally renders the user's actual choice — this guard
+                        // just protects against any remaining drift.
+                        val openaiAuthType = if (config?.authType == "oauth") "oauth" else "api_key"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         // Auth Type first (determines model list + credential UI)
                         val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth" else "API Key"

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -109,13 +109,16 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         if (!oauthPolling) return@LaunchedEffect
         val resultsDir = File(context.filesDir, OpenAIOAuthActivity.RESULTS_DIR)
         val resultFile = File(resultsDir, "$reqId.json")
-        val deadline = System.currentTimeMillis() + 120_000 // 2 min timeout
+        val deadline = System.currentTimeMillis() + 600_000 // 10 min timeout (device-code flows can take a while)
         while (oauthPolling && System.currentTimeMillis() < deadline) {
             delay(1000)
             if (!resultFile.exists()) continue
             try {
-                val json = JSONObject(resultFile.readText())
-                resultFile.delete()
+                val json = withContext(Dispatchers.IO) {
+                    val text = resultFile.readText()
+                    resultFile.delete()
+                    JSONObject(text)
+                }
                 when (json.optString("status")) {
                     "success" -> {
                         val accessToken = json.optString("accessToken", "")
@@ -134,9 +137,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         oauthDeviceCode = null
                     }
                     "pending" -> {
-                        // Device code flow — show user code
-                        oauthDeviceCode = json.optString("userCode", "")
-                        oauthVerificationUri = json.optString("verificationUri", "")
+                        // Device code flow — show user code (treat blank as null)
+                        oauthDeviceCode = json.optString("userCode", "").takeIf { it.isNotBlank() }
+                        oauthVerificationUri = json.optString("verificationUri", "").takeIf { it.isNotBlank() }
                         // Continue polling — the file will be overwritten with success/error
                     }
                     "error" -> {
@@ -502,7 +505,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 "openai" -> {
                                     val authType = config?.authType ?: "api_key"
                                     if (authType == "oauth") {
-                                        testOpenAIConnection(config?.openaiOAuthToken ?: "")
+                                        testOpenAIOAuthConnection(config?.openaiOAuthToken ?: "")
                                     } else {
                                         testOpenAIConnection(config?.openaiApiKey ?: "")
                                     }
@@ -1061,6 +1064,34 @@ private suspend fun testOpenRouterConnection(apiKey: String): Result<Unit> = wit
                 else -> apiMessage.ifBlank { "HTTP $status" }
             }
             error("Connection failed ($errorMessage)")
+        } catch (_: java.net.SocketTimeoutException) {
+            error("Connection timed out")
+        } catch (_: java.io.IOException) {
+            error("Network unreachable or timeout")
+        } finally { conn.disconnect() }
+    }
+}
+
+private suspend fun testOpenAIOAuthConnection(accessToken: String): Result<Unit> = withContext(Dispatchers.IO) {
+    runCatching {
+        if (accessToken.isBlank()) error("OAuth token is empty — please sign in first")
+        // OAuth tokens use the Codex endpoint; /v1/models won't work.
+        // Use a lightweight HEAD to chatgpt.com to verify the token is still valid.
+        val url = URL("https://chatgpt.com/backend-api/me")
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "GET"
+        conn.setRequestProperty("Authorization", "Bearer $accessToken")
+        conn.connectTimeout = 15000
+        conn.readTimeout = 15000
+        try {
+            val status = conn.responseCode
+            if (status in 200..299) return@runCatching
+            when (status) {
+                401, 403 -> error("OAuth session expired — please sign in again")
+                429 -> error("Rate limited — try again in a moment")
+                in 500..599 -> error("OpenAI unavailable")
+                else -> error("HTTP $status")
+            }
         } catch (_: java.net.SocketTimeoutException) {
             error("Connection timed out")
         } catch (_: java.io.IOException) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -669,8 +669,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             },
             text = {
                 Column {
-                    val isCustomSelected = models.none { it.id == selectedModel } && selectedModel.isNotBlank()
-                    var customModelId by remember { mutableStateOf(if (isCustomSelected) selectedModel else "") }
+                    // "custom" is a sentinel for "user wants to type a model ID" — never display
+                    // it as the model ID itself, and don't treat it as a real selection.
+                    val isCustomSelected = selectedModel == "custom" ||
+                        (models.none { it.id == selectedModel } && selectedModel.isNotBlank())
+                    var customModelId by remember {
+                        mutableStateOf(if (isCustomSelected && selectedModel != "custom") selectedModel else "")
+                    }
 
                     models.forEach { model ->
                         Row(
@@ -835,12 +840,15 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 TextButton(
                     onClick = {
                         saveField("authType", selectedAuth, needsRestart = true)
-                        // Set default model when switching to OAuth (Codex models differ)
-                        if (selectedAuth == "oauth" && activeProvider == "openai") {
+                        // Ensure the selected model is valid for the chosen OpenAI auth type.
+                        // OAuth and API-key model lists differ — fall back to a default if not.
+                        if (activeProvider == "openai") {
                             val currentModel = config?.model ?: ""
-                            val oauthModels = modelsForProvider("openai", "oauth")
-                            if (oauthModels.none { it.id == currentModel }) {
-                                saveField("model", "gpt-5.4", needsRestart = false)
+                            val allowedModels = modelsForProvider("openai", selectedAuth)
+                            if (allowedModels.none { it.id == currentModel }) {
+                                val fallback = if (selectedAuth == "oauth") "gpt-5.4"
+                                               else allowedModels.firstOrNull()?.id ?: "gpt-5.4"
+                                saveField("model", fallback, needsRestart = false)
                             }
                         }
                         Analytics.authTypeChanged(selectedAuth)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -102,6 +102,23 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     var oauthError by remember { mutableStateOf<String?>(null) }
     // Note: device code UI removed — only browser flow used for now
 
+    // Clean up stale OAuth result files when this screen opens. If the user navigated
+    // away mid-flow or the process was killed, orphaned status files can accumulate
+    // under filesDir/oauth_results. Anything older than 1 hour is safe to delete.
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            try {
+                val resultsDir = File(context.filesDir, OpenAIOAuthActivity.RESULTS_DIR)
+                if (resultsDir.isDirectory) {
+                    val cutoff = System.currentTimeMillis() - 3_600_000L
+                    resultsDir.listFiles()?.forEach { f ->
+                        if (f.lastModified() < cutoff) f.delete()
+                    }
+                }
+            } catch (_: Exception) { /* best effort */ }
+        }
+    }
+
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
     // OAuth result file polling
@@ -858,7 +875,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
             },
             confirmButton = {
+                // Block saving oauth without a token — Node's strict validation would
+                // hard-crash on the next startup. The user must sign in first.
+                val oauthMissingToken = activeProvider == "openai" &&
+                    selectedAuth == "oauth" &&
+                    config?.openaiOAuthToken.isNullOrBlank()
                 TextButton(
+                    enabled = !oauthMissingToken,
                     onClick = {
                         saveField("authType", selectedAuth, needsRestart = true)
                         // Remember per-provider so a round-trip through another provider preserves it.
@@ -867,9 +890,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             .putString("lastAuthType_$activeProvider", selectedAuth)
                             .apply()
                         // Ensure the selected model is valid for the chosen OpenAI auth type.
-                        // OAuth and API-key model lists differ — derive the fallback from the
-                        // available models so a model list change doesn't silently leave a
-                        // hardcoded ID that no longer exists.
                         if (activeProvider == "openai") {
                             val currentModel = config?.model ?: ""
                             val allowedModels = modelsForProvider("openai", selectedAuth)
@@ -882,7 +902,12 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         showAuthTypePicker = false
                     },
                 ) {
-                    Text("Save", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, color = SeekerClawColors.ActionPrimary)
+                    Text(
+                        if (oauthMissingToken) "Sign in first" else "Save",
+                        fontFamily = RethinkSans,
+                        fontWeight = FontWeight.Bold,
+                        color = if (oauthMissingToken) SeekerClawColors.TextDim else SeekerClawColors.ActionPrimary,
+                    )
                 }
             },
             dismissButton = {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -641,6 +641,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             },
             text = {
                 Column {
+                    val isCustomSelected = models.none { it.id == selectedModel } && selectedModel.isNotBlank()
+                    var customModelId by remember { mutableStateOf(if (isCustomSelected) selectedModel else "") }
+
                     models.forEach { model ->
                         Row(
                             modifier = Modifier
@@ -671,6 +674,51 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     color = SeekerClawColors.TextDim,
                                 )
                             }
+                        }
+                    }
+                    // Custom model option
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { selectedModel = customModelId.ifBlank { "custom" } }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = isCustomSelected || selectedModel == "custom",
+                            onClick = { selectedModel = customModelId.ifBlank { "custom" } },
+                            colors = RadioButtonDefaults.colors(
+                                selectedColor = SeekerClawColors.Primary,
+                                unselectedColor = SeekerClawColors.TextDim,
+                            ),
+                        )
+                        Column(modifier = Modifier.padding(start = 8.dp).fillMaxWidth()) {
+                            Text(
+                                text = "Custom model",
+                                fontFamily = RethinkSans,
+                                fontSize = 14.sp,
+                                color = SeekerClawColors.TextPrimary,
+                            )
+                            OutlinedTextField(
+                                value = customModelId,
+                                onValueChange = {
+                                    customModelId = it
+                                    if (it.isNotBlank()) selectedModel = it
+                                },
+                                placeholder = { Text("e.g. gpt-5.4-pro", fontSize = 12.sp) },
+                                textStyle = androidx.compose.ui.text.TextStyle(
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 12.sp,
+                                    color = SeekerClawColors.TextPrimary,
+                                ),
+                                modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                                singleLine = true,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = SeekerClawColors.Primary,
+                                    unfocusedBorderColor = SeekerClawColors.TextDim,
+                                    cursorColor = SeekerClawColors.Primary,
+                                ),
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -170,6 +170,10 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     fun switchProvider(newProviderId: String) {
         val oldProviderId = config?.provider ?: "claude"
         val currentModel = config?.model ?: ""
+        // Capture authType BEFORE saveField("provider", ...) — saveField triggers a config
+        // reload that may normalize/mutate authType, which would otherwise corrupt the
+        // lastAuthType_<oldProvider> we're about to save.
+        val oldAuthType = config?.authType
 
         // Remember the current model for the old provider before switching
         val prefs = context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
@@ -182,11 +186,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         // We also remember the user's last-used authType per provider (similar to
         // lastModel_*) so an explicit "api_key" choice for OpenAI survives a round-trip
         // through another provider, while a fresh switch-in still defaults to OAuth.
-        val currentAuthType = config?.authType
         val oldProviderAuthKey = "lastAuthType_$oldProviderId"
-        if (currentAuthType != null) {
-            prefs.edit().putString(oldProviderAuthKey, currentAuthType).apply()
+        if (oldAuthType != null) {
+            prefs.edit().putString(oldProviderAuthKey, oldAuthType).apply()
         }
+        val currentAuthType = oldAuthType
         val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
         val effectiveAuthType = when (newProviderId) {
             "openai" -> when (savedNewAuthType) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -376,9 +376,10 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     }
                     "openai" -> {
                         // Match Node's view: only "oauth" is OAuth; everything else is API key.
-                        // switchProvider() persists "api_key" when entering OpenAI unless an
-                        // OAuth token already exists, so this branch normally reflects the
-                        // user's actual saved choice. The guard protects against any drift.
+                        // switchProvider() defaults OpenAI to "oauth" on first switch-in (unless
+                        // a previous lastAuthType_openai is being restored), so this branch
+                        // normally reflects the saved choice. The guard normalizes any legacy
+                        // or drifted non-"oauth" value to "api_key".
                         val openaiAuthType = if (config?.authType == "oauth") "oauth" else "api_key"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         // Auth Type first (determines model list + credential UI)
@@ -918,6 +919,15 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             if (allowedModels.none { it.id == currentModel }) {
                                 val fallback = allowedModels.firstOrNull()?.id ?: "gpt-5.4"
                                 saveField("model", fallback, needsRestart = false)
+                            }
+                            // If switching away from OAuth, clear any leftover OAuth UI state
+                            // so the API key field renders cleanly. The showOAuthSection guard
+                            // is forced on by oauthError/oauthPolling — without this clear, a
+                            // prior OAuth error would keep the OAuth section visible.
+                            if (selectedAuth == "api_key") {
+                                oauthPolling = false
+                                oauthError = null
+                                oauthRequestId = null
                             }
                         }
                         Analytics.authTypeChanged(selectedAuth)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -875,21 +875,24 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 }
             },
             confirmButton = {
-                // Block saving oauth without a token — Node's strict validation would
-                // hard-crash on the next startup. The user must sign in first.
+                // If switching to OpenAI OAuth without a token, the Save button becomes
+                // "Sign in with OpenAI" — it launches the browser flow directly and only
+                // persists authType=oauth after the OAuth section flow completes (the
+                // OAuth section will be rendered as soon as the picker closes because
+                // the OAuth UI is gated on the presence of the token, not the picker).
                 val oauthMissingToken = activeProvider == "openai" &&
                     selectedAuth == "oauth" &&
                     config?.openaiOAuthToken.isNullOrBlank()
                 TextButton(
-                    enabled = !oauthMissingToken,
                     onClick = {
+                        // Persist the selection regardless — the strict-validation hard
+                        // crash is prevented by the existing sign-out → api_key flow and
+                        // by the user completing sign-in before any restart.
                         saveField("authType", selectedAuth, needsRestart = true)
-                        // Remember per-provider so a round-trip through another provider preserves it.
                         context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
                             .edit()
                             .putString("lastAuthType_$activeProvider", selectedAuth)
                             .apply()
-                        // Ensure the selected model is valid for the chosen OpenAI auth type.
                         if (activeProvider == "openai") {
                             val currentModel = config?.model ?: ""
                             val allowedModels = modelsForProvider("openai", selectedAuth)
@@ -900,13 +903,26 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         }
                         Analytics.authTypeChanged(selectedAuth)
                         showAuthTypePicker = false
+                        // Auto-launch sign-in if user picked OAuth and has no token yet,
+                        // so they don't have to find the OAuth section after the picker
+                        // closes.
+                        if (oauthMissingToken) {
+                            val requestId = UUID.randomUUID().toString()
+                            val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
+                                putExtra("requestId", requestId)
+                            }
+                            context.startActivity(intent)
+                            oauthRequestId = requestId
+                            oauthPolling = true
+                            oauthError = null
+                        }
                     },
                 ) {
                     Text(
-                        if (oauthMissingToken) "Sign in first" else "Save",
+                        if (oauthMissingToken) "Sign in with OpenAI" else "Save",
                         fontFamily = RethinkSans,
                         fontWeight = FontWeight.Bold,
-                        color = if (oauthMissingToken) SeekerClawColors.TextDim else SeekerClawColors.ActionPrimary,
+                        color = SeekerClawColors.ActionPrimary,
                     )
                 }
             },

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -216,8 +216,10 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
 
         // Resolve the effective authType for the new provider. OpenAI defaults to OAuth
         // (ChatGPT subscription) on first switch-in — the OAuth section shows a Sign In
-        // button and writeConfigJson translates oauth+blank → api_key for Node so the
-        // agent stays startable. Explicit picker choice is remembered per-provider.
+        // button. writeConfigJson translates oauth+blank → api_key only so Node doesn't
+        // crash on an unsupported authType combination; a valid OpenAI API key is still
+        // required if the user never completes sign-in. Explicit picker choice is
+        // remembered per-provider via lastAuthType_<id>.
         val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
         val effectiveAuthType = when (newProviderId) {
             "openai" -> when (savedNewAuthType) {
@@ -396,10 +398,9 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             info = SettingsHelpTexts.MODEL,
                         )
                         // Show the OAuth section whenever an OAuth flow is in progress or has
-                        // produced an error, even if persisted authType is still "api_key".
-                        // This is the case during a first-time sign-in launched from the auth
-                        // picker — we deferred persisting authType=oauth until the token
-                        // arrives, so without this guard the polling/error UI would be invisible.
+                        // produced an error, even if the resolved authType is currently
+                        // "api_key". This keeps the polling/error UI visible during transient
+                        // OAuth state changes and recovery flows.
                         val showOAuthSection = openaiAuthType == "oauth" || oauthPolling || oauthError != null
                         if (!showOAuthSection) {
                             ConfigField(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -141,8 +141,20 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                 when (json.optString("status")) {
                     "success" -> {
                         // Tokens were persisted directly by OpenAIOAuthActivity via
-                        // ConfigManager.saveConfig — they never touch the result file.
-                        // We just reload to pick up the encrypted values.
+                        // ConfigManager.saveConfig. Now that we have a valid token, also
+                        // flip authType=oauth (the picker intentionally deferred this
+                        // until token-present so a canceled sign-in couldn't strand the
+                        // agent in an unstartable state).
+                        withContext(Dispatchers.IO) {
+                            val current = ConfigManager.loadConfig(context)
+                            if (current != null && !current.openaiOAuthToken.isBlank() && current.authType != "oauth") {
+                                ConfigManager.saveConfig(context, current.copy(authType = "oauth"))
+                            }
+                        }
+                        context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
+                            .edit()
+                            .putString("lastAuthType_openai", "oauth")
+                            .apply()
                         config = withContext(Dispatchers.IO) { ConfigManager.loadConfig(context) }
                         showRestartDialog = true
                         oauthPolling = false
@@ -209,10 +221,17 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
         }
         val currentAuthType = oldAuthType
         val savedNewAuthType = prefs.getString("lastAuthType_$newProviderId", null)
+        // Resolve authType for the new provider with a strict safety rule for OpenAI:
+        // never persist "oauth" unless an OAuth token is already present, otherwise the
+        // strict Node validation would hard-crash on the next restart with an unsignable
+        // state. The OAuth section UI will still let the user start sign-in from here.
+        val openaiHasToken = !config?.openaiOAuthToken.isNullOrBlank()
         val effectiveAuthType = when (newProviderId) {
-            "openai" -> when (savedNewAuthType) {
-                "oauth", "api_key" -> savedNewAuthType
-                else -> "oauth" // default for first-time switch into OpenAI
+            "openai" -> when {
+                savedNewAuthType == "oauth" && openaiHasToken -> "oauth"
+                savedNewAuthType == "api_key" -> "api_key"
+                openaiHasToken -> "oauth"
+                else -> "api_key"
             }
             "claude" -> when (savedNewAuthType) {
                 "api_key", "setup_token" -> savedNewAuthType
@@ -885,9 +904,24 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                     config?.openaiOAuthToken.isNullOrBlank()
                 TextButton(
                     onClick = {
-                        // Persist the selection regardless — the strict-validation hard
-                        // crash is prevented by the existing sign-out → api_key flow and
-                        // by the user completing sign-in before any restart.
+                        if (oauthMissingToken) {
+                            // Don't persist oauth yet — only after sign-in succeeds, the
+                            // OAuth result handler will set authType=oauth alongside the
+                            // token save. Persisting here would leave the agent unstartable
+                            // (oauth + blank token) if the user dismisses the restart dialog
+                            // or sign-in fails.
+                            Analytics.authTypeChanged(selectedAuth)
+                            showAuthTypePicker = false
+                            val requestId = UUID.randomUUID().toString()
+                            val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
+                                putExtra("requestId", requestId)
+                            }
+                            context.startActivity(intent)
+                            oauthRequestId = requestId
+                            oauthPolling = true
+                            oauthError = null
+                            return@TextButton
+                        }
                         saveField("authType", selectedAuth, needsRestart = true)
                         context.getSharedPreferences("seekerclaw_prefs", android.content.Context.MODE_PRIVATE)
                             .edit()
@@ -903,19 +937,6 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         }
                         Analytics.authTypeChanged(selectedAuth)
                         showAuthTypePicker = false
-                        // Auto-launch sign-in if user picked OAuth and has no token yet,
-                        // so they don't have to find the OAuth section after the picker
-                        // closes.
-                        if (oauthMissingToken) {
-                            val requestId = UUID.randomUUID().toString()
-                            val intent = Intent(context, OpenAIOAuthActivity::class.java).apply {
-                                putExtra("requestId", requestId)
-                            }
-                            context.startActivity(intent)
-                            oauthRequestId = requestId
-                            oauthPolling = true
-                            oauthError = null
-                        }
                     },
                 ) {
                     Text(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -311,12 +311,12 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         )
                     }
                     "openai" -> {
-                        // Normalize: only "api_key" and "oauth" are valid for OpenAI;
-                        // other values (e.g. "setup_token" from Claude) fall back to "api_key"
-                        val openaiAuthType = if (config?.authType == "oauth") "oauth" else "api_key"
+                        // Normalize: only "oauth" and "api_key" are valid for OpenAI;
+                        // other values (e.g. "setup_token" from Claude) default to "oauth"
+                        val openaiAuthType = if (config?.authType == "api_key") "api_key" else "oauth"
                         val openaiModelList = modelsForProvider("openai", openaiAuthType)
                         // Auth Type first (determines model list + credential UI)
-                        val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth (experimental)" else "API Key"
+                        val openaiAuthLabel = if (openaiAuthType == "oauth") "ChatGPT OAuth" else "API Key"
                         ConfigField(
                             label = "Auth Type",
                             value = openaiAuthLabel,
@@ -758,7 +758,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
     // Auth type picker (Claude + OpenAI)
     if (showAuthTypePicker) {
         val authOptions = when (activeProvider) {
-            "openai" -> listOf("api_key" to "API Key", "oauth" to "ChatGPT OAuth (experimental)")
+            "openai" -> listOf("oauth" to "ChatGPT OAuth", "api_key" to "API Key")
             else -> listOf("api_key" to "API Key", "setup_token" to "Pro/Max Setup Token")
         }
         // Normalize: ensure selectedAuth is a valid option for the current provider
@@ -905,7 +905,7 @@ private fun OpenAIOAuthSection(
                 .padding(12.dp),
         ) {
             Text(
-                text = "Experimental: uses OpenAI's Codex OAuth. Not officially supported for third-party apps. Subscription rate limits apply.",
+                text = "Uses your ChatGPT subscription via Codex OAuth.",
                 fontFamily = RethinkSans,
                 fontSize = 13.sp,
                 color = SeekerClawColors.Warning,

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -951,7 +951,7 @@ fun SettingsScreen(
 
         CardSurface {
             InfoRow("Version", "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
-            InfoRow("OpenClaw", BuildConfig.OPENCLAW_VERSION)
+            InfoRow("Claw Engine", BuildConfig.OPENCLAW_VERSION)
             InfoRow("Node.js", BuildConfig.NODEJS_VERSION, isLast = true)
         }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -424,7 +424,14 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     }
                     apiKeyError = null
                     errorMessage = null
-                    authType = if (newProvider == "claude") existingConfig?.authType ?: "api_key" else "api_key"
+                    // Claude only supports {api_key, setup_token}; everything else (including
+                    // a leftover "oauth" from OpenAI) must fall back to api_key.
+                    authType = if (newProvider == "claude") {
+                        when (existingConfig?.authType) {
+                            "setup_token" -> "setup_token"
+                            else -> "api_key"
+                        }
+                    } else "api_key"
                     // Restore model: use existing config's model if same provider, else default
                     // Setup screen always uses API-key auth — OAuth flow happens later in settings.
                     val models = modelsForProvider(newProvider, "api_key")

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -131,15 +131,14 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
     var ownerId by remember { mutableStateOf(existingConfig?.telegramOwnerId ?: "") }
     val existingProvider = existingConfig?.provider ?: "claude"
     var selectedModel by remember {
-        // Setup screen: use existing config's authType when present, else null.
-        // Initial setup never has an OAuth token yet, so API-key model list is correct.
-        val setupAuthType = existingConfig?.authType
+        // Setup screen always uses API-key auth (OAuth happens later in settings),
+        // so derive the model list from the api_key list to match what saveAndStart persists.
         mutableStateOf(
             existingConfig?.model?.let { model ->
-                val models = modelsForProvider(existingProvider, setupAuthType)
+                val models = modelsForProvider(existingProvider, "api_key")
                 if (models.isEmpty() || models.any { it.id == model }) model
                 else models[0].id
-            } ?: modelsForProvider(existingProvider, setupAuthType).firstOrNull()?.id ?: availableModels[0].id
+            } ?: modelsForProvider(existingProvider, "api_key").firstOrNull()?.id ?: availableModels[0].id
         )
     }
     var agentName by remember { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }
@@ -184,7 +183,8 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     }
                     botToken = cfg.telegramBotToken
                     ownerId = cfg.telegramOwnerId
-                    val providerModels = modelsForProvider(cfg.provider, cfg.authType)
+                    // Setup uses api_key auth — see saveAndStart. Match the model list.
+                    val providerModels = modelsForProvider(cfg.provider, "api_key")
                     selectedModel = if (providerModels.isEmpty()) {
                         cfg.model // OpenRouter: accept freeform model as-is
                     } else {

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -131,12 +131,15 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
     var ownerId by remember { mutableStateOf(existingConfig?.telegramOwnerId ?: "") }
     val existingProvider = existingConfig?.provider ?: "claude"
     var selectedModel by remember {
+        // Setup screen: use existing config's authType when present, else null.
+        // Initial setup never has an OAuth token yet, so API-key model list is correct.
+        val setupAuthType = existingConfig?.authType
         mutableStateOf(
             existingConfig?.model?.let { model ->
-                val models = modelsForProvider(existingProvider)
+                val models = modelsForProvider(existingProvider, setupAuthType)
                 if (models.isEmpty() || models.any { it.id == model }) model
                 else models[0].id
-            } ?: modelsForProvider(existingProvider).firstOrNull()?.id ?: availableModels[0].id
+            } ?: modelsForProvider(existingProvider, setupAuthType).firstOrNull()?.id ?: availableModels[0].id
         )
     }
     var agentName by remember { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }
@@ -181,7 +184,7 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     }
                     botToken = cfg.telegramBotToken
                     ownerId = cfg.telegramOwnerId
-                    val providerModels = modelsForProvider(cfg.provider)
+                    val providerModels = modelsForProvider(cfg.provider, cfg.authType)
                     selectedModel = if (providerModels.isEmpty()) {
                         cfg.model // OpenRouter: accept freeform model as-is
                     } else {
@@ -423,7 +426,8 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     errorMessage = null
                     authType = if (newProvider == "claude") existingConfig?.authType ?: "api_key" else "api_key"
                     // Restore model: use existing config's model if same provider, else default
-                    val models = modelsForProvider(newProvider)
+                    // Setup screen always uses API-key auth — OAuth flow happens later in settings.
+                    val models = modelsForProvider(newProvider, "api_key")
                     selectedModel = if (newProvider == existingConfig?.provider) {
                         existingConfig.model
                     } else {
@@ -1088,7 +1092,8 @@ private fun OptionsStep(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            val setupModels = modelsForProvider(provider)
+            // Setup screen: API-key auth only (OAuth flows from settings, post-setup).
+            val setupModels = modelsForProvider(provider, "api_key")
             if (setupModels.isEmpty()) {
                 // Freeform model (e.g. OpenRouter) — editable text field
                 OutlinedTextField(

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -126,7 +126,7 @@ fun SystemScreen(onBack: () -> Unit) {
                 append("${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
                 if (BuildConfig.DEBUG) append(" · ${BuildConfig.GIT_SHA}")
             })
-            InfoRow("OpenClaw", BuildConfig.OPENCLAW_VERSION)
+            InfoRow("Claw Engine", BuildConfig.OPENCLAW_VERSION)
             InfoRow(
                 label = "Node.js",
                 value = "${BuildConfig.NODEJS_VERSION} — ${when (status) {


### PR DESCRIPTION
## Summary
Add ChatGPT subscription auth (Codex OAuth) as a second auth type for the OpenAI provider. ChatGPT Plus/Pro subscribers can use SeekerClaw without separate API credits.

## Sign-in flow
- **Browser PKCE**: Custom Tab → OpenAI login → 127.0.0.1:1455 callback → token exchange → tokens persisted via Android Keystore

(Device-code flow was prototyped but didn't work reliably and has been removed.)

## Changes
- `OpenAIOAuthActivity.kt` — PKCE S256 flow, NanoHTTPD callback, Custom Tabs, idempotent handler, 10-min safety timeout. Persists tokens directly via `ConfigManager` (encrypted Keystore); the result file only carries a status flag.
- `Providers.kt` — OAuth auth type + OAuth-specific model list
- `ConfigManager.kt` — encrypted OAuth token + email storage; legacy plaintext email migration
- `ProviderConfigScreen.kt` — auth type selector, sign-in button, connected status, polling UI, normalized authType on provider switch
- `AndroidBridge.kt` — token refresh endpoint
- `config.js` — strict OPENAI_AUTH_TYPE (no silent fallback to api_key)
- `providers/openai.js` — Codex endpoint routing + auto-refresh on 401, mutable refresh token, non-retryable on refresh failure

## Test plan
- [x] JS syntax check + Kotlin compile
- [ ] Browser PKCE sign-in on device
- [ ] Agent responds via Codex endpoint
- [ ] Token refresh works (force 401)
- [ ] Sign-out clears tokens
- [ ] Existing API Key flow unchanged

DO NOT MERGE — device test required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)