### PR TITLE
feat: OpenClaw parity port v2026.4.10 (BAT-488)

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -27,6 +27,7 @@ const deferStatus = CHANNEL === 'telegram' ? require('./telegram').deferStatus :
 const { httpStreamingRequest, httpOpenAIStreamingRequest, httpChatCompletionsStreamingRequest } = require('./http');
 const { getAdapter } = require('./providers');
 const { androidBridgeCall } = require('./bridge');
+const { stripSilentReply } = require('./silent-reply');
 
 const {
     loadSoul, loadBootstrap, loadIdentity, loadUser,
@@ -910,11 +911,13 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('- Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.');
     lines.push('- Never use it to avoid doing requested work or to end an actionable turn early.');
     lines.push('- It must be your ENTIRE message — nothing else.');
+    lines.push('- The only valid silent reply is the exact plain-text token SILENT_REPLY.');
     lines.push('- Never append it to an actual response (never include "SILENT_REPLY" in real replies).');
-    lines.push('- Never wrap it in markdown or code blocks.');
+    lines.push('- Never wrap it in markdown, code blocks, JSON, or any envelope form.');
     lines.push('');
     lines.push('❌ Wrong: "Here\'s help... SILENT_REPLY"');
     lines.push('❌ Wrong: "**SILENT_REPLY**"');
+    lines.push('❌ Wrong: {"action":"SILENT_REPLY"}');
     lines.push('✅ Right: SILENT_REPLY');
     lines.push('');
 
@@ -2296,10 +2299,15 @@ async function chat(chatId, userMessage, options = {}) {
 
             if (summaryRes.status === 200) {
                 const summaryParsed = adapter.fromApiResponse(summaryRes.data);
-                if (summaryParsed.text && summaryParsed.text.trim() !== 'SILENT_REPLY') {
-                    textContent = { text: summaryParsed.text };
-                } else if (summaryParsed.text) {
-                    log('Summary returned SILENT_REPLY token — falling through to fallback', 'DEBUG');
+                if (summaryParsed.text) {
+                    // Use the centralized strip helper so we catch envelope/wrap/glued
+                    // forms — not just the literal 'SILENT_REPLY' string.
+                    const cleaned = stripSilentReply(summaryParsed.text);
+                    if (cleaned) {
+                        textContent = { text: cleaned };
+                    } else {
+                        log('Summary returned SILENT_REPLY token (any form) — falling through to fallback', 'DEBUG');
+                    }
                 }
             }
 

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -880,6 +880,8 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('- **agentTurn**: Runs a full AI turn with tools at the scheduled time (for research, monitoring, analysis). Costs API tokens per execution.');
     lines.push(`- **reminder**: Sends raw text to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'} (for simple alerts like "take meds"). Zero cost.`);
     lines.push('Use agentTurn when the task needs intelligence (check prices, generate reports, analyze data). Use reminder for simple text notifications.');
+    // OpenClaw parity (v2026.4.10 BAT-488) — steer away from degenerate polling loops
+    lines.push('For any follow-up at a future time (reminders, run-later work, recurring tasks) use cron instead of shell_exec sleep, js_eval setTimeout loops, or process polling. Those waste tool rounds, burn battery, and die on restart.');
     lines.push('When a message starts with [cron:...], you are executing a scheduled task in an isolated session.');
     lines.push('Complete the task directly and concisely. Do not greet or ask follow-up questions — deliver results.');
     lines.push('If nothing needs attention, reply SILENT_REPLY.');
@@ -890,12 +892,30 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push(`Authorized senders: ${getOwnerId() || '(pending auto-detect)'}. These senders are allowlisted; do not assume they are the owner.`);
     lines.push('');
 
-    // Silent Replies section - OpenClaw style
+    // Execution Bias section — OpenClaw parity (v2026.4.10 BAT-488)
+    // Stops models from planning-instead-of-doing on actionable requests.
+    lines.push('## Execution Bias');
+    lines.push('If the user asks you to do the work, start doing it in the same turn.');
+    lines.push('Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.');
+    lines.push('Commentary-only turns are incomplete when tools are available and the next action is clear.');
+    lines.push('If the work will take multiple steps or a while to finish, send one short progress update before or while acting.');
+    lines.push('');
+
+    // Silent Replies section — OpenClaw parity (v2026.4.10 BAT-488)
+    // Tightened wording to stop models from using SILENT_REPLY to avoid work.
     lines.push('## Silent Replies');
-    lines.push('If nothing useful to say (no action taken, no information to convey), reply with exactly:');
-    lines.push('SILENT_REPLY');
-    lines.push(`SeekerClaw will discard the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
-    lines.push('Use sparingly — most messages should have content.');
+    lines.push(`Use SILENT_REPLY ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
+    lines.push('');
+    lines.push('⚠️ Rules:');
+    lines.push('- Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.');
+    lines.push('- Never use it to avoid doing requested work or to end an actionable turn early.');
+    lines.push('- It must be your ENTIRE message — nothing else.');
+    lines.push('- Never append it to an actual response (never include "SILENT_REPLY" in real replies).');
+    lines.push('- Never wrap it in markdown or code blocks.');
+    lines.push('');
+    lines.push('❌ Wrong: "Here\'s help... SILENT_REPLY"');
+    lines.push('❌ Wrong: "**SILENT_REPLY**"');
+    lines.push('✅ Right: SILENT_REPLY');
     lines.push('');
 
     // Reply Tags section - OpenClaw style (Telegram-specific)

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -38,6 +38,7 @@ setRedactFn(redactSecrets);
 // ============================================================================
 
 const { androidBridgeCall } = require('./bridge');
+const { stripSilentReply, containsSilentReply } = require('./silent-reply');
 
 // ── MCP (Model Context Protocol) — Remote tool servers (BAT-168) ───
 const { MCPManager } = require('./mcp-client');
@@ -331,12 +332,12 @@ async function autoResumeOnStartup() {
             const task = prev.then(async () => {
                 try {
                     const response = await chat(chatId, 'continue', { isResume: true, originalGoal: full.originalGoal || null });
-                    // Strip protocol tokens (BAT-279, OpenClaw parity 2026.3.1)
-                    if (response && /\bSILENT_REPLY\b/i.test(response)) log('[Audit] AutoResume sent SILENT_REPLY', 'DEBUG');
-                    const cleaned = response ? response.trim()
-                        .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
-                        .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
-                        .trim() : '';
+                    // Strip protocol tokens (BAT-279, OpenClaw parity 2026.3.1; BAT-488 centralized silent-reply strip)
+                    if (response && containsSilentReply(response)) log('[Audit] AutoResume sent SILENT_REPLY', 'DEBUG');
+                    const cleaned = response ? stripSilentReply(
+                        response.trim()
+                            .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
+                    ) : '';
                     if (cleaned) {
                         await sendMessage(chatId, cleaned);
                     }
@@ -925,10 +926,10 @@ async function runCronAgentTurn(message, jobId) {
         const response = await chat(cronChatId, prompt);
 
         // Strip protocol tokens (same pattern as heartbeat probe)
-        const cleaned = response.trim()
-            .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
-            .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
-            .trim();
+        const cleaned = stripSilentReply(
+            response.trim()
+                .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
+        );
 
         if (!cleaned) {
             log(`[Cron] Agent turn ${jobId} returned silent response`, 'DEBUG');
@@ -1001,12 +1002,12 @@ async function runHeartbeat() {
 
             const response = await chat(HEARTBEAT_CHAT_ID, HEARTBEAT_PROMPT);
             // Strip protocol tokens the agent may have mixed into content (OpenClaw parity 2026.3.1)
-            if (/\bSILENT_REPLY\b/i.test(response)) log('[Audit] Heartbeat sent SILENT_REPLY', 'DEBUG');
+            if (containsSilentReply(response)) log('[Audit] Heartbeat sent SILENT_REPLY', 'DEBUG');
             const hadToken = /\bHEARTBEAT_OK\b/i.test(response);
-            const cleaned = response.trim()
-                .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
-                .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
-                .trim();
+            const cleaned = stripSilentReply(
+                response.trim()
+                    .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
+            );
             // OpenClaw parity: if the agent included HEARTBEAT_OK but also added
             // short filler text (≤HEARTBEAT_ACK_MAX_CHARS), treat it as an ack, not an alert.
             // This prevents verbose-but-harmless responses like

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const { CHANNEL } = require('./config');
+const { stripSilentReply, containsSilentReply } = require('./silent-reply');
 
 let deps = {};
 let initialized = false;
@@ -606,12 +607,13 @@ async function handleMessage(normalized) {
         let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction });
 
         // Strip protocol tokens the agent may have mixed into content (BAT-279)
-        // Also strip preceding bold-markdown/whitespace before tokens (OpenClaw parity 2026.3.1)
-        if (/\bSILENT_REPLY\b/i.test(response)) deps.log('[Audit] Agent sent SILENT_REPLY', 'DEBUG');
-        response = response.trim()
-            .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
-            .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
-            .trim();
+        // Uses centralized silent-reply.js helper (BAT-488) that also handles
+        // leading-attached cases like "SILENT_REPLYhello" + JSON envelope form.
+        if (containsSilentReply(response)) deps.log('[Audit] Agent sent SILENT_REPLY', 'DEBUG');
+        response = stripSilentReply(
+            response.trim()
+                .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
+        );
         if (!response) {
             deps.log('Agent returned protocol-token-only response, discarding', 'DEBUG');
             await statusReaction.clear();

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -68,29 +68,49 @@ function isSilentReplyPayloadText(text) {
     return isSilentReplyText(text) || isSilentReplyEnvelopeText(text);
 }
 
+// Markdown-wrapped variants the system prompt explicitly calls out as wrong:
+//   **SILENT_REPLY**, *SILENT_REPLY*, `SILENT_REPLY`, ```SILENT_REPLY```,
+//   _SILENT_REPLY_, [SILENT_REPLY], (SILENT_REPLY), <SILENT_REPLY>, ~SILENT_REPLY~
+// Match the token plus its surrounding wrapper chars in one pass so we don't
+// leave behind orphan punctuation like `****` or `\`\``.
+const MARKDOWN_WRAPPED_REGEX = /[`*_~\[\]()<>]+\s*SILENT_REPLY\s*[`*_~\[\]()<>]+/gi;
+
+// "Empty after strip" check — if the only thing left is whitespace and
+// markdown punctuation (no actual content), treat as fully silent. Prevents
+// orphan `****` / `\`\`` / `[]` from being sent to the user when the model
+// emits a markdown-wrapped variant the regex pass missed.
+const ONLY_MARKDOWN_PUNCT_REGEX = /^[\s`*_~\[\]()<>]*$/;
+
 /**
- * Strip all SILENT_REPLY occurrences from mixed-content text. Runs the four
- * passes in order: leading-attached → leading-spaced → trailing → word-boundary.
- * Returns the cleaned text (trimmed). An empty result means the entire message
- * should be treated as silent.
+ * Strip all SILENT_REPLY occurrences from mixed-content text. Runs the passes
+ * in order: JSON envelope short-circuit → markdown-wrapped → leading-attached →
+ * leading-spaced → trailing → word-boundary. Returns the cleaned text (trimmed).
+ * An empty result means the entire message should be treated as silent.
  *
- * Short-circuits to '' if the input is the exact `{"action":"SILENT_REPLY"}`
- * envelope form — otherwise the token strip would leave behind a mangled
- * `{"action":""}` JSON string that would be sent to the user.
+ * Short-circuits to '' for:
+ *   - Exact `{"action":"SILENT_REPLY"}` envelope (otherwise the token strip
+ *     would leave a mangled `{"action":""}` JSON string)
+ *   - Result that is only whitespace + markdown punctuation after stripping
+ *     (otherwise `**SILENT_REPLY**` would leave orphan `****`)
  *
  * Replaces the old inline pattern:
  *   .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
- * which missed leading-attached and JSON envelope cases.
+ * which missed leading-attached, JSON envelope, and markdown-wrapped cases.
  */
 function stripSilentReply(text) {
     if (!text) return '';
     if (isSilentReplyEnvelopeText(text)) return '';
-    return text
+    const stripped = text
+        .replace(MARKDOWN_WRAPPED_REGEX, '')
         .replace(LEADING_ATTACHED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
         .replace(TRAILING_REGEX, '')
         .replace(WORD_BOUNDARY_REGEX, '')
         .trim();
+    // If the model wrapped the token in markdown and only orphan punctuation
+    // remains, treat the whole message as silent.
+    if (ONLY_MARKDOWN_PUNCT_REGEX.test(stripped)) return '';
+    return stripped;
 }
 
 /**

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -18,11 +18,16 @@
 
 const TOKEN = 'SILENT_REPLY';
 
+// Single source of truth: build all regexes from TOKEN so renaming the
+// protocol token is a one-line change.
+function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+const T = escapeRegex(TOKEN);
+
 // Exact match — "SILENT_REPLY" with optional surrounding whitespace
-const EXACT_REGEX = /^\s*SILENT_REPLY\s*$/i;
+const EXACT_REGEX = new RegExp(`^\\s*${T}\\s*$`, 'i');
 
 // Trailing token (optionally preceded by whitespace or markdown emphasis stars)
-const TRAILING_REGEX = /(?:^|\s+|\*+)SILENT_REPLY\s*$/gi;
+const TRAILING_REGEX = new RegExp(`(?:^|\\s+|\\*+)${T}\\s*$`, 'gi');
 
 // Two char classes for boundary detection (Copilot 4th-pass suggestion):
 // - IDENT_CHAR includes underscore — used for OUTER boundary lookbehind/ahead
@@ -40,26 +45,22 @@ const CONTENT_CHAR = '[\\p{L}\\p{N}]';
 // Outer lookbehind requires non-identifier so identifiers like
 // `MY_SILENT_REPLY_HANDLE` don't match (preceding `_` is in IDENT).
 // Allows preceding repeated tokens ("SILENT_REPLY SILENT_REPLYhello").
-const LEADING_ATTACHED_REGEX = new RegExp(
-    `(?<!${IDENT_CHAR})(?:SILENT_REPLY\\s+)*(?:SILENT_REPLY_(?=${CONTENT_CHAR})|SILENT_REPLY(?=${IDENT_CHAR}))`,
-    'giu'
-);
+const LEADING_ATTACHED_PATTERN = `(?<!${IDENT_CHAR})(?:${T}\\s+)*(?:${T}_(?=${CONTENT_CHAR})|${T}(?=${IDENT_CHAR}))`;
+const LEADING_ATTACHED_REGEX = new RegExp(LEADING_ATTACHED_PATTERN, 'giu');
 // Non-global twin used by .test() to avoid stateful lastIndex bugs.
-const LEADING_ATTACHED_TEST = new RegExp(
-    `(?<!${IDENT_CHAR})(?:SILENT_REPLY\\s+)*(?:SILENT_REPLY_(?=${CONTENT_CHAR})|SILENT_REPLY(?=${IDENT_CHAR}))`,
-    'iu'
-);
+const LEADING_ATTACHED_TEST = new RegExp(LEADING_ATTACHED_PATTERN, 'iu');
 
 // Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
-const LEADING_SPACED_REGEX = /^(?:\s*SILENT_REPLY)+\s*/i;
+const LEADING_SPACED_REGEX = new RegExp(`^(?:\\s*${T})+\\s*`, 'i');
 
 // Generic strip — matches the token in any position when not glued to an
 // identifier char on EITHER side. Catches `Hello SILENT_REPLY world` and
 // preserves underscore-containing identifiers like `MY_SILENT_REPLY_HANDLE`.
 // NOTE: only used with .replace(). For .test() use TEST_REGEX (no /g flag) to
 // avoid the stateful lastIndex bug.
-const WORD_BOUNDARY_REGEX = new RegExp(`(?<!${IDENT_CHAR})SILENT_REPLY(?!${IDENT_CHAR})`, 'giu');
-const TEST_REGEX = new RegExp(`(?<!${IDENT_CHAR})SILENT_REPLY(?!${IDENT_CHAR})`, 'iu');
+const WORD_BOUNDARY_PATTERN = `(?<!${IDENT_CHAR})${T}(?!${IDENT_CHAR})`;
+const WORD_BOUNDARY_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'giu');
+const TEST_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'iu');
 
 /**
  * Exact silent-reply check. True only when the entire (trimmed) text is just
@@ -77,7 +78,9 @@ function isSilentReplyText(text) {
 function isSilentReplyEnvelopeText(text) {
     if (!text) return false;
     const trimmed = text.trim();
-    if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}') || !trimmed.includes(TOKEN)) {
+    // Case-insensitive contains check — model may emit lowercase variants.
+    if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}') ||
+        !trimmed.toUpperCase().includes(TOKEN.toUpperCase())) {
         return false;
     }
     try {
@@ -85,7 +88,10 @@ function isSilentReplyEnvelopeText(text) {
         if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
         const keys = Object.keys(parsed);
         return keys.length === 1 && keys[0] === 'action'
-            && typeof parsed.action === 'string' && parsed.action.trim() === TOKEN;
+            && typeof parsed.action === 'string'
+            // Case-insensitive comparison — matches the rest of the SILENT_REPLY
+            // handling which uses /i flag throughout.
+            && parsed.action.trim().toUpperCase() === TOKEN.toUpperCase();
     } catch (_) {
         return false;
     }
@@ -107,7 +113,7 @@ function isSilentReplyPayloadText(text) {
 // identifier). Match the token + its surrounding wrapper chars in one pass so
 // we don't leave behind orphan punctuation like `****` or `\`\``.
 const MARKDOWN_WRAPPED_REGEX = new RegExp(
-    `(?<!${IDENT_CHAR})[\`*_~\\[\\]()<>]+\\s*SILENT_REPLY\\s*[\`*_~\\[\\]()<>]+`,
+    `(?<!${IDENT_CHAR})[\`*_~\\[\\]()<>]+\\s*${T}\\s*[\`*_~\\[\\]()<>]+`,
     'giu'
 );
 

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -24,36 +24,42 @@ const EXACT_REGEX = /^\s*SILENT_REPLY\s*$/i;
 // Trailing token (optionally preceded by whitespace or markdown emphasis stars)
 const TRAILING_REGEX = /(?:^|\s+|\*+)SILENT_REPLY\s*$/gi;
 
-// Letter-or-number class (NO underscore). Used by lookbehind/lookahead to
-// detect identifier boundaries without `\b` (which fails between word chars).
-// Underscore is excluded because we want `_` to count as a strip boundary so
-// `SILENT_REPLY_hello` strips cleanly instead of being treated as one ident.
-const LN = '[\\p{L}\\p{N}]';
+// Two char classes for boundary detection (Copilot 4th-pass suggestion):
+// - IDENT_CHAR includes underscore — used for OUTER boundary lookbehind/ahead
+//   so legitimate identifiers like `MY_SILENT_REPLY_HANDLE` aren't mangled.
+// - CONTENT_CHAR excludes underscore — used to detect "token glued to a word"
+//   in the special `SILENT_REPLY_word` pass below.
+const IDENT_CHAR = '[\\p{L}\\p{N}_]';
+const CONTENT_CHAR = '[\\p{L}\\p{N}]';
 
-// Token attached to following letter/number content, anywhere in the text:
-// matches "SILENT_REPLYhello" at start AND "Hello SILENT_REPLYworld" mid-message.
-// Lookbehind ensures the token isn't itself glued to a preceding letter/number.
+// Token attached to following content, anywhere in the text. Two alternations:
+//   1. `SILENT_REPLY_` followed by letter/number → strip the trailing underscore too
+//      (catches `SILENT_REPLY_hello` cleanly → `hello`)
+//   2. `SILENT_REPLY` followed by any identifier char → strip just the token
+//      (catches `SILENT_REPLYhello` → `hello`)
+// Outer lookbehind requires non-identifier so identifiers like
+// `MY_SILENT_REPLY_HANDLE` don't match (preceding `_` is in IDENT).
 // Allows preceding repeated tokens ("SILENT_REPLY SILENT_REPLYhello").
 const LEADING_ATTACHED_REGEX = new RegExp(
-    `(?<!${LN})(?:SILENT_REPLY\\s+)*SILENT_REPLY(?=${LN})`,
+    `(?<!${IDENT_CHAR})(?:SILENT_REPLY\\s+)*(?:SILENT_REPLY_(?=${CONTENT_CHAR})|SILENT_REPLY(?=${IDENT_CHAR}))`,
     'giu'
 );
 // Non-global twin used by .test() to avoid stateful lastIndex bugs.
 const LEADING_ATTACHED_TEST = new RegExp(
-    `(?<!${LN})(?:SILENT_REPLY\\s+)*SILENT_REPLY(?=${LN})`,
+    `(?<!${IDENT_CHAR})(?:SILENT_REPLY\\s+)*(?:SILENT_REPLY_(?=${CONTENT_CHAR})|SILENT_REPLY(?=${IDENT_CHAR}))`,
     'iu'
 );
 
 // Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
 const LEADING_SPACED_REGEX = /^(?:\s*SILENT_REPLY)+\s*/i;
 
-// Generic strip — matches the token in any position when not glued to a
-// letter/number on EITHER side. Catches `Hello SILENT_REPLY world` and the
-// word-boundary mid-cases.
+// Generic strip — matches the token in any position when not glued to an
+// identifier char on EITHER side. Catches `Hello SILENT_REPLY world` and
+// preserves underscore-containing identifiers like `MY_SILENT_REPLY_HANDLE`.
 // NOTE: only used with .replace(). For .test() use TEST_REGEX (no /g flag) to
 // avoid the stateful lastIndex bug.
-const WORD_BOUNDARY_REGEX = new RegExp(`(?<!${LN})SILENT_REPLY(?!${LN})`, 'giu');
-const TEST_REGEX = new RegExp(`(?<!${LN})SILENT_REPLY(?!${LN})`, 'iu');
+const WORD_BOUNDARY_REGEX = new RegExp(`(?<!${IDENT_CHAR})SILENT_REPLY(?!${IDENT_CHAR})`, 'giu');
+const TEST_REGEX = new RegExp(`(?<!${IDENT_CHAR})SILENT_REPLY(?!${IDENT_CHAR})`, 'iu');
 
 /**
  * Exact silent-reply check. True only when the entire (trimmed) text is just
@@ -101,7 +107,7 @@ function isSilentReplyPayloadText(text) {
 // identifier). Match the token + its surrounding wrapper chars in one pass so
 // we don't leave behind orphan punctuation like `****` or `\`\``.
 const MARKDOWN_WRAPPED_REGEX = new RegExp(
-    `(?<!${LN})[\`*_~\\[\\]()<>]+\\s*SILENT_REPLY\\s*[\`*_~\\[\\]()<>]+`,
+    `(?<!${IDENT_CHAR})[\`*_~\\[\\]()<>]+\\s*SILENT_REPLY\\s*[\`*_~\\[\\]()<>]+`,
     'giu'
 );
 

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -1,0 +1,103 @@
+// silent-reply.js — centralized SILENT_REPLY token handling.
+//
+// Ported from OpenClaw's src/auto-reply/tokens.ts (v2026.4.10). We keep the
+// legacy SILENT_REPLY token instead of upstream's NO_REPLY so existing user
+// prompts/memory continue to work.
+//
+// Handles three failure modes the old `\bSILENT_REPLY\b` regex missed:
+//   1. Leading glued:  "SILENT_REPLYhello"   — \b fails between two word chars
+//   2. Leading spaced: "SILENT_REPLY hello"  — picked up by \b but stripped cleanly
+//   3. JSON envelope:  '{"action":"SILENT_REPLY"}' — model sometimes emits this
+
+const TOKEN = 'SILENT_REPLY';
+
+// Exact match — "SILENT_REPLY" with optional surrounding whitespace
+const EXACT_REGEX = /^\s*SILENT_REPLY\s*$/i;
+
+// Trailing token (optionally preceded by whitespace or markdown emphasis stars)
+const TRAILING_REGEX = /(?:^|\s+|\*+)SILENT_REPLY\s*$/gi;
+
+// Leading-attached: "SILENT_REPLYhello" — final token glued to word/number content.
+// \p{L}=letter, \p{N}=number. `iu` flags for case-insensitive + Unicode.
+const LEADING_ATTACHED_REGEX = /^\s*(?:SILENT_REPLY\s+)*SILENT_REPLY(?=[\p{L}\p{N}])/iu;
+
+// Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
+const LEADING_SPACED_REGEX = /^(?:\s*SILENT_REPLY)+\s*/i;
+
+// Generic word-boundary strip — catches mid-message tokens after specific cases
+const WORD_BOUNDARY_REGEX = /\bSILENT_REPLY\b/gi;
+
+/**
+ * Exact silent-reply check. True only when the entire (trimmed) text is just
+ * the token. Used for "should we reply at all?" gating.
+ */
+function isSilentReplyText(text) {
+    if (!text) return false;
+    return EXACT_REGEX.test(text);
+}
+
+/**
+ * JSON envelope check — catches `{"action":"SILENT_REPLY"}` shape. Some models
+ * emit structured output instead of the bare token.
+ */
+function isSilentReplyEnvelopeText(text) {
+    if (!text) return false;
+    const trimmed = text.trim();
+    if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}') || !trimmed.includes(TOKEN)) {
+        return false;
+    }
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+        const keys = Object.keys(parsed);
+        return keys.length === 1 && keys[0] === 'action'
+            && typeof parsed.action === 'string' && parsed.action.trim() === TOKEN;
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * Full silent-reply check — exact token OR JSON envelope. Use this at send
+ * gates where either form should suppress the outbound message.
+ */
+function isSilentReplyPayloadText(text) {
+    return isSilentReplyText(text) || isSilentReplyEnvelopeText(text);
+}
+
+/**
+ * Strip all SILENT_REPLY occurrences from mixed-content text. Runs the four
+ * passes in order: leading-attached → leading-spaced → trailing → word-boundary.
+ * Returns the cleaned text (trimmed). An empty result means the entire message
+ * should be treated as silent.
+ *
+ * Replaces the old inline pattern:
+ *   .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
+ * which missed leading-attached and JSON envelope cases.
+ */
+function stripSilentReply(text) {
+    if (!text) return '';
+    return text
+        .replace(LEADING_ATTACHED_REGEX, '')
+        .replace(LEADING_SPACED_REGEX, '')
+        .replace(TRAILING_REGEX, '')
+        .replace(WORD_BOUNDARY_REGEX, '')
+        .trim();
+}
+
+/**
+ * Quick "contains any silent-reply form" check for logging/audit hooks.
+ */
+function containsSilentReply(text) {
+    if (!text) return false;
+    return WORD_BOUNDARY_REGEX.test(text) || isSilentReplyEnvelopeText(text);
+}
+
+module.exports = {
+    TOKEN,
+    isSilentReplyText,
+    isSilentReplyEnvelopeText,
+    isSilentReplyPayloadText,
+    stripSilentReply,
+    containsSilentReply,
+};

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -24,8 +24,11 @@ const LEADING_ATTACHED_REGEX = /^\s*(?:SILENT_REPLY\s+)*SILENT_REPLY(?=[\p{L}\p{
 // Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
 const LEADING_SPACED_REGEX = /^(?:\s*SILENT_REPLY)+\s*/i;
 
-// Generic word-boundary strip — catches mid-message tokens after specific cases
+// Generic word-boundary strip — catches mid-message tokens after specific cases.
+// NOTE: only used with .replace() (not .test()). For .test() use TEST_REGEX
+// below to avoid the stateful lastIndex bug from the /g flag.
 const WORD_BOUNDARY_REGEX = /\bSILENT_REPLY\b/gi;
+const TEST_REGEX = /\bSILENT_REPLY\b/i;
 
 /**
  * Exact silent-reply check. True only when the entire (trimmed) text is just
@@ -71,12 +74,17 @@ function isSilentReplyPayloadText(text) {
  * Returns the cleaned text (trimmed). An empty result means the entire message
  * should be treated as silent.
  *
+ * Short-circuits to '' if the input is the exact `{"action":"SILENT_REPLY"}`
+ * envelope form — otherwise the token strip would leave behind a mangled
+ * `{"action":""}` JSON string that would be sent to the user.
+ *
  * Replaces the old inline pattern:
  *   .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
  * which missed leading-attached and JSON envelope cases.
  */
 function stripSilentReply(text) {
     if (!text) return '';
+    if (isSilentReplyEnvelopeText(text)) return '';
     return text
         .replace(LEADING_ATTACHED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
@@ -87,10 +95,16 @@ function stripSilentReply(text) {
 
 /**
  * Quick "contains any silent-reply form" check for logging/audit hooks.
+ * Uses the non-global TEST_REGEX so repeated calls aren't stateful via
+ * lastIndex (which would flip true→false intermittently with /g).
+ * Also catches the leading-attached form (`SILENT_REPLYhello`) and the
+ * JSON envelope form so audit logs match what stripSilentReply() can strip.
  */
 function containsSilentReply(text) {
     if (!text) return false;
-    return WORD_BOUNDARY_REGEX.test(text) || isSilentReplyEnvelopeText(text);
+    return TEST_REGEX.test(text)
+        || LEADING_ATTACHED_REGEX.test(text)
+        || isSilentReplyEnvelopeText(text);
 }
 
 module.exports = {

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -4,10 +4,17 @@
 // legacy SILENT_REPLY token instead of upstream's NO_REPLY so existing user
 // prompts/memory continue to work.
 //
-// Handles three failure modes the old `\bSILENT_REPLY\b` regex missed:
-//   1. Leading glued:  "SILENT_REPLYhello"   — \b fails between two word chars
-//   2. Leading spaced: "SILENT_REPLY hello"  — picked up by \b but stripped cleanly
-//   3. JSON envelope:  '{"action":"SILENT_REPLY"}' — model sometimes emits this
+// Handles failure modes the old `\bSILENT_REPLY\b` regex missed:
+//   1. Leading glued:    "SILENT_REPLYhello"        — \b fails between word chars
+//   2. Mid-glued:        "Hello SILENT_REPLYworld"  — same \b failure mid-message
+//   3. Underscore-glued: "SILENT_REPLY_hello"       — _ is a word char, \b fails
+//   4. Markdown wrapped: "**SILENT_REPLY**"         — leaves orphan punctuation
+//   5. JSON envelope:    '{"action":"SILENT_REPLY"}' — model emits structured form
+//   6. Leading spaced:   "SILENT_REPLY hello"       — \b ok but cleaner with own pass
+//
+// Boundaries use identifier-aware lookbehind/lookahead instead of `\b` so all
+// of the above strip cleanly without stripping legitimate identifier matches
+// like `MY_SILENT_REPLY_HANDLE`.
 
 const TOKEN = 'SILENT_REPLY';
 
@@ -17,18 +24,36 @@ const EXACT_REGEX = /^\s*SILENT_REPLY\s*$/i;
 // Trailing token (optionally preceded by whitespace or markdown emphasis stars)
 const TRAILING_REGEX = /(?:^|\s+|\*+)SILENT_REPLY\s*$/gi;
 
-// Leading-attached: "SILENT_REPLYhello" — final token glued to word/number content.
-// \p{L}=letter, \p{N}=number. `iu` flags for case-insensitive + Unicode.
-const LEADING_ATTACHED_REGEX = /^\s*(?:SILENT_REPLY\s+)*SILENT_REPLY(?=[\p{L}\p{N}])/iu;
+// Letter-or-number class (NO underscore). Used by lookbehind/lookahead to
+// detect identifier boundaries without `\b` (which fails between word chars).
+// Underscore is excluded because we want `_` to count as a strip boundary so
+// `SILENT_REPLY_hello` strips cleanly instead of being treated as one ident.
+const LN = '[\\p{L}\\p{N}]';
+
+// Token attached to following letter/number content, anywhere in the text:
+// matches "SILENT_REPLYhello" at start AND "Hello SILENT_REPLYworld" mid-message.
+// Lookbehind ensures the token isn't itself glued to a preceding letter/number.
+// Allows preceding repeated tokens ("SILENT_REPLY SILENT_REPLYhello").
+const LEADING_ATTACHED_REGEX = new RegExp(
+    `(?<!${LN})(?:SILENT_REPLY\\s+)*SILENT_REPLY(?=${LN})`,
+    'giu'
+);
+// Non-global twin used by .test() to avoid stateful lastIndex bugs.
+const LEADING_ATTACHED_TEST = new RegExp(
+    `(?<!${LN})(?:SILENT_REPLY\\s+)*SILENT_REPLY(?=${LN})`,
+    'iu'
+);
 
 // Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
 const LEADING_SPACED_REGEX = /^(?:\s*SILENT_REPLY)+\s*/i;
 
-// Generic word-boundary strip — catches mid-message tokens after specific cases.
-// NOTE: only used with .replace() (not .test()). For .test() use TEST_REGEX
-// below to avoid the stateful lastIndex bug from the /g flag.
-const WORD_BOUNDARY_REGEX = /\bSILENT_REPLY\b/gi;
-const TEST_REGEX = /\bSILENT_REPLY\b/i;
+// Generic strip — matches the token in any position when not glued to a
+// letter/number on EITHER side. Catches `Hello SILENT_REPLY world` and the
+// word-boundary mid-cases.
+// NOTE: only used with .replace(). For .test() use TEST_REGEX (no /g flag) to
+// avoid the stateful lastIndex bug.
+const WORD_BOUNDARY_REGEX = new RegExp(`(?<!${LN})SILENT_REPLY(?!${LN})`, 'giu');
+const TEST_REGEX = new RegExp(`(?<!${LN})SILENT_REPLY(?!${LN})`, 'iu');
 
 /**
  * Exact silent-reply check. True only when the entire (trimmed) text is just
@@ -71,9 +96,14 @@ function isSilentReplyPayloadText(text) {
 // Markdown-wrapped variants the system prompt explicitly calls out as wrong:
 //   **SILENT_REPLY**, *SILENT_REPLY*, `SILENT_REPLY`, ```SILENT_REPLY```,
 //   _SILENT_REPLY_, [SILENT_REPLY], (SILENT_REPLY), <SILENT_REPLY>, ~SILENT_REPLY~
-// Match the token plus its surrounding wrapper chars in one pass so we don't
-// leave behind orphan punctuation like `****` or `\`\``.
-const MARKDOWN_WRAPPED_REGEX = /[`*_~\[\]()<>]+\s*SILENT_REPLY\s*[`*_~\[\]()<>]+/gi;
+// Lookbehind anchors the opening wrapper to a non-letter/number context so we
+// don't grab `_SILENT_REPLY_` out of `MY_SILENT_REPLY_HANDLE` (legitimate
+// identifier). Match the token + its surrounding wrapper chars in one pass so
+// we don't leave behind orphan punctuation like `****` or `\`\``.
+const MARKDOWN_WRAPPED_REGEX = new RegExp(
+    `(?<!${LN})[\`*_~\\[\\]()<>]+\\s*SILENT_REPLY\\s*[\`*_~\\[\\]()<>]+`,
+    'giu'
+);
 
 // "Empty after strip" check — if the only thing left is whitespace and
 // markdown punctuation (no actual content), treat as fully silent. Prevents
@@ -123,7 +153,7 @@ function stripSilentReply(text) {
 function containsSilentReply(text) {
     if (!text) return false;
     return TEST_REGEX.test(text)
-        || LEADING_ATTACHED_REGEX.test(text)
+        || LEADING_ATTACHED_TEST.test(text)
         || isSilentReplyEnvelopeText(text);
 }
 


### PR DESCRIPTION
## Summary

Ports 3 portable improvements from OpenClaw **v2026.3.24 → v2026.4.10** (8,215 upstream commits scanned, 13 files skipped for channel/Node22/sandbox/refactor reasons).

### 1. Silent Replies wording + Execution Bias section
`ai.js → buildSystemBlocks()`. Drop-in text from upstream `system-prompt.ts`. Stops models from planning-instead-of-doing on actionable requests, and tightens the SILENT_REPLY rule with explicit ⚠️ Rules + wrong/right examples to prevent dodging work.

### 2. Fix SILENT_REPLY strip regex
Real bug found upstream: `\bSILENT_REPLY\b` fails on glued cases like `SILENT_REPLYhello` because `\b` doesn't match between two word chars. Ports leading-attached strip + JSON envelope detection into a new centralized `silent-reply.js` module. 4 strip sites in `main.js` (AutoResume, cron turn, heartbeat) and `message-handler.js` now use the shared helper.

### 3. Cron vs sleep-loop guidance
`ai.js` Tooling section. Steers models away from `shell_exec sleep` and `js_eval setTimeout` loops toward `cron_create` for future-time follow-ups. Both sleep primitives are available in the tool sandbox so this real risk needed explicit steering.

## Test plan
- [x] `node --check` passes on all 4 modified/new JS files
- [x] 13 regex smoke tests pass including the critical `SILENT_REPLYhello` → `hello` bug fix
- [ ] Build APK in Android Studio and install on Seeker
- [ ] Send a message with `SILENT_REPLYhello` in model output → verify it's stripped cleanly
- [ ] Ask agent "remind me in 30 minutes" → verify it uses cron_create, not sleep
- [ ] Ask agent an actionable task → verify it starts doing it (tool call) rather than replying with a plan

## Skipped from the sync (documented)
- System prompt: `promptContribution` provider overrides, cache boundary marker, exec approvals, `update_plan` tool, TOOLS list removal
- Model selection: pure TS refactor, no new Claude params
- Cron: timer/ops fixes already safer in our code (we recompute on every update)
- Memory manager: deleted upstream, depends on Node 22 `node:sqlite`
- Telegram extensions: webhook (polling only), single-bot fallback (we have one bot), topic/threading (flat DM)
- Skills workspace refactor: no behavioral changes

Ref: parity sync `b7d70ade3b..origin/main` (v2026.4.10).
Closes BAT-488.

Generated with [Claude Code](https://claude.com/claude-code)