### PR TITLE
fix: rename silent-reply sentinel to [[SILENT_REPLY]] (BAT-491)

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -27,7 +27,7 @@ const deferStatus = CHANNEL === 'telegram' ? require('./telegram').deferStatus :
 const { httpStreamingRequest, httpOpenAIStreamingRequest, httpChatCompletionsStreamingRequest } = require('./http');
 const { getAdapter } = require('./providers');
 const { androidBridgeCall } = require('./bridge');
-const { stripSilentReply } = require('./silent-reply');
+const { stripSilentReply, TOKEN: SILENT_REPLY_TOKEN } = require('./silent-reply');
 
 const {
     loadSoul, loadBootstrap, loadIdentity, loadUser,
@@ -401,7 +401,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
         lines.push('Complete the task described in the user message efficiently and concisely.');
         lines.push(`Your output will be delivered to the owner via ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
         lines.push('Do not greet, do not ask follow-up questions — deliver the result directly.');
-        lines.push('If there is nothing to report, reply with the literal token [[SILENT_REPLY]] (include the double brackets exactly as shown).');
+        lines.push(`If there is nothing to report, reply with the literal token ${SILENT_REPLY_TOKEN} (include the double brackets exactly as shown).`);
         lines.push('Confirmation-gated tools (swaps, transfers) are NOT available in scheduled tasks.');
         lines.push('');
     }
@@ -885,7 +885,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('For any follow-up at a future time (reminders, run-later work, recurring tasks) use cron instead of shell_exec sleep, js_eval setTimeout loops, or process polling. Those waste tool rounds, burn battery, and die on restart.');
     lines.push('When a message starts with [cron:...], you are executing a scheduled task in an isolated session.');
     lines.push('Complete the task directly and concisely. Do not greet or ask follow-up questions — deliver results.');
-    lines.push('If nothing needs attention, reply with the literal token [[SILENT_REPLY]] (include the double brackets exactly as shown).');
+    lines.push(`If nothing needs attention, reply with the literal token ${SILENT_REPLY_TOKEN} (include the double brackets exactly as shown).`);
     lines.push('');
 
     // Authorized Senders section - OpenClaw style
@@ -909,22 +909,22 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     // without being over-stripped (BAT-491 follow-up to BAT-488 parity
     // port over-strip bug caught in BAT-489 device testing).
     lines.push('## Silent Replies');
-    lines.push(`Use the token \`[[SILENT_REPLY]]\` ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
+    lines.push(`Use the token \`${SILENT_REPLY_TOKEN}\` ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
     lines.push('');
     lines.push('⚠️ Rules:');
-    lines.push('- The canonical sentinel is `[[SILENT_REPLY]]` with the double brackets included exactly. That is the only form that will reliably suppress the outbound message.');
+    lines.push(`- The canonical sentinel is \`${SILENT_REPLY_TOKEN}\` with the double brackets included exactly. That is the only form that will reliably suppress the outbound message.`);
     lines.push('- Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.');
     lines.push('- Never use it to avoid doing requested work or to end an actionable turn early.');
-    lines.push('- When used as a signal, `[[SILENT_REPLY]]` must be your ENTIRE message — nothing else, no preamble, no trailing punctuation.');
+    lines.push(`- When used as a signal, \`${SILENT_REPLY_TOKEN}\` must be your ENTIRE message — nothing else, no preamble, no trailing punctuation.`);
     lines.push('- Never wrap it in markdown, code blocks, JSON, or any envelope form.');
     lines.push('');
     lines.push('### Discussing the protocol in a reply');
     lines.push('If the user asks you about silent replies, or you want to write a memory note about when you used one, you MAY write the bare word `SILENT_REPLY` (without brackets) freely in normal prose — that form is treated as discussion and passes through to the user untouched. You may also write "silent reply" (space) or "silent-reply" (hyphen). The brackets are reserved EXCLUSIVELY for the control signal.');
     lines.push('');
-    lines.push('❌ Wrong (inline sentinel — leaks or gets stripped): "Here\'s help... [[SILENT_REPLY]]"');
-    lines.push('❌ Wrong (wrapped): "**[[SILENT_REPLY]]**"');
-    lines.push('❌ Wrong (envelope): {"action":"[[SILENT_REPLY]]"}');
-    lines.push('✅ Right (signal — the entire message): [[SILENT_REPLY]]');
+    lines.push(`❌ Wrong (inline sentinel — leaks or gets stripped): "Here's help... ${SILENT_REPLY_TOKEN}"`);
+    lines.push(`❌ Wrong (wrapped): "**${SILENT_REPLY_TOKEN}**"`);
+    lines.push(`❌ Wrong (envelope): {"action":"${SILENT_REPLY_TOKEN}"}`);
+    lines.push(`✅ Right (signal — the entire message): ${SILENT_REPLY_TOKEN}`);
     lines.push('✅ Right (discussion — prose with bare word): "SILENT_REPLY is a token I use when there\'s nothing to send."');
     lines.push('');
 
@@ -2345,8 +2345,8 @@ async function chat(chatId, userMessage, options = {}) {
             // A text-only response (e.g. failed resume attempt) should not wipe checkpoints.
             if (toolUseCount > 0) cleanupChatCheckpoints(chatId);
             addToConversation(chatId, 'assistant', '[No response generated]');
-            log('No text content in response (no tools used), returning [[SILENT_REPLY]]', 'DEBUG');
-            return '[[SILENT_REPLY]]';
+            log(`No text content in response (no tools used), returning ${SILENT_REPLY_TOKEN}`, 'DEBUG');
+            return SILENT_REPLY_TOKEN;
         }
         const assistantMessage = textContent.text;
 

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -401,7 +401,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
         lines.push('Complete the task described in the user message efficiently and concisely.');
         lines.push(`Your output will be delivered to the owner via ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
         lines.push('Do not greet, do not ask follow-up questions — deliver the result directly.');
-        lines.push('If there is nothing to report, reply with SILENT_REPLY.');
+        lines.push('If there is nothing to report, reply with the literal token [[SILENT_REPLY]] (include the double brackets exactly as shown).');
         lines.push('Confirmation-gated tools (swaps, transfers) are NOT available in scheduled tasks.');
         lines.push('');
     }
@@ -885,7 +885,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('For any follow-up at a future time (reminders, run-later work, recurring tasks) use cron instead of shell_exec sleep, js_eval setTimeout loops, or process polling. Those waste tool rounds, burn battery, and die on restart.');
     lines.push('When a message starts with [cron:...], you are executing a scheduled task in an isolated session.');
     lines.push('Complete the task directly and concisely. Do not greet or ask follow-up questions — deliver results.');
-    lines.push('If nothing needs attention, reply SILENT_REPLY.');
+    lines.push('If nothing needs attention, reply with the literal token [[SILENT_REPLY]] (include the double brackets exactly as shown).');
     lines.push('');
 
     // Authorized Senders section - OpenClaw style
@@ -902,23 +902,30 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('If the work will take multiple steps or a while to finish, send one short progress update before or while acting.');
     lines.push('');
 
-    // Silent Replies section — OpenClaw parity (v2026.4.10 BAT-488)
-    // Tightened wording to stop models from using SILENT_REPLY to avoid work.
+    // Silent Replies section — BAT-491 sentinel rename.
+    // Canonical form is now [[SILENT_REPLY]] (double-bracketed). The
+    // brackets make the sentinel structurally distinguishable from natural
+    // prose so the agent can freely discuss the protocol in replies
+    // without being over-stripped (BAT-491 follow-up to BAT-488 parity
+    // port over-strip bug caught in BAT-489 device testing).
     lines.push('## Silent Replies');
-    lines.push(`Use SILENT_REPLY ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
+    lines.push(`Use the token \`[[SILENT_REPLY]]\` ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
     lines.push('');
     lines.push('⚠️ Rules:');
+    lines.push('- The canonical sentinel is `[[SILENT_REPLY]]` with the double brackets included exactly. That is the only form that will reliably suppress the outbound message.');
     lines.push('- Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.');
     lines.push('- Never use it to avoid doing requested work or to end an actionable turn early.');
-    lines.push('- It must be your ENTIRE message — nothing else.');
-    lines.push('- The only valid silent reply is the exact plain-text token SILENT_REPLY.');
-    lines.push('- Never append it to an actual response (never include "SILENT_REPLY" in real replies).');
+    lines.push('- When used as a signal, `[[SILENT_REPLY]]` must be your ENTIRE message — nothing else, no preamble, no trailing punctuation.');
     lines.push('- Never wrap it in markdown, code blocks, JSON, or any envelope form.');
     lines.push('');
-    lines.push('❌ Wrong: "Here\'s help... SILENT_REPLY"');
-    lines.push('❌ Wrong: "**SILENT_REPLY**"');
-    lines.push('❌ Wrong: {"action":"SILENT_REPLY"}');
-    lines.push('✅ Right: SILENT_REPLY');
+    lines.push('### Discussing the protocol in a reply');
+    lines.push('If the user asks you about silent replies, or you want to write a memory note about when you used one, you MAY write the bare word `SILENT_REPLY` (without brackets) freely in normal prose — that form is treated as discussion and passes through to the user untouched. You may also write "silent reply" (space) or "silent-reply" (hyphen). The brackets are reserved EXCLUSIVELY for the control signal.');
+    lines.push('');
+    lines.push('❌ Wrong (inline sentinel — leaks or gets stripped): "Here\'s help... [[SILENT_REPLY]]"');
+    lines.push('❌ Wrong (wrapped): "**[[SILENT_REPLY]]**"');
+    lines.push('❌ Wrong (envelope): {"action":"[[SILENT_REPLY]]"}');
+    lines.push('✅ Right (signal — the entire message): [[SILENT_REPLY]]');
+    lines.push('✅ Right (discussion — prose with bare word): "SILENT_REPLY is a token I use when there\'s nothing to send."');
     lines.push('');
 
     // Reply Tags section - OpenClaw style (Telegram-specific)
@@ -2330,15 +2337,16 @@ async function chat(chatId, userMessage, options = {}) {
             }
         }
 
-        // If no text and NO tools were used, return SILENT_REPLY (genuine silent response)
+        // If no text and NO tools were used, return the canonical silent-reply
+        // sentinel (BAT-491: [[SILENT_REPLY]] double-bracketed form).
         if (!textContent) {
             clearActiveTask(chatId);
             // Only clean up checkpoints if tools were used (task progressed).
             // A text-only response (e.g. failed resume attempt) should not wipe checkpoints.
             if (toolUseCount > 0) cleanupChatCheckpoints(chatId);
             addToConversation(chatId, 'assistant', '[No response generated]');
-            log('No text content in response (no tools used), returning SILENT_REPLY', 'DEBUG');
-            return 'SILENT_REPLY';
+            log('No text content in response (no tools used), returning [[SILENT_REPLY]]', 'DEBUG');
+            return '[[SILENT_REPLY]]';
         }
         const assistantMessage = textContent.text;
 

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -912,7 +912,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push(`Use the token \`${SILENT_REPLY_TOKEN}\` ONLY when no user-visible reply is required. SeekerClaw discards the message instead of sending it to ${CHANNEL === 'discord' ? 'Discord' : 'Telegram'}.`);
     lines.push('');
     lines.push('⚠️ Rules:');
-    lines.push(`- The canonical sentinel is \`${SILENT_REPLY_TOKEN}\` with the double brackets included exactly. That is the only form that will reliably suppress the outbound message.`);
+    lines.push(`- The canonical sentinel is \`${SILENT_REPLY_TOKEN}\` with the double brackets included exactly. Always emit this form for silent-reply signals. (SeekerClaw also accepts a bare \`SILENT_REPLY\` whole-message as a legacy form for backward compatibility, but the bracketed canonical form is what you should always write.)`);
     lines.push('- Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.');
     lines.push('- Never use it to avoid doing requested work or to end an actionable turn early.');
     lines.push(`- When used as a signal, \`${SILENT_REPLY_TOKEN}\` must be your ENTIRE message — nothing else, no preamble, no trailing punctuation.`);

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -32,6 +32,7 @@
 //   2. Left-glued:       "OK[[SILENT_REPLY]]"           → "OK"
 //   3. Both-sides glued: "foo[[SILENT_REPLY]]bar"       → "foobar"
 //   4. Mid-token spaced: "Hello [[SILENT_REPLY]] world" → "Hello world"
+//                        (surrounding spaces collapse to ONE space, not two)
 //   5. Markdown wrapped: "**[[SILENT_REPLY]]**"         → ""
 //   6. JSON envelope:    '{"action":"[[SILENT_REPLY]]"}' → ""
 //   7. Leading spaced:   "[[SILENT_REPLY]] hello"       → "hello"
@@ -85,7 +86,16 @@ const LEGACY_BARE_EXACT_REGEX = new RegExp(`^\\s*${LT}\\s*$`, 'i');
 //
 // The caller still handles markdown orphans and leading-whitespace trim
 // via MARKDOWN_WRAPPED_REGEX and LEADING_SPACED_REGEX below.
-const CANONICAL_STRIP_REGEX = new RegExp(T, 'gi');
+//
+// The strip pattern captures adjacent horizontal whitespace (space/tab,
+// NOT newlines) on both sides so stripSilentReply can collapse
+// "Hello [[SILENT_REPLY]] world" to "Hello world" (single space) instead
+// of "Hello  world" (double space left behind by a naked token strip).
+// The replacer logic lives in stripSilentReply — see the comment there.
+// Newlines are deliberately NOT in the boundary class so multi-line
+// structure is preserved: `Line 1\n[[SILENT_REPLY]]\nLine 2` → the token
+// is removed but the newlines stay, giving `Line 1\n\nLine 2`.
+const CANONICAL_STRIP_REGEX = new RegExp(`([ \\t]*)${T}([ \\t]*)`, 'gi');
 // Non-global twin for .test() — avoids the stateful lastIndex bug that
 // /g regexes have when reused across calls.
 const CANONICAL_TEST_REGEX = new RegExp(T, 'i');
@@ -197,7 +207,23 @@ function stripSilentReply(text) {
     const stripped = text
         .replace(MARKDOWN_WRAPPED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
-        .replace(CANONICAL_STRIP_REGEX, '')
+        // Replacer collapses surrounding horizontal whitespace:
+        //   "Hello [[SILENT_REPLY]] world"  → "Hello world"   (both sides → 1 space)
+        //   "done[[SILENT_REPLY]] and more" → "done and more" (trailing only → 1 space)
+        //   "hello [[SILENT_REPLY]]"        → "hello"         (leading only → 1 space, then .trim())
+        //   "OK[[SILENT_REPLY]]bar"          → "OKbar"         (neither side → empty)
+        //   "foo[[SILENT_REPLY]]bar"         → "foobar"        (neither side → empty)
+        //   "Handled it.[[SILENT_REPLY]]"   → "Handled it."   (neither side → empty)
+        // Rule: if EITHER side has horizontal whitespace, emit a single
+        // space so word boundaries are preserved. Only when there is NO
+        // whitespace on either side (glued case) do we emit empty. This
+        // prevents the "double space left behind by a naked strip" output
+        // bug Copilot flagged on PR #324 round 2 while still handling the
+        // fully-glued variants from round 1 correctly.
+        .replace(CANONICAL_STRIP_REGEX, (_match, before, after) => {
+            if (before || after) return ' ';
+            return '';
+        })
         .trim();
     // If the model wrapped the token in markdown and only orphan punctuation
     // remains, treat the whole message as silent.

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -242,6 +242,13 @@ function stripSilentReply(text) {
     // Only strips when the entire message is the wrapped bare token;
     // inline wrapped bare in prose still passes through as discussion.
     if (LEGACY_BARE_WRAPPED_EXACT_REGEX.test(text)) return '';
+    // Fast path: if no sentinel form is present in the text at all, return
+    // the trimmed text unchanged. This avoids the downstream "empty after
+    // strip" punct-only guard from accidentally suppressing legitimate
+    // punctuation-only replies like `[]`, `()`, or `**` that never
+    // contained a sentinel in the first place (flagged by Copilot round 5
+    // on PR #324).
+    if (!containsSilentReply(text)) return text.trim();
     const stripped = text
         .replace(MARKDOWN_WRAPPED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
@@ -264,7 +271,10 @@ function stripSilentReply(text) {
         })
         .trim();
     // If the model wrapped the token in markdown and only orphan punctuation
-    // remains, treat the whole message as silent.
+    // remains AFTER a sentinel was stripped, treat the whole message as
+    // silent. The `containsSilentReply(text)` guard above ensures this only
+    // runs when there was actually a sentinel in the input, so unrelated
+    // punctuation-only messages pass through unchanged.
     if (ONLY_MARKDOWN_PUNCT_REGEX.test(stripped)) return '';
     return stripped;
 }

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -27,16 +27,23 @@
 // passes through unchanged. This dual-recognition shim can be removed in a
 // future release once telemetry confirms the bracketed form is reliable.
 //
-// Handles failure modes the old `\b[[SILENT_REPLY]]\b` regex would miss:
-//   1. Leading glued:    "[[SILENT_REPLY]]hello"        → "hello"
-//   2. Mid-glued:        "Hello [[SILENT_REPLY]]world"  → "Hello world"
-//   3. Markdown wrapped: "**[[SILENT_REPLY]]**"         → ""
-//   4. JSON envelope:    '{"action":"[[SILENT_REPLY]]"}' → ""
-//   5. Leading spaced:   "[[SILENT_REPLY]] hello"       → "hello"
+// Variants that must all be stripped from mixed-content text:
+//   1. Right-glued:      "[[SILENT_REPLY]]hello"        → "hello"
+//   2. Left-glued:       "OK[[SILENT_REPLY]]"           → "OK"
+//   3. Both-sides glued: "foo[[SILENT_REPLY]]bar"       → "foobar"
+//   4. Mid-token spaced: "Hello [[SILENT_REPLY]] world" → "Hello world"
+//   5. Markdown wrapped: "**[[SILENT_REPLY]]**"         → ""
+//   6. JSON envelope:    '{"action":"[[SILENT_REPLY]]"}' → ""
+//   7. Leading spaced:   "[[SILENT_REPLY]] hello"       → "hello"
 //
-// Boundaries use ASCII `\w` lookbehind/lookahead (not Unicode property
-// escapes — those crash nodejs-mobile's V8 at module-load time; see the
-// BAT-489 comment in the earlier iteration for the full story).
+// The previous iteration of this file (bare `SILENT_REPLY`, BAT-488 port)
+// used ASCII `\w` lookbehind/lookahead boundaries to prevent false matches
+// inside identifiers like `MY_SILENT_REPLY_HANDLE`. That concern is moot
+// with the bracketed form — `[[` and `]]` cannot appear in any legitimate
+// identifier — so the canonical strip now uses plain literal matching
+// without boundary constraints. This catches the glued-left variant
+// (e.g. `OK[[SILENT_REPLY]]`) that the boundary-constrained form would
+// leak to the user (flagged by Copilot round 1 on PR #324).
 
 // The canonical sentinel. Wiki-link style: `[[...]]` cannot appear in
 // natural English prose, so the agent can freely say "the silent reply
@@ -62,44 +69,41 @@ const EXACT_REGEX = new RegExp(`^\\s*${T}\\s*$`, 'i');
 // as a standalone message. Inline bare is intentionally NOT matched.
 const LEGACY_BARE_EXACT_REGEX = new RegExp(`^\\s*${LT}\\s*$`, 'i');
 
-// Trailing canonical token (optionally preceded by whitespace or markdown
-// emphasis stars). Matches `something [[SILENT_REPLY]]` at end of message.
-const TRAILING_REGEX = new RegExp(`(?:^|\\s+|\\*+)${T}\\s*$`, 'gi');
+// Plain literal canonical strip — matches `[[SILENT_REPLY]]` wherever it
+// appears in the text, case-insensitive, no boundary constraints.
+//
+// WHY NO BOUNDARIES:
+//   The bracketed form is structurally unambiguous — `[[` and `]]` never
+//   appear in natural prose or legitimate identifiers, so there is no
+//   false-match surface to protect against. Left- and right-glued cases
+//   like `OK[[SILENT_REPLY]]` or `foo[[SILENT_REPLY]]bar` are always
+//   model-output bugs, and we WANT to strip them so the user doesn't see
+//   the sentinel leak. Adding word-boundary lookbehind/lookahead would
+//   cause those cases to silently leak (flagged by Copilot round 1 on
+//   PR #324: `OK[[SILENT_REPLY]]` wasn't being stripped because `K` is a
+//   word char).
+//
+// The caller still handles markdown orphans and leading-whitespace trim
+// via MARKDOWN_WRAPPED_REGEX and LEADING_SPACED_REGEX below.
+const CANONICAL_STRIP_REGEX = new RegExp(T, 'gi');
+// Non-global twin for .test() — avoids the stateful lastIndex bug that
+// /g regexes have when reused across calls.
+const CANONICAL_TEST_REGEX = new RegExp(T, 'i');
 
-// ASCII boundary fragments. Identical to BAT-489's rewrite — no Unicode
-// property escapes (those crash nodejs-mobile v18.20.4's V8).
-const IDENT_CHAR = '\\w';           // [A-Za-z0-9_]
-const CONTENT_CHAR = '[^\\W_]';     // [A-Za-z0-9]
-
-// Canonical token attached to following content (e.g. `[[SILENT_REPLY]]hello`).
-// The lookahead `(?=${IDENT_CHAR})` catches the glue; the outer lookbehind
-// `(?<!${IDENT_CHAR})` anchors the start to a non-word context so we don't
-// match inside a larger identifier. Two alternations handle the edge case
-// where the token has a trailing underscore glued to content.
-const LEADING_ATTACHED_PATTERN = `(?<!${IDENT_CHAR})(?:${T}\\s+)*(?:${T}_(?=${CONTENT_CHAR})|${T}(?=${IDENT_CHAR}))`;
-const LEADING_ATTACHED_REGEX = new RegExp(LEADING_ATTACHED_PATTERN, 'gi');
-const LEADING_ATTACHED_TEST = new RegExp(LEADING_ATTACHED_PATTERN, 'i');
-
-// Leading canonical form with whitespace after: "[[SILENT_REPLY]] The user..."
-// or "[[SILENT_REPLY]]\nhello".
+// Leading canonical form with whitespace after, repeated occurrences:
+// "[[SILENT_REPLY]] [[SILENT_REPLY]] hello" → "hello". This pass exists
+// to collapse repeated leading sentinels into a clean trim; the main
+// CANONICAL_STRIP_REGEX above would leave double spaces behind otherwise.
 const LEADING_SPACED_REGEX = new RegExp(`^(?:\\s*${T})+\\s*`, 'i');
-
-// Generic strip — canonical token in any position when not glued to an
-// identifier char on EITHER side. Catches `Hello [[SILENT_REPLY]] world`.
-// IMPORTANT: this only targets the bracketed canonical form. Bare
-// `SILENT_REPLY` inline in prose is NEVER stripped by this regex (or any
-// other in this file), which is the entire point of the rename.
-const WORD_BOUNDARY_PATTERN = `(?<!${IDENT_CHAR})${T}(?!${IDENT_CHAR})`;
-const WORD_BOUNDARY_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'gi');
-const TEST_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'i');
 
 // Markdown-wrapped canonical variants:
 //   **[[SILENT_REPLY]]**, *[[SILENT_REPLY]]*, `[[SILENT_REPLY]]`,
-//   ```[[SILENT_REPLY]]```, _[[SILENT_REPLY]]_, etc. Match the token plus
-//   its surrounding wrapper chars in one pass so we don't leave behind
-//   orphan punctuation like `****` or `\`\``.
+//   ```[[SILENT_REPLY]]```, _[[SILENT_REPLY]]_, etc.
+// Matches the token plus its surrounding wrapper chars in one pass so we
+// don't leave behind orphan punctuation like `****` or `\`\``. No left
+// boundary constraint — same rationale as CANONICAL_STRIP_REGEX.
 const MARKDOWN_WRAPPED_REGEX = new RegExp(
-    `(?<!${IDENT_CHAR})[\`*_~\\[\\]()<>]+\\s*${T}\\s*[\`*_~\\[\\]()<>]+`,
+    `[\`*_~\\[\\]()<>]+\\s*${T}\\s*[\`*_~\\[\\]()<>]+`,
     'gi'
 );
 
@@ -169,8 +173,14 @@ function isSilentReplyPayloadText(text) {
  *      `{"action":""}` string)
  *   2. Legacy bare whole-message short-circuit (safety net for agents that
  *      still emit the bare form as their entire message)
- *   3. Markdown-wrapped → leading-attached → leading-spaced → trailing →
- *      word-boundary passes, ALL targeting the canonical bracketed form only
+ *   3. Markdown-wrapped pass — strips wrapper+token+wrapper atoms together
+ *      so we don't leave behind orphan `****` or `\`\``
+ *   4. Leading-spaced pass — collapses repeated leading sentinels plus
+ *      their trailing whitespace so the result trims cleanly
+ *   5. Plain canonical strip — removes every remaining `[[SILENT_REPLY]]`
+ *      occurrence anywhere in the text, left-glued / right-glued / mid /
+ *      end — no boundary constraints because the bracketed form is
+ *      structurally unambiguous
  *
  * Bare `SILENT_REPLY` inline in prose is DELIBERATELY NOT stripped. That's
  * the whole point of the rename — discussion of the protocol passes
@@ -186,10 +196,8 @@ function stripSilentReply(text) {
     if (LEGACY_BARE_EXACT_REGEX.test(text)) return '';
     const stripped = text
         .replace(MARKDOWN_WRAPPED_REGEX, '')
-        .replace(LEADING_ATTACHED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
-        .replace(TRAILING_REGEX, '')
-        .replace(WORD_BOUNDARY_REGEX, '')
+        .replace(CANONICAL_STRIP_REGEX, '')
         .trim();
     // If the model wrapped the token in markdown and only orphan punctuation
     // remains, treat the whole message as silent.
@@ -201,7 +209,8 @@ function stripSilentReply(text) {
  * Quick "contains any silent-reply signal form" check for logging/audit hooks.
  *
  * Returns true when:
- *   - The canonical `[[SILENT_REPLY]]` token appears (inline, glued, or wrapped)
+ *   - The canonical `[[SILENT_REPLY]]` token appears ANYWHERE in the text
+ *     (inline, left-glued, right-glued, mid, wrapped — no boundary check)
  *   - The legacy bare `SILENT_REPLY` form is the ENTIRE trimmed message
  *   - A JSON envelope form is present (canonical or legacy inner action)
  *
@@ -210,8 +219,7 @@ function stripSilentReply(text) {
  */
 function containsSilentReply(text) {
     if (!text) return false;
-    return TEST_REGEX.test(text)
-        || LEADING_ATTACHED_TEST.test(text)
+    return CANONICAL_TEST_REGEX.test(text)
         || LEGACY_BARE_EXACT_REGEX.test(text)
         || isSilentReplyEnvelopeText(text);
 }

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -1,132 +1,103 @@
-// silent-reply.js — centralized SILENT_REPLY token handling.
+// silent-reply.js — centralized silent-reply token handling.
 //
-// Ported from OpenClaw's src/auto-reply/tokens.ts (v2026.4.10). We keep the
-// legacy SILENT_REPLY token instead of upstream's NO_REPLY so existing user
-// prompts/memory continue to work.
+// CANONICAL TOKEN: [[SILENT_REPLY]]  (double-bracketed, Wiki/Obsidian-link style)
 //
-// Handles failure modes the old `\bSILENT_REPLY\b` regex missed:
-//   1. Leading glued:    "SILENT_REPLYhello"        — \b fails between word chars
-//   2. Mid-glued:        "Hello SILENT_REPLYworld"  — same \b failure mid-message
-//   3. Underscore-glued: "SILENT_REPLY_hello"       — _ is a word char, \b fails
-//   4. Markdown wrapped: "**SILENT_REPLY**"         — leaves orphan punctuation
-//   5. JSON envelope:    '{"action":"SILENT_REPLY"}' — model emits structured form
-//   6. Leading spaced:   "SILENT_REPLY hello"       — \b ok but cleaner with own pass
+// Why brackets? The original bare `SILENT_REPLY` string collided with natural
+// English prose whenever the agent needed to *discuss* the protocol (e.g.
+// answering "What is SILENT_REPLY?"). Our aggressive strip passes would eat
+// legitimate mentions of the word inside sentences — the agent would write
+// "SILENT_REPLY is a token used for..." and the user would see "is a token
+// used for..." with the opening word removed. That over-strip was shipped
+// accidentally in the BAT-488 parity port and caught during BAT-489 device
+// testing.
 //
-// Boundaries use identifier-aware lookbehind/lookahead instead of `\b` so all
-// of the above strip cleanly without stripping legitimate identifier matches
-// like `MY_SILENT_REPLY_HANDLE`.
+// Disambiguation must be STRUCTURAL, not heuristic. The bracketed form
+// [[SILENT_REPLY]] cannot appear in natural English prose — it looks like
+// Wiki/Obsidian markup or a template variable, never a word. That
+// structurally prevents collision: the agent would never write
+// "[[SILENT_REPLY]] is a token used for..." in discussion.
+//
+// LEGACY COMPATIBILITY
+// --------------------
+// Existing agents (running older system prompts or mid-turn before they've
+// adapted to the new canonical form) may still emit bare `SILENT_REPLY`. To
+// protect those users' conversations, bare `SILENT_REPLY` is still honored
+// as a sentinel — but ONLY when it is the entire trimmed message. Inline
+// bare mentions in prose are never stripped, so discussion of the protocol
+// passes through unchanged. This dual-recognition shim can be removed in a
+// future release once telemetry confirms the bracketed form is reliable.
+//
+// Handles failure modes the old `\b[[SILENT_REPLY]]\b` regex would miss:
+//   1. Leading glued:    "[[SILENT_REPLY]]hello"        → "hello"
+//   2. Mid-glued:        "Hello [[SILENT_REPLY]]world"  → "Hello world"
+//   3. Markdown wrapped: "**[[SILENT_REPLY]]**"         → ""
+//   4. JSON envelope:    '{"action":"[[SILENT_REPLY]]"}' → ""
+//   5. Leading spaced:   "[[SILENT_REPLY]] hello"       → "hello"
+//
+// Boundaries use ASCII `\w` lookbehind/lookahead (not Unicode property
+// escapes — those crash nodejs-mobile's V8 at module-load time; see the
+// BAT-489 comment in the earlier iteration for the full story).
 
-const TOKEN = 'SILENT_REPLY';
+// The canonical sentinel. Wiki-link style: `[[...]]` cannot appear in
+// natural English prose, so the agent can freely say "the silent reply
+// token" or "SILENT_REPLY" (bare) in discussion without being over-stripped.
+const TOKEN = '[[SILENT_REPLY]]';
+
+// Legacy bare form — honored only as a whole-message match, never inline.
+const LEGACY_BARE_TOKEN = 'SILENT_REPLY';
 
 // Single source of truth: build all regexes from TOKEN so renaming the
-// protocol token is a one-line change.
+// protocol token is a one-line change. escapeRegex handles the `[` and `]`
+// metacharacters in the canonical form so they become literal in patterns.
 function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
 const T = escapeRegex(TOKEN);
+const LT = escapeRegex(LEGACY_BARE_TOKEN);
 
-// Exact match — "SILENT_REPLY" with optional surrounding whitespace
+// Exact match of the CANONICAL form — "[[SILENT_REPLY]]" with optional
+// surrounding whitespace. Case-insensitive.
 const EXACT_REGEX = new RegExp(`^\\s*${T}\\s*$`, 'i');
 
-// Trailing token (optionally preceded by whitespace or markdown emphasis stars)
+// Exact match of the LEGACY bare form — whole-message only. This is the
+// dual-recognition safety net for agents that still emit bare SILENT_REPLY
+// as a standalone message. Inline bare is intentionally NOT matched.
+const LEGACY_BARE_EXACT_REGEX = new RegExp(`^\\s*${LT}\\s*$`, 'i');
+
+// Trailing canonical token (optionally preceded by whitespace or markdown
+// emphasis stars). Matches `something [[SILENT_REPLY]]` at end of message.
 const TRAILING_REGEX = new RegExp(`(?:^|\\s+|\\*+)${T}\\s*$`, 'gi');
 
-// Two char-class fragments for boundary detection.
-// - IDENT_CHAR includes underscore — used for OUTER boundary lookbehind/ahead
-//   so legitimate identifiers like `MY_SILENT_REPLY_HANDLE` aren't mangled.
-// - CONTENT_CHAR excludes underscore — used to detect "token glued to a word"
-//   in the special `SILENT_REPLY_word` pass below.
-//
-// IMPORTANT: these use ASCII character classes, NOT Unicode property escapes
-// (`\p{L}\p{N}`). The Unicode-property-escape form worked on desktop Node 22
-// but crashed nodejs-mobile v18.20.4's V8 at module-load time with
-// "Invalid property name in character class" (discovered 2026-04-11 when
-// BAT-489 RC5 failed to start on device — the regex constructor threw during
-// require() and the entire Node runtime failed to initialize).
-//
-// Trade-off: `\w` in JavaScript is ASCII-only (`[A-Za-z0-9_]`), so a non-ASCII
-// letter adjacent to the token — e.g. `SILENT_REPLYこんにちは` — is NOT treated
-// as a boundary hit and the token IS stripped, leaving `こんにちは`. That's
-// the correct outcome for our use case (the model emits the token in ASCII
-// and we want to strip it regardless of what follows). The identifier
-// preservation case (`MY_SILENT_REPLY_HANDLE`) still works because the
-// surrounding `_` IS in `\w` so the lookbehind fires.
+// ASCII boundary fragments. Identical to BAT-489's rewrite — no Unicode
+// property escapes (those crash nodejs-mobile v18.20.4's V8).
 const IDENT_CHAR = '\\w';           // [A-Za-z0-9_]
-const CONTENT_CHAR = '[^\\W_]';     // [A-Za-z0-9] (word char minus underscore)
+const CONTENT_CHAR = '[^\\W_]';     // [A-Za-z0-9]
 
-// Token attached to following content, anywhere in the text. Two alternations:
-//   1. `SILENT_REPLY_` followed by letter/number → strip the trailing underscore too
-//      (catches `SILENT_REPLY_hello` cleanly → `hello`)
-//   2. `SILENT_REPLY` followed by any identifier char → strip just the token
-//      (catches `SILENT_REPLYhello` → `hello`)
-// Outer lookbehind requires non-identifier so identifiers like
-// `MY_SILENT_REPLY_HANDLE` don't match (preceding `_` is in IDENT).
-// Allows preceding repeated tokens ("SILENT_REPLY SILENT_REPLYhello").
+// Canonical token attached to following content (e.g. `[[SILENT_REPLY]]hello`).
+// The lookahead `(?=${IDENT_CHAR})` catches the glue; the outer lookbehind
+// `(?<!${IDENT_CHAR})` anchors the start to a non-word context so we don't
+// match inside a larger identifier. Two alternations handle the edge case
+// where the token has a trailing underscore glued to content.
 const LEADING_ATTACHED_PATTERN = `(?<!${IDENT_CHAR})(?:${T}\\s+)*(?:${T}_(?=${CONTENT_CHAR})|${T}(?=${IDENT_CHAR}))`;
 const LEADING_ATTACHED_REGEX = new RegExp(LEADING_ATTACHED_PATTERN, 'gi');
-// Non-global twin used by .test() to avoid stateful lastIndex bugs.
 const LEADING_ATTACHED_TEST = new RegExp(LEADING_ATTACHED_PATTERN, 'i');
 
-// Leading with any whitespace after: "SILENT_REPLY The user..." or "SILENT_REPLY\nhello"
+// Leading canonical form with whitespace after: "[[SILENT_REPLY]] The user..."
+// or "[[SILENT_REPLY]]\nhello".
 const LEADING_SPACED_REGEX = new RegExp(`^(?:\\s*${T})+\\s*`, 'i');
 
-// Generic strip — matches the token in any position when not glued to an
-// identifier char on EITHER side. Catches `Hello SILENT_REPLY world` and
-// preserves underscore-containing identifiers like `MY_SILENT_REPLY_HANDLE`.
-// NOTE: only used with .replace(). For .test() use TEST_REGEX (no /g flag) to
-// avoid the stateful lastIndex bug.
+// Generic strip — canonical token in any position when not glued to an
+// identifier char on EITHER side. Catches `Hello [[SILENT_REPLY]] world`.
+// IMPORTANT: this only targets the bracketed canonical form. Bare
+// `SILENT_REPLY` inline in prose is NEVER stripped by this regex (or any
+// other in this file), which is the entire point of the rename.
 const WORD_BOUNDARY_PATTERN = `(?<!${IDENT_CHAR})${T}(?!${IDENT_CHAR})`;
 const WORD_BOUNDARY_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'gi');
 const TEST_REGEX = new RegExp(WORD_BOUNDARY_PATTERN, 'i');
 
-/**
- * Exact silent-reply check. True only when the entire (trimmed) text is just
- * the token. Used for "should we reply at all?" gating.
- */
-function isSilentReplyText(text) {
-    if (!text) return false;
-    return EXACT_REGEX.test(text);
-}
-
-/**
- * JSON envelope check — catches `{"action":"SILENT_REPLY"}` shape. Some models
- * emit structured output instead of the bare token.
- */
-function isSilentReplyEnvelopeText(text) {
-    if (!text) return false;
-    const trimmed = text.trim();
-    // Case-insensitive contains check — model may emit lowercase variants.
-    if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}') ||
-        !trimmed.toUpperCase().includes(TOKEN.toUpperCase())) {
-        return false;
-    }
-    try {
-        const parsed = JSON.parse(trimmed);
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
-        const keys = Object.keys(parsed);
-        return keys.length === 1 && keys[0] === 'action'
-            && typeof parsed.action === 'string'
-            // Case-insensitive comparison — matches the rest of the SILENT_REPLY
-            // handling which uses /i flag throughout.
-            && parsed.action.trim().toUpperCase() === TOKEN.toUpperCase();
-    } catch (_) {
-        return false;
-    }
-}
-
-/**
- * Full silent-reply check — exact token OR JSON envelope. Use this at send
- * gates where either form should suppress the outbound message.
- */
-function isSilentReplyPayloadText(text) {
-    return isSilentReplyText(text) || isSilentReplyEnvelopeText(text);
-}
-
-// Markdown-wrapped variants the system prompt explicitly calls out as wrong:
-//   **SILENT_REPLY**, *SILENT_REPLY*, `SILENT_REPLY`, ```SILENT_REPLY```,
-//   _SILENT_REPLY_, [SILENT_REPLY], (SILENT_REPLY), <SILENT_REPLY>, ~SILENT_REPLY~
-// Lookbehind anchors the opening wrapper to a non-letter/number context so we
-// don't grab `_SILENT_REPLY_` out of `MY_SILENT_REPLY_HANDLE` (legitimate
-// identifier). Match the token + its surrounding wrapper chars in one pass so
-// we don't leave behind orphan punctuation like `****` or `\`\``.
+// Markdown-wrapped canonical variants:
+//   **[[SILENT_REPLY]]**, *[[SILENT_REPLY]]*, `[[SILENT_REPLY]]`,
+//   ```[[SILENT_REPLY]]```, _[[SILENT_REPLY]]_, etc. Match the token plus
+//   its surrounding wrapper chars in one pass so we don't leave behind
+//   orphan punctuation like `****` or `\`\``.
 const MARKDOWN_WRAPPED_REGEX = new RegExp(
     `(?<!${IDENT_CHAR})[\`*_~\\[\\]()<>]+\\s*${T}\\s*[\`*_~\\[\\]()<>]+`,
     'gi'
@@ -139,24 +110,80 @@ const MARKDOWN_WRAPPED_REGEX = new RegExp(
 const ONLY_MARKDOWN_PUNCT_REGEX = /^[\s`*_~\[\]()<>]*$/;
 
 /**
- * Strip all SILENT_REPLY occurrences from mixed-content text. Runs the passes
- * in order: JSON envelope short-circuit → markdown-wrapped → leading-attached →
- * leading-spaced → trailing → word-boundary. Returns the cleaned text (trimmed).
+ * Exact silent-reply check. True when the entire (trimmed) text is the
+ * canonical `[[SILENT_REPLY]]` token OR the legacy bare `SILENT_REPLY`
+ * token. Used for "should we reply at all?" gating.
+ *
+ * Inline bare mentions of SILENT_REPLY in prose return FALSE — that's
+ * discussion, not a sentinel.
+ */
+function isSilentReplyText(text) {
+    if (!text) return false;
+    return EXACT_REGEX.test(text) || LEGACY_BARE_EXACT_REGEX.test(text);
+}
+
+/**
+ * JSON envelope check — catches `{"action":"[[SILENT_REPLY]]"}` OR the
+ * legacy `{"action":"SILENT_REPLY"}` shape. Some models emit structured
+ * output instead of the bare token.
+ */
+function isSilentReplyEnvelopeText(text) {
+    if (!text) return false;
+    const trimmed = text.trim();
+    if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}')) return false;
+    const upper = trimmed.toUpperCase();
+    // Early reject if neither form appears anywhere in the string — saves
+    // the JSON.parse cost on normal JSON payloads.
+    if (!upper.includes(TOKEN.toUpperCase()) &&
+        !upper.includes(LEGACY_BARE_TOKEN.toUpperCase())) {
+        return false;
+    }
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+        const keys = Object.keys(parsed);
+        if (keys.length !== 1 || keys[0] !== 'action') return false;
+        if (typeof parsed.action !== 'string') return false;
+        const action = parsed.action.trim().toUpperCase();
+        return action === TOKEN.toUpperCase() ||
+               action === LEGACY_BARE_TOKEN.toUpperCase();
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * Full silent-reply check — exact token (canonical or legacy) OR JSON
+ * envelope. Use this at send gates where either form should suppress the
+ * outbound message.
+ */
+function isSilentReplyPayloadText(text) {
+    return isSilentReplyText(text) || isSilentReplyEnvelopeText(text);
+}
+
+/**
+ * Strip all canonical silent-reply occurrences from mixed-content text.
+ *
+ * Order matters:
+ *   1. JSON envelope short-circuit (otherwise token strip leaves a mangled
+ *      `{"action":""}` string)
+ *   2. Legacy bare whole-message short-circuit (safety net for agents that
+ *      still emit the bare form as their entire message)
+ *   3. Markdown-wrapped → leading-attached → leading-spaced → trailing →
+ *      word-boundary passes, ALL targeting the canonical bracketed form only
+ *
+ * Bare `SILENT_REPLY` inline in prose is DELIBERATELY NOT stripped. That's
+ * the whole point of the rename — discussion of the protocol passes
+ * through unchanged. The trade-off: if an older agent falls back to bare
+ * inline (e.g. "Handled it. SILENT_REPLY"), the user sees it raw. Rare
+ * and recoverable, vs. the over-strip bug which was a certainty.
+ *
  * An empty result means the entire message should be treated as silent.
- *
- * Short-circuits to '' for:
- *   - Exact `{"action":"SILENT_REPLY"}` envelope (otherwise the token strip
- *     would leave a mangled `{"action":""}` JSON string)
- *   - Result that is only whitespace + markdown punctuation after stripping
- *     (otherwise `**SILENT_REPLY**` would leave orphan `****`)
- *
- * Replaces the old inline pattern:
- *   .replace(/(?:^|\s+|\*+)SILENT_REPLY\s*$/gi, '').replace(/\bSILENT_REPLY\b/gi, '')
- * which missed leading-attached, JSON envelope, and markdown-wrapped cases.
  */
 function stripSilentReply(text) {
     if (!text) return '';
     if (isSilentReplyEnvelopeText(text)) return '';
+    if (LEGACY_BARE_EXACT_REGEX.test(text)) return '';
     const stripped = text
         .replace(MARKDOWN_WRAPPED_REGEX, '')
         .replace(LEADING_ATTACHED_REGEX, '')
@@ -171,21 +198,27 @@ function stripSilentReply(text) {
 }
 
 /**
- * Quick "contains any silent-reply form" check for logging/audit hooks.
- * Uses the non-global TEST_REGEX so repeated calls aren't stateful via
- * lastIndex (which would flip true→false intermittently with /g).
- * Also catches the leading-attached form (`SILENT_REPLYhello`) and the
- * JSON envelope form so audit logs match what stripSilentReply() can strip.
+ * Quick "contains any silent-reply signal form" check for logging/audit hooks.
+ *
+ * Returns true when:
+ *   - The canonical `[[SILENT_REPLY]]` token appears (inline, glued, or wrapped)
+ *   - The legacy bare `SILENT_REPLY` form is the ENTIRE trimmed message
+ *   - A JSON envelope form is present (canonical or legacy inner action)
+ *
+ * Inline bare `SILENT_REPLY` in prose returns FALSE — that's discussion,
+ * not a signal.
  */
 function containsSilentReply(text) {
     if (!text) return false;
     return TEST_REGEX.test(text)
         || LEADING_ATTACHED_TEST.test(text)
+        || LEGACY_BARE_EXACT_REGEX.test(text)
         || isSilentReplyEnvelopeText(text);
 }
 
 module.exports = {
     TOKEN,
+    LEGACY_BARE_TOKEN,
     isSilentReplyText,
     isSilentReplyEnvelopeText,
     isSilentReplyPayloadText,

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -70,6 +70,21 @@ const EXACT_REGEX = new RegExp(`^\\s*${T}\\s*$`, 'i');
 // as a standalone message. Inline bare is intentionally NOT matched.
 const LEGACY_BARE_EXACT_REGEX = new RegExp(`^\\s*${LT}\\s*$`, 'i');
 
+// Whole-message markdown-wrapped LEGACY bare form. The old silent-reply
+// module used to strip `**SILENT_REPLY**`, `` `SILENT_REPLY` ``,
+// `_SILENT_REPLY_`, etc. as sentinels — an agent running an older system
+// prompt may still emit these as their entire message. We preserve that
+// behavior BUT only for whole-message matches, so an agent that writes
+// "When I say **SILENT_REPLY** I mean stay quiet" in normal prose is NOT
+// over-stripped (that's discussion, same as bare inline).
+//
+// The wrapper char class matches MARKDOWN_WRAPPED_REGEX's below so the
+// set of accepted wrapper forms is consistent across canonical and legacy.
+const LEGACY_BARE_WRAPPED_EXACT_REGEX = new RegExp(
+    `^[\\s\`*_~\\[\\]()<>]*${LT}[\\s\`*_~\\[\\]()<>]*$`,
+    'i'
+);
+
 // Plain literal canonical strip — matches `[[SILENT_REPLY]]` wherever it
 // appears in the text, case-insensitive, no boundary constraints.
 //
@@ -124,16 +139,21 @@ const MARKDOWN_WRAPPED_REGEX = new RegExp(
 const ONLY_MARKDOWN_PUNCT_REGEX = /^[\s`*_~\[\]()<>]*$/;
 
 /**
- * Exact silent-reply check. True when the entire (trimmed) text is the
- * canonical `[[SILENT_REPLY]]` token OR the legacy bare `SILENT_REPLY`
- * token. Used for "should we reply at all?" gating.
+ * Exact silent-reply check. True when the entire (trimmed) text is:
+ *   - the canonical `[[SILENT_REPLY]]` token (EXACT_REGEX), OR
+ *   - the legacy bare `SILENT_REPLY` token (LEGACY_BARE_EXACT_REGEX), OR
+ *   - a markdown-wrapped legacy form like `**SILENT_REPLY**` or
+ *     `` `SILENT_REPLY` `` as the WHOLE message
+ *     (LEGACY_BARE_WRAPPED_EXACT_REGEX)
  *
  * Inline bare mentions of SILENT_REPLY in prose return FALSE — that's
  * discussion, not a sentinel.
  */
 function isSilentReplyText(text) {
     if (!text) return false;
-    return EXACT_REGEX.test(text) || LEGACY_BARE_EXACT_REGEX.test(text);
+    return EXACT_REGEX.test(text)
+        || LEGACY_BARE_EXACT_REGEX.test(text)
+        || LEGACY_BARE_WRAPPED_EXACT_REGEX.test(text);
 }
 
 /**
@@ -183,11 +203,15 @@ function isSilentReplyPayloadText(text) {
  *      `{"action":""}` string)
  *   2. Legacy bare whole-message short-circuit (safety net for agents that
  *      still emit the bare form as their entire message)
- *   3. Markdown-wrapped pass — strips wrapper+token+wrapper atoms together
- *      so we don't leave behind orphan `****` or `\`\``
- *   4. Leading-spaced pass — collapses repeated leading sentinels plus
+ *   3. Legacy bare markdown-wrapped whole-message short-circuit — catches
+ *      `**SILENT_REPLY**`, `` `SILENT_REPLY` ``, `_SILENT_REPLY_`, etc.
+ *      when they are the ENTIRE message. Older agents running the pre-
+ *      BAT-491 system prompt may still emit these.
+ *   4. Markdown-wrapped canonical pass — strips wrapper+token+wrapper
+ *      atoms together so we don't leave behind orphan `****` or `\`\``
+ *   5. Leading-spaced pass — collapses repeated leading sentinels plus
  *      their trailing whitespace so the result trims cleanly
- *   5. Plain canonical strip — removes every remaining `[[SILENT_REPLY]]`
+ *   6. Plain canonical strip — removes every remaining `[[SILENT_REPLY]]`
  *      occurrence anywhere in the text, left-glued / right-glued / mid /
  *      end — no boundary constraints because the bracketed form is
  *      structurally unambiguous
@@ -204,6 +228,11 @@ function stripSilentReply(text) {
     if (!text) return '';
     if (isSilentReplyEnvelopeText(text)) return '';
     if (LEGACY_BARE_EXACT_REGEX.test(text)) return '';
+    // Legacy whole-message markdown-wrapped form (`**SILENT_REPLY**`,
+    // `` `SILENT_REPLY` ``, etc.) — older agents may still emit this.
+    // Only strips when the entire message is the wrapped bare token;
+    // inline wrapped bare in prose still passes through as discussion.
+    if (LEGACY_BARE_WRAPPED_EXACT_REGEX.test(text)) return '';
     const stripped = text
         .replace(MARKDOWN_WRAPPED_REGEX, '')
         .replace(LEADING_SPACED_REGEX, '')
@@ -247,6 +276,7 @@ function containsSilentReply(text) {
     if (!text) return false;
     return CANONICAL_TEST_REGEX.test(text)
         || LEGACY_BARE_EXACT_REGEX.test(text)
+        || LEGACY_BARE_WRAPPED_EXACT_REGEX.test(text)
         || isSilentReplyEnvelopeText(text);
 }
 

--- a/app/src/main/assets/nodejs-project/silent-reply.js
+++ b/app/src/main/assets/nodejs-project/silent-reply.js
@@ -78,10 +78,19 @@ const LEGACY_BARE_EXACT_REGEX = new RegExp(`^\\s*${LT}\\s*$`, 'i');
 // "When I say **SILENT_REPLY** I mean stay quiet" in normal prose is NOT
 // over-stripped (that's discussion, same as bare inline).
 //
+// Requires AT LEAST ONE wrapper character on each side (the `+`
+// quantifiers on the wrapper char class). This is important:
+//   - With `*` (zero-or-more), the regex would also match plain bare
+//     `SILENT_REPLY` and `  SILENT_REPLY  `, making LEGACY_BARE_EXACT_REGEX
+//     redundant and the intent unclear. The `+` enforces "there must be
+//     a wrapper, this isn't just the bare form."
+//   - Whitespace is allowed separately (outside the wrapper quantifier)
+//     so `  **SILENT_REPLY**  ` still matches via `<ws>**<token>**<ws>`.
+//
 // The wrapper char class matches MARKDOWN_WRAPPED_REGEX's below so the
 // set of accepted wrapper forms is consistent across canonical and legacy.
 const LEGACY_BARE_WRAPPED_EXACT_REGEX = new RegExp(
-    `^[\\s\`*_~\\[\\]()<>]*${LT}[\\s\`*_~\\[\\]()<>]*$`,
+    `^\\s*[\`*_~\\[\\]()<>]+\\s*${LT}\\s*[\`*_~\\[\\]()<>]+\\s*$`,
     'i'
 );
 

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -56,7 +56,14 @@ const cases = [
     ['canonical glued-left (sentence tail)',   'Handled it.[[SILENT_REPLY]]',                   'Handled it.',                true],
     ['canonical glued-both-sides',             'foo[[SILENT_REPLY]]bar',                        'foobar',                     true],
     ['canonical glued-left then space+word',   'done[[SILENT_REPLY]] and more',                 'done and more',              true],
-    ['canonical mid-token space bounded',      'Hello [[SILENT_REPLY]] world',                  'Hello  world',               true],
+    // Mid-token with spaces on both sides — strip collapses to a SINGLE space,
+    // not a double space. Verifies the whitespace-aware replacer in stripSilentReply
+    // (Copilot PR #324 round 2 flagged the previous double-space behavior).
+    ['canonical mid-token space bounded',      'Hello [[SILENT_REPLY]] world',                  'Hello world',                true],
+    ['canonical mid-token tab bounded',        'Hello\t[[SILENT_REPLY]]\tworld',                'Hello world',                true],
+    // Multi-line structure preserved — newlines are NOT consumed by the
+    // whitespace-collapse replacer, so paragraph breaks stay intact.
+    ['canonical mid-token newline preserved',  'Line 1\n[[SILENT_REPLY]]\nLine 2',              'Line 1\n\nLine 2',           true],
     ['canonical repeated leading',             '[[SILENT_REPLY]] [[SILENT_REPLY]]',             '',                           true],
     ['canonical repeat then glued',            '[[SILENT_REPLY]] [[SILENT_REPLY]]hello',        'hello',                      true],
     ['canonical bold wrapped',                 '**[[SILENT_REPLY]]**',                          '',                           true],

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -39,10 +39,13 @@
 //
 // Coverage sections:
 //   1. Canonical [[SILENT_REPLY]] form — stripped aggressively
-//   2. Legacy bare SILENT_REPLY — whole-message only (compat safety net)
+//   2. Legacy bare SILENT_REPLY — whole-message only (compat safety net),
+//      including markdown-wrapped variants like **SILENT_REPLY**
 //   3. Protocol discussion — bare inline passes through (THE BAT-491 FIX)
 //   4. Identifier preservation — MY_SILENT_REPLY_HANDLE stays intact
 //   5. Plain text passthrough
+//   6. Punctuation-only passthrough — `[]`, `()`, `**`, etc. are kept
+//      when no sentinel was present (Copilot round 5 on PR #324)
 
 const path = require('path');
 const sr = require(path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project', 'silent-reply.js'));

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -99,6 +99,11 @@ const cases = [
     ['legacy wrapped italic bare',             '_SILENT_REPLY_',                                '',                           true],
     ['legacy wrapped tilde bare',              '~SILENT_REPLY~',                                '',                           true],
     ['legacy wrapped with whitespace padding', '  **SILENT_REPLY**  ',                          '',                           true],
+    // Mixed wrappers — require at least one wrapper char on each side, so
+    // `(SILENT_REPLY)` and similar alternation patterns still qualify.
+    ['legacy wrapped parens bare',             '(SILENT_REPLY)',                                '',                           true],
+    ['legacy wrapped brackets bare',           '[SILENT_REPLY]',                                '',                           true],
+    ['legacy wrapped angle bare',              '<SILENT_REPLY>',                                '',                           true],
 
     // ── Section 3: protocol discussion (THE BAT-491 FIX) ────────────────
     // These all contain the literal bare `SILENT_REPLY` string INLINE in

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// silent-reply.test.js — unit tests for the centralized SILENT_REPLY token
+// silent-reply.test.js — unit tests for the centralized silent-reply token
 // handling in app/src/main/assets/nodejs-project/silent-reply.js.
 //
 // Run:  node tests/nodejs-project/silent-reply.test.js
@@ -9,11 +9,25 @@
 // --------------------
 // silent-reply.js is critical — it gates whether the agent sends a message
 // to the user at all. A regression here is user-visible (either stray tokens
-// leak into chat, or legitimate replies get swallowed). On 2026-04-11 the
-// file shipped with a Unicode-property-escape regex (`\p{L}\p{N}`) that
-// crashed nodejs-mobile's V8 at module load; we rewrote it to ASCII `\w`
-// boundaries. These cases lock in the ASCII boundary semantics so future
-// rewrites can't silently regress.
+// leak into chat, or legitimate replies get swallowed).
+//
+// History:
+//   - 2026-04-11 (BAT-489): file shipped with a Unicode-property-escape
+//     regex (`\p{L}\p{N}`) that crashed nodejs-mobile's V8 at module load.
+//     Rewrote to ASCII `\w` boundaries. These cases lock in the ASCII
+//     boundary semantics so future rewrites can't silently regress.
+//   - 2026-04-11 (BAT-491): renamed the canonical sentinel from
+//     `SILENT_REPLY` to `[[SILENT_REPLY]]` because the bare form collided
+//     with natural prose when the agent discussed the protocol. Bare
+//     whole-message is still honored as a legacy backward-compat sentinel;
+//     bare inline is now discussion that passes through untouched.
+//
+// Coverage sections:
+//   1. Canonical [[SILENT_REPLY]] form — stripped aggressively
+//   2. Legacy bare SILENT_REPLY — whole-message only (compat safety net)
+//   3. Protocol discussion — bare inline passes through (THE BAT-491 FIX)
+//   4. Identifier preservation — MY_SILENT_REPLY_HANDLE stays intact
+//   5. Plain text passthrough
 
 const path = require('path');
 const sr = require(path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project', 'silent-reply.js'));
@@ -21,42 +35,48 @@ const sr = require(path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'as
 const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
 const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
 const RESET = '\x1b[0m';
 
-// [label, input, expected stripSilentReply, expected containsSilentReply]
+// [label, input, expected stripSilentReply output, expected containsSilentReply]
 const cases = [
-    // --- Exact / standalone
-    ['exact token',                     'SILENT_REPLY',                               '',                             true],
-    ['exact with surrounding whitespace', '  SILENT_REPLY  ',                          '',                             true],
-    ['lowercase exact (case insensitive)', 'silent_reply',                             '',                             true],
+    // ── Section 1: canonical [[SILENT_REPLY]] form ──────────────────────
+    ['canonical exact',                        '[[SILENT_REPLY]]',                              '',                           true],
+    ['canonical exact with whitespace',        '  [[SILENT_REPLY]]  ',                          '',                           true],
+    ['canonical lowercase (case insensitive)', '[[silent_reply]]',                              '',                           true],
+    ['canonical leading-spaced',               '[[SILENT_REPLY]] hello',                        'hello',                      true],
+    ['canonical leading-spaced newline',       '[[SILENT_REPLY]]\nhello',                       'hello',                      true],
+    ['canonical leading-glued',                '[[SILENT_REPLY]]hello',                         'hello',                      true],
+    ['canonical mid-token space bounded',      'Hello [[SILENT_REPLY]] world',                  'Hello  world',               true],
+    ['canonical repeated leading',             '[[SILENT_REPLY]] [[SILENT_REPLY]]',             '',                           true],
+    ['canonical repeat then glued',            '[[SILENT_REPLY]] [[SILENT_REPLY]]hello',        'hello',                      true],
+    ['canonical bold wrapped',                 '**[[SILENT_REPLY]]**',                          '',                           true],
+    ['canonical code wrapped',                 '`[[SILENT_REPLY]]`',                            '',                           true],
+    ['canonical json envelope',                '{"action":"[[SILENT_REPLY]]"}',                 '',                           true],
 
-    // --- Leading-spaced form ("SILENT_REPLY <content>")
-    ['leading spaced',                  'SILENT_REPLY hello',                         'hello',                        true],
-    ['leading spaced newline',          'SILENT_REPLY\nhello',                        'hello',                        true],
+    // ── Section 2: legacy bare-form whole-message (backward compat) ─────
+    ['legacy bare exact',                      'SILENT_REPLY',                                  '',                           true],
+    ['legacy bare with whitespace',            '  SILENT_REPLY  ',                              '',                           true],
+    ['legacy bare lowercase',                  'silent_reply',                                  '',                           true],
+    ['legacy json envelope bare',              '{"action":"SILENT_REPLY"}',                     '',                           true],
 
-    // --- Leading-glued form ("SILENT_REPLYhello")
-    ['leading glued',                   'SILENT_REPLYhello',                          'hello',                        true],
-    ['leading underscore-glued',        'SILENT_REPLY_hello',                         'hello',                        true],
+    // ── Section 3: protocol discussion (THE BAT-491 FIX) ────────────────
+    // These all contain the literal bare `SILENT_REPLY` string INLINE in
+    // normal prose. Expectation: pass through UNCHANGED, containsSilentReply
+    // returns false. This is what the old regex would break (over-strip).
+    // If any case in this section fails, we've regressed.
+    ['discussion: leading bare',               'SILENT_REPLY is a special internal token I use when I should do work silently.', 'SILENT_REPLY is a special internal token I use when I should do work silently.', false],
+    ['discussion: mid bare',                   'If I send SILENT_REPLY by itself, SeekerClaw discards the message.', 'If I send SILENT_REPLY by itself, SeekerClaw discards the message.', false],
+    ['discussion: trailing bare',              'The token is called SILENT_REPLY',              'The token is called SILENT_REPLY', false],
+    ['discussion: multiple inline bares',      'Use SILENT_REPLY when you have nothing to say. SILENT_REPLY is NOT a shortcut.', 'Use SILENT_REPLY when you have nothing to say. SILENT_REPLY is NOT a shortcut.', false],
 
-    // --- Mid-glued and multi-token
-    ['mid token, space bounded',        'Hello SILENT_REPLY world',                   'Hello  world',                 true],
-    ['repeated leading tokens',         'SILENT_REPLY SILENT_REPLY',                  '',                             true],
-    ['repeat then glued',               'SILENT_REPLY SILENT_REPLYhello',             'hello',                        true],
+    // ── Section 4: identifier preservation (must NOT strip or flag) ─────
+    ['identifier: underscore-bounded',         'MY_SILENT_REPLY_HANDLE',                        'MY_SILENT_REPLY_HANDLE',     false],
+    ['identifier: word glue both sides',       'testSILENT_REPLYbar',                           'testSILENT_REPLYbar',        false],
 
-    // --- Markdown-wrapped
-    ['bold wrapped',                    '**SILENT_REPLY**',                           '',                             true],
-    ['code wrapped',                    '`SILENT_REPLY`',                             '',                             true],
-
-    // --- JSON envelope
-    ['json envelope exact',             '{"action":"SILENT_REPLY"}',                  '',                             true],
-
-    // --- Identifier preservation (must NOT strip or report as match)
-    ['identifier with both-side glue',  'MY_SILENT_REPLY_HANDLE',                     'MY_SILENT_REPLY_HANDLE',       false],
-    ['identifier word glue',            'testSILENT_REPLYbar',                        'testSILENT_REPLYbar',          false],
-
-    // --- Plain text should be unchanged
-    ['regular sentence',                'Just a regular message',                     'Just a regular message',       false],
-    ['empty string',                    '',                                           '',                             false],
+    // ── Section 5: plain text passthrough ───────────────────────────────
+    ['regular sentence',                       'Just a regular message with no sentinel.',      'Just a regular message with no sentinel.', false],
+    ['empty string',                           '',                                              '',                           false],
 ];
 
 let pass = 0;
@@ -77,7 +97,7 @@ for (const [label, input, expectStrip, expectContains] of cases) {
     }
 }
 
-console.log(`\nsilent-reply.js — ${cases.length} cases`);
+console.log(`\n${BOLD}silent-reply.js${RESET} — ${cases.length} cases`);
 console.log(`${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}`);
 if (fail === 0) {
     console.log(`${GREEN}✓${RESET} ${pass}/${cases.length} passed`);

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -47,6 +47,15 @@ const cases = [
     ['canonical leading-spaced',               '[[SILENT_REPLY]] hello',                        'hello',                      true],
     ['canonical leading-spaced newline',       '[[SILENT_REPLY]]\nhello',                       'hello',                      true],
     ['canonical leading-glued',                '[[SILENT_REPLY]]hello',                         'hello',                      true],
+    // ── Glued-LEFT cases (Copilot PR #324 round 1) — model appends sentinel ──
+    // directly to a real reply without a separating space. These MUST be
+    // stripped so the sentinel doesn't leak to the user. Since [[...]] is
+    // structurally unambiguous, the canonical strip has no left-boundary
+    // constraint.
+    ['canonical glued-left (word)',            'OK[[SILENT_REPLY]]',                            'OK',                         true],
+    ['canonical glued-left (sentence tail)',   'Handled it.[[SILENT_REPLY]]',                   'Handled it.',                true],
+    ['canonical glued-both-sides',             'foo[[SILENT_REPLY]]bar',                        'foobar',                     true],
+    ['canonical glued-left then space+word',   'done[[SILENT_REPLY]] and more',                 'done and more',              true],
     ['canonical mid-token space bounded',      'Hello [[SILENT_REPLY]] world',                  'Hello  world',               true],
     ['canonical repeated leading',             '[[SILENT_REPLY]] [[SILENT_REPLY]]',             '',                           true],
     ['canonical repeat then glued',            '[[SILENT_REPLY]] [[SILENT_REPLY]]hello',        'hello',                      true],

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -14,13 +14,28 @@
 // History:
 //   - 2026-04-11 (BAT-489): file shipped with a Unicode-property-escape
 //     regex (`\p{L}\p{N}`) that crashed nodejs-mobile's V8 at module load.
-//     Rewrote to ASCII `\w` boundaries. These cases lock in the ASCII
-//     boundary semantics so future rewrites can't silently regress.
+//     Rewrote the regex compilation to be compatible with Node 18's V8.
+//     The current implementation was rewritten again for BAT-491; these
+//     tests lock in the externally visible BEHAVIOR rather than any
+//     particular regex strategy, so future rewrites that keep the
+//     user-facing semantics intact will continue to pass.
 //   - 2026-04-11 (BAT-491): renamed the canonical sentinel from
 //     `SILENT_REPLY` to `[[SILENT_REPLY]]` because the bare form collided
 //     with natural prose when the agent discussed the protocol. Bare
-//     whole-message is still honored as a legacy backward-compat sentinel;
-//     bare inline is now discussion that passes through untouched.
+//     whole-message (plain and markdown-wrapped) is still honored as a
+//     legacy backward-compat sentinel; bare inline is now discussion
+//     that passes through untouched.
+//
+// Invariants these tests protect:
+//   - Canonical `[[SILENT_REPLY]]` is stripped everywhere it appears
+//     (including left/right/both-sides-glued variants).
+//   - Whole-message legacy bare `SILENT_REPLY` is honored as a sentinel.
+//   - Whole-message legacy WRAPPED bare (`**SILENT_REPLY**` etc.) is
+//     honored as a sentinel (added in Copilot round 3 on PR #324).
+//   - Inline bare `SILENT_REPLY` in prose passes through UNCHANGED —
+//     this is the BAT-491 over-strip fix.
+//   - Identifier-like strings (`MY_SILENT_REPLY_HANDLE`) are never
+//     touched.
 //
 // Coverage sections:
 //   1. Canonical [[SILENT_REPLY]] form — stripped aggressively
@@ -75,6 +90,15 @@ const cases = [
     ['legacy bare with whitespace',            '  SILENT_REPLY  ',                              '',                           true],
     ['legacy bare lowercase',                  'silent_reply',                                  '',                           true],
     ['legacy json envelope bare',              '{"action":"SILENT_REPLY"}',                     '',                           true],
+    // Legacy markdown-wrapped whole-message forms (Copilot round 3 on PR #324).
+    // Older agents running the pre-BAT-491 system prompt may still emit these
+    // as their ENTIRE message — we honor them as sentinels for backward compat.
+    // Inline wrapped-bare in prose is still NOT stripped (discussion passthrough).
+    ['legacy wrapped bold bare',               '**SILENT_REPLY**',                              '',                           true],
+    ['legacy wrapped code bare',               '`SILENT_REPLY`',                                '',                           true],
+    ['legacy wrapped italic bare',             '_SILENT_REPLY_',                                '',                           true],
+    ['legacy wrapped tilde bare',              '~SILENT_REPLY~',                                '',                           true],
+    ['legacy wrapped with whitespace padding', '  **SILENT_REPLY**  ',                          '',                           true],
 
     // ── Section 3: protocol discussion (THE BAT-491 FIX) ────────────────
     // These all contain the literal bare `SILENT_REPLY` string INLINE in

--- a/tests/nodejs-project/silent-reply.test.js
+++ b/tests/nodejs-project/silent-reply.test.js
@@ -122,6 +122,19 @@ const cases = [
     // ── Section 5: plain text passthrough ───────────────────────────────
     ['regular sentence',                       'Just a regular message with no sentinel.',      'Just a regular message with no sentinel.', false],
     ['empty string',                           '',                                              '',                           false],
+
+    // ── Section 6: punctuation-only messages without a sentinel ─────────
+    // Copilot round 5 on PR #324 caught that ONLY_MARKDOWN_PUNCT_REGEX
+    // used to run unconditionally — an assistant reply consisting solely
+    // of punctuation like `[]` or `**` was being dropped even though no
+    // sentinel was ever present. These cases lock in the fix: the
+    // punct-only suppression now only applies AFTER a sentinel was
+    // actually stripped. A standalone punctuation message passes through.
+    ['punct-only empty brackets',              '[]',                                            '[]',                         false],
+    ['punct-only empty parens',                '()',                                            '()',                         false],
+    ['punct-only empty angles',                '<>',                                            '<>',                         false],
+    ['punct-only bold markers',                '**',                                            '**',                         false],
+    ['punct-only code fence',                  '```',                                           '```',                        false],
 ];
 
 let pass = 0;


### PR DESCRIPTION
## Summary

Fixes the protocol-discussion over-strip bug caught during BAT-489 Test 2: when the agent explained the silent-reply protocol in a user-visible reply, the aggressive strip regex ate legitimate mentions of the token.

**Two confirmed over-strips on device:**
1. **Leading**: `SILENT_REPLY is a special internal token...` rendered as `is a special internal token...`
2. **Mid-prose**: `If I send SILENT_REPLY by itself...` rendered as `If I send  by itself...` (telltale double space)

The agent still communicated clearly because context carried it, but this is real over-correction. Any future scenario where the agent needs to debug its own behavior in chat, teach the protocol to a user, or write memory notes about sentinel usage is actively broken.

## Root cause

The bare `SILENT_REPLY` string is a valid English identifier and collides with natural prose whenever the agent discusses the protocol. No regex heuristic can reliably distinguish control-signal emission from discussion emission when the two are textually identical — it's the same class of problem as SMTP's `.` end-of-data marker or markdown's `*` emphasis.

## Fix: structural disambiguation via sentinel rename

Rename the canonical sentinel to `[[SILENT_REPLY]]` (double-bracketed, Wiki/Obsidian-link style). The bracketed form **cannot appear in natural English prose** — it looks like template syntax, not discussion — so collision is eliminated by construction.

| Form | Interpretation |
|---|---|
| `[[SILENT_REPLY]]` anywhere | Control signal — aggressive strip |
| Bare `SILENT_REPLY` as entire message | Legacy whole-message sentinel (backward compat) |
| Bare `SILENT_REPLY` inline in prose | **Discussion — passes through unchanged** |

Why this form:
- ASCII only (compatible with the BAT-489 ASCII-only regex on nodejs-mobile V8)
- Cannot collide with natural English
- Visually distinctive in logs
- Not a special tokenizer token in Claude / GPT / Llama
- Doesn't collide with JSX / Handlebars / Mustache syntax

## Dual-recognition safety net for existing users

Existing agents — running the old system prompt or mid-turn before they adapt to the new canonical form — may still emit bare `SILENT_REPLY` as a standalone message. To protect those users, bare `SILENT_REPLY` is still honored as a sentinel, **but only when it is the entire trimmed message**. Inline bare mentions in prose are never stripped.

The dual-recognition shim is explicit, well-tested (see Section 2 of the test file), and can be removed in a future release once telemetry confirms the bracketed form is being used reliably.

## Why not the alternatives

- **T1 prompt-only** — probabilistic at scale; instruction-following drifts. Fails quietly.
- **T3 tool-use inversion** — overengineering for this specific problem. Would require rewriting the turn loop in ai.js, the send path in telegram.js + discord.js, and deeper system prompt changes. The bug is sentinel collision, not architecture.
- **T2 rename (this PR)** — structural fix, ~90 minutes of work, preserves existing coverage, reversible. Right tier for the problem.

See https://linear.app/batcave/issue/BAT-491 for the full problem statement and trade-off analysis.

## Changes

1. **`silent-reply.js`** — `TOKEN = '[[SILENT_REPLY]]'`, all five aggressive strip regexes target the bracketed form, new `LEGACY_BARE_EXACT_REGEX` honors bare `SILENT_REPLY` as whole-message only, `isSilentReplyEnvelopeText` accepts both canonical and legacy inner-action values.
2. **`ai.js buildSystemBlocks()`** — Silent Replies section rewritten with explicit canonical form, right/wrong examples, and a new "Discussing the protocol in a reply" subsection that tells the agent it MAY write bare `SILENT_REPLY` freely in prose.
3. **`ai.js` cron + heartbeat prompts + fallback emission** — all three locations updated to use `[[SILENT_REPLY]]`.
4. **`tests/nodejs-project/silent-reply.test.js`** — 24 cases in 5 sections (canonical, legacy, discussion-passthrough, identifier-preservation, plain-text). The 4 discussion cases are the BAT-491 fix verification: if any fails, we've regressed to over-strip.

## Test plan

- [x] `node tests/nodejs-project/silent-reply.test.js` — 24/24 pass on Node 22
- [x] `node tests/nodejs-project/smoke.js` — 39/39 files parse clean, silent-reply.js + loop-detector.js load without crashes
- [ ] Install on Seeker via Android Studio Run, verify Node runtime initializes (no module-load crash from the regex rewrite)
- [ ] Device Test 1: send 👍 emoji to @SeekerClaw_bot → agent reacts only, no text reply, logs show `[[SILENT_REPLY]]` strip path fired
- [ ] Device Test 2: send `What is SILENT_REPLY and when do you use it?` → agent replies with full protocol explanation, the bare word `SILENT_REPLY` appears in the reply text unchanged (no double spaces, no missing leading word)
- [ ] Device: normal conversation still works end-to-end
- [ ] Heartbeat / cron silent turns still suppressed (watch logs for ~5 min of heartbeat cycles)

**Will not tag RC5 until all device tests pass** (never-tag-before-device-check rule).

Generated with [Claude Code](https://claude.com/claude-code)