### PR TITLE
fix: OAuth diagnostic logging + server-stop race condition (BAT-494)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
+++ b/app/src/main/java/com/seekerclaw/app/oauth/OpenAIOAuthActivity.kt
@@ -173,6 +173,12 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 }
                 Log.i(TAG, "Browser flow completed successfully")
             } catch (e: Exception) {
+                // Log.w survives R8 optimization (Log.d is stripped).
+                // Include the exception class + message explicitly so release-build
+                // logcat shows the actual error — R8 can strip the Throwable stack
+                // trace from Log.e's 3-arg overload, leaving "Token exchange failed"
+                // with zero diagnostic context (discovered BAT-494 Pixel 7 diagnosis).
+                Log.w(TAG, "Exchange error: ${e.javaClass.simpleName}: ${e.message}")
                 Log.e(TAG, "Token exchange failed", e)
                 // Only write error result if still active — don't clobber a newer flow.
                 if (!isActiveFlow(requestId)) return
@@ -204,8 +210,11 @@ class OpenAIOAuthActivity : ComponentActivity() {
                 val stream = if (statusCode in 200..299) conn.inputStream else conn.errorStream
                 val responseBody = stream?.bufferedReader()?.use { it.readText() } ?: ""
                 if (statusCode !in 200..299) {
-                    Log.d(TAG, "httpPostStatic non-2xx response: HTTP $statusCode")
-                    throw RuntimeException("HTTP $statusCode")
+                    // Log.w survives R8 (Log.d doesn't). Include response body
+                    // so release-build logcat shows what the token endpoint returned
+                    // (e.g. "invalid_grant", "redirect_uri mismatch", etc.).
+                    Log.w(TAG, "Token endpoint HTTP $statusCode: ${responseBody.take(500)}")
+                    throw RuntimeException("HTTP $statusCode: ${responseBody.take(200)}")
                 }
                 return responseBody
             } finally {
@@ -383,6 +392,15 @@ class OpenAIOAuthActivity : ComponentActivity() {
                     code = code,
                     codeVerifier = codeVerifier,
                     onComplete = {
+                        // Brief delay before stopping the server so NanoHTTPD's serve
+                        // thread has time to finish writing the HTTP response to Chrome.
+                        // Without this, the exchange coroutine's finally block races
+                        // against the serve thread: if the exchange fails fast, the
+                        // server socket closes while NanoHTTPD is mid-write, and Chrome
+                        // sees a broken/empty response instead of the success/error HTML
+                        // page. 500ms is plenty for a small HTML payload on localhost.
+                        // Runs on Dispatchers.IO (EXCHANGE_SCOPE) so blocking is safe.
+                        try { Thread.sleep(500) } catch (_: InterruptedException) { }
                         serverInstance.stop()
                         synchronized(FLOW_LOCK) {
                             if (activeFlowId == requestId) {


### PR DESCRIPTION
## Summary

Two fixes discovered during Pixel 7 adb logcat diagnosis:

### 1. Token exchange error is invisible in release builds

`Log.e(TAG, "Token exchange failed", e)` in the release build produces ZERO stack trace — R8 strips the Throwable. We saw "Token exchange failed" in logcat with nothing after it, completely blind to the actual error (HTTP status, exception class, OpenAI error message).

**Fix**: Added `Log.w()` (survives R8) with explicit `e.javaClass.simpleName: e.message` before the Log.e call. Also upgraded `httpPostStatic`'s Log.d to Log.w with the response body, and enriched the RuntimeException message with `HTTP <code>: <body>` so the catch block has diagnostic context.

### 2. Server-stop race condition

When the token exchange fails fast (immediate HTTP error from OpenAI), `onComplete()` fires from the exchange coroutine's `finally` block and calls `serverInstance.stop()` — while NanoHTTPD's serve thread is still writing the HTTP response to Chrome. The server socket closes mid-write → `SocketException: Socket closed` → Chrome sees a broken/empty response.

Observed in logcat:
```
12:25:38.552 E/OpenAIOAuth: Token exchange failed
12:25:38.562 E/ma.l: Could not send response to the client
12:25:38.562 E/ma.l: java.net.SocketException: Socket closed
```

**Fix**: Added 500ms `Thread.sleep` before `serverInstance.stop()` in `onComplete`. Runs on Dispatchers.IO so blocking is safe. Gives NanoHTTPD time to finish writing the response.

## Test plan

- [ ] Install debug APK on Pixel 7 via Android Studio
- [ ] Reproduce the OAuth flow → check logcat for the new Log.w lines
- [ ] The new logs should show the ACTUAL error (e.g. "Exchange error: RuntimeException: HTTP 400: {error: invalid_grant}")
- [ ] Once we know the real error, fix it in a follow-up

This is a DIAGNOSTIC build — the goal is to see the actual error, not to fix the OAuth flow itself. The race condition fix is a bonus that prevents Chrome from seeing broken responses.

Generated with [Claude Code](https://claude.com/claude-code)