### PR TITLE
fix(BAT-486): Codex SSE parser — resolve output_index via item_id

### DIFF
--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -296,13 +296,15 @@ function httpOpenAIStreamingRequest(options, body = null) {
                 for (const idx of indices) {
                     const item = outputItems[idx];
                     if (item.type === 'message') {
-                        const content = [];
-                        // Collect all text parts for this output index
-                        for (const key of Object.keys(textAccum)) {
-                            if (key.startsWith(`${idx}:`)) {
-                                content.push({ type: 'output_text', text: textAccum[key] });
-                            }
-                        }
+                        // Collect all text parts for this output index, sorted by
+                        // content_index so multi-part messages reconstruct in the
+                        // order the server emitted them. textAccum keys are
+                        // "<output_index>:<content_index>" — extract and sort numerically.
+                        const prefix = `${idx}:`;
+                        const partKeys = Object.keys(textAccum)
+                            .filter(k => k.startsWith(prefix))
+                            .sort((a, b) => Number(a.slice(prefix.length)) - Number(b.slice(prefix.length)));
+                        const content = partKeys.map(k => ({ type: 'output_text', text: textAccum[k] }));
                         output.push({ ...item, content });
                     } else if (item.type === 'function_call') {
                         output.push({
@@ -342,7 +344,7 @@ function httpOpenAIStreamingRequest(options, body = null) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {
                                 outputItems[parsed.output_index] = parsed.item;
-                                if (parsed.item.id) {
+                                if (typeof parsed.item.id === 'string') {
                                     itemIdToOutputIndex[parsed.item.id] = parsed.output_index;
                                 }
                                 if (parsed.item.type === 'function_call') {

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -263,6 +263,12 @@ function httpOpenAIStreamingRequest(options, body = null) {
             const outputItems = {};  // output_index → item skeleton
             const textAccum = {};    // "output_index:content_index" → accumulated text
             const funcArgAccum = {}; // output_index → accumulated arguments string
+            // item_id → output_index lookup. Codex backend (gpt-5.x reasoning models
+            // served via chatgpt.com/backend-api/codex/responses) emits delta events
+            // with `item_id` instead of `output_index` — we build this map from the
+            // earlier `response.output_item.added` events (which carry both fields)
+            // and use it to resolve item_id back to output_index in the delta handlers.
+            const itemIdToOutputIndex = {};
             let accumulatedUsage = null;
             let sseBuffer = '';
             let parsedEventCount = 0; // tracks successful SSE event parses for end-of-stream diagnostics
@@ -316,34 +322,66 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
                     parsedEventCount++;
 
+                    // Resolve output_index from either the event's own `output_index`
+                    // (older Responses API shape, used by api.openai.com) or by looking
+                    // up `item_id` in our map (Codex backend / gpt-5.x reasoning models —
+                    // they only emit `item_id` on delta events, not `output_index`).
+                    // Returns null if neither is available.
+                    const resolveOutputIndex = (p) => {
+                        if (typeof p.output_index === 'number') return p.output_index;
+                        if (typeof p.item_id === 'string' && p.item_id in itemIdToOutputIndex) {
+                            return itemIdToOutputIndex[p.item_id];
+                        }
+                        return null;
+                    };
+
                     switch (eventType) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {
                                 outputItems[parsed.output_index] = parsed.item;
+                                if (parsed.item.id) {
+                                    itemIdToOutputIndex[parsed.item.id] = parsed.output_index;
+                                }
                                 if (parsed.item.type === 'function_call') {
                                     funcArgAccum[parsed.output_index] = '';
                                 }
                             }
                             break;
 
-                        case 'response.output_text.delta':
-                            if (typeof parsed.output_index === 'number') {
-                                const key = `${parsed.output_index}:${parsed.content_index ?? 0}`;
+                        case 'response.output_text.delta': {
+                            const oi = resolveOutputIndex(parsed);
+                            if (oi !== null) {
+                                const key = `${oi}:${parsed.content_index ?? 0}`;
                                 textAccum[key] = (textAccum[key] || '') + (parsed.delta || '');
                             }
                             break;
+                        }
 
-                        case 'response.function_call_arguments.delta':
-                            if (typeof parsed.output_index === 'number') {
-                                funcArgAccum[parsed.output_index] =
-                                    (funcArgAccum[parsed.output_index] || '') + (parsed.delta || '');
+                        case 'response.function_call_arguments.delta': {
+                            const oi = resolveOutputIndex(parsed);
+                            if (oi !== null) {
+                                funcArgAccum[oi] = (funcArgAccum[oi] || '') + (parsed.delta || '');
                             }
                             break;
+                        }
 
                         case 'response.completed':
                             clearTimeout(hardTimer);
-                            // Authoritative: use the full response object directly
-                            settle(resolve, { status: 200, data: parsed, headers: res.headers });
+                            // Codex backend's `response.completed` event sometimes carries
+                            // an empty `output: []` array because the actual content was
+                            // delivered piece-by-piece via earlier delta events. If the
+                            // server's response.output is empty BUT we accumulated items
+                            // ourselves, prefer our local accumulation so the user sees
+                            // the model's actual reply instead of an empty response.
+                            {
+                                const serverResp = parsed.response || {};
+                                const serverOutput = Array.isArray(serverResp.output) ? serverResp.output : [];
+                                if (serverOutput.length === 0 && Object.keys(outputItems).length > 0) {
+                                    settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });
+                                } else {
+                                    settle(resolve, { status: 200, data: parsed, headers: res.headers });
+                                }
+                            }
                             return;
 
                         case 'response.incomplete':

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -268,10 +268,26 @@ function httpOpenAIStreamingRequest(options, body = null) {
             // with `item_id` instead of `output_index` — we build this map from the
             // earlier `response.output_item.added` events (which carry both fields)
             // and use it to resolve item_id back to output_index in the delta handlers.
-            const itemIdToOutputIndex = {};
+            // Object.create(null) avoids prototype pollution since the keys come from
+            // server-controlled item.id values.
+            const itemIdToOutputIndex = Object.create(null);
             let accumulatedUsage = null;
             let sseBuffer = '';
             let parsedEventCount = 0; // tracks successful SSE event parses for end-of-stream diagnostics
+
+            // Resolve output_index from either the event's own `output_index`
+            // (older Responses API shape, used by api.openai.com) or by looking
+            // up `item_id` in our map (Codex backend / gpt-5.x reasoning models —
+            // they only emit `item_id` on delta events, not `output_index`).
+            // Returns null if neither is available. Hoisted out of the per-event
+            // hot path so it's allocated once per request, not per SSE event.
+            const resolveOutputIndex = (p) => {
+                if (typeof p.output_index === 'number') return p.output_index;
+                if (typeof p.item_id === 'string' && Object.prototype.hasOwnProperty.call(itemIdToOutputIndex, p.item_id)) {
+                    return itemIdToOutputIndex[p.item_id];
+                }
+                return null;
+            };
 
             // Build response from accumulated deltas (fallback path)
             const buildFromAccum = () => {
@@ -322,19 +338,6 @@ function httpOpenAIStreamingRequest(options, body = null) {
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
                     parsedEventCount++;
 
-                    // Resolve output_index from either the event's own `output_index`
-                    // (older Responses API shape, used by api.openai.com) or by looking
-                    // up `item_id` in our map (Codex backend / gpt-5.x reasoning models —
-                    // they only emit `item_id` on delta events, not `output_index`).
-                    // Returns null if neither is available.
-                    const resolveOutputIndex = (p) => {
-                        if (typeof p.output_index === 'number') return p.output_index;
-                        if (typeof p.item_id === 'string' && p.item_id in itemIdToOutputIndex) {
-                            return itemIdToOutputIndex[p.item_id];
-                        }
-                        return null;
-                    };
-
                     switch (eventType) {
                         case 'response.output_item.added':
                             if (typeof parsed.output_index === 'number' && parsed.item) {
@@ -373,8 +376,13 @@ function httpOpenAIStreamingRequest(options, body = null) {
                             // server's response.output is empty BUT we accumulated items
                             // ourselves, prefer our local accumulation so the user sees
                             // the model's actual reply instead of an empty response.
+                            //
+                            // Use `parsed.response || parsed` to match the existing
+                            // `fromApiResponse(raw.response || raw)` logic — handles both
+                            // wrapped (`{type, response: {output, ...}}`) and unwrapped
+                            // (`{output, ...}`) backend payload shapes.
                             {
-                                const serverResp = parsed.response || {};
+                                const serverResp = parsed.response || parsed;
                                 const serverOutput = Array.isArray(serverResp.output) ? serverResp.output : [];
                                 if (serverOutput.length === 0 && Object.keys(outputItems).length > 0) {
                                     settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -386,6 +386,12 @@ function httpOpenAIStreamingRequest(options, body = null) {
                             {
                                 const serverResp = parsed.response || parsed;
                                 const serverOutput = Array.isArray(serverResp.output) ? serverResp.output : [];
+                                // Capture usage from the completed event BEFORE building
+                                // from accumulated deltas. Codex typically only emits the
+                                // final token counts on response.completed, and this case
+                                // returns early before the post-switch usage update runs —
+                                // without this, buildFromAccum() would lose token accounting.
+                                if (serverResp.usage) accumulatedUsage = serverResp.usage;
                                 if (serverOutput.length === 0 && Object.keys(outputItems).length > 0) {
                                     settle(resolve, { status: 200, data: buildFromAccum(), headers: res.headers });
                                 } else {

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -255,32 +255,18 @@ function formatRequest(model, maxTokens, instructions, input, tools) {
         body.tools = tools;
     }
 
+    // Codex endpoint REQUIRES store: false (returns 400 "Store must be set to
+    // false" if omitted). Confirmed via device test on v1.9.0-rc1+. The OpenClaw
+    // store:true convention does NOT apply here — that's for api.openai.com only.
+    if (isOAuth) {
+        body.store = false;
+    }
+
     // The Codex endpoint serves reasoning models exclusively — every model on
     // chatgpt.com/backend-api/codex (gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, etc.)
     // requires the `reasoning` parameter or it returns `output: []`.
     if (isOAuth || (model && model.includes('codex'))) {
         body.reasoning = { effort: 'medium', summary: 'auto' };
-    }
-
-    // DEBUG: dump the full sanitized request body shape so we can see what we're
-    // actually sending to Codex. Logs to WARN level so it always shows up.
-    // Sanitization: drop the long instructions/input/tools fields, only show types.
-    if (isOAuth) {
-        const shape = {
-            model: body.model,
-            stream: body.stream,
-            instructions_chars: typeof body.instructions === 'string' ? body.instructions.length : 0,
-            input_count: Array.isArray(body.input) ? body.input.length : (typeof body.input),
-            input_first_role: Array.isArray(body.input) && body.input[0] ? body.input[0].role : 'n/a',
-            input_first_content_type: Array.isArray(body.input) && body.input[0]
-                ? (Array.isArray(body.input[0].content) ? body.input[0].content.map(c => c.type).join('|') : typeof body.input[0].content)
-                : 'n/a',
-            tools_count: Array.isArray(body.tools) ? body.tools.length : 0,
-            store: body.store,
-            reasoning: body.reasoning,
-            max_output_tokens: body.max_output_tokens,
-        };
-        log('[Codex] request shape: ' + JSON.stringify(shape), 'WARN');
     }
 
     return JSON.stringify(body);


### PR DESCRIPTION
## Summary

Fixes the empty-response regression on OpenAI Codex OAuth (v1.9.0). Agent was silently returning SILENT_REPLY instead of the model's actual text. **Two related bugs in one commit, ~50 net lines.**

## Bug 1 (root cause): SSE delta handler dropped Codex text chunks

The Codex backend at `chatgpt.com/backend-api/codex/responses` (which serves the gpt-5.x reasoning model family) emits `response.output_text.delta` SSE events with `item_id` instead of `output_index` to identify the parent output item. Confirmed event shape from device-side SSE event-type diagnostic:

```
response.output_text.delta keys=[type, content_index, delta, item_id, logprobs, obfuscation]
```

The legacy `api.openai.com` Responses API includes `output_index` in delta events, so our parser checked `typeof parsed.output_index === 'number'` before accumulating text. For Codex events that check fails on every delta, every text chunk gets silently dropped, and by the time `response.completed` arrives the local `textAccum` is empty. Result: `output: []` returned upstream → agent sends SILENT_REPLY → user thinks the agent is dead.

### Fix
1. New `itemIdToOutputIndex` map populated from `response.output_item.added` events (which carry both `item.id` and `output_index`).
2. New `resolveOutputIndex(parsed)` helper that returns the event's own `output_index` if present, otherwise looks up `parsed.item_id` in the map.
3. Use the helper in both `response.output_text.delta` and `response.function_call_arguments.delta` handlers.
4. `response.completed` now checks if the server's `response.output` is empty AND we accumulated items locally — if so, build from accumulated deltas via the existing `buildFromAccum()` helper. Codex specifically does this on the new event shape.

The resolver is **forward-and-backward compatible**: works for old API responses (uses `output_index` directly) and new Codex responses (falls back to `item_id` lookup). No regression risk for non-OAuth OpenAI users.

## Bug 2: \`store: false\` was missing for OAuth (regression from \`90e2449\`)

Commit `90e2449` ("debug: drop store:false + dump Codex request shape") was an A/B test commit that removed \`body.store = false\` for OAuth requests to test if it was the gate. Result: \`400 "Store must be set to false"\`. The test confirmed it IS required, but the field was never added back.

Restoring it here.

## Test plan

- [x] Local: \`node --check\` passes on both \`http.js\` and \`providers/openai.js\`
- [x] Device: agent responds to "hey" via Telegram with the fingerprint branch (which had this same parser fix among other things)
- [ ] Device: rebuild this PR branch (clean of all the debug logging from the bisect cycle) and re-verify "hey" still works
- [ ] No regression on Anthropic / OpenRouter / Custom providers
- [ ] No regression on OpenAI api.openai.com (non-OAuth) — the parser fix is forward-and-backward compatible

## Why so small

The original investigation branch (\`fix/BAT-486-codex-cli-fingerprinting\`) was a 9-commit bisect with debug logging, JWT decoder, fingerprint headers (originator/User-Agent/ChatGPT-Account-ID/session_id), body fingerprint fields (tool_choice/parallel_tool_calls/include/prompt_cache_key), typed content parts, model slug experiments, and version-code hacks. **None of those turned out to be necessary** — the parser fix alone produces a working response.

This PR distills the investigation into the actual minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)