### PR TITLE
fix: OpenAI OAuth on Pixel 7 + fresh-install default (BAT-489)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -630,8 +630,17 @@ object ConfigManager {
         if (email.isNotBlank()) {
             val enc = KeystoreHelper.encrypt(email)
             editor.putString(KEY_OPENAI_OAUTH_EMAIL_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
+            // If an older install still has the legacy plaintext pref hanging
+            // around (loadConfigUnchecked migrates it on read, but not every code
+            // path has triggered a read since the migration landed), drop it too
+            // to ensure the encrypted value becomes the single source of truth.
+            editor.remove("openai_oauth_email")
         } else {
+            // Clear email in both locations — the encrypted key that we own and
+            // the legacy plaintext key from pre-migration installs. Leaving the
+            // plaintext pref behind on sign-out would be a PII regression.
             editor.remove(KEY_OPENAI_OAUTH_EMAIL_ENC)
+            editor.remove("openai_oauth_email")
         }
 
         editor.putString(KEY_OPENAI_OAUTH_EXPIRES_AT, expiresAt)

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -332,9 +332,33 @@ object ConfigManager {
         }
     }
 
+    /**
+     * Returns the persisted config if setup is complete, otherwise null.
+     *
+     * For a "read whatever is there, even pre-setup" variant — used during
+     * onboarding to pick up OAuth tokens written by [OpenAIOAuthActivity]
+     * before saveAndStart has ever run — see [loadConfigOrBootstrap].
+     */
     fun loadConfig(context: Context): AppConfig? {
+        if (!isSetupComplete(context)) return null
+        return loadConfigUnchecked(context)
+    }
+
+    /**
+     * Loads whatever config fields are currently in SharedPreferences regardless
+     * of whether the setup flow has completed. Use this in places that must work
+     * mid-onboarding — specifically, the OpenAI OAuth controller (needs to show
+     * "connected" immediately after the callback writes tokens) and saveAndStart
+     * (needs to preserve those tokens into the first full saveConfig call).
+     *
+     * All fields default to empty strings / safe defaults if not persisted yet,
+     * so this never throws on a truly fresh install — it just returns a blank
+     * AppConfig with whatever few fields have been written so far.
+     */
+    fun loadConfigOrBootstrap(context: Context): AppConfig = loadConfigUnchecked(context)
+
+    private fun loadConfigUnchecked(context: Context): AppConfig {
         val p = prefs(context)
-        if (!p.getBoolean(KEY_SETUP_COMPLETE, false)) return null
 
         val apiKey = try {
             val enc = p.getString(KEY_API_KEY_ENC, null)
@@ -565,6 +589,59 @@ object ConfigManager {
 
     fun setKeepScreenOn(context: Context, enabled: Boolean) {
         prefs(context).edit().putBoolean(KEY_KEEP_SCREEN_ON, enabled).commit()
+    }
+
+    /**
+     * Persist OpenAI OAuth tokens directly to SharedPreferences, bypassing the
+     * full [saveConfig] path. Used by [OpenAIOAuthActivity] during the
+     * post-callback token exchange so the flow works on a fresh install — at
+     * that point [saveConfig]'s prerequisites (bot token, agent name, etc.)
+     * don't exist yet, and [loadConfig] still returns null because setup isn't
+     * marked complete.
+     *
+     * This deliberately does NOT set `KEY_SETUP_COMPLETE`: the user still needs
+     * to finish the onboarding flow normally. It only writes the four OAuth
+     * prefs (access token + refresh token + email + expiry) and bumps
+     * [configVersion] so reactive UI picks up the change.
+     */
+    fun persistOpenAIOAuthTokens(
+        context: Context,
+        accessToken: String,
+        refreshToken: String,
+        email: String,
+        expiresAt: String,
+    ) {
+        val editor = prefs(context).edit()
+
+        if (accessToken.isNotBlank()) {
+            val enc = KeystoreHelper.encrypt(accessToken)
+            editor.putString(KEY_OPENAI_OAUTH_TOKEN_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_TOKEN_ENC)
+        }
+
+        if (refreshToken.isNotBlank()) {
+            val enc = KeystoreHelper.encrypt(refreshToken)
+            editor.putString(KEY_OPENAI_OAUTH_REFRESH_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_REFRESH_ENC)
+        }
+
+        if (email.isNotBlank()) {
+            val enc = KeystoreHelper.encrypt(email)
+            editor.putString(KEY_OPENAI_OAUTH_EMAIL_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_OPENAI_OAUTH_EMAIL_ENC)
+        }
+
+        editor.putString(KEY_OPENAI_OAUTH_EXPIRES_AT, expiresAt)
+
+        val persisted = editor.commit()
+        if (persisted) {
+            configVersion.intValue++
+        } else {
+            LogCollector.append("[Config] Failed to persist OAuth tokens (commit=false)", LogLevel.ERROR)
+        }
     }
 
     fun updateConfigField(context: Context, field: String, value: String) {

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -686,16 +686,19 @@ class OpenAIOAuthActivity : ComponentActivity() {
         port: Int,
         private val onCallback: (Map<String, String>) -> String
     ) : NanoHTTPD(port) {
-        // Bind to all loopback interfaces (NanoHTTPD's no-hostname constructor binds
-        // to 0.0.0.0). We used to pass "localhost" here, but on newer Android devices
-        // (e.g. Pixel 7 / Android 14) InetAddress.getByName("localhost") resolves to
-        // ::1 only, so the server bound only to IPv6 loopback. Meanwhile Chrome's
-        // Custom Tab resolves "localhost" to 127.0.0.1 for the redirect, causing
-        // connection refused on the callback. Reported as BAT-489.
+        // Bind to the wildcard address (NanoHTTPD's no-hostname constructor binds to
+        // 0.0.0.0, i.e. all network interfaces). We used to pass "localhost" here,
+        // but on newer Android devices (e.g. Pixel 7 / Android 14)
+        // InetAddress.getByName("localhost") resolves to ::1 only, so the server
+        // bound only to IPv6 loopback. Meanwhile Chrome's Custom Tab resolves
+        // "localhost" to 127.0.0.1 for the redirect, causing connection refused on
+        // the callback. Reported as BAT-489.
         //
-        // Binding to 0.0.0.0 accepts both 127.0.0.1 and ::1 connections. We preserve
-        // the localhost-only security intent by validating the remote IP in serve()
-        // below — any non-loopback request is rejected with 403.
+        // Binding wildcard accepts both 127.0.0.1 and ::1 connections — but it also
+        // accepts connections from other hosts on the same network, which we do NOT
+        // want. The localhost-only security guarantee is therefore NOT provided by
+        // the bind itself; it is enforced in serve() below by rejecting any request
+        // whose remote IP is outside the loopback range with 403 Forbidden.
 
         override fun serve(session: IHTTPSession): Response {
             // Security: reject anything that isn't loopback. With a 0.0.0.0 bind we

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -32,7 +32,10 @@ import java.security.SecureRandom
 
 /**
  * Activity that handles the OpenAI OAuth PKCE flow:
- * Custom Tabs → user signs in on auth.openai.com → 127.0.0.1:1455 callback → token exchange.
+ * Custom Tabs → user signs in on auth.openai.com → localhost:1455 loopback callback → token exchange.
+ *
+ * The callback server accepts both IPv4 (127.0.0.1) and IPv6 (::1) loopback connections,
+ * so it works regardless of which one the browser resolves "localhost" to on a given device.
  *
  * Tokens obtained from the flow are persisted directly via [ConfigManager] (encrypted via
  * Android Keystore). The on-disk result file under `filesDir/oauth_results/` only carries

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -50,9 +50,10 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // Must be exactly "localhost" — the Codex OAuth client (app_EMoamEEZ...) is
         // registered with this redirect URI. Using 127.0.0.1 causes OpenAI to reject the
         // authorize request as a redirect_uri mismatch ("unknown_error" on their side).
-        // NOTE: this is the URI the browser resolves. The NanoHTTPD server itself binds
-        // to all loopback interfaces (see CallbackServer below) so it's reachable
-        // regardless of whether the OS resolves "localhost" to 127.0.0.1 or ::1.
+        // NOTE: the browser may resolve "localhost" to either 127.0.0.1 or ::1 depending
+        // on the device (Pixel 7 / Android 14 prefer IPv6). CallbackServer binds to the
+        // wildcard address and accepts only loopback-originated requests, so the
+        // callback arrives successfully regardless of which loopback address Chrome uses.
         const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -50,8 +50,9 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // Must be exactly "localhost" — the Codex OAuth client (app_EMoamEEZ...) is
         // registered with this redirect URI. Using 127.0.0.1 causes OpenAI to reject the
         // authorize request as a redirect_uri mismatch ("unknown_error" on their side).
-        // The IPv6-resolution risk Copilot flagged is theoretical — Codex CLI itself
-        // uses "localhost" in production and the NanoHTTPD listener resolves correctly.
+        // NOTE: this is the URI the browser resolves. The NanoHTTPD server itself binds
+        // to all loopback interfaces (see CallbackServer below) so it's reachable
+        // regardless of whether the OS resolves "localhost" to 127.0.0.1 or ::1.
         const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
@@ -684,15 +685,29 @@ class OpenAIOAuthActivity : ComponentActivity() {
     private class CallbackServer(
         port: Int,
         private val onCallback: (Map<String, String>) -> String
-    ) : NanoHTTPD("localhost", port) {
-        // Bind explicitly to "localhost" so the OAuth callback listener is reachable
-        // only from the local device — never from all network interfaces (NanoHTTPD's
-        // no-hostname constructor binds to 0.0.0.0). The redirect URI must also stay
-        // as "localhost" because Codex's OAuth client (app_EMoamEEZ...) is registered
-        // with that exact string — switching to "127.0.0.1" causes auth.openai.com
-        // to reject the authorize request as redirect_uri mismatch.
+    ) : NanoHTTPD(port) {
+        // Bind to all loopback interfaces (NanoHTTPD's no-hostname constructor binds
+        // to 0.0.0.0). We used to pass "localhost" here, but on newer Android devices
+        // (e.g. Pixel 7 / Android 14) InetAddress.getByName("localhost") resolves to
+        // ::1 only, so the server bound only to IPv6 loopback. Meanwhile Chrome's
+        // Custom Tab resolves "localhost" to 127.0.0.1 for the redirect, causing
+        // connection refused on the callback. Reported as BAT-489.
+        //
+        // Binding to 0.0.0.0 accepts both 127.0.0.1 and ::1 connections. We preserve
+        // the localhost-only security intent by validating the remote IP in serve()
+        // below — any non-loopback request is rejected with 403.
 
         override fun serve(session: IHTTPSession): Response {
+            // Security: reject anything that isn't loopback. With a 0.0.0.0 bind we
+            // could in principle be reached from other hosts on the same network, so
+            // we gate every request on the client IP. NanoHTTPD reports the remote
+            // address in v4 form (127.0.0.1) or v6 form (0:0:0:0:0:0:0:1 or ::1)
+            // depending on how the client connected.
+            val remoteIp = session.remoteIpAddress ?: ""
+            if (!isLoopback(remoteIp)) {
+                Log.w(TAG, "Rejecting non-loopback callback request from $remoteIp")
+                return newFixedLengthResponse(Response.Status.FORBIDDEN, "text/plain", "Forbidden")
+            }
             if (session.uri == "/auth/callback" && session.method == Method.GET) {
                 @Suppress("DEPRECATION")
                 val params = session.parms ?: emptyMap()
@@ -700,6 +715,15 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 return newFixedLengthResponse(Response.Status.OK, "text/html", html)
             }
             return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "Not found")
+        }
+
+        private fun isLoopback(ip: String): Boolean {
+            if (ip.isEmpty()) return false
+            // IPv4 loopback: entire 127.0.0.0/8 block
+            if (ip.startsWith("127.")) return true
+            // IPv6 loopback, short and long forms
+            if (ip == "::1" || ip == "0:0:0:0:0:0:0:1") return true
+            return false
         }
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -25,6 +25,7 @@ import org.json.JSONObject
 import java.io.File
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
+import java.net.InetAddress
 import java.net.URL
 import java.net.URLEncoder
 import java.security.MessageDigest
@@ -726,11 +727,20 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
         private fun isLoopback(ip: String): Boolean {
             if (ip.isEmpty()) return false
-            // IPv4 loopback: entire 127.0.0.0/8 block
-            if (ip.startsWith("127.")) return true
-            // IPv6 loopback, short and long forms
-            if (ip == "::1" || ip == "0:0:0:0:0:0:0:1") return true
-            return false
+            // Strip any IPv6 zone suffix (e.g. "fe80::1%eth0") before parsing.
+            val stripped = ip.substringBefore('%')
+            // IPv4-mapped IPv6 form ("::ffff:127.0.0.1") must be explicitly
+            // recognized — Inet6Address.isLoopbackAddress() only returns true for
+            // "::1" and doesn't unwrap the v4 mapping on all JDK/Android versions.
+            if (stripped.startsWith("::ffff:127.", ignoreCase = true)) return true
+            // Canonical path: parse as an InetAddress (no DNS lookup for numeric IPs)
+            // and let the platform classify it. Covers 127.0.0.0/8 via Inet4Address
+            // and ::1 / 0:0:0:0:0:0:0:1 via Inet6Address.
+            return try {
+                InetAddress.getByName(stripped).isLoopbackAddress
+            } catch (e: Exception) {
+                false
+            }
         }
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -112,16 +112,20 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val email = extractEmailFromJwtStatic(idToken) ?: extractEmailFromJwtStatic(accessToken)
 
                 withContext(NonCancellable + Dispatchers.IO) {
-                    val current = ConfigManager.loadConfig(appCtx)
-                        ?: throw IllegalStateException("Config not loaded — cannot persist OAuth tokens")
-                    ConfigManager.saveConfig(
-                        appCtx,
-                        current.copy(
-                            openaiOAuthToken = accessToken,
-                            openaiOAuthRefresh = refreshToken.ifBlank { current.openaiOAuthRefresh },
-                            openaiOAuthEmail = email ?: current.openaiOAuthEmail,
-                            openaiOAuthExpiresAt = expiresAt,
-                        )
+                    // Persist the 4 OAuth fields directly via ConfigManager's
+                    // bootstrap-friendly path. This works on fresh install (before
+                    // saveAndStart has ever run) and also on subsequent sign-ins
+                    // (where saveConfig has already marked setup complete). We read
+                    // the prior refresh token and email from loadConfigOrBootstrap
+                    // so blank fields from the token response don't wipe values the
+                    // user previously had.
+                    val prior = ConfigManager.loadConfigOrBootstrap(appCtx)
+                    ConfigManager.persistOpenAIOAuthTokens(
+                        context = appCtx,
+                        accessToken = accessToken,
+                        refreshToken = refreshToken.ifBlank { prior.openaiOAuthRefresh },
+                        email = email ?: prior.openaiOAuthEmail,
+                        expiresAt = expiresAt,
                     )
                     writeResultFileStatic(appCtx, requestId, JSONObject().apply {
                         put("status", "success")

--- a/app/src/main/java/com/seekerclaw/app/ui/components/OpenAIOAuth.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/OpenAIOAuth.kt
@@ -72,7 +72,11 @@ fun rememberOpenAIOAuthController(
     onSignedOut: () -> Unit = {},
 ): OpenAIOAuthController {
     val configVer by ConfigManager.configVersion
-    val config = remember(configVer) { ConfigManager.loadConfig(context) }
+    // loadConfigOrBootstrap returns a config even before setup is marked
+    // complete — required so the onboarding Sign in with ChatGPT flow can
+    // show "connected" immediately after the OAuth activity persists tokens,
+    // before the user has reached the final "Create Agent" button.
+    val config = remember(configVer) { ConfigManager.loadConfigOrBootstrap(context) }
 
     var requestId by remember { mutableStateOf<String?>(null) }
     var isPolling by remember { mutableStateOf(false) }
@@ -93,8 +97,9 @@ fun rememberOpenAIOAuthController(
         }
     }
 
-    // Poll the result file written by OpenAIOAuthActivity. Tokens are persisted by the
-    // activity directly via ConfigManager.saveConfig — we just watch for status here.
+    // Poll the result file written by OpenAIOAuthActivity. Tokens are persisted by
+    // the activity directly via ConfigManager.persistOpenAIOAuthTokens — we just
+    // watch the status flag here to update the UI state.
     LaunchedEffect(requestId, isPolling) {
         val reqId = requestId ?: return@LaunchedEffect
         if (!isPolling) return@LaunchedEffect
@@ -139,8 +144,8 @@ fun rememberOpenAIOAuthController(
     }
 
     val state = OpenAIOAuthState(
-        isConnected = config?.openaiOAuthToken?.isNotBlank() == true,
-        email = config?.openaiOAuthEmail ?: "",
+        isConnected = config.openaiOAuthToken.isNotBlank(),
+        email = config.openaiOAuthEmail,
         isPolling = isPolling,
         error = error,
     )
@@ -158,10 +163,16 @@ fun rememberOpenAIOAuthController(
             error = null
         },
         signOut = {
-            ConfigManager.updateConfigField(context, "openaiOAuthToken", "")
-            ConfigManager.updateConfigField(context, "openaiOAuthRefresh", "")
-            ConfigManager.updateConfigField(context, "openaiOAuthEmail", "")
-            ConfigManager.updateConfigField(context, "openaiOAuthExpiresAt", "")
+            // Clear all 4 OAuth prefs directly — using updateConfigField would
+            // no-op on a fresh install (loadConfig returns null until setup is
+            // complete), leaving tokens orphaned after a mid-onboarding sign-out.
+            ConfigManager.persistOpenAIOAuthTokens(
+                context = context,
+                accessToken = "",
+                refreshToken = "",
+                email = "",
+                expiresAt = "",
+            )
             onSignedOut()
         },
         cancel = {

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -568,6 +568,14 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                         if (newAuthType == "api_key") {
                             apiKey = existingConfig?.openaiApiKey ?: ""
                         }
+                        // OpenAI's OAuth and API-key model lists are disjoint (OAuth has
+                        // the GPT-5.x Codex family, API-key has the public GPT-5 line).
+                        // Coerce selectedModel to a valid entry for the new auth type so
+                        // a cross-auth stale model never gets persisted by saveAndStart.
+                        val openaiModels = modelsForProvider("openai", newAuthType)
+                        if (openaiModels.isNotEmpty() && openaiModels.none { it.id == selectedModel }) {
+                            selectedModel = openaiModels[0].id
+                        }
                     }
                     apiKeyError = null
                     errorMessage = null

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -518,10 +518,15 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     }
                     apiKeyError = null
                     errorMessage = null
-                    // Per-provider auth defaults: Claude → api_key/setup_token,
-                    // OpenAI → oauth (Sign in with ChatGPT is the onboarding-friendly
-                    // default — matches fresh-install behaviour above and Settings
-                    // first-time switch-in default).
+                    // Per-provider auth defaults:
+                    //   Claude  → "setup_token" if the user previously used one,
+                    //             otherwise "api_key".
+                    //   OpenAI  → "oauth" on fresh install (existingConfig == null),
+                    //             or if the user previously chose oauth, or if there's
+                    //             already an OAuth token on file. Otherwise "api_key"
+                    //             — e.g. user came from Settings where they had set
+                    //             an OpenAI API key directly.
+                    //   Other   → "api_key".
                     val newAuthType = when (newProvider) {
                         "claude" -> when (existingConfig?.authType) {
                             "setup_token" -> "setup_token"

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -538,14 +538,27 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                         else -> "api_key"
                     }
                     authType = newAuthType
-                    // Restore model: use existing config's model if same provider, else default.
-                    // Model list must match the effective auth type (OpenAI OAuth has its own list).
+                    // Restore model. Two concerns:
+                    //  1. Freeform providers (OpenRouter/custom) have no fixed model
+                    //     list — prefer existingConfig.model for the same provider,
+                    //     otherwise use the freeform fallback.
+                    //  2. Providers with a fixed list must validate existingConfig.model
+                    //     against the list for the EFFECTIVE auth type. Example: an
+                    //     existing config with openai + api_key + "gpt-5.4-mini" would
+                    //     otherwise survive a provider-change round-trip even though
+                    //     gpt-5.4-mini is only present in the OAuth model list. Always
+                    //     coerce to the first valid entry when the stored model isn't.
                     val modelAuthType = if (newProvider == "openai") newAuthType else "api_key"
                     val models = modelsForProvider(newProvider, modelAuthType)
-                    selectedModel = if (newProvider == existingConfig?.provider) {
-                        existingConfig.model
+                    selectedModel = if (models.isEmpty()) {
+                        // Freeform (OpenRouter/custom): no validation possible
+                        if (newProvider == existingConfig?.provider) existingConfig.model
+                        else OPENROUTER_DEFAULT_MODEL
                     } else {
-                        models.firstOrNull()?.id ?: OPENROUTER_DEFAULT_MODEL
+                        val existingModel = existingConfig?.model?.takeIf { m ->
+                            newProvider == existingConfig.provider && models.any { it.id == m }
+                        }
+                        existingModel ?: models[0].id
                     }
                 },
                 apiKey = apiKey,
@@ -573,13 +586,15 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                         if (newAuthType == "api_key") {
                             apiKey = existingConfig?.openaiApiKey ?: ""
                         }
-                        // OpenAI's OAuth and API-key model lists are disjoint (OAuth has
-                        // the GPT-5.x Codex family, API-key has the public GPT-5 line).
-                        // Coerce selectedModel to a valid entry for the new auth type so
-                        // a cross-auth stale model never gets persisted by saveAndStart.
-                        val openaiModels = modelsForProvider("openai", newAuthType)
-                        if (openaiModels.isNotEmpty() && openaiModels.none { it.id == selectedModel }) {
-                            selectedModel = openaiModels[0].id
+                        // OpenAI's OAuth and API-key model lists overlap on the main
+                        // GPT-5.x entries but aren't identical — gpt-5.4-mini is
+                        // OAuth-only, for example. If the currently-selected model
+                        // isn't in the new auth type's list, coerce to the first valid
+                        // entry so a cross-auth stale model never gets persisted by
+                        // saveAndStart. Shared models are left alone.
+                        val validModels = modelsForProvider("openai", newAuthType)
+                        if (validModels.isNotEmpty() && validModels.none { it.id == selectedModel }) {
+                            selectedModel = validModels[0].id
                         }
                     }
                     apiKeyError = null

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -338,6 +338,17 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
         try {
             val trimmedKey = apiKey.trim()
             val existing = ConfigManager.loadConfig(context)
+            // On fresh install (existing == null) the user may have already
+            // completed OAuth via OpenAIOAuthActivity during this setup session
+            // — those tokens are persisted to prefs independently of saveConfig,
+            // so read them via loadConfigOrBootstrap to preserve them through
+            // this first full saveConfig call. On subsequent launches `existing`
+            // is non-null and we use its values directly.
+            val bootstrap = if (existing == null) ConfigManager.loadConfigOrBootstrap(context) else null
+            val preservedOAuthToken = existing?.openaiOAuthToken ?: bootstrap?.openaiOAuthToken ?: ""
+            val preservedOAuthRefresh = existing?.openaiOAuthRefresh ?: bootstrap?.openaiOAuthRefresh ?: ""
+            val preservedOAuthEmail = existing?.openaiOAuthEmail ?: bootstrap?.openaiOAuthEmail ?: ""
+            val preservedOAuthExpiresAt = existing?.openaiOAuthExpiresAt ?: bootstrap?.openaiOAuthExpiresAt ?: ""
             val config = when (scannedProvider) {
                 "openai" -> AppConfig(
                     anthropicApiKey = existing?.anthropicApiKey ?: "",
@@ -345,11 +356,13 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     // Don't wipe an existing openaiApiKey when the user picked OAuth.
                     openaiApiKey = if (isOpenAIOAuth) (existing?.openaiApiKey ?: "") else trimmedKey,
                     openrouterApiKey = existing?.openrouterApiKey ?: "",
-                    // Preserve OAuth tokens written by OpenAIOAuthActivity.
-                    openaiOAuthToken = existing?.openaiOAuthToken ?: "",
-                    openaiOAuthRefresh = existing?.openaiOAuthRefresh ?: "",
-                    openaiOAuthEmail = existing?.openaiOAuthEmail ?: "",
-                    openaiOAuthExpiresAt = existing?.openaiOAuthExpiresAt ?: "",
+                    // Preserve OAuth tokens written by OpenAIOAuthActivity — on
+                    // fresh install these come from the bootstrap config, not the
+                    // (null) loadConfig result.
+                    openaiOAuthToken = preservedOAuthToken,
+                    openaiOAuthRefresh = preservedOAuthRefresh,
+                    openaiOAuthEmail = preservedOAuthEmail,
+                    openaiOAuthExpiresAt = preservedOAuthExpiresAt,
                     provider = "openai",
                     authType = effectiveAuthType,
                     telegramBotToken = botToken.trim(),

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -179,11 +179,13 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
     //     keeps these strings across activity recreation).
     var apiKey by rememberSaveable {
         mutableStateOf(
-            when (existingConfig?.provider) {
-                "openai" -> existingConfig.openaiApiKey
-                "openrouter" -> existingConfig.openrouterApiKey
-                else -> existingConfig?.activeCredential ?: ""
-            }
+            existingConfig?.let { cfg ->
+                when (cfg.provider) {
+                    "openai" -> cfg.openaiApiKey
+                    "openrouter" -> cfg.openrouterApiKey
+                    else -> cfg.activeCredential
+                }
+            } ?: ""
         )
     }
     var authType by rememberSaveable { mutableStateOf(initialAuthType) }
@@ -562,9 +564,14 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                             "setup_token" -> "setup_token"
                             else -> "api_key"
                         }
-                        "openai" -> if (existingConfig == null ||
-                            existingConfig.authType == "oauth" ||
-                            existingConfig.openaiOAuthToken.isNotBlank()) "oauth" else "api_key"
+                        "openai" -> existingConfig?.let { cfg ->
+                            // Honour prior choice when we have one: oauth if that's
+                            // what was selected, or if there's already a token on
+                            // file; api_key otherwise (e.g. user set an OpenAI API
+                            // key directly in Settings).
+                            if (cfg.authType == "oauth" || cfg.openaiOAuthToken.isNotBlank()) "oauth"
+                            else "api_key"
+                        } ?: "oauth" // fresh install → default to Sign in with ChatGPT
                         else -> "api_key"
                     }
                     authType = newAuthType

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -252,9 +252,12 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     botToken = cfg.telegramBotToken
                     ownerId = cfg.telegramOwnerId
                     // Match the model list to the imported config's effective auth type.
-                    // OpenAI's OAuth and API-key model lists differ (gpt-5.4-mini is
-                    // OAuth-only), so a QR config with provider=openai + authType=oauth
-                    // must validate against the OAuth list — not the API-key list.
+                    // In practice ConfigClaimImporter.parseImport() currently forces
+                    // authType="api_key" for openai (QR/claim payloads don't carry OAuth
+                    // tokens yet), so this branch resolves to the api_key model list
+                    // today. The conditional is kept deliberately: if the importer ever
+                    // learns to produce openai+oauth claims, gpt-5.4-mini and other
+                    // OAuth-only models need the OAuth list to validate correctly.
                     val qrModelAuthType = if (cfg.provider == "openai") cfg.authType else "api_key"
                     val providerModels = modelsForProvider(cfg.provider, qrModelAuthType)
                     selectedModel = if (providerModels.isEmpty()) {

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -160,6 +160,13 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
     val configVersion = ConfigManager.configVersion.intValue
     val existingConfig = remember(configVersion) { ConfigManager.loadConfig(context) }
 
+    // Fresh-install defaults land on OpenAI + OAuth (Sign in with ChatGPT) — it's the
+    // first provider in the onboarding picker and the smoothest onboarding path (no
+    // key to paste, just a browser tap). If existingConfig is present (user came back
+    // from Settings or a previous partial setup), honour whatever they chose before.
+    val initialProvider = existingConfig?.provider ?: "openai"
+    val initialAuthType = existingConfig?.authType ?: "oauth"
+
     var apiKey by remember(configVersion) {
         mutableStateOf(
             when (existingConfig?.provider) {
@@ -169,20 +176,21 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
             }
         )
     }
-    var authType by remember(configVersion) { mutableStateOf(existingConfig?.authType ?: "api_key") }
-    var scannedProvider by remember(configVersion) { mutableStateOf(existingConfig?.provider ?: "claude") }
+    var authType by remember(configVersion) { mutableStateOf(initialAuthType) }
+    var scannedProvider by remember(configVersion) { mutableStateOf(initialProvider) }
     var botToken by remember(configVersion) { mutableStateOf(existingConfig?.telegramBotToken ?: "") }
     var ownerId by remember(configVersion) { mutableStateOf(existingConfig?.telegramOwnerId ?: "") }
-    val existingProvider = existingConfig?.provider ?: "claude"
     var selectedModel by remember(configVersion) {
-        // Setup screen always uses API-key auth (OAuth happens later in settings),
-        // so derive the model list from the api_key list to match what saveAndStart persists.
+        // Use the effective auth type so OpenAI+OAuth picks from the OAuth model list
+        // (GPT-5.x Codex) instead of the API-key list — modelsForProvider throws for
+        // openai when authType is null, so we must pass it through.
+        val modelAuthType = if (initialProvider == "openai") initialAuthType else "api_key"
+        val models = modelsForProvider(initialProvider, modelAuthType)
         mutableStateOf(
             existingConfig?.model?.let { model ->
-                val models = modelsForProvider(existingProvider, "api_key")
                 if (models.isEmpty() || models.any { it.id == model }) model
                 else models[0].id
-            } ?: modelsForProvider(existingProvider, "api_key").firstOrNull()?.id ?: availableModels[0].id
+            } ?: models.firstOrNull()?.id ?: availableModels[0].id
         )
     }
     var agentName by remember(configVersion) { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }
@@ -511,19 +519,24 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     apiKeyError = null
                     errorMessage = null
                     // Per-provider auth defaults: Claude → api_key/setup_token,
-                    // OpenAI → oauth (matches Settings first-time switch-in default).
-                    authType = when (newProvider) {
+                    // OpenAI → oauth (Sign in with ChatGPT is the onboarding-friendly
+                    // default — matches fresh-install behaviour above and Settings
+                    // first-time switch-in default).
+                    val newAuthType = when (newProvider) {
                         "claude" -> when (existingConfig?.authType) {
                             "setup_token" -> "setup_token"
                             else -> "api_key"
                         }
-                        "openai" -> if (existingConfig?.authType == "oauth" ||
-                            existingConfig?.openaiOAuthToken?.isNotBlank() == true) "oauth" else "api_key"
+                        "openai" -> if (existingConfig == null ||
+                            existingConfig.authType == "oauth" ||
+                            existingConfig.openaiOAuthToken.isNotBlank()) "oauth" else "api_key"
                         else -> "api_key"
                     }
-                    // Restore model: use existing config's model if same provider, else default
-                    // Setup screen always uses API-key auth — OAuth flow happens later in settings.
-                    val models = modelsForProvider(newProvider, "api_key")
+                    authType = newAuthType
+                    // Restore model: use existing config's model if same provider, else default.
+                    // Model list must match the effective auth type (OpenAI OAuth has its own list).
+                    val modelAuthType = if (newProvider == "openai") newAuthType else "api_key"
+                    val models = modelsForProvider(newProvider, modelAuthType)
                     selectedModel = if (newProvider == existingConfig?.provider) {
                         existingConfig.model
                     } else {

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -617,17 +617,22 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                 onAuthTypeChange = { newAuthType ->
                     authType = newAuthType
                     // Swap displayed key to the value stored under the new auth type so
-                    // the field always reflects what's saved for the active tab.
+                    // the field always reflects what's saved for the active tab. Only
+                    // overwrite when there's actually a saved value to restore — on a
+                    // fresh install (existingConfig == null) we preserve whatever the
+                    // user has already typed, otherwise toggling tabs mid-entry would
+                    // silently wipe their input.
                     if (scannedProvider == "claude") {
-                        apiKey = if (newAuthType == "setup_token")
-                            existingConfig?.setupToken ?: ""
-                        else
-                            existingConfig?.anthropicApiKey ?: ""
+                        val saved = if (newAuthType == "setup_token") existingConfig?.setupToken
+                                    else existingConfig?.anthropicApiKey
+                        if (!saved.isNullOrBlank()) apiKey = saved
                     } else if (scannedProvider == "openai") {
                         // OAuth tab doesn't use the apiKey field — leave it untouched.
-                        // Switching to API Key restores the saved OpenAI key.
+                        // Switching to API Key restores the saved OpenAI key only if
+                        // one exists; otherwise keep the in-flight draft.
                         if (newAuthType == "api_key") {
-                            apiKey = existingConfig?.openaiApiKey ?: ""
+                            val saved = existingConfig?.openaiApiKey
+                            if (!saved.isNullOrBlank()) apiKey = saved
                         }
                         // OpenAI's OAuth and API-key model lists overlap on the main
                         // GPT-5.x entries but aren't identical — gpt-5.4-mini is

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -155,10 +156,14 @@ private object SetupSteps {
 fun SetupScreen(onSetupComplete: () -> Unit) {
     val context = LocalContext.current
 
-    // Pre-fill from existing config — reactive to ConfigManager.configVersion so any
-    // edit made in Settings while onboarding is on the back stack flows through here.
-    val configVersion = ConfigManager.configVersion.intValue
-    val existingConfig = remember(configVersion) { ConfigManager.loadConfig(context) }
+    // Load the persisted config ONCE on first composition — stored in a non-reactive
+    // remember so that OAuth token writes mid-onboarding (which bump ConfigManager's
+    // configVersion via persistOpenAIOAuthTokens) don't cascade into the form state
+    // below and wipe what the user has typed. The Settings screen still reacts to
+    // configVersion for its own reload; this local snapshot is only used to seed
+    // initial field values and to drive onProviderChange "preserve the other
+    // credential" restore logic.
+    val existingConfig = remember { ConfigManager.loadConfig(context) }
 
     // Fresh-install defaults land on OpenAI + OAuth (Sign in with ChatGPT) — it's the
     // first provider in the onboarding picker and the smoothest onboarding path (no
@@ -167,7 +172,12 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
     val initialProvider = existingConfig?.provider ?: "openai"
     val initialAuthType = existingConfig?.authType ?: "oauth"
 
-    var apiKey by remember(configVersion) {
+    // rememberSaveable is used for all form state so that:
+    //  1. Mid-flow recompositions triggered by OAuth token writes do NOT re-initialize
+    //     form fields from existingConfig (which would wipe a half-entered botToken).
+    //  2. The form also survives process death during onboarding (the Bundle saver
+    //     keeps these strings across activity recreation).
+    var apiKey by rememberSaveable {
         mutableStateOf(
             when (existingConfig?.provider) {
                 "openai" -> existingConfig.openaiApiKey
@@ -176,11 +186,11 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
             }
         )
     }
-    var authType by remember(configVersion) { mutableStateOf(initialAuthType) }
-    var scannedProvider by remember(configVersion) { mutableStateOf(initialProvider) }
-    var botToken by remember(configVersion) { mutableStateOf(existingConfig?.telegramBotToken ?: "") }
-    var ownerId by remember(configVersion) { mutableStateOf(existingConfig?.telegramOwnerId ?: "") }
-    var selectedModel by remember(configVersion) {
+    var authType by rememberSaveable { mutableStateOf(initialAuthType) }
+    var scannedProvider by rememberSaveable { mutableStateOf(initialProvider) }
+    var botToken by rememberSaveable { mutableStateOf(existingConfig?.telegramBotToken ?: "") }
+    var ownerId by rememberSaveable { mutableStateOf(existingConfig?.telegramOwnerId ?: "") }
+    var selectedModel by rememberSaveable {
         // Use the effective auth type so OpenAI+OAuth picks from the OAuth model list
         // (GPT-5.x Codex) instead of the API-key list — modelsForProvider throws for
         // openai when authType is null, so we must pass it through.
@@ -193,7 +203,7 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
             } ?: models.firstOrNull()?.id ?: availableModels[0].id
         )
     }
-    var agentName by remember(configVersion) { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }
+    var agentName by rememberSaveable { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var apiKeyError by remember { mutableStateOf<String?>(null) }
     var botTokenError by remember { mutableStateOf<String?>(null) }

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -251,8 +251,12 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     }
                     botToken = cfg.telegramBotToken
                     ownerId = cfg.telegramOwnerId
-                    // Setup uses api_key auth — see saveAndStart. Match the model list.
-                    val providerModels = modelsForProvider(cfg.provider, "api_key")
+                    // Match the model list to the imported config's effective auth type.
+                    // OpenAI's OAuth and API-key model lists differ (gpt-5.4-mini is
+                    // OAuth-only), so a QR config with provider=openai + authType=oauth
+                    // must validate against the OAuth list — not the API-key list.
+                    val qrModelAuthType = if (cfg.provider == "openai") cfg.authType else "api_key"
+                    val providerModels = modelsForProvider(cfg.provider, qrModelAuthType)
                     selectedModel = if (providerModels.isEmpty()) {
                         cfg.model // OpenRouter: accept freeform model as-is
                     } else {

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -564,14 +564,23 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                             "setup_token" -> "setup_token"
                             else -> "api_key"
                         }
-                        "openai" -> existingConfig?.let { cfg ->
-                            // Honour prior choice when we have one: oauth if that's
-                            // what was selected, or if there's already a token on
-                            // file; api_key otherwise (e.g. user set an OpenAI API
-                            // key directly in Settings).
-                            if (cfg.authType == "oauth" || cfg.openaiOAuthToken.isNotBlank()) "oauth"
+                        "openai" -> {
+                            // Read CURRENT persisted state, not the one-time
+                            // existingConfig snapshot. The user may have completed
+                            // OAuth during this session (tokens written via
+                            // persistOpenAIOAuthTokens, configVersion bumped) and
+                            // then switched providers away and back — the snapshot
+                            // would still show openaiOAuthToken = "" and incorrectly
+                            // default back to api_key. loadConfigOrBootstrap
+                            // bypasses the SETUP_COMPLETE gate so it works mid-
+                            // onboarding too.
+                            val current = ConfigManager.loadConfigOrBootstrap(context)
+                            val hasStoredOAuthToken = current.openaiOAuthToken.isNotBlank()
+                            val previouslySelectedOAuth =
+                                existingConfig?.authType == "oauth" || current.authType == "oauth"
+                            if (existingConfig == null || hasStoredOAuthToken || previouslySelectedOAuth) "oauth"
                             else "api_key"
-                        } ?: "oauth" // fresh install → default to Sign in with ChatGPT
+                        }
                         else -> "api_key"
                     }
                     authType = newAuthType

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -550,15 +550,21 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     //     coerce to the first valid entry when the stored model isn't.
                     val modelAuthType = if (newProvider == "openai") newAuthType else "api_key"
                     val models = modelsForProvider(newProvider, modelAuthType)
+                    // Capture existingConfig into a stable local so the null check
+                    // propagates cleanly (Kotlin doesn't smart-cast a nullable into
+                    // lambdas, so we need an already-non-null local to work with).
+                    val cfgModelForProvider = existingConfig
+                        ?.takeIf { it.provider == newProvider }
+                        ?.model
                     selectedModel = if (models.isEmpty()) {
-                        // Freeform (OpenRouter/custom): no validation possible
-                        if (newProvider == existingConfig?.provider) existingConfig.model
-                        else OPENROUTER_DEFAULT_MODEL
+                        // Freeform (OpenRouter/custom): no validation possible —
+                        // preserve the stored freeform model, fall back to default.
+                        cfgModelForProvider ?: OPENROUTER_DEFAULT_MODEL
                     } else {
-                        val existingModel = existingConfig?.model?.takeIf { m ->
-                            newProvider == existingConfig.provider && models.any { it.id == m }
-                        }
-                        existingModel ?: models[0].id
+                        // Fixed list: restore only if the stored model is still valid
+                        // for the effective auth type; otherwise coerce to first entry.
+                        cfgModelForProvider?.takeIf { m -> models.any { it.id == m } }
+                            ?: models[0].id
                     }
                 },
                 apiKey = apiKey,

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -387,6 +387,14 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                     setupToken = existing?.setupToken ?: "",
                     openaiApiKey = existing?.openaiApiKey ?: "",
                     openrouterApiKey = trimmedKey,
+                    // Preserve OAuth tokens even when saving as a different provider
+                    // — saveConfig writes all fields, so an empty default here would
+                    // wipe tokens the user set previously (or just set during this
+                    // session but then changed their mind about the provider).
+                    openaiOAuthToken = preservedOAuthToken,
+                    openaiOAuthRefresh = preservedOAuthRefresh,
+                    openaiOAuthEmail = preservedOAuthEmail,
+                    openaiOAuthExpiresAt = preservedOAuthExpiresAt,
                     provider = "openrouter",
                     authType = "api_key",
                     telegramBotToken = botToken.trim(),
@@ -403,6 +411,11 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
                         else (existing?.setupToken ?: ""),
                     openaiApiKey = existing?.openaiApiKey ?: "",
                     openrouterApiKey = existing?.openrouterApiKey ?: "",
+                    // Preserve OAuth tokens — same rationale as the openrouter branch.
+                    openaiOAuthToken = preservedOAuthToken,
+                    openaiOAuthRefresh = preservedOAuthRefresh,
+                    openaiOAuthEmail = preservedOAuthEmail,
+                    openaiOAuthExpiresAt = preservedOAuthExpiresAt,
                     provider = "claude",
                     authType = effectiveAuthType,
                     telegramBotToken = botToken.trim(),


### PR DESCRIPTION
## Summary

Two linked fixes that together blocked OpenAI OAuth onboarding on any fresh install, especially Pixel 7.

### 1. OAuth callback unreachable on Pixel 7 (IPv4/IPv6 loopback mismatch)

**Symptom:** Fresh install on Pixel 7 → Sign in with ChatGPT → browser opens, user authenticates, redirect to `http://localhost:1455/auth/callback` → blank "site can't be reached". Flow stalls indefinitely. Works on Seeker (IPv4-first), broken on Pixel 7 (IPv6-first on Android 14).

**Root cause:** `CallbackServer` was bound via literal `"localhost"`, so NanoHTTPD called `InetAddress.getByName("localhost")` — which on newer Android resolves to `::1` only. Chrome's Custom Tab on the same device resolves `"localhost"` to `127.0.0.1` for the redirect, so the callback hits a socket the server isn't listening on → connection refused.

The comment at line 53-54 previously dismissed the Copilot flag for exactly this as "theoretical." It was not theoretical — it reproduced on a real device as soon as we tested outside Seeker.

**Fix:** Bind NanoHTTPD via the no-hostname constructor (`NanoHTTPD(port)` → `0.0.0.0`), accepting both IPv4 and IPv6 loopback. Preserve the localhost-only security intent by validating `session.remoteIpAddress` in `serve()` — reject anything that isn't `127.0.0.0/8`, `::1`, or `0:0:0:0:0:0:0:1` with `403 Forbidden`. `REDIRECT_URI` stays as `http://localhost:1455/auth/callback` (OAuth client registration constraint, separate from the bind).

### 2. Fresh-install default provider was Anthropic/api_key, not OpenAI/OAuth

**Symptom:** On fresh install the provider picker on step 3 *visually* shows OpenAI first (per the BAT-487 reorder), but the underlying state still defaulted to `provider="claude"` + `authType="api_key"`. New users had to manually click OpenAI and the OAuth tab before they could Sign in with ChatGPT — the "smoothest onboarding path" was two clicks deeper than it should have been.

**Fix:** Hoist `initialProvider`/`initialAuthType` vals that default to `"openai"` / `"oauth"` when no `existingConfig` is present. Model list selection threads the effective auth type so OpenAI+OAuth picks from the GPT-5.x OAuth model list (not the API-key list — `modelsForProvider` throws for openai on null authType). `onProviderChange` also defaults fresh-install OpenAI switches to `oauth` for consistency, and its model-list lookup now honors the effective auth type.

The `NavButtons` `nextEnabled` gate (`oauthController.state.isConnected`) already blocks advancing past step 3 until the OAuth round-trip completes, so no new validation is needed.

## Test plan

- [ ] Fresh install on **Pixel 7** → step 3 lands on OpenAI + Sign in with ChatGPT (no clicks) → sign in → round-trip completes → shows "Connected as <email>"
- [ ] Fresh install on **Seeker** → same flow still works (no regression)
- [ ] External probe (curl from another host on same WiFi) to `http://<device-ip>:1455/auth/callback` → 403 Forbidden (localhost-only security preserved)
- [ ] Existing install with `provider="claude"` → step 3 still lands on Claude/api_key (existingConfig honored)
- [ ] Existing install with `provider="openai"` + `authType="api_key"` → step 3 still lands on OpenAI/api_key (existingConfig honored)
- [ ] Switch provider: Claude → OpenAI on fresh install → defaults to OAuth tab
- [ ] Switch provider: OpenAI → Claude → back to OpenAI → still defaults to OAuth tab
- [ ] Setup → Next button stays disabled on OpenAI/OAuth until sign-in succeeds

Blocks v1.9.0 release — RC4 is broken on Pixel 7 and has the wrong defaults. Needs RC5 after merge.

Generated with [Claude Code](https://claude.com/claude-code)