### PR TITLE
fix: OAuth callback server survives Activity destruction (BAT-493)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.ComponentActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import com.seekerclaw.app.config.ConfigManager
 import fi.iki.elonen.NanoHTTPD
-import java.util.concurrent.atomic.AtomicReference
 import android.content.Context
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
@@ -17,7 +16,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -35,13 +33,20 @@ import java.security.SecureRandom
  * Activity that handles the OpenAI OAuth PKCE flow:
  * Custom Tabs → user signs in on auth.openai.com → localhost:1455 loopback callback → token exchange.
  *
- * The callback server accepts both IPv4 (127.0.0.1) and IPv6 (::1) loopback connections,
- * so it works regardless of which one the browser resolves "localhost" to on a given device.
+ * IMPORTANT — Activity lifecycle vs. server lifetime:
+ * The NanoHTTPD callback server lives in the companion object (application-lifetime),
+ * NOT as an Activity instance variable. This is critical because Android can destroy
+ * the stopped Activity while the user is authenticating in Chrome Custom Tab (observed
+ * on Pixel 7 / stock Android 14, which aggressively reclaims stopped Activities during
+ * fresh install when no foreground service is running). If the server died with the
+ * Activity, Chrome's redirect to localhost:1455 would get "connection refused."
  *
- * Tokens obtained from the flow are persisted directly via [ConfigManager] (encrypted via
- * Android Keystore). The on-disk result file under `filesDir/oauth_results/` only carries
- * a status flag (success/error/canceled) — it never contains secrets — and is consumed by
- * `ProviderConfigScreen`'s polling coroutine to know when to reload config.
+ * The server is cleaned up by three paths:
+ * 1. Callback received (success or error) → handleCallbackStatic stops it
+ * 2. User presses Cancel button → cancel UI stops it
+ * 3. 10-minute timeout on EXCHANGE_SCOPE → timeout stops it
+ *
+ * onDestroy() deliberately does NOT stop the server.
  */
 class OpenAIOAuthActivity : ComponentActivity() {
 
@@ -54,32 +59,65 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // Must be exactly "localhost" — the Codex OAuth client (app_EMoamEEZ...) is
         // registered with this redirect URI. Using 127.0.0.1 causes OpenAI to reject the
         // authorize request as a redirect_uri mismatch ("unknown_error" on their side).
-        // NOTE: the browser may resolve "localhost" to either 127.0.0.1 or ::1 depending
-        // on the device (Pixel 7 / Android 14 prefer IPv6). CallbackServer binds to the
-        // wildcard address and accepts only loopback-originated requests, so the
-        // callback arrives successfully regardless of which loopback address Chrome uses.
         const val REDIRECT_URI = "http://localhost:1455/auth/callback"
         const val SCOPES = "openid profile email offline_access"
         private const val CALLBACK_PORT = 1455
 
         private val UUID_PATTERN = Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
-        // Application-lifetime scope for the token exchange. Survives Activity destruction
-        // (rotation, system reclaim, fast back-press) so a successful browser redirect
-        // always completes its persist + result-write, regardless of UI lifecycle.
-        // SupervisorJob means a single failed exchange doesn't cancel sibling jobs.
+        // Application-lifetime scope for the token exchange AND the server timeout.
+        // Survives Activity destruction so a successful browser redirect always
+        // completes its persist + result-write, and the timeout always fires.
         private val EXCHANGE_SCOPE = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-        /**
-         * Static token-exchange entry point. Pure function — takes only Application
-         * Context + the OAuth params + a cleanup callback. Does NOT capture an Activity
-         * instance, so launching this on EXCHANGE_SCOPE cannot leak the Activity.
-         *
-         * Persists tokens via ConfigManager (encrypted via Keystore) and writes the
-         * status result file directly to filesDir. Calls [onComplete] on the same
-         * thread when done so the caller can do whatever cleanup it likes (typically
-         * via a WeakReference back to the Activity).
-         */
+        // ── Active flow state (application-lifetime) ────────────────────
+        // Lives in companion so the NanoHTTPD server survives Activity destruction.
+        // ALL reads and writes of these fields are guarded by FLOW_LOCK so that
+        // resetActiveFlow(), claimWrite(), and callback handling are atomic with
+        // respect to each other. Without the lock, a callback from an old flow
+        // could pass isActiveFlow() + claimWrite() while resetActiveFlow() is
+        // mid-way through resetting fields for a new flow.
+        //
+        // Per-flow isolation: activeFlowId is set to the requestId at the start
+        // of each flow. All async completions (token exchange, timeout, cancel
+        // write) check their captured flowId against activeFlowId before mutating
+        // shared state — stale coroutines from a prior flow become no-ops.
+
+        private val FLOW_LOCK = Any()
+        private var activeServer: CallbackServer? = null
+        private var activeCallbackReceived = false
+        private var activeFlowId: String? = null
+        private var activeTimeoutJob: Job? = null
+
+        private enum class WriteState { IDLE, WRITING, COMPLETED }
+        private var activeWriteState = WriteState.IDLE
+
+        private fun claimWrite(): Boolean = synchronized(FLOW_LOCK) {
+            if (activeWriteState != WriteState.IDLE) return false
+            activeWriteState = WriteState.WRITING
+            true
+        }
+        private fun markWriteCompleted() = synchronized(FLOW_LOCK) {
+            activeWriteState = WriteState.COMPLETED
+        }
+
+        /** Check if a flow is still the active one before mutating shared state. */
+        private fun isActiveFlow(flowId: String): Boolean =
+            synchronized(FLOW_LOCK) { activeFlowId == flowId }
+
+        /** Stop the callback server and reset flow state for a new OAuth attempt. */
+        private fun resetActiveFlow() = synchronized(FLOW_LOCK) {
+            activeTimeoutJob?.cancel()
+            activeTimeoutJob = null
+            activeServer?.stop()
+            activeServer = null
+            activeCallbackReceived = false
+            activeFlowId = null
+            activeWriteState = WriteState.IDLE
+        }
+
+        // ── Static token exchange ───────────────────────────────────────
+
         suspend fun exchangeCodeForTokensStatic(
             appCtx: Context,
             requestId: String,
@@ -111,14 +149,16 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val expiresAt = java.time.Instant.now().plusSeconds(expiresIn).toString()
                 val email = extractEmailFromJwtStatic(idToken) ?: extractEmailFromJwtStatic(accessToken)
 
+                // Guard: only persist tokens and write success if this is still
+                // the active flow. A newer flow may have started while the HTTP
+                // exchange was in flight — persisting stale tokens would overwrite
+                // the newer flow's credentials.
+                if (!isActiveFlow(requestId)) {
+                    Log.w(TAG, "Token exchange completed for stale flow $requestId — discarding tokens")
+                    return
+                }
+
                 withContext(NonCancellable + Dispatchers.IO) {
-                    // Persist the 4 OAuth fields directly via ConfigManager's
-                    // bootstrap-friendly path. This works on fresh install (before
-                    // saveAndStart has ever run) and also on subsequent sign-ins
-                    // (where saveConfig has already marked setup complete). We read
-                    // the prior refresh token and email from loadConfigOrBootstrap
-                    // so blank fields from the token response don't wipe values the
-                    // user previously had.
                     val prior = ConfigManager.loadConfigOrBootstrap(appCtx)
                     ConfigManager.persistOpenAIOAuthTokens(
                         context = appCtx,
@@ -133,10 +173,9 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 }
                 Log.i(TAG, "Browser flow completed successfully")
             } catch (e: Exception) {
-                // Log the full exception (including any details) only to Logcat. The
-                // result file gets a generic user-safe message — `e.message` can
-                // contain raw HTTP response bodies that may include tokens or PII.
                 Log.e(TAG, "Token exchange failed", e)
+                // Only write error result if still active — don't clobber a newer flow.
+                if (!isActiveFlow(requestId)) return
                 try {
                     withContext(NonCancellable + Dispatchers.IO) {
                         writeResultFileStatic(appCtx, requestId, JSONObject().apply {
@@ -152,7 +191,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
             }
         }
 
-        /** Static HTTP POST helper — used by both the companion exchange and the instance flow. */
         private fun httpPostStatic(url: String, body: String): String {
             val conn = URL(url).openConnection() as HttpURLConnection
             try {
@@ -166,9 +204,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
                 val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
                 if (statusCode !in 200..299) {
-                    // Don't put the response body into logs OR the exception message —
-                    // OAuth/token endpoints can return content that includes secrets or
-                    // untrusted HTML. Status code is enough for diagnostics.
                     Log.d(TAG, "httpPostStatic non-2xx response: HTTP $statusCode")
                     throw RuntimeException("HTTP $statusCode")
                 }
@@ -178,8 +213,30 @@ class OpenAIOAuthActivity : ComponentActivity() {
             }
         }
 
-        /** Static result-file writer using only application Context — no Activity capture. */
+        /**
+         * Write a result JSON file for the polling UI. Retries once on failure,
+         * then falls back to a minimal status-only write so the poller always
+         * sees a terminal status instead of hanging until its own 10-min timeout.
+         */
         private fun writeResultFileStatic(appCtx: Context, requestId: String, result: JSONObject) {
+            try {
+                doWriteResultFile(appCtx, requestId, result)
+            } catch (e: Exception) {
+                Log.e(TAG, "Result file write failed, retrying", e)
+                try {
+                    doWriteResultFile(appCtx, requestId, result)
+                } catch (retry: Exception) {
+                    Log.e(TAG, "Retry also failed, writing minimal fallback", retry)
+                    try {
+                        File(appCtx.filesDir, RESULTS_DIR).apply { mkdirs() }
+                            .resolve("$requestId.json")
+                            .writeText("""{"status":"error","message":"Failed to persist OAuth result"}""")
+                    } catch (_: Exception) { /* nothing more we can do */ }
+                }
+            }
+        }
+
+        private fun doWriteResultFile(appCtx: Context, requestId: String, result: JSONObject) {
             val resultDir = File(appCtx.filesDir, RESULTS_DIR).apply { mkdirs() }
             val tmpFile = File(resultDir, "$requestId.tmp")
             val jsonFile = File(resultDir, "$requestId.json")
@@ -192,7 +249,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
             Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
         }
 
-        /** Static JWT email extractor — no Activity dependency. */
         private fun extractEmailFromJwtStatic(jwt: String): String? {
             return try {
                 val parts = jwt.split(".")
@@ -213,25 +269,204 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 null
             }
         }
+
+        // ── Static callback handler ─────────────────────────────────────
+        // Runs on NanoHTTPD's server thread. Uses only companion state +
+        // captured locals — no Activity instance reference (may be destroyed).
+
+        private fun handleCallbackStatic(
+            appCtx: Context,
+            activityRef: WeakReference<OpenAIOAuthActivity>,
+            requestId: String,
+            serverInstance: CallbackServer,
+            params: Map<String, String>,
+            expectedState: String,
+            codeVerifier: String,
+        ): String {
+            val code = params["code"]
+            val state = params["state"]
+            val error = params["error"]
+
+            if (state != expectedState) {
+                Log.w(TAG, "State mismatch — ignoring stray callback (not flipping guard)")
+                return buildHtmlResponse(
+                    "Ignored Redirect",
+                    "This sign-in redirect was ignored because it did not match the active request. " +
+                        "Return to SeekerClaw to retry or cancel the sign-in."
+                )
+            }
+
+            // Reject callbacks from a stale flow — a new OAuth attempt may have
+            // started (resetting shared state). Don't flip any shared guards.
+            if (!isActiveFlow(requestId)) {
+                Log.w(TAG, "Callback arrived for stale flow $requestId — ignoring")
+                serverInstance.stop()
+                return buildHtmlResponse(
+                    "Ignored Redirect",
+                    "A newer sign-in attempt is active. Return to SeekerClaw."
+                )
+            }
+
+            // Idempotency guard — uses companion state under FLOW_LOCK.
+            synchronized(FLOW_LOCK) {
+                if (activeCallbackReceived) {
+                    Log.d(TAG, "Duplicate valid callback ignored")
+                    return buildHtmlResponse(
+                        "Completing Sign-In",
+                        "Already processing — please return to SeekerClaw for status."
+                    )
+                }
+                activeCallbackReceived = true
+            }
+
+            if (error != null) {
+                Log.e(TAG, "OAuth error: $error")
+                if (claimWrite()) {
+                    try {
+                        writeResultFileStatic(appCtx, requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "Authentication failed. Please try again.")
+                        })
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to write OAuth error result on callback thread", e)
+                    }
+                    markWriteCompleted()
+                }
+                // Stop THIS flow's server via the captured instance — activeServer
+                // may not be assigned yet or may point to a newer flow's server.
+                serverInstance.stop()
+                synchronized(FLOW_LOCK) {
+                    activeTimeoutJob?.cancel()
+                    activeTimeoutJob = null
+                    if (activeServer === serverInstance) activeServer = null
+                }
+                activityRef.get()?.finishOnMain()
+                return buildHtmlResponse("Error", "Authentication failed. Please try again.")
+            }
+
+            if (code == null) {
+                Log.e(TAG, "No code in callback")
+                if (claimWrite()) {
+                    try {
+                        writeResultFileStatic(appCtx, requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "No authorization code received")
+                        })
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to write no-code result on callback thread", e)
+                    }
+                    markWriteCompleted()
+                }
+                serverInstance.stop()
+                synchronized(FLOW_LOCK) {
+                    activeTimeoutJob?.cancel()
+                    activeTimeoutJob = null
+                    if (activeServer === serverInstance) activeServer = null
+                }
+                activityRef.get()?.finishOnMain()
+                return buildHtmlResponse("Error", "No authorization code received.")
+            }
+
+            if (!claimWrite()) {
+                Log.w(TAG, "Write slot already claimed before exchange could start")
+                return buildHtmlResponse("Error", "Sign-in already completed in another tab.")
+            }
+
+            // exchangeCodeForTokensStatic checks isActiveFlow before persisting
+            // tokens or writing results — stale exchanges discard their tokens.
+            // onComplete uses serverInstance to stop THIS flow's server, and only
+            // clears activeServer if it still points to this instance.
+            EXCHANGE_SCOPE.launch {
+                exchangeCodeForTokensStatic(
+                    appCtx = appCtx,
+                    requestId = requestId,
+                    code = code,
+                    codeVerifier = codeVerifier,
+                    onComplete = {
+                        serverInstance.stop()
+                        synchronized(FLOW_LOCK) {
+                            if (activeFlowId == requestId) {
+                                activeTimeoutJob?.cancel()
+                                activeTimeoutJob = null
+                                if (activeServer === serverInstance) activeServer = null
+                                activeWriteState = WriteState.COMPLETED
+                                activeFlowId = null
+                                activeCallbackReceived = false
+                            }
+                        }
+                        activityRef.get()?.finishOnMain()
+                    },
+                )
+            }
+
+            return buildHtmlResponse(
+                "Signed In",
+                "You can close this tab and return to SeekerClaw."
+            )
+        }
+
+        // ── HTML helpers (pure functions) ────────────────────────────────
+
+        private fun escapeHtml(text: String): String = text
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            .replace("\"", "&quot;").replace("'", "&#39;")
+
+        private fun buildHtmlResponse(title: String, message: String): String {
+            val safeTitle = escapeHtml(title)
+            val safeMessage = escapeHtml(message)
+            val isSuccess = title == "Success" || title == "Completing Sign-In" || title == "Signed In"
+            val accentColor = if (isSuccess) "#4ADE80" else "#F87171"
+            val icon = if (isSuccess) "&#10003;" else "&#10007;"
+            return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>SeekerClaw — $safeTitle</title>
+                <style>
+                    * { margin: 0; padding: 0; box-sizing: border-box; }
+                    body {
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+                        display: flex; justify-content: center; align-items: center;
+                        height: 100vh; background: #0A0A0F; color: #fff;
+                    }
+                    .card {
+                        text-align: center; padding: 3rem 2rem;
+                        max-width: 400px; width: 90%;
+                    }
+                    .icon {
+                        width: 80px; height: 80px; border-radius: 50%;
+                        background: ${accentColor}15;
+                        border: 2px solid ${accentColor};
+                        display: flex; align-items: center; justify-content: center;
+                        margin: 0 auto 1.5rem; font-size: 36px; color: $accentColor;
+                    }
+                    h1 {
+                        font-size: 24px; font-weight: 700; color: $accentColor;
+                        margin-bottom: 0.75rem; letter-spacing: -0.5px;
+                    }
+                    .message {
+                        font-size: 15px; color: rgba(255,255,255,0.6);
+                        line-height: 1.5; margin-bottom: 2rem;
+                    }
+                    .brand {
+                        font-size: 12px; color: rgba(255,255,255,0.25);
+                        letter-spacing: 1px; text-transform: uppercase;
+                    }
+                </style>
+                </head>
+                <body>
+                    <div class="card">
+                        <div class="icon">$icon</div>
+                        <h1>$safeTitle</h1>
+                        <p class="message">$safeMessage</p>
+                        <p class="brand">SeekerClaw</p>
+                    </div>
+                </body>
+                </html>
+            """.trimIndent()
+        }
     }
-
-    private var callbackServer: CallbackServer? = null
-    private val scope = CoroutineScope(Dispatchers.Main + Job())
-    // Written from the NanoHTTPD server thread, read from the Main timeout coroutine — needs @Volatile.
-    @Volatile
-    private var callbackReceived = false
-    // Three-state machine so onDestroy() never races with an in-flight result write
-    // AND a write that fails mid-way still falls back to a canceled result on destroy.
-    //   IDLE      — no write attempted yet; onDestroy may take over
-    //   WRITING   — a write is in progress; onDestroy must NOT also write
-    //   COMPLETED — write finished; onDestroy must NOT write
-    private enum class WriteState { IDLE, WRITING, COMPLETED }
-    private val writeState = AtomicReference(WriteState.IDLE)
-    private var currentRequestId: String? = null
-
-    /** Atomically claim the write slot. Returns true if the caller may proceed to write. */
-    private fun claimWrite(): Boolean = writeState.compareAndSet(WriteState.IDLE, WriteState.WRITING)
-    private fun markWriteCompleted() { writeState.set(WriteState.COMPLETED) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -241,20 +476,13 @@ class OpenAIOAuthActivity : ComponentActivity() {
             finish()
             return
         }
-        // Sanitize requestId — even though the activity is exported=false, we want to
-        // ensure the value can never escape filesDir/oauth_results via path traversal.
-        // Accept only UUID format (hex digits, either case, separated by dashes).
         if (!UUID_PATTERN.matches(rawRequestId)) {
             Log.w(TAG, "Rejected non-UUID requestId: ${rawRequestId.take(40)}")
             finish()
             return
         }
         val requestId = rawRequestId
-        currentRequestId = requestId
 
-        // Minimal "waiting for sign-in" UI so the user doesn't return from the
-        // browser to a blank translucent activity. The Cancel button stops the
-        // local callback server, writes a canceled result, and finishes.
         setContentView(buildWaitingView(requestId))
 
         Log.i(TAG, "Starting OAuth browser flow (request: $requestId)")
@@ -296,15 +524,24 @@ class OpenAIOAuthActivity : ComponentActivity() {
             text = "Cancel"
             setOnClickListener {
                 Log.i(TAG, "User canceled OAuth flow")
-                callbackServer?.stop()
-                callbackServer = null
+                // Only touch shared state if this is still the active flow.
+                // A new flow may have started if the user navigated away and
+                // came back — don't let a stale cancel clobber it.
+                if (!isActiveFlow(requestId)) {
+                    Log.d(TAG, "Cancel pressed for stale flow — ignoring shared state")
+                    finish()
+                    return@setOnClickListener
+                }
+                // Stop server + timeout synchronously so the port is freed and
+                // no stale timeout can fire after the user pressed Cancel.
+                synchronized(FLOW_LOCK) {
+                    activeTimeoutJob?.cancel()
+                    activeTimeoutJob = null
+                    activeServer?.stop()
+                    activeServer = null
+                }
+                val appCtx = applicationContext
                 if (claimWrite()) {
-                    // Use EXCHANGE_SCOPE (application-lifetime) so the write completes
-                    // even if the activity is destroyed before scope.launch would have
-                    // started. Capture only locals — no `this` reference inside the
-                    // lambda — and signal completion via the AtomicReference directly.
-                    val appCtx = applicationContext
-                    val stateRef = writeState
                     EXCHANGE_SCOPE.launch {
                         try {
                             writeResultFileStatic(appCtx, requestId, JSONObject().apply {
@@ -314,11 +551,16 @@ class OpenAIOAuthActivity : ComponentActivity() {
                         } catch (e: Exception) {
                             Log.w(TAG, "Failed to write canceled result", e)
                         } finally {
-                            stateRef.set(WriteState.COMPLETED)
+                            if (isActiveFlow(requestId)) {
+                                synchronized(FLOW_LOCK) {
+                                    activeFlowId = null
+                                    activeWriteState = WriteState.COMPLETED
+                                }
+                            }
                         }
                     }
                 }
-                finishOnMain()
+                finish()
             }
         }
         root.addView(title)
@@ -332,63 +574,49 @@ class OpenAIOAuthActivity : ComponentActivity() {
         return root
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        callbackServer?.stop()
-        callbackServer = null
-        // If the activity is dismissed (Back button, system kill, swipe-away) BEFORE a
-        // valid callback has arrived AND no other path has claimed the write slot, leave
-        // a canceled result so ProviderConfigScreen stops polling immediately. We MUST
-        // gate on !callbackReceived — if a callback has already arrived, the EXCHANGE_SCOPE
-        // exchange is in flight and writing a synthetic "canceled" here would race a real
-        // sign-in and produce a misleading status. Use EXCHANGE_SCOPE (application-
-        // lifetime) instead of scope (being cancelled here) so the write actually runs.
-        val reqId = currentRequestId
-        if (reqId != null && !callbackReceived && claimWrite()) {
-            // Capture only application Context and a local reference to the state
-            // AtomicReference. The launched lambda must NOT call any instance method
-            // (no markWriteCompleted, no writeResultFile, no Log without TAG capture)
-            // so it doesn't pin the Activity beyond destroy.
-            val appCtx = applicationContext
-            val stateRef = writeState
-            EXCHANGE_SCOPE.launch {
-                try {
-                    writeResultFileStatic(appCtx, reqId, JSONObject().apply {
-                        put("status", "error")
-                        put("message", "Sign-in canceled")
-                    })
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to write canceled result on destroy", e)
-                } finally {
-                    stateRef.set(WriteState.COMPLETED)
-                }
-            }
-        }
-        scope.cancel()
-    }
+    // IMPORTANT: No onDestroy() override — the callback server lives in the
+    // companion object and must survive Activity destruction. Android can destroy
+    // this Activity while the user authenticates in Chrome Custom Tab (observed
+    // on Pixel 7 / stock Android 14 during fresh install). The server is cleaned
+    // up by: callback handler, cancel button, or 10-minute timeout on EXCHANGE_SCOPE.
 
-    // ── Flow A: Browser Redirect (PKCE) ──────────────────────────────────
+    // ── Browser Redirect Flow (PKCE) ────────────────────────────────────
 
     private fun startBrowserFlow(requestId: String) {
         val codeVerifier = generateCodeVerifier()
         val codeChallenge = generateCodeChallenge(codeVerifier)
         val state = generateState()
 
-        // Start local callback server
-        val server = CallbackServer(CALLBACK_PORT) { params ->
-            handleCallback(requestId, params, state, codeVerifier)
+        // Reset any prior flow (e.g. user retries after a failure).
+        // Cancels stale timeout, stops old server, resets write state.
+        resetActiveFlow()
+
+        val appCtx = applicationContext
+        val activityRef = WeakReference(this)
+
+        // Start callback server — lives in companion object, survives Activity destruction.
+        // Pass the server instance into the callback so handleCallbackStatic can stop
+        // THIS server (not whatever activeServer points to if a new flow starts).
+        var server: CallbackServer? = null
+        server = CallbackServer(CALLBACK_PORT) { params ->
+            handleCallbackStatic(appCtx, activityRef, requestId, server!!, params, state, codeVerifier)
+        }
+        // Publish flowId BEFORE server.start() so callbacks from NanoHTTPD's
+        // accept thread are recognized as the active flow from the first request.
+        // If start() fails, we clean up flowId in the catch block.
+        synchronized(FLOW_LOCK) {
+            activeFlowId = requestId
         }
         try {
             server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false)
-            callbackServer = server
+            synchronized(FLOW_LOCK) {
+                activeServer = server
+            }
             Log.i(TAG, "Callback server started on port $CALLBACK_PORT")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start callback server", e)
+            synchronized(FLOW_LOCK) { activeFlowId = null }
             if (claimWrite()) {
-                // EXCHANGE_SCOPE so the write survives even if the activity is
-                // destroyed before this coroutine starts. No `this` capture.
-                val appCtx = applicationContext
-                val stateRef = writeState
                 EXCHANGE_SCOPE.launch {
                     try {
                         writeResultFileStatic(appCtx, requestId, JSONObject().apply {
@@ -398,11 +626,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     } catch (writeErr: Exception) {
                         Log.w(TAG, "Failed to write server-fail result", writeErr)
                     } finally {
-                        stateRef.set(WriteState.COMPLETED)
+                        markWriteCompleted()
                     }
                 }
             }
-            finishOnMain()
+            finish()
             return
         }
 
@@ -430,137 +658,41 @@ class OpenAIOAuthActivity : ComponentActivity() {
             startActivity(browserIntent)
         }
 
-        // Safety timeout: if user abandons browser login, stop server and write error after 10 min.
-        // Gate on !callbackReceived so a slow token exchange (already in progress) isn't clobbered
-        // by a timeout error written over its eventual success/error result.
-        scope.launch {
-            delay(600_000)
-            if (!callbackReceived && callbackServer != null && claimWrite()) {
-                Log.w(TAG, "Browser flow timed out after 10 minutes")
-                callbackServer?.stop()
-                callbackServer = null
-                withContext(NonCancellable + Dispatchers.IO) {
-                    writeResultFile(requestId, JSONObject().apply {
-                        put("status", "error")
-                        put("message", "Browser login timed out. Please try again.")
-                    })
+        // Safety timeout on EXCHANGE_SCOPE (survives Activity destruction).
+        // If user abandons browser login, stop server and write error after 10 min.
+        // Stored in activeTimeoutJob (under FLOW_LOCK) so resetActiveFlow() can
+        // cancel it on retry. All state reads + mutations inside the lock.
+        synchronized(FLOW_LOCK) {
+            activeTimeoutJob = EXCHANGE_SCOPE.launch {
+                delay(600_000)
+                // Check + mutate under FLOW_LOCK so we don't race with
+                // resetActiveFlow() or a callback that arrived just now.
+                val shouldFire = synchronized(FLOW_LOCK) {
+                    if (activeFlowId == requestId && !activeCallbackReceived
+                        && activeServer != null && activeWriteState == WriteState.IDLE
+                    ) {
+                        activeWriteState = WriteState.WRITING
+                        true
+                    } else false
                 }
-                markWriteCompleted()
-                finishOnMain()
+                if (shouldFire) {
+                    Log.w(TAG, "Browser flow timed out after 10 minutes")
+                    withContext(NonCancellable + Dispatchers.IO) {
+                        writeResultFileStatic(appCtx, requestId, JSONObject().apply {
+                            put("status", "error")
+                            put("message", "Browser login timed out. Please try again.")
+                        })
+                    }
+                    synchronized(FLOW_LOCK) {
+                        activeServer?.stop()
+                        activeServer = null
+                        activeTimeoutJob = null
+                        activeWriteState = WriteState.COMPLETED
+                    }
+                    activityRef.get()?.finishOnMain()
+                }
             }
         }
-    }
-
-    private fun handleCallback(
-        requestId: String,
-        params: Map<String, String>,
-        expectedState: String,
-        codeVerifier: String
-    ): String {
-        val code = params["code"]
-        val state = params["state"]
-        val error = params["error"]
-
-        // Reject stray/hostile requests BEFORE flipping the idempotency guard.
-        // Otherwise an attacker (or buggy client) hitting 127.0.0.1:1455/auth/callback
-        // with the wrong state could permanently lock out the real browser redirect
-        // and DoS the sign-in flow.
-        if (state != expectedState) {
-            Log.w(TAG, "State mismatch — ignoring stray callback (not flipping guard)")
-            return buildHtmlResponse(
-                "Ignored Redirect",
-                "This sign-in redirect was ignored because it did not match the active request. " +
-                    "Return to SeekerClaw to retry or cancel the sign-in."
-            )
-        }
-
-        // Idempotency guard: flip only after state is validated. Browser refresh on a
-        // valid redirect would otherwise launch multiple token exchanges that race
-        // on the same result file.
-        synchronized(this) {
-            if (callbackReceived) {
-                Log.d(TAG, "Duplicate valid callback ignored")
-                return buildHtmlResponse(
-                    "Completing Sign-In",
-                    "Already processing — please return to SeekerClaw for status."
-                )
-            }
-            callbackReceived = true
-        }
-
-        // From here on, we know this is the legitimate browser redirect. Log any
-        // OpenAI-side error for diagnostics, but persist/display only a generic
-        // message — callback query params are untrusted input (any local app can
-        // hit 127.0.0.1:1455) and may contain arbitrary content.
-        if (error != null) {
-            Log.e(TAG, "OAuth error: $error")
-            if (claimWrite()) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "Authentication failed. Please try again.")
-                })
-                markWriteCompleted()
-            }
-            finishOnMain()
-            return buildHtmlResponse("Error", "Authentication failed. Please try again.")
-        }
-
-        if (code == null) {
-            Log.e(TAG, "No code in callback")
-            if (claimWrite()) {
-                writeResultFile(requestId, JSONObject().apply {
-                    put("status", "error")
-                    put("message", "No authorization code received")
-                })
-                markWriteCompleted()
-            }
-            finishOnMain()
-            return buildHtmlResponse("Error", "No authorization code received.")
-        }
-
-        // Claim the write slot HERE, before launching the exchange. This closes the race
-        // window where onDestroy() (e.g. user kills the activity right after the redirect)
-        // could otherwise sneak in and write a "canceled" result before the exchange
-        // coroutine even starts. The exchange will see the slot already claimed and just
-        // markWriteCompleted() when done.
-        if (!claimWrite()) {
-            Log.w(TAG, "Write slot already claimed before exchange could start")
-            return buildHtmlResponse("Error", "Sign-in already completed in another tab.")
-        }
-
-        // Run the exchange on the application-lifetime EXCHANGE_SCOPE via a companion
-        // function that takes only appCtx + a WeakReference for cleanup. The launched
-        // coroutine therefore does NOT capture the Activity instance — it survives
-        // destruction without leaking, and the cleanup callback is a no-op if the
-        // activity is already gone.
-        val appCtx = applicationContext
-        val activityRef = WeakReference(this)
-        EXCHANGE_SCOPE.launch {
-            exchangeCodeForTokensStatic(
-                appCtx = appCtx,
-                requestId = requestId,
-                code = code,
-                codeVerifier = codeVerifier,
-                onComplete = { activityRef.get()?.onExchangeComplete() },
-            )
-        }
-
-        return buildHtmlResponse(
-            "Signed In",
-            "You can close this tab and return to SeekerClaw."
-        )
-    }
-
-    /**
-     * Called by the companion-object exchange when it completes (success or failure).
-     * Runs on whatever thread the companion finishes on; hops to Main for UI work.
-     * No-op if the activity is already gone (the WeakReference returns null).
-     */
-    private fun onExchangeComplete() {
-        callbackServer?.stop()
-        callbackServer = null
-        markWriteCompleted()
-        finishOnMain()
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
@@ -582,111 +714,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
     }
 
-    private fun writeResultFile(requestId: String, result: JSONObject) {
-        try {
-            doWriteResultFile(requestId, result)
-        } catch (e: Exception) {
-            // Storage full or filesystem error. Retry once on EXCHANGE_SCOPE after a
-            // short delay (transient pressure self-resolves). If retry also fails, write
-            // a minimal status-only file so the polling UI sees *something* and stops.
-            Log.e(TAG, "Failed to write OAuth result file for requestId=$requestId", e)
-            val appCtx = applicationContext
-            EXCHANGE_SCOPE.launch {
-                kotlinx.coroutines.delay(500)
-                try {
-                    writeResultFileStatic(appCtx, requestId, result)
-                    Log.i(TAG, "Result file write succeeded on retry")
-                } catch (retry: Exception) {
-                    Log.e(TAG, "Result file retry also failed", retry)
-                    try {
-                        File(appCtx.filesDir, RESULTS_DIR).apply { mkdirs() }
-                            .resolve("$requestId.json")
-                            .writeText("""{"status":"error","message":"Failed to persist OAuth result"}""")
-                    } catch (_: Exception) { /* nothing more we can do */ }
-                }
-            }
-            try { finishOnMain() } catch (finishEx: Exception) {
-                Log.e(TAG, "Failed to finish activity after writeResultFile error", finishEx)
-            }
-        }
-    }
-
-    private fun doWriteResultFile(requestId: String, result: JSONObject) {
-        val resultDir = File(filesDir, RESULTS_DIR).apply { mkdirs() }
-        val tmpFile = File(resultDir, "$requestId.tmp")
-        val jsonFile = File(resultDir, "$requestId.json")
-        tmpFile.writeText(result.toString())
-        jsonFile.delete() // renameTo won't overwrite existing file on Android
-        if (!tmpFile.renameTo(jsonFile)) {
-            // Fallback: copy + delete if rename fails on some Android filesystems
-            tmpFile.copyTo(jsonFile, overwrite = true)
-            tmpFile.delete()
-        }
-        Log.d(TAG, "Result written: ${jsonFile.absolutePath}")
-    }
-
     private fun finishOnMain() {
         runOnUiThread { finish() }
-    }
-
-    private fun escapeHtml(text: String): String = text
-        .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        .replace("\"", "&quot;").replace("'", "&#39;")
-
-    private fun buildHtmlResponse(title: String, message: String): String {
-        val safeTitle = escapeHtml(title)
-        val safeMessage = escapeHtml(message)
-        val isSuccess = title == "Success" || title == "Completing Sign-In" || title == "Signed In"
-        val accentColor = if (isSuccess) "#4ADE80" else "#F87171"
-        val icon = if (isSuccess) "&#10003;" else "&#10007;"
-        return """
-            <!DOCTYPE html>
-            <html>
-            <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>SeekerClaw — $safeTitle</title>
-            <style>
-                * { margin: 0; padding: 0; box-sizing: border-box; }
-                body {
-                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-                    display: flex; justify-content: center; align-items: center;
-                    height: 100vh; background: #0A0A0F; color: #fff;
-                }
-                .card {
-                    text-align: center; padding: 3rem 2rem;
-                    max-width: 400px; width: 90%;
-                }
-                .icon {
-                    width: 80px; height: 80px; border-radius: 50%;
-                    background: ${accentColor}15;
-                    border: 2px solid ${accentColor};
-                    display: flex; align-items: center; justify-content: center;
-                    margin: 0 auto 1.5rem; font-size: 36px; color: $accentColor;
-                }
-                h1 {
-                    font-size: 24px; font-weight: 700; color: $accentColor;
-                    margin-bottom: 0.75rem; letter-spacing: -0.5px;
-                }
-                .message {
-                    font-size: 15px; color: rgba(255,255,255,0.6);
-                    line-height: 1.5; margin-bottom: 2rem;
-                }
-                .brand {
-                    font-size: 12px; color: rgba(255,255,255,0.25);
-                    letter-spacing: 1px; text-transform: uppercase;
-                }
-            </style>
-            </head>
-            <body>
-                <div class="card">
-                    <div class="icon">$icon</div>
-                    <h1>$safeTitle</h1>
-                    <p class="message">$safeMessage</p>
-                    <p class="brand">SeekerClaw</p>
-                </div>
-            </body>
-            </html>
-        """.trimIndent()
     }
 
     // ── NanoHTTPD Callback Server ────────────────────────────────────────
@@ -710,11 +739,6 @@ class OpenAIOAuthActivity : ComponentActivity() {
         // whose remote IP is outside the loopback range with 403 Forbidden.
 
         override fun serve(session: IHTTPSession): Response {
-            // Security: reject anything that isn't loopback. With a 0.0.0.0 bind we
-            // could in principle be reached from other hosts on the same network, so
-            // we gate every request on the client IP. NanoHTTPD reports the remote
-            // address in v4 form (127.0.0.1) or v6 form (0:0:0:0:0:0:0:1 or ::1)
-            // depending on how the client connected.
             val remoteIp = session.remoteIpAddress ?: ""
             if (!isLoopback(remoteIp)) {
                 Log.w(TAG, "Rejecting non-loopback callback request from $remoteIp")
@@ -731,15 +755,8 @@ class OpenAIOAuthActivity : ComponentActivity() {
 
         private fun isLoopback(ip: String): Boolean {
             if (ip.isEmpty()) return false
-            // Strip any IPv6 zone suffix (e.g. "fe80::1%eth0") before parsing.
             val stripped = ip.substringBefore('%')
-            // IPv4-mapped IPv6 form ("::ffff:127.0.0.1") must be explicitly
-            // recognized — Inet6Address.isLoopbackAddress() only returns true for
-            // "::1" and doesn't unwrap the v4 mapping on all JDK/Android versions.
             if (stripped.startsWith("::ffff:127.", ignoreCase = true)) return true
-            // Canonical path: parse as an InetAddress (no DNS lookup for numeric IPs)
-            // and let the platform classify it. Covers 127.0.0.0/8 via Inet4Address
-            // and ::1 / 0:0:0:0:0:0:0:1 via Inet6Address.
             return try {
                 InetAddress.getByName(stripped).isLoopbackAddress
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Move NanoHTTPD callback server from Activity instance variable to companion object scope
- **Root cause:** Android destroys the stopped `OpenAIOAuthActivity` while user authenticates in Chrome Custom Tab. On Pixel 7 (stock Android 14) during fresh install, no foreground service is running → no process importance boost → Activity gets reclaimed. `onDestroy()` stopped the server → Chrome's redirect to `localhost:1455` got "connection refused"
- **Fix:** Server now lives in companion object (same pattern as `EXCHANGE_SCOPE`). `onDestroy()` no longer touches it. Cleaned up by: callback handler, cancel button, or 10-minute timeout on `EXCHANGE_SCOPE`
- Net -119 lines — removed instance state management, instance `writeResultFile` wrapper, `doWriteResultFile` (replaced by existing static equivalents)

## Test plan
- [ ] Fresh install on Pixel 7 → Sign in with ChatGPT → complete auth → verify tokens persisted
- [ ] Fresh install on Seeker → same flow → verify no regression
- [ ] Cancel button during OAuth → verify "canceled" result written
- [ ] Verify server stops after successful callback (check port 1455 free)
- [ ] Force-kill Activity via dev tools while in Chrome → verify server stays alive and callback succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)