### PR TITLE
feat(school): Go to School — log infra + self-reflection feature (PR-A + PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,6 @@
 All notable changes to SeekerClaw are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
-
-### Added (internal — no user-facing change yet)
-- **Tool-call + skill-trigger logging infrastructure** — new `tool_call_log` and `skill_trigger_log` SQL.js tables record every tool invocation and skill-trigger match on-device. Buffered async logger (5s / 100-row flush, re-trigger on backlog, 10× hard cap on persistent failure) keeps writes off the tool-execution hot path. Per-tool `call_shape` structural classifier buckets calls without leaking sensitive values (wallet addresses, URL query strings, user text, private filenames). 30-day retention with 50,000-row cap, purged on service start off the boot critical path. Foundational for the upcoming **Go to School** self-improvement feature — no user-visible behavior change in this release.
-
 ## [1.9.0] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to SeekerClaw are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added (internal — no user-facing change yet)
+- **Tool-call + skill-trigger logging infrastructure** — new `tool_call_log` and `skill_trigger_log` SQL.js tables record every tool invocation and skill-trigger match on-device. Buffered async logger (5s / 100-row flush, re-trigger on backlog, 10× hard cap on persistent failure) keeps writes off the tool-execution hot path. Per-tool `call_shape` structural classifier buckets calls without leaking sensitive values (wallet addresses, URL query strings, user text, private filenames). 30-day retention with 50,000-row cap, purged on service start off the boot critical path. Foundational for the upcoming **Go to School** self-improvement feature — no user-visible behavior change in this release.
+
 ## [1.9.0] - 2026-04-13
 
 ### Added

--- a/app/src/main/assets/default-skills/go-to-school/SKILL.md
+++ b/app/src/main/assets/default-skills/go-to-school/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: go-to-school
+description: "Analyze recent activity and propose new skills, skill patches, or skill retirements. Triggered by /school command or phrases like 'go to school', 'run school', 'study time'. Challenges its own findings with a 5-gate rubric; surfaces rejections so the user can audit the thinking. Two-gate approval: /review N → YES N writes the file."
+version: "1.0.0"
+emoji: "🎓"
+requires:
+  bins: []
+  env: []
+allowed-tools:
+  - school_begin
+  - school_scan
+  - school_write_skill
+  - school_retire_skill
+  - school_end
+  - school_handle_input
+  - file_read
+  - file_write
+  - telegram_send
+---
+
+# Go to School — Structured Self-Reflection
+
+When the user invokes /school (or a natural-language trigger), you analyze your own recent behavior and propose concrete self-improvements. Your output is a ranked list of proposals, each passing a 5-gate rubric. The user approves per-proposal in two steps (/review N → YES N).
+
+## Session flow
+
+1. Call `school_begin({ reason: "on_demand" })`.
+   - If `resumed: true`: you're picking up a prior session. Use `resumed_state` and continue in the state it's in.
+   - Else: proceed to scanning.
+2. Call `school_scan({ window_days: 7, min_repetition: 3 })`.
+   - If `empty: true`: send one message "Not enough signal to propose anything — try again after more activity." and call `school_end` with empty summary. Stop.
+3. Read memory files for context:
+   - `file_read(MEMORY.md)` and the 7 most recent `memory/YYYY-MM-DD.md` daily notes.
+4. Apply the rubric (below) to every candidate pattern from `school_scan`. Build proposals.
+5. Apply the dedup gate against `prior_sessions` (also from `school_begin`).
+6. Send the proposals message (format below) to the user via `telegram_send`.
+7. For each user input, CLASSIFY it per the Input Classification Rubric. For school-relevant inputs, call `school_handle_input`. Execute the `next_action` it returns.
+8. When all proposals are resolved (state=done), call `school_end` with the final summary.
+
+## The rubric (5 gates)
+
+Every candidate pattern must pass **all 5** before it's shown as a proposal.
+
+| Gate | Type | Test |
+|---|---|---|
+| **Repetition** | Quantitative | `scan.repeated_patterns[i].count >= 3` (or failed/unused counts ≥ 3) |
+| **Permanence** | Quantitative | `scan.repeated_patterns[i].spans_distinct_days >= 2` |
+| **Gap** | Qualitative (requires artifact) | Produce a `coverage_check` block listing every existing tool/bundled-skill/workspace-skill considered and one line each on why it doesn't cover this pattern. No list → fail. |
+| **Utility** | Qualitative (honest yes/no) | Answer yes/no with one sentence referencing scan data: "Will this skill fire often enough to earn its prompt-size cost?" FORBIDDEN: fake arithmetic. |
+| **Actionable** | Structural | Draft the **When to Use** section inline, with concrete trigger keywords + specific tools + output format. If the draft reduces to "be smarter about X", fail. Soft-warning keyword check (`smarter`, `better`, `improved` without a concrete mechanism) flags for extra scrutiny. |
+
+### Dedup gate (pre-rubric)
+
+For each candidate, compute the signature `sha256(type + normalize(title))`. If it matches any entry in `prior_sessions` with `outcome` in `{drafted_but_denied, skipped, ignored, rejected_by_rubric, abandoned_stale, rejected_as_duplicate}` from the last 30 days, drop as `rejected_as_duplicate`.
+
+## Proposal message format
+
+Use HTML (Telegram). ≤ 4096 chars, chunked if longer.
+
+```
+🎓 School — <date> scan (last N days)
+
+📝 CREATE  · <count>
+🔧 PATCH   · <count>
+🗑️ RETIRE  · <count>
+❌ REJECTED · <count>
+
+─── [1] CREATE · <slug> ───
+Evidence: <evidence line>
+Rubric: rep ✓ perm ✓ gap ✓ util ✓ action ✓ (5/5)
+Confidence: N/10
+Skeptical take: <one honest sentence>
+> /review 1
+
+... more proposals ...
+
+─── Rejected (<count>) ───
+· <slug> — fails <GATE>: <reason>
+... more ...
+
+Reply: /review N  |  /skip N  |  /stop
+Reply on review: YES N  |  NO N  (bare YES/NO works if only one review open)
+```
+
+## Input Classification Rubric
+
+An input is **school-relevant** iff it matches exactly one of:
+- Starts with `/review ` + positive integer → `kind: "review"`, `proposal_n: <int>`
+- Starts with `/skip ` + positive integer → `kind: "skip"`, `proposal_n: <int>`
+- Equals `/stop` (exact, trimmed) → `kind: "stop"`
+- Matches `^(YES|NO|Y|N|👍|👎)\s*(\d+)?\s*$` case-insensitive after trim (≤ 120 chars) → `kind: "yes"` or `"no"`, `proposal_n` optional
+- Starts with `YES ` or `NO ` followed by number + non-empty trailing text → YES/NO captured, trailing text routed to normal handling in the same turn.
+
+**Everything else is unrelated** — do NOT call `school_handle_input`. Route through normal message handling. If state is `reviewing_<N>`, append to your normal reply: *"Still awaiting YES/NO on proposal {N}."*
+
+## Classification echo rule
+
+After calling `school_handle_input` with a school-relevant input, the first sentence of your reply MUST echo back your classification — e.g. *"Understood as YES on proposal 3 — writing now."* or *"Taking that as /skip 2 — logged."*
+
+This gives the user a visible correction hook. The state machine is deterministic from `school_handle_input` onwards, but input classification is still your judgment.
+
+## Write-failure handling
+
+If `next_action.kind` is `write_skill` or `retire_skill` and the follow-up tool call fails, do NOT proceed as if it succeeded. State stays at `reviewing_<N>`. Surface the error to the user: *"Couldn't write proposal {N}: {error}. Reply YES {N} to retry, NO {N} to decline, or /stop to end."* No log entry is written until the write succeeds or the user explicitly declines.
+
+## Silent exit
+
+If `school_scan` returns `empty: true` or all candidates fail the rubric + dedup, send one line — *"Not enough signal to propose anything — try again after more activity."* — and call `school_end` cleanly. No filler proposals.
+
+## Post-approval note
+
+Append to the success message after any write: *"Live on next turn."* — confirms no manual restart is needed; the existing `loadSkills()` live-read picks up new skills automatically.

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -349,3 +349,33 @@ grep -i "rate limit.*mcp\|rate limit.*exceeded" node_debug.log | tail -10
 1. For missing API keys: guide the user to configure them in Settings
 2. For missing binaries: explain the requirement and suggest alternatives
 3. Use `skill_diagnostics` (if available) to see all skill loading status
+
+## Go to School troubleshooting
+
+**Symptom: `/school` replies "School session already open"**
+- An active session exists (`workspace/SCHOOL.md`). Reply `/stop` to end it, or `/review N` / `/skip N` to resolve open proposals.
+- If truly stuck: `/school-reset` (then `/school-reset-confirm` within 60s).
+
+**Symptom: `/school` returns "Not enough signal to propose anything"**
+- Fewer than 20 tool calls recorded in the last 7-day window. Normal on a new install or after a quiet week. Use the agent for a few days, then try `/school` again.
+
+**Symptom: Proposal rejected with "fails GAP"**
+- An existing capability (tool, bundled skill, workspace skill) already covers the pattern. The rubric's `coverage_check` artifact in the rejection reason names which existing capability it considered.
+
+**Symptom: `/school` returns "Cannot patch bundled skill"**
+- Bundled skills (shipped in the APK under `default-skills/`) are read-only. File a GitHub issue for improvements to bundled skills.
+
+**Symptom: Stale-session message on service start**
+- A prior `/school` session crossed the 48h threshold without resolution. Normal cleanup — abandoned proposals are logged with `outcome: abandoned_stale`. Run `/school` to start fresh.
+
+**Symptom: Same proposal keeps appearing after I rejected it**
+- Check `workspace/school/log.jsonl`. The proposal's signature may differ across runs due to title drift (the dedup gate hashes `type + normalize(title)` — cosmetic changes shouldn't matter, but substantive wording changes do). If titles look identical but sigs differ, file a bug.
+
+**Symptom: "Ambiguous YES/NO — bare reply needs a number"**
+- More than 60 seconds elapsed since the last `/review N`, OR multiple reviews were opened in quick succession. Reply `YES N` or `NO N` with the specific proposal number.
+
+**Symptom: Write-skill failed — retry prompt**
+- Disk full, path-sandbox rejection, oversize body (> 64KB), or missing markdown heading. The error message names the cause. Resolve it (free disk, trim body, or reply `NO N` and start a new session), then retry `YES N`.
+
+**Symptom: `/school` throttled — "School ran recently"**
+- 5-minute cooldown between invocations, 10-per-day cap. Normal rate-limit. Message shows the next-available time.

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -711,6 +711,28 @@ function buildSystemBlocks(matchedSkills = [], chatId = null) {
     lines.push('- **memory_stats** reports memory file counts and sizes.');
     lines.push('All memory files (MEMORY.md + daily notes) are automatically indexed into searchable chunks on startup and when files change.');
     lines.push('Your API requests are logged with token counts and latency — use session_status to see your own usage stats.');
+    lines.push('Two other SQL.js tables back the Self-Improvement feature: `tool_call_log` (every tool call with shape + outcome + error_kind, 30-day retention, privacy-safe call_shape — no wallet addresses, URL query strings, user text, or private filenames) and `skill_trigger_log` (which skills matched which messages, UNIQUE(skill_name, message_id) dedup).');
+    lines.push('');
+
+    // Self-Improvement (Go to School) — agent self-awareness for B9
+    lines.push('## Self-Improvement (Go to School)');
+    lines.push('You have a /school command that triggers a structured self-reflection session: analyze your recent tool-call history (from the `tool_call_log` SQL.js table) and skill-trigger history (from `skill_trigger_log`), then propose concrete changes to your skill set — new skills, patches to existing ones, retirements of unused ones.');
+    lines.push('');
+    lines.push('**Tools (6):**');
+    lines.push('- `school_begin` — start or resume a session. Creates workspace/SCHOOL.md trigger file.');
+    lines.push('- `school_scan` — pattern-mine the logs. Returns repeated_patterns (call_shape ≥ 3×), failed_sequences, expensive_turns, and triggered_skills.');
+    lines.push('- `school_write_skill` — write or patch a SKILL.md. Auto-injects school frontmatter marker on create; preserves existing source field on patch. Enforces workspace/skills/ path sandbox + 64KB size cap + YAML-safe evidence.');
+    lines.push('- `school_retire_skill` — move a workspace skill to workspace/school/retired/ (reversible archive, not delete).');
+    lines.push('- `school_end` — append one JSON line to workspace/school/log.jsonl, delete SCHOOL.md.');
+    lines.push('- `school_handle_input` — advance the state machine for YES/NO/review/skip/stop inputs.');
+    lines.push('');
+    lines.push('**Rubric (5 gates — all must pass):** Repetition (≥ 3 occurrences), Permanence (≥ 2 distinct days), Gap (no existing capability covers it), Utility (honest yes/no on whether it earns its prompt cost), Actionable (concrete playbook, not "be smarter about X").');
+    lines.push('');
+    lines.push('**Two-gate approval:** /review N shows the user the drafted SKILL.md; YES N writes it. Bundled skills cannot be patched or retired.');
+    lines.push('');
+    lines.push('**Effect timing:** Newly-written skills are picked up on the next agent turn automatically — `loadSkills()` reads the filesystem fresh on every message, so no service restart is needed.');
+    lines.push('');
+    lines.push('**State machine is deterministic JS** in school.js; you do NOT drive it directly. You classify user input per the classification rubric in the go-to-school SKILL.md, call school_handle_input, then execute the next_action it returns. Echo your classification back in every state-changing reply so the user can catch misclassifications.');
     lines.push('');
 
     // Diagnostics — agent knows about its debug log for self-diagnosis

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2132,7 +2132,7 @@ async function chat(chatId, userMessage, options = {}) {
                             if (confirmed) {
                                 const status = deferStatus(chatId, TOOL_STATUS_MAP[toolUse.name]);
                                 try {
-                                    result = await _deps.executeTool(toolUse.name, toolUse.input, chatId);
+                                    result = await _deps.executeTool(toolUse.name, toolUse.input, chatId, options.messageId);
                                     if (_deps.lastToolUseTime) _deps.lastToolUseTime.set(toolUse.name, Date.now());
                                 } finally {
                                     await status.cleanup();
@@ -2146,7 +2146,7 @@ async function chat(chatId, userMessage, options = {}) {
                         // Normal tool execution (no confirmation needed)
                         const status = deferStatus(chatId, TOOL_STATUS_MAP[toolUse.name]);
                         try {
-                            result = await _deps.executeTool(toolUse.name, toolUse.input, chatId);
+                            result = await _deps.executeTool(toolUse.name, toolUse.input, chatId, options.messageId);
                         } finally {
                             await status.cleanup();
                         }

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1938,7 +1938,10 @@ async function chat(chatId, userMessage, options = {}) {
             ? userMessage
             : (userMessage.find(b => b.type === 'text')?.text || '')
     );
-    const matchedSkills = findMatchingSkills(textForSkills);
+    const matchedSkills = findMatchingSkills(textForSkills, {
+        message_id: options.messageId ? String(options.messageId) : null,
+        timestamp: Date.now(),
+    });
     if (matchedSkills.length > 0) {
         log(`Matched skills: ${matchedSkills.map(s => s.name).join(', ')}`, 'DEBUG');
     }

--- a/app/src/main/assets/nodejs-project/call-shape.js
+++ b/app/src/main/assets/nodejs-project/call-shape.js
@@ -1,0 +1,72 @@
+// call-shape.js — structural classifier per tool for tool_call_log.
+// Pure functions. Never stores sensitive data. Max 64 chars per shape.
+//
+// Each builder receives the tool's args and returns a short string that
+// captures the *class* of the call (e.g. "web_fetch:api.anthropic.com:POST")
+// without any user-specific values.
+
+const KNOWN_MINTS = {
+    'So11111111111111111111111111111111111111112': 'SOL',
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': 'USDC',
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': 'USDT',
+    'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263': 'BONK',
+};
+function mintLabel(mint) {
+    if (!mint) return 'unknown';
+    return KNOWN_MINTS[mint] || 'other';
+}
+
+function hostOf(url) {
+    if (!url || typeof url !== 'string') return 'unknown';
+    try {
+        const u = new URL(url);
+        return u.hostname;
+    } catch (_) {
+        return 'malformed';
+    }
+}
+
+function pathPattern(p) {
+    if (!p || typeof p !== 'string') return 'unknown';
+    // memory/YYYY-MM-DD.md → memory/*.md
+    if (/^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(p)) return 'memory/*.md';
+    if (/^memory\//.test(p)) return 'memory/*';
+    if (/^skills\/[^/]+\.md$/.test(p)) return 'skills/*.md';
+    if (/^skills\//.test(p)) return 'skills/*';
+    if (/^workspace\/school\//.test(p)) return 'workspace/school/*';
+    // Root-level .md files expose filename (safe — SOUL/MEMORY/IDENTITY/USER/HEARTBEAT only)
+    if (/^[A-Z]+\.md$/.test(p)) return p;
+    // Everything else → bucket by depth
+    return p.split('/').slice(0, 2).join('/') + '/*';
+}
+
+const builders = {
+    web_fetch: (args) => `web_fetch:${hostOf(args.url)}:${(args.method || 'GET').toUpperCase()}`,
+    web_search: (args) => `web_search:${args.provider || 'default'}`,
+    solana_swap: (args) => `solana_swap:${mintLabel(args.inputMint)}:${mintLabel(args.outputMint)}`,
+    solana_balance: (args) => args && args.address ? 'solana_balance:other' : 'solana_balance:self',
+    solana_send: (args) => `solana_send:${mintLabel(args && args.mint)}`,
+    solana_price: (args) => `solana_price:${mintLabel(args && args.mint)}`,
+    file_read: (args) => `file_read:${pathPattern(args && args.path)}`,
+    file_write: (args) => `file_write:${pathPattern(args && args.path)}`,
+    file_edit: (args) => `file_edit:${pathPattern(args && args.path)}`,
+    file_delete: (args) => `file_delete:${pathPattern(args && args.path)}`,
+    shell_exec: (args) => {
+        const cmd = (args && args.cmd) || '';
+        const first = cmd.trim().split(/\s+/)[0] || 'empty';
+        return `shell_exec:${first}`;
+    },
+    android_sms: () => 'android_sms',
+    android_call: () => 'android_call',
+    telegram_send: () => 'telegram_send',
+};
+
+function getShape(toolName, args) {
+    const b = builders[toolName];
+    const raw = b ? b(args || {}) : toolName;
+    // Cap to 64 chars with trailing … if truncated
+    if (raw.length <= 64) return raw;
+    return raw.slice(0, 63) + '…';
+}
+
+module.exports = { getShape };

--- a/app/src/main/assets/nodejs-project/call-shape.js
+++ b/app/src/main/assets/nodejs-project/call-shape.js
@@ -28,16 +28,19 @@ function hostOf(url) {
 
 function pathPattern(p) {
     if (!p || typeof p !== 'string') return 'unknown';
-    // memory/YYYY-MM-DD.md → memory/*.md
+    // Normalize: strip leading './', collapse repeated slashes.
+    p = p.replace(/^\.\//, '').replace(/\/+/g, '/');
+    // Known workspace buckets.
     if (/^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(p)) return 'memory/*.md';
     if (/^memory\//.test(p)) return 'memory/*';
     if (/^skills\/[^/]+\.md$/.test(p)) return 'skills/*.md';
     if (/^skills\//.test(p)) return 'skills/*';
     if (/^workspace\/school\//.test(p)) return 'workspace/school/*';
-    // Root-level .md files expose filename (safe — SOUL/MEMORY/IDENTITY/USER/HEARTBEAT only)
-    if (/^[A-Z]+\.md$/.test(p)) return p;
-    // Everything else → bucket by depth
-    return p.split('/').slice(0, 2).join('/') + '/*';
+    // Root-level workspace identity/memory files — known allowlist only, exposed as-is.
+    if (/^(SOUL|MEMORY|IDENTITY|USER|HEARTBEAT)\.md$/.test(p)) return p;
+    // Everything else — collapse to a generic bucket with depth hint, never exposing segments.
+    const depth = p.split('/').length;
+    return `other:depth${depth}`;
 }
 
 const builders = {

--- a/app/src/main/assets/nodejs-project/call-shape.js
+++ b/app/src/main/assets/nodejs-project/call-shape.js
@@ -57,6 +57,11 @@ const builders = {
     shell_exec: (args) => {
         const cmd = (args && args.cmd) || '';
         const first = cmd.trim().split(/\s+/)[0] || 'empty';
+        // If the first token is a path (./foo, /usr/bin/foo, ../foo) or contains
+        // any filesystem separators, collapse to 'other' to avoid leaking filenames.
+        // Only bare command names (ls, cat, curl, etc.) are exposed.
+        if (first === 'empty') return 'shell_exec:empty';
+        if (/[\/\\]/.test(first) || first.startsWith('.')) return 'shell_exec:other';
         return `shell_exec:${first}`;
     },
     android_sms: () => 'android_sms',

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -74,6 +74,22 @@ function createToolCallLogSchema(dbInstance) {
     dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at)`);
 }
 
+const TOOL_CALL_LOG_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;  // 30 days
+const MAX_TOOL_CALL_LOG_ROWS = 50000;
+
+function purgeOldLogs(dbInstance, now = Date.now()) {
+    const cutoff = now - TOOL_CALL_LOG_RETENTION_MS;
+    // Each DELETE wrapped independently — tolerate missing tables on fresh installs.
+    try { dbInstance.run(`DELETE FROM tool_call_log WHERE created_at < ?`, [cutoff]); } catch (_) {}
+    try { dbInstance.run(`DELETE FROM skill_trigger_log WHERE created_at < ?`, [cutoff]); } catch (_) {}
+    // Cap row count
+    try {
+        dbInstance.run(`DELETE FROM tool_call_log WHERE id IN (
+            SELECT id FROM tool_call_log ORDER BY created_at DESC LIMIT -1 OFFSET ?
+        )`, [MAX_TOOL_CALL_LOG_ROWS]);
+    } catch (_) {}
+}
+
 function createSkillTriggerLogSchema(dbInstance) {
     dbInstance.run(`CREATE TABLE IF NOT EXISTS skill_trigger_log (
         id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -660,6 +676,7 @@ module.exports = {
     initDatabase,
     createToolCallLogSchema,
     createSkillTriggerLogSchema,
+    purgeOldLogs,
     indexMemoryFiles,
     saveSession,
     getRecentSessions,

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -72,6 +72,19 @@ function createToolCallLogSchema(dbInstance) {
     dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at)`);
 }
 
+function createSkillTriggerLogSchema(dbInstance) {
+    dbInstance.run(`CREATE TABLE IF NOT EXISTS skill_trigger_log (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        skill_name  TEXT    NOT NULL,
+        message_id  TEXT,
+        match_type  TEXT    NOT NULL,
+        created_at  INTEGER NOT NULL,
+        UNIQUE(skill_name, message_id)
+    )`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_stl_skill_created ON skill_trigger_log(skill_name, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_stl_created       ON skill_trigger_log(created_at)`);
+}
+
 async function initDatabase() {
     try {
         const initSqlJs = require('./sql-wasm.js');
@@ -114,6 +127,9 @@ async function initDatabase() {
 
         // Tool call log — feeds "Go to School" self-improvement analysis
         createToolCallLogSchema(db);
+
+        // Skill trigger log — feeds "Go to School" self-improvement analysis
+        createSkillTriggerLogSchema(db);
 
         // Memory indexing tables (BAT-25)
         db.run(`CREATE TABLE IF NOT EXISTS chunks (
@@ -633,6 +649,7 @@ module.exports = {
     setShutdownDeps,
     initDatabase,
     createToolCallLogSchema,
+    createSkillTriggerLogSchema,
     indexMemoryFiles,
     saveSession,
     getRecentSessions,

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -32,6 +32,7 @@ let _shutdownDeps = {
     conversations: null,          // Map — from main.js (will move to ai.js in BAT-203)
     saveSessionSummary: null,     // async fn — from main.js (will move to ai.js in BAT-203)
     MIN_MESSAGES_FOR_SUMMARY: 3,  // constant — from main.js (will move to ai.js in BAT-203)
+    flushToolCallLog: null,       // async fn — flushes buffered tool-call log rows before saveDatabase()
 };
 
 /**
@@ -46,6 +47,7 @@ function setShutdownDeps(deps) {
     if (deps.conversations) _shutdownDeps.conversations = deps.conversations;
     if (typeof deps.saveSessionSummary === 'function') _shutdownDeps.saveSessionSummary = deps.saveSessionSummary;
     if (typeof deps.MIN_MESSAGES_FOR_SUMMARY === 'number') _shutdownDeps.MIN_MESSAGES_FOR_SUMMARY = deps.MIN_MESSAGES_FOR_SUMMARY;
+    if (typeof deps.flushToolCallLog === 'function') _shutdownDeps.flushToolCallLog = deps.flushToolCallLog;
 }
 
 // ============================================================================
@@ -505,6 +507,11 @@ async function gracefulShutdown(signal) {
         }
     } catch (err) {
         log(`[Shutdown] Summary failed: ${err.message}`, 'ERROR');
+    }
+    // Flush buffered tool-call log rows before persisting the db to disk (A5).
+    // Otherwise INSERTs hit the in-memory db AFTER saveDatabase() serializes it → rows lost.
+    if (_shutdownDeps.flushToolCallLog) {
+        try { await _shutdownDeps.flushToolCallLog(); } catch (e) { log(`[DB] tool-call log flush on shutdown failed: ${e.message}`, 'WARN'); }
     }
     saveDatabase();
     process.exit(0);

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -76,8 +76,11 @@ function createToolCallLogSchema(dbInstance) {
 
 // Cap applied on next startup; mid-session growth is bounded by mobile reboot cadence.
 const TOOL_CALL_LOG_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;  // 30 days
-// Row cap for tool_call_log only; skill_trigger_log is naturally bounded by UNIQUE(skill_name, message_id)
+// Row cap for tool_call_log (each row is larger + tool calls happen more frequently than triggers).
 const MAX_TOOL_CALL_LOG_ROWS = 50000;
+// Row cap for skill_trigger_log. UNIQUE(skill_name, message_id) bounds dup-per-message,
+// but the row count can still grow large over 30 days on a busy device.
+const MAX_SKILL_TRIGGER_LOG_ROWS = 20000;
 
 function purgeOldLogs(dbInstance, now = Date.now()) {
     const cutoff = now - TOOL_CALL_LOG_RETENTION_MS;
@@ -92,6 +95,11 @@ function purgeOldLogs(dbInstance, now = Date.now()) {
             SELECT id FROM tool_call_log ORDER BY created_at DESC LIMIT -1 OFFSET ?
         )`, [MAX_TOOL_CALL_LOG_ROWS]);
     } catch (e) { log(`[DB] purge tool_call_log by row cap failed (non-fatal): ${e.message}`, 'WARN'); }
+    try {
+        dbInstance.run(`DELETE FROM skill_trigger_log WHERE id IN (
+            SELECT id FROM skill_trigger_log ORDER BY created_at DESC LIMIT -1 OFFSET ?
+        )`, [MAX_SKILL_TRIGGER_LOG_ROWS]);
+    } catch (e) { log(`[DB] purge skill_trigger_log by row cap failed (non-fatal): ${e.message}`, 'WARN'); }
 }
 
 function createSkillTriggerLogSchema(dbInstance) {

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -52,6 +52,26 @@ function setShutdownDeps(deps) {
 // INIT & PERSISTENCE
 // ============================================================================
 
+function createToolCallLogSchema(dbInstance) {
+    dbInstance.run(`CREATE TABLE IF NOT EXISTS tool_call_log (
+        id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+        turn_id            TEXT    NOT NULL,
+        message_id         TEXT,
+        tool_name          TEXT    NOT NULL,
+        triggered_by_skill TEXT,
+        call_shape         TEXT    NOT NULL,
+        result_status      TEXT    NOT NULL,
+        error_kind         TEXT,
+        latency_ms         INTEGER,
+        created_at         INTEGER NOT NULL
+    )`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_created ON tool_call_log(created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_tool    ON tool_call_log(tool_name, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_shape   ON tool_call_log(call_shape, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_turn    ON tool_call_log(turn_id)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at)`);
+}
+
 async function initDatabase() {
     try {
         const initSqlJs = require('./sql-wasm.js');
@@ -91,6 +111,9 @@ async function initDatabase() {
             retry_count INTEGER DEFAULT 0,
             duration_ms INTEGER
         )`);
+
+        // Tool call log — feeds "Go to School" self-improvement analysis
+        createToolCallLogSchema(db);
 
         // Memory indexing tables (BAT-25)
         db.run(`CREATE TABLE IF NOT EXISTS chunks (
@@ -609,6 +632,7 @@ module.exports = {
     getDb,
     setShutdownDeps,
     initDatabase,
+    createToolCallLogSchema,
     indexMemoryFiles,
     saveSession,
     getRecentSessions,

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -132,6 +132,9 @@ async function initDatabase() {
 
         // Skill trigger log — feeds "Go to School" self-improvement analysis
         createSkillTriggerLogSchema(db);
+        // Wire the db into skills.js so findMatchingSkills can record triggers.
+        const { setSkillTriggerDb } = require('./skills');
+        setSkillTriggerDb(db);
 
         // Memory indexing tables (BAT-25)
         db.run(`CREATE TABLE IF NOT EXISTS chunks (

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -74,20 +74,24 @@ function createToolCallLogSchema(dbInstance) {
     dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at)`);
 }
 
+// Cap applied on next startup; mid-session growth is bounded by mobile reboot cadence.
 const TOOL_CALL_LOG_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;  // 30 days
+// Row cap for tool_call_log only; skill_trigger_log is naturally bounded by UNIQUE(skill_name, message_id)
 const MAX_TOOL_CALL_LOG_ROWS = 50000;
 
 function purgeOldLogs(dbInstance, now = Date.now()) {
     const cutoff = now - TOOL_CALL_LOG_RETENTION_MS;
     // Each DELETE wrapped independently — tolerate missing tables on fresh installs.
-    try { dbInstance.run(`DELETE FROM tool_call_log WHERE created_at < ?`, [cutoff]); } catch (_) {}
-    try { dbInstance.run(`DELETE FROM skill_trigger_log WHERE created_at < ?`, [cutoff]); } catch (_) {}
+    try { dbInstance.run(`DELETE FROM tool_call_log WHERE created_at < ?`, [cutoff]); }
+    catch (e) { log(`[DB] purge tool_call_log by age failed (non-fatal): ${e.message}`, 'WARN'); }
+    try { dbInstance.run(`DELETE FROM skill_trigger_log WHERE created_at < ?`, [cutoff]); }
+    catch (e) { log(`[DB] purge skill_trigger_log by age failed (non-fatal): ${e.message}`, 'WARN'); }
     // Cap row count
     try {
         dbInstance.run(`DELETE FROM tool_call_log WHERE id IN (
             SELECT id FROM tool_call_log ORDER BY created_at DESC LIMIT -1 OFFSET ?
         )`, [MAX_TOOL_CALL_LOG_ROWS]);
-    } catch (_) {}
+    } catch (e) { log(`[DB] purge tool_call_log by row cap failed (non-fatal): ${e.message}`, 'WARN'); }
 }
 
 function createSkillTriggerLogSchema(dbInstance) {

--- a/app/src/main/assets/nodejs-project/error-classifier.js
+++ b/app/src/main/assets/nodejs-project/error-classifier.js
@@ -5,6 +5,10 @@
 // Heuristic list intentionally small. Tune based on real tool_call_log
 // distributions after PR-A soaks in production.
 
+// Module-scope constants — avoid re-allocating on every classify call.
+const HTTP_ALLOWLIST = new Set(['400','401','403','404','409','422','429','500','502','503','504']);
+const HTTP_STATUS_RE = /\b(4\d{2}|5\d{2})\b/;
+
 function classifyError(raw) {
     if (!raw) return 'unknown';
     const s = String(raw);
@@ -31,11 +35,10 @@ function classifyError(raw) {
 
     // HTTP status. Allowlist common codes to keep error_kind low-cardinality;
     // unknown 4xx/5xx collapse to http_4xx / http_5xx.
-    const httpStatus = s.match(/\b(4\d{2}|5\d{2})\b/);
+    const httpStatus = s.match(HTTP_STATUS_RE);
     if (httpStatus) {
         const code = httpStatus[1];
-        const allowlist = new Set(['400','401','403','404','409','422','429','500','502','503','504']);
-        if (allowlist.has(code)) return `http_${code}`;
+        if (HTTP_ALLOWLIST.has(code)) return `http_${code}`;
         return code[0] === '4' ? 'http_4xx' : 'http_5xx';
     }
 

--- a/app/src/main/assets/nodejs-project/error-classifier.js
+++ b/app/src/main/assets/nodejs-project/error-classifier.js
@@ -1,30 +1,9 @@
-// error-classifier.js — map tool error text to low-cardinality buckets for
-// tool_call_log.error_kind. Privacy: bucket labels are constants; free-text
-// fallback is redacted + truncated to 40 chars.
+// error-classifier.js — map tool error text to a low-cardinality, privacy-safe
+// bucket for tool_call_log.error_kind. All returns are constants from a fixed
+// enum of ~14 buckets + 'unknown' + 'other'. No free-text, no user-derived strings.
 //
-// Heuristic list intentionally small (~10 categories). Tune based on
-// real tool_call_log distributions after PR-A soaks in production.
-//
-// NOTE: uses a self-contained redaction helper (static regex patterns only) so
-// this module has no dependency on config.js and can be smoke-loaded in
-// isolation. The main redactSecrets() in security.js adds dynamic patterns
-// from config (API keys, MCP tokens) — we don't need those here because the
-// error-classifier fallback is already truncated to 40 chars, which limits the
-// leak surface independently.
-
-// Static redaction patterns — same known-secret shapes as security.js
-// (Anthropic/OpenAI/OpenRouter keys, Telegram bot tokens, Solana privkeys, etc.)
-// but without the dynamic config-derived keys. Good enough for a 40-char
-// fallback bucket.
-function redactStatic(msg) {
-    if (typeof msg !== 'string') return msg;
-    msg = msg.replace(/sk-ant-[a-zA-Z0-9_-]{10,}/g, 'sk-ant-***');
-    msg = msg.replace(/\d{8,}:[A-Za-z0-9_-]{20,}/g, '***:***');
-    msg = msg.replace(/BSA[a-zA-Z0-9_-]{10,}/g, 'BSA***');
-    msg = msg.replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***');
-    msg = msg.replace(/sk-or-[a-zA-Z0-9_-]{10,}/g, 'sk-or-***');
-    return msg;
-}
+// Heuristic list intentionally small. Tune based on real tool_call_log
+// distributions after PR-A soaks in production.
 
 function classifyError(raw) {
     if (!raw) return 'unknown';
@@ -60,10 +39,13 @@ function classifyError(raw) {
     // Confirmation / user action
     if (/user did not confirm|canceled|cancelled/i.test(s)) return 'user_canceled';
 
-    // Fallback: redacted + truncated to 40 chars (tighter than the previous
-    // 60-char slice — bucket-by-bucket is preferred over free-text, so only
-    // truly novel errors should reach here).
-    return redactStatic(s).slice(0, 40);
+    // Fallback: constant bucket only. Never leak user-derived strings into
+    // error_kind — paths, URL query strings, wallet-like identifiers, or any
+    // other sensitive-but-non-key patterns would survive redactSecrets() and
+    // show up in analytics. 'other' is low-cardinality and privacy-safe.
+    // If a pattern keeps landing here, add a new bucket above, don't widen
+    // the fallback.
+    return 'other';
 }
 
 module.exports = { classifyError };

--- a/app/src/main/assets/nodejs-project/error-classifier.js
+++ b/app/src/main/assets/nodejs-project/error-classifier.js
@@ -29,9 +29,15 @@ function classifyError(raw) {
     // rather than http_401/http_403 — more useful for pattern-mining)
     if (/unauthorized|401|authentication|forbidden|403/i.test(s)) return 'unauthorized';
 
-    // HTTP status codes (remaining 4xx/5xx)
+    // HTTP status. Allowlist common codes to keep error_kind low-cardinality;
+    // unknown 4xx/5xx collapse to http_4xx / http_5xx.
     const httpStatus = s.match(/\b(4\d{2}|5\d{2})\b/);
-    if (httpStatus) return `http_${httpStatus[1]}`;
+    if (httpStatus) {
+        const code = httpStatus[1];
+        const allowlist = new Set(['400','401','403','404','409','422','429','500','502','503','504']);
+        if (allowlist.has(code)) return `http_${code}`;
+        return code[0] === '4' ? 'http_4xx' : 'http_5xx';
+    }
 
     // Validation / user input
     if (/invalid|expected|must be|required/i.test(lower)) return 'validation_error';

--- a/app/src/main/assets/nodejs-project/error-classifier.js
+++ b/app/src/main/assets/nodejs-project/error-classifier.js
@@ -1,0 +1,69 @@
+// error-classifier.js — map tool error text to low-cardinality buckets for
+// tool_call_log.error_kind. Privacy: bucket labels are constants; free-text
+// fallback is redacted + truncated to 40 chars.
+//
+// Heuristic list intentionally small (~10 categories). Tune based on
+// real tool_call_log distributions after PR-A soaks in production.
+//
+// NOTE: uses a self-contained redaction helper (static regex patterns only) so
+// this module has no dependency on config.js and can be smoke-loaded in
+// isolation. The main redactSecrets() in security.js adds dynamic patterns
+// from config (API keys, MCP tokens) — we don't need those here because the
+// error-classifier fallback is already truncated to 40 chars, which limits the
+// leak surface independently.
+
+// Static redaction patterns — same known-secret shapes as security.js
+// (Anthropic/OpenAI/OpenRouter keys, Telegram bot tokens, Solana privkeys, etc.)
+// but without the dynamic config-derived keys. Good enough for a 40-char
+// fallback bucket.
+function redactStatic(msg) {
+    if (typeof msg !== 'string') return msg;
+    msg = msg.replace(/sk-ant-[a-zA-Z0-9_-]{10,}/g, 'sk-ant-***');
+    msg = msg.replace(/\d{8,}:[A-Za-z0-9_-]{20,}/g, '***:***');
+    msg = msg.replace(/BSA[a-zA-Z0-9_-]{10,}/g, 'BSA***');
+    msg = msg.replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***');
+    msg = msg.replace(/sk-or-[a-zA-Z0-9_-]{10,}/g, 'sk-or-***');
+    return msg;
+}
+
+function classifyError(raw) {
+    if (!raw) return 'unknown';
+    const s = String(raw);
+    const lower = s.toLowerCase();
+
+    // File system
+    if (/ENOENT|no such file|file not found/i.test(s)) return 'file_not_found';
+    if (/EACCES|EPERM|permission denied|access denied/i.test(s)) return 'permission_denied';
+    if (/EISDIR|is a directory/i.test(s)) return 'is_directory';
+    if (/ENOSPC|no space left/i.test(s)) return 'disk_full';
+
+    // Network
+    if (/ECONNREFUSED|connection refused/i.test(s)) return 'connection_refused';
+    if (/ENOTFOUND|dns|getaddrinfo/i.test(s)) return 'dns_error';
+    if (/ETIMEDOUT|timeout|timed out/i.test(s)) return 'timeout';
+    if (/ECONNRESET|socket hang up|connection reset/i.test(s)) return 'connection_reset';
+
+    // Rate limiting (check before the generic HTTP match so "429" routes here)
+    if (/rate limit|too many requests|429/i.test(s)) return 'rate_limited';
+
+    // Auth (check before the generic HTTP match so "401"/"403" bucket as unauthorized
+    // rather than http_401/http_403 — more useful for pattern-mining)
+    if (/unauthorized|401|authentication|forbidden|403/i.test(s)) return 'unauthorized';
+
+    // HTTP status codes (remaining 4xx/5xx)
+    const httpStatus = s.match(/\b(4\d{2}|5\d{2})\b/);
+    if (httpStatus) return `http_${httpStatus[1]}`;
+
+    // Validation / user input
+    if (/invalid|expected|must be|required/i.test(lower)) return 'validation_error';
+
+    // Confirmation / user action
+    if (/user did not confirm|canceled|cancelled/i.test(s)) return 'user_canceled';
+
+    // Fallback: redacted + truncated to 40 chars (tighter than the previous
+    // 60-char slice — bucket-by-bucket is preferred over free-text, so only
+    // truly novel errors should reach here).
+    return redactStatic(s).slice(0, 40);
+}
+
+module.exports = { classifyError };

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -881,8 +881,16 @@ telegram('getMe')
 
 // Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram)
 // Runs before database.js's gracefulShutdown which handles session summaries + DB save.
-process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} });
-process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} });
+// Also flushes buffered tool-call log rows so they aren't lost on exit (A5).
+async function flushToolCallLogOnShutdown() {
+    try {
+        const { flushLoggerNow, stopLogger } = require('./tools');
+        if (flushLoggerNow) await flushLoggerNow();
+        if (stopLogger) await stopLogger();
+    } catch (_) { /* best-effort */ }
+}
+process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} flushToolCallLogOnShutdown(); });
+process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} flushToolCallLogOnShutdown(); });
 
 // Runtime status log (uptime/memory debug, every 5 min)
 setInterval(() => {

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -724,6 +724,7 @@ telegram('getMe')
                     { command: 'resume', description: 'Resume an interrupted task' },
                     { command: 'approve', description: 'Confirm pending action' },
                     { command: 'deny', description: 'Reject pending action' },
+                    { command: 'school', description: 'Self-improvement scan — propose skills' },
                     { command: 'help', description: 'List all commands' },
                     { command: 'commands', description: 'List all commands' },
                 ],
@@ -743,6 +744,30 @@ telegram('getMe')
                     log(`setMyCommands failed: ${JSON.stringify(r)}`, 'WARN');
                 }
             }).catch(e => log(`setMyCommands error: ${e.message}`, 'WARN'));
+
+            // Stale /school session cleanup on boot — if SCHOOL.md has been sitting
+            // open for > 48h (user walked away mid-review, or the app crashed during
+            // one), auto-end it and notify the owner. Fails open: any error is logged
+            // at WARN and does not block boot.
+            try {
+                const { SCHOOL_STALE_THRESHOLD_MS, buildStaleEndEntry } = require('./tools/school');
+                const { readSchoolMd, appendLogLine, schoolMdPath } = require('./school');
+                const pre = readSchoolMd(workDir);
+                if (pre && (Date.now() - (pre.started_at || 0)) > SCHOOL_STALE_THRESHOLD_MS) {
+                    appendLogLine(workDir, buildStaleEndEntry(pre, Date.now()));
+                    try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+                    const ownerChat = parseInt(getOwnerId(), 10);
+                    if (!isNaN(ownerChat)) {
+                        telegram('sendMessage', {
+                            chat_id: ownerChat,
+                            text: `Cleaned up a stale /school session from ${new Date(pre.started_at).toLocaleString()}.`,
+                            disable_notification: true,
+                        }).catch(e => log(`[school] stale-notice send failed: ${e.message}`, 'WARN'));
+                    }
+                }
+            } catch (e) {
+                log(`[school] stale cleanup failed: ${e.message}`, 'WARN');
+            }
 
             poll();
             startClaudeUsagePolling();

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -620,7 +620,7 @@ telegram('getMe')
                     const { purgeOldLogs, getDb } = require('./database');
                     const db = getDb();
                     if (db) purgeOldLogs(db);
-                } catch (e) { /* best-effort */ }
+                } catch (e) { log(`[DB] retention purge setup failed (non-fatal): ${e.message}`, 'WARN'); }
             });
 
             indexMemoryFiles();

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -613,6 +613,16 @@ telegram('getMe')
 
             // Initialize SQL.js database before polling (non-fatal if WASM fails)
             await initDatabase();
+
+            // Retention purge runs async, off the boot critical path
+            setImmediate(() => {
+                try {
+                    const { purgeOldLogs, getDb } = require('./database');
+                    const db = getDb();
+                    if (db) purgeOldLogs(db);
+                } catch (e) { /* best-effort */ }
+            });
+
             indexMemoryFiles();
             backfillSessionsFromFiles(); // BAT-322: one-time migration for existing users
             seedHeartbeatMd();

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -618,7 +618,18 @@ telegram('getMe')
             seedHeartbeatMd();
 
             // Wire shutdown deps now that conversations + saveSessionSummary exist
-            setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY });
+            setShutdownDeps({
+                conversations,
+                saveSessionSummary,
+                MIN_MESSAGES_FOR_SUMMARY,
+                flushToolCallLog: async () => {
+                    try {
+                        const { flushLoggerNow, stopLogger } = require('./tools');
+                        if (flushLoggerNow) await flushLoggerNow();
+                        if (stopLogger) await stopLogger();
+                    } catch (_) { /* best-effort */ }
+                },
+            });
 
             // Wire chat deps: inject main.js state into ai.js
             setChatDeps({
@@ -777,7 +788,18 @@ telegram('getMe')
         seedHeartbeatMd();
 
         // Wire shutdown deps
-        setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY });
+        setShutdownDeps({
+            conversations,
+            saveSessionSummary,
+            MIN_MESSAGES_FOR_SUMMARY,
+            flushToolCallLog: async () => {
+                try {
+                    const { flushLoggerNow, stopLogger } = require('./tools');
+                    if (flushLoggerNow) await flushLoggerNow();
+                    if (stopLogger) await stopLogger();
+                } catch (_) { /* best-effort */ }
+            },
+        });
 
         // Wire chat deps: inject main.js state into ai.js
         setChatDeps({
@@ -879,18 +901,12 @@ telegram('getMe')
     });
 }
 
-// Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram)
-// Runs before database.js's gracefulShutdown which handles session summaries + DB save.
-// Also flushes buffered tool-call log rows so they aren't lost on exit (A5).
-async function flushToolCallLogOnShutdown() {
-    try {
-        const { flushLoggerNow, stopLogger } = require('./tools');
-        if (flushLoggerNow) await flushLoggerNow();
-        if (stopLogger) await stopLogger();
-    } catch (_) { /* best-effort */ }
-}
-process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} flushToolCallLogOnShutdown(); });
-process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} flushToolCallLogOnShutdown(); });
+// Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram).
+// Tool-call log flush is handled inside database.js's gracefulShutdown via the
+// flushToolCallLog dep injected above — runs BEFORE saveDatabase() so buffered rows
+// make it into the serialized db (A5).
+process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} });
+process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} });
 
 // Runtime status log (uptime/memory debug, every 5 min)
 setInterval(() => {

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -67,6 +67,13 @@ function assertInit() {
 
 async function handleCommand(chatId, command, args) {
     assertInit();
+    // Auto-cancel any pending /school-reset confirmation on ANY other command.
+    // Without this, a user could /school-reset, chat for 50s, then accidentally
+    // wipe state by sending /school-reset-confirm within the 60s TTL. The
+    // confirmation should only apply to the immediately-following input.
+    if (command !== '/school-reset-confirm' && command !== '/school-reset' && pendingSchoolReset) {
+        pendingSchoolReset = null;
+    }
     switch (command) {
         case '/start': {
             // Templates defined in TEMPLATES.md — update there first, then sync here
@@ -501,6 +508,15 @@ async function handleMessage(normalized) {
         // P2.4: resume flag — set by /resume handler, passed to chat() as option
         let isResume = false;
         let resumeGoal = null;
+
+        // Auto-cancel any pending /school-reset confirmation on a NON-command
+        // message (plain chat). The confirmation window is intended for the
+        // immediately-following user action only. Command messages get the
+        // same treatment inside handleCommand (except /school-reset-confirm
+        // and /school-reset themselves).
+        if (!combinedText.startsWith('/') && pendingSchoolReset) {
+            pendingSchoolReset = null;
+        }
 
         // Check for commands (use combinedText so /commands work even in replies)
         if (combinedText.startsWith('/')) {

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -562,7 +562,7 @@ async function handleMessage(normalized) {
                             try {
                                 const mdContent = fs.readFileSync(saved.localPath, 'utf8');
                                 if (mdContent.startsWith('---')) {
-                                    const installResult = await deps.executeTool('skill_install', { content: mdContent }, chatId);
+                                    const installResult = await deps.executeTool('skill_install', { content: mdContent }, chatId, messageId);
                                     if (installResult && installResult.result) {
                                         deps.log(`Skill auto-installed from attachment: ${installResult.result}`, 'INFO');
                                         // Set flag BEFORE sendMessage so a Telegram error can't cause a fall-through to chat()

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -3,11 +3,54 @@
 // Uses init() dependency injection — all external dependencies received via init(deps).
 
 const fs = require('fs');
-const { CHANNEL } = require('./config');
+const path = require('path');
+const { CHANNEL, workDir } = require('./config');
 const { stripSilentReply, containsSilentReply } = require('./silent-reply');
 
 let deps = {};
 let initialized = false;
+
+// Go to School — Telegram command state.
+// Rate-limit: 1 /school per 5 min, 10/day. Two-step /school-reset with 60s TTL.
+const SCHOOL_MIN_INTERVAL_MS = 5 * 60 * 1000;
+const SCHOOL_DAILY_CAP = 10;
+const SCHOOL_RESET_TTL_MS = 60 * 1000;
+const schoolRateState = { lastInvokedAt: 0, invokesToday: 0, dayStart: 0 };
+let pendingSchoolReset = null;  // { expires_at: ms }
+
+function checkSchoolRateLimit(now = Date.now()) {
+    if (new Date(schoolRateState.dayStart).toDateString() !== new Date(now).toDateString()) {
+        schoolRateState.invokesToday = 0;
+        schoolRateState.dayStart = now;
+    }
+    if (now - schoolRateState.lastInvokedAt < SCHOOL_MIN_INTERVAL_MS) {
+        const nextAt = new Date(schoolRateState.lastInvokedAt + SCHOOL_MIN_INTERVAL_MS).toLocaleTimeString();
+        return { ok: false, message: `School ran recently. Next available at ${nextAt}.` };
+    }
+    if (schoolRateState.invokesToday >= SCHOOL_DAILY_CAP) {
+        return { ok: false, message: `School daily cap (${SCHOOL_DAILY_CAP}) reached. Try again tomorrow.` };
+    }
+    schoolRateState.lastInvokedAt = now;
+    schoolRateState.invokesToday++;
+    return { ok: true };
+}
+
+function renderSchoolLog(limit = 10) {
+    const logPath = path.join(workDir, 'school', 'log.jsonl');
+    if (!fs.existsSync(logPath)) return 'No school sessions yet.';
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+    if (lines.length === 0) return 'No school sessions yet.';
+    const recent = lines.slice(-limit).reverse();
+    const rows = recent.map(l => {
+        try {
+            const e = JSON.parse(l);
+            const when = new Date(e.started_at || e.ended_at || 0).toISOString().slice(0, 10);
+            const n = (e.proposals || []).length;
+            return `• ${when} — ${e.trigger || 'on_demand'} · ${n} proposal${n === 1 ? '' : 's'}`;
+        } catch (_) { return '• (malformed entry)'; }
+    });
+    return `*Recent school sessions*\n\n${rows.join('\n')}`;
+}
 
 function init(d) {
     deps = d;
@@ -202,6 +245,40 @@ Use YAML frontmatter with \`name\`, \`description\`, and \`triggers\` fields.`;
             }
             response += `\nRun a skill: \`/skill name\``;
             return response;
+        }
+
+        case '/school': {
+            const arg = (args || '').trim().toLowerCase();
+            if (arg === 'log') return renderSchoolLog();
+            if (arg && arg !== '') return 'Unknown /school subcommand. Try `/school` (run) or `/school log` (history).';
+            const gate = checkSchoolRateLimit();
+            if (!gate.ok) return gate.message;
+            // Dispatch via the skill matcher — same pattern as /skill <name>.
+            // The bundled go-to-school SKILL.md declares 'go to school' as a trigger.
+            return { __skillFallthrough: true, trigger: 'go to school' };
+        }
+
+        case '/school-reset': {
+            pendingSchoolReset = { expires_at: Date.now() + SCHOOL_RESET_TTL_MS };
+            return 'This will discard the current open school session and any drafts. Reply `/school-reset-confirm` within 60s to proceed.';
+        }
+
+        case '/school-reset-confirm': {
+            if (!pendingSchoolReset || pendingSchoolReset.expires_at < Date.now()) {
+                pendingSchoolReset = null;
+                return 'No pending reset — type `/school-reset` first.';
+            }
+            pendingSchoolReset = null;
+            try { fs.unlinkSync(path.join(workDir, 'SCHOOL.md')); } catch (_) {}
+            try {
+                const draftsDir = path.join(workDir, 'school', 'drafts');
+                if (fs.existsSync(draftsDir)) {
+                    for (const f of fs.readdirSync(draftsDir)) {
+                        try { fs.unlinkSync(path.join(draftsDir, f)); } catch (_) {}
+                    }
+                }
+            } catch (_) {}
+            return 'School state cleared.';
         }
 
         case '/version': {

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -604,7 +604,7 @@ async function handleMessage(normalized) {
             }
         }
 
-        let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction });
+        let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction, messageId });
 
         // Strip protocol tokens the agent may have mixed into content (BAT-279)
         // Uses centralized silent-reply.js helper (BAT-488) that also handles

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -289,9 +289,42 @@ function readSchoolMd(workDir) {
     return { ...fm, proposals, raw: content };
 }
 
+// Rolling retention for school/log.jsonl. Tool description + DIAGNOSTICS claim
+// 90 days; enforce it at append time by read-filter-rewrite. Normal usage is
+// a handful of /school sessions per month, so the log stays well under 1000
+// lines — the O(n) rewrite cost on each append is negligible.
+const SCHOOL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+function logEntryTimeMs(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    // Prefer ended_at (when the session finalized) over started_at. Both are
+    // written by schoolEndHandler; ended_at better reflects the retention cutoff.
+    for (const key of ['ended_at', 'started_at', 'logged_at', 'created_at']) {
+        if (entry[key] == null) continue;
+        const n = typeof entry[key] === 'number' ? entry[key] : Date.parse(String(entry[key]));
+        if (Number.isFinite(n)) return n;
+    }
+    return null;
+}
+
 function appendLogLine(workDir, obj) {
     ensureSchoolDir(workDir);
-    fs.appendFileSync(schoolLogPath(workDir), JSON.stringify(obj) + '\n');
+    const p = schoolLogPath(workDir);
+    const cutoff = Date.now() - SCHOOL_LOG_RETENTION_MS;
+    let kept = [];
+    if (fs.existsSync(p)) {
+        const lines = fs.readFileSync(p, 'utf8').split('\n').filter(Boolean);
+        for (const l of lines) {
+            let parsed;
+            try { parsed = JSON.parse(l); } catch (_) { continue; }  // drop malformed
+            const t = logEntryTimeMs(parsed);
+            // If entry has no recognizable timestamp, keep it (can't judge age).
+            // Otherwise keep only entries newer than the cutoff.
+            if (t == null || t >= cutoff) kept.push(parsed);
+        }
+    }
+    kept.push(obj);
+    fs.writeFileSync(p, kept.map(e => JSON.stringify(e)).join('\n') + '\n');
 }
 
 function readPriorSessions(workDir, limit = 10) {
@@ -319,18 +352,47 @@ function yamlScalar(val) {
 function injectOrReplaceFrontmatterKeys(body, keys) {
     const m = body.match(/^---\n([\s\S]+?)\n---/);
     if (!m) throw new Error('no_frontmatter');
-    const existing = m[1].split('\n');
-    const existingMap = {};
-    const order = [];
-    for (const line of existing) {
-        const kv = line.match(/^(\w[\w-]*):\s*(.+)$/);
-        if (kv) { existingMap[kv[1]] = kv[2]; if (!order.includes(kv[1])) order.push(kv[1]); }
+    const rawLines = m[1].split('\n');
+    const TOP_KEY_RE = /^([A-Za-z0-9_][\w-]*):\s*(.*)$/;
+
+    // Group rawLines into blocks: { key, lines[] }. A block owns the key line
+    // plus all indented/blank continuation lines until the next top-level key.
+    const blocks = [];
+    let current = null;
+    for (const line of rawLines) {
+        const km = line.match(TOP_KEY_RE);
+        if (km) {
+            if (current) blocks.push(current);
+            current = { key: km[1], lines: [line] };
+        } else {
+            if (current) current.lines.push(line);
+            // Line before the first key (shouldn't happen for well-formed YAML,
+            // but preserve it as an anonymous leading block if it does).
+            else blocks.push({ key: null, lines: [line] });
+        }
     }
+    if (current) blocks.push(current);
+
+    // Build output: for each block, if its key is in `keys`, replace the WHOLE
+    // block with a single "key: value" line (this is the intended semantic — we
+    // own these keys and we're setting them to scalar values). Otherwise keep
+    // the block verbatim to preserve nested structure.
+    const replaced = new Set();
+    const out = [];
+    for (const block of blocks) {
+        if (block.key && Object.prototype.hasOwnProperty.call(keys, block.key)) {
+            out.push(`${block.key}: ${yamlScalar(keys[block.key])}`);
+            replaced.add(block.key);
+        } else {
+            out.push(...block.lines);
+        }
+    }
+    // Append any keys in `keys` that didn't already exist.
     for (const k of Object.keys(keys)) {
-        existingMap[k] = yamlScalar(keys[k]);
-        if (!order.includes(k)) order.push(k);
+        if (!replaced.has(k)) out.push(`${k}: ${yamlScalar(keys[k])}`);
     }
-    const newFm = '---\n' + order.map(k => `${k}: ${existingMap[k]}`).join('\n') + '\n---';
+
+    const newFm = '---\n' + out.join('\n') + '\n---';
     return body.replace(/^---\n[\s\S]+?\n---/, newFm);
 }
 

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -267,4 +267,61 @@ function readPriorSessions(workDir, limit = 10) {
     return lines.slice(-limit).map(l => { try { return JSON.parse(l); } catch (_) { return null; } }).filter(Boolean);
 }
 
-module.exports = { normalizeTitle, signatureOf, transition, scanLogs, writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath };
+const MAX_SKILL_BYTES = 64 * 1024;
+
+function injectOrReplaceFrontmatterKeys(body, keys) {
+    const m = body.match(/^---\n([\s\S]+?)\n---/);
+    if (!m) throw new Error('no_frontmatter');
+    const existing = m[1].split('\n');
+    const existingMap = {};
+    const order = [];
+    for (const line of existing) {
+        const kv = line.match(/^(\w[\w-]*):\s*(.+)$/);
+        if (kv) { existingMap[kv[1]] = kv[2]; if (!order.includes(kv[1])) order.push(kv[1]); }
+    }
+    for (const k of Object.keys(keys)) {
+        existingMap[k] = JSON.stringify(keys[k]).replace(/^"|"$/g, '');
+        if (!order.includes(k)) order.push(k);
+    }
+    const newFm = '---\n' + order.map(k => `${k}: ${existingMap[k]}`).join('\n') + '\n---';
+    return body.replace(/^---\n[\s\S]+?\n---/, newFm);
+}
+
+function todayStr() { return new Date().toISOString().slice(0, 10); }
+
+async function writeSkillFile({ workDir, mode, relPath, body, evidence }) {
+    if (!relPath.startsWith('skills/') || relPath.includes('..')) {
+        return { ok: false, error: 'path_outside_workspace_skills' };
+    }
+    if (Buffer.byteLength(body, 'utf8') > MAX_SKILL_BYTES) {
+        return { ok: false, error: 'oversize', limit_bytes: MAX_SKILL_BYTES };
+    }
+    if (!body.startsWith('---\n')) return { ok: false, error: 'missing_frontmatter' };
+    if (!/^#\s+.+/m.test(body.replace(/^---\n[\s\S]+?\n---\n/, ''))) {
+        return { ok: false, error: 'missing_body_heading' };
+    }
+    const fullPath = pathMod.join(workDir, relPath);
+    let finalBody;
+    if (mode === 'create') {
+        finalBody = injectOrReplaceFrontmatterKeys(body, {
+            source: 'school', created: todayStr(), evidence,
+        });
+    } else if (mode === 'patch') {
+        if (!fs.existsSync(fullPath)) return { ok: false, error: 'patch_target_missing' };
+        const existing = fs.readFileSync(fullPath, 'utf8');
+        const existingSourceMatch = existing.match(/^source:\s*(.+)$/m);
+        const existingSource = existingSourceMatch ? existingSourceMatch[1].trim() : 'user';
+        finalBody = injectOrReplaceFrontmatterKeys(body, {
+            last_patched_by: 'school', last_patched_at: todayStr(), patch_evidence: evidence,
+        });
+        finalBody = finalBody.replace(/^source:\s*.+$/m, `source: ${existingSource}`);
+    } else {
+        return { ok: false, error: 'invalid_mode' };
+    }
+    fs.mkdirSync(pathMod.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, finalBody);
+    const sha = crypto.createHash('sha256').update(finalBody).digest('hex');
+    return { ok: true, path: relPath, action: mode, sha256: sha };
+}
+
+module.exports = { normalizeTitle, signatureOf, transition, scanLogs, writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath, writeSkillFile };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -21,4 +21,102 @@ function signatureOf(type, title) {
     return 'sha256:' + crypto.createHash('sha256').update(`${type}|${norm}`).digest('hex');
 }
 
-module.exports = { normalizeTitle, signatureOf };
+const STALE_BARE_YES_MS = 60 * 1000;
+
+// transition(state, input) — pure function, no I/O.
+// state: { kind: 'awaiting_approval' | 'reviewing_<N>' | 'done' | 'scanning', open_proposal_ns: int[], reviewing_n?: int, reviewing_opened_at?: ms }
+// input: { kind: 'yes'|'no'|'review'|'skip'|'stop', proposal_n?: int, message_date: ms, raw_text?: string }
+// returns: { nextState, nextAction: { kind, ...details } }
+function transition(state, input) {
+    const open = state.open_proposal_ns || [];
+    const n = input.proposal_n;
+    const lastAfterRemoval = (removeN) => open.filter(x => x !== removeN);
+
+    if (state.kind === 'awaiting_approval') {
+        if (input.kind === 'review') {
+            if (!open.includes(n)) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'proposal_not_open', open } };
+            }
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: n, open_proposal_ns: open, reviewing_opened_at: input.message_date },
+                nextAction: { kind: 'send_review_artifact', proposal_n: n },
+            };
+        }
+        if (input.kind === 'skip') {
+            const remaining = lastAfterRemoval(n);
+            if (remaining.length === 0) {
+                return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', skipped: [n] } };
+            }
+            return {
+                nextState: { kind: 'awaiting_approval', open_proposal_ns: remaining },
+                nextAction: { kind: 'reply_only', template: 'skipped', n, remaining },
+            };
+        }
+        if (input.kind === 'stop') {
+            return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', ignored: open } };
+        }
+        if (input.kind === 'yes' || input.kind === 'no') {
+            return { nextState: state, nextAction: { kind: 'reply_only', template: 'yes_no_outside_review' } };
+        }
+        return { nextState: state, nextAction: { kind: 'reply_only', template: 'unknown_input' } };
+    }
+
+    if (state.kind === 'reviewing_<N>') {
+        const cur = state.reviewing_n;
+        if (input.kind === 'yes' || input.kind === 'no') {
+            let targetN = n;
+            if (targetN === undefined) {
+                const elapsed = input.message_date - (state.reviewing_opened_at || 0);
+                if (elapsed <= STALE_BARE_YES_MS) targetN = cur;
+                else return { nextState: state, nextAction: { kind: 'reply_only', template: 'ambiguous_bare_yes_no' } };
+            }
+            if (targetN !== cur) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'invalid_proposal_n', got: targetN, expected: cur } };
+            }
+            if (input.kind === 'no') {
+                return {
+                    nextState: { kind: 'awaiting_approval', open_proposal_ns: open },
+                    nextAction: { kind: 'reply_only', template: 'drafted_but_denied', n: cur },
+                };
+            }
+            const remaining = lastAfterRemoval(cur);
+            const next = remaining.length === 0
+                ? { kind: 'done', open_proposal_ns: [] }
+                : { kind: 'awaiting_approval', open_proposal_ns: remaining };
+            return { nextState: next, nextAction: { kind: 'write_skill', n: cur } };
+        }
+        if (input.kind === 'review') {
+            if (!open.includes(n)) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'proposal_not_open', open } };
+            }
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: n, open_proposal_ns: open, reviewing_opened_at: input.message_date },
+                nextAction: { kind: 'send_review_artifact', proposal_n: n, skipped_n: cur },
+            };
+        }
+        if (input.kind === 'skip') {
+            if (n === cur) {
+                const remaining = lastAfterRemoval(n);
+                if (remaining.length === 0) {
+                    return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', skipped: [n] } };
+                }
+                return {
+                    nextState: { kind: 'awaiting_approval', open_proposal_ns: remaining },
+                    nextAction: { kind: 'reply_only', template: 'skipped', n, remaining },
+                };
+            }
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: cur, open_proposal_ns: lastAfterRemoval(n), reviewing_opened_at: state.reviewing_opened_at },
+                nextAction: { kind: 'reply_only', template: 'skipped_other', n, cur },
+            };
+        }
+        if (input.kind === 'stop') {
+            return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', drafted_but_denied: [cur], ignored: lastAfterRemoval(cur) } };
+        }
+        return { nextState: state, nextAction: { kind: 'reply_only', template: 'unknown_input' } };
+    }
+
+    return { nextState: state, nextAction: { kind: 'reply_only', template: 'unsupported_state', state: state.kind } };
+}
+
+module.exports = { normalizeTitle, signatureOf, transition };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -120,6 +120,7 @@ function transition(state, input) {
 }
 
 const INSUFFICIENT_SIGNAL_MIN_CALLS = 20;
+const EXPENSIVE_TURN_MIN_TOOLS = 8;
 
 function scanLogs(db, { window_days = 7, min_repetition = 3, now_ms = Date.now(), caps = {} } = {}) {
     const capPatterns = caps.patterns ?? 5;
@@ -168,9 +169,9 @@ function scanLogs(db, { window_days = 7, min_repetition = 3, now_ms = Date.now()
         FROM tool_call_log
         WHERE created_at > ?
         GROUP BY turn_id
-        HAVING tool_count >= 8
+        HAVING tool_count >= ?
         ORDER BY tool_count DESC, latency_sum DESC
-        LIMIT ?`, [cutoff, capTurns]);
+        LIMIT ?`, [cutoff, EXPENSIVE_TURN_MIN_TOOLS, capTurns]);
     const expensive_turns = (exRows[0] ? exRows[0].values : []).map(r => ({
         turn_id: r[0], message_id: r[1], tool_count: r[2], latency_ms_total: r[3]
     }));

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -1,9 +1,12 @@
-// school.js — pure module for Go to School feature.
-// Provides state-machine transition, pattern mining, skill file writers,
-// and persistent-log helpers. No side effects at module load.
+// school.js — pure module for Go to School feature. No side effects at module load.
+// Grows over Phase B: B1 (this commit) = normalizeTitle + signatureOf.
+// B2+ adds state-machine transition, pattern mining, skill file writers, persistent-log helpers.
 
 const crypto = require('crypto');
 
+// normalizeTitle(raw: string) → kebab-case slug.
+// Non-ASCII chars (é, ñ, CJK) are dropped by the [^a-z0-9-] filter — acceptable
+// for v1 since titles are agent-generated and always English.
 function normalizeTitle(raw) {
     return String(raw || '')
         .toLowerCase()

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -3,6 +3,8 @@
 // B2+ adds state-machine transition, pattern mining, skill file writers, persistent-log helpers.
 
 const crypto = require('crypto');
+const fs = require('fs');
+const pathMod = require('path');
 
 // normalizeTitle(raw: string) → kebab-case slug.
 // Non-ASCII chars (é, ñ, CJK) are dropped by the [^a-z0-9-] filter — acceptable
@@ -192,4 +194,77 @@ function scanLogs(db, { window_days = 7, min_repetition = 3, now_ms = Date.now()
     };
 }
 
-module.exports = { normalizeTitle, signatureOf, transition, scanLogs };
+function schoolDir(workDir) { return pathMod.join(workDir, 'school'); }
+function schoolMdPath(workDir) { return pathMod.join(workDir, 'SCHOOL.md'); }
+function schoolLogPath(workDir) { return pathMod.join(workDir, 'school', 'log.jsonl'); }
+
+function ensureSchoolDir(workDir) {
+    const d = schoolDir(workDir);
+    fs.mkdirSync(d, { recursive: true });
+    fs.mkdirSync(pathMod.join(d, 'drafts'), { recursive: true });
+    fs.mkdirSync(pathMod.join(d, 'retired'), { recursive: true });
+}
+
+function writeSchoolMd(workDir, sessionObj) {
+    ensureSchoolDir(workDir);
+    const frontmatter = [
+        '---',
+        `session_id: ${sessionObj.session_id}`,
+        `started_at: ${sessionObj.started_at}`,
+        `trigger: ${sessionObj.trigger || 'on_demand'}`,
+        `state: ${sessionObj.state || 'scanning'}`,
+        `window_days: ${sessionObj.window_days || 7}`,
+        `open_proposal_ns: [${(sessionObj.open_proposal_ns || []).join(', ')}]`,
+        `rubric_version: "${sessionObj.rubric_version || '1.0.0'}"`,
+        sessionObj.reviewing_opened_at ? `reviewing_opened_at: ${sessionObj.reviewing_opened_at}` : '',
+        '---',
+        '',
+        `# School Session — ${new Date(sessionObj.started_at).toISOString()}`,
+        '',
+        '## Proposals',
+        JSON.stringify(sessionObj.proposals || [], null, 2),
+        '',
+    ].filter(Boolean).join('\n');
+    fs.writeFileSync(schoolMdPath(workDir), frontmatter);
+}
+
+function readSchoolMd(workDir) {
+    const p = schoolMdPath(workDir);
+    if (!fs.existsSync(p)) return null;
+    const content = fs.readFileSync(p, 'utf8');
+    const m = content.match(/^---\n([\s\S]+?)\n---/);
+    if (!m) throw new Error('SCHOOL.md malformed (no YAML frontmatter)');
+    const fm = {};
+    for (const line of m[1].split('\n')) {
+        const kv = line.match(/^(\w+):\s*(.+)$/);
+        if (!kv) continue;
+        const [, k, v] = kv;
+        if (k === 'open_proposal_ns') {
+            fm[k] = v.replace(/[\[\]]/g, '').split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
+        } else if (k === 'started_at' || k === 'reviewing_opened_at' || k === 'window_days') {
+            fm[k] = parseInt(v, 10);
+        } else {
+            fm[k] = v.replace(/^["']|["']$/g, '');
+        }
+    }
+    let proposals = [];
+    const pm = content.match(/## Proposals\n(\[[\s\S]*?\])\n/);
+    if (pm) {
+        try { proposals = JSON.parse(pm[1]); } catch (_) { proposals = []; }
+    }
+    return { ...fm, proposals, raw: content };
+}
+
+function appendLogLine(workDir, obj) {
+    ensureSchoolDir(workDir);
+    fs.appendFileSync(schoolLogPath(workDir), JSON.stringify(obj) + '\n');
+}
+
+function readPriorSessions(workDir, limit = 10) {
+    const p = schoolLogPath(workDir);
+    if (!fs.existsSync(p)) return [];
+    const lines = fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean);
+    return lines.slice(-limit).map(l => { try { return JSON.parse(l); } catch (_) { return null; } }).filter(Boolean);
+}
+
+module.exports = { normalizeTitle, signatureOf, transition, scanLogs, writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -1,0 +1,21 @@
+// school.js — pure module for Go to School feature.
+// Provides state-machine transition, pattern mining, skill file writers,
+// and persistent-log helpers. No side effects at module load.
+
+const crypto = require('crypto');
+
+function normalizeTitle(raw) {
+    return String(raw || '')
+        .toLowerCase()
+        .replace(/[_\s.]+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+function signatureOf(type, title) {
+    const norm = normalizeTitle(title);
+    return 'sha256:' + crypto.createHash('sha256').update(`${type}|${norm}`).digest('hex');
+}
+
+module.exports = { normalizeTitle, signatureOf };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -24,12 +24,30 @@ function signatureOf(type, title) {
 }
 
 const STALE_BARE_YES_MS = 60 * 1000;
+// Unix-seconds timestamps are bounded by ~1e10 through year 2286; any ms
+// timestamp post-2001 is > 1e12. Use 1e12 as the dividing line — if a caller
+// hands us seconds (e.g. forwarded straight from Telegram's message.date),
+// normalize to ms so STALE_BARE_YES_MS stays meaningful.
+const MS_SECONDS_THRESHOLD = 1e12;
+function toMs(t) {
+    const n = Number(t);
+    if (!Number.isFinite(n)) return 0;
+    return n < MS_SECONDS_THRESHOLD ? n * 1000 : n;
+}
 
 // transition(state, input) — pure function, no I/O.
 // state: { kind: 'awaiting_approval' | 'reviewing_<N>' | 'done' | 'scanning', open_proposal_ns: int[], reviewing_n?: int, reviewing_opened_at?: ms }
-// input: { kind: 'yes'|'no'|'review'|'skip'|'stop', proposal_n?: int, message_date: ms, raw_text?: string }
+// input: { kind: 'yes'|'no'|'review'|'skip'|'stop', proposal_n?: int, message_date: ms-or-seconds, raw_text?: string }
+//   - message_date is normalized to ms at the boundary. Passing seconds (Telegram's
+//     message.date) or ms (Date.now()) both work; state is always stored in ms.
 // returns: { nextState, nextAction: { kind, ...details } }
 function transition(state, input) {
+    // Normalize time-bearing fields to ms so the state machine can compare
+    // against STALE_BARE_YES_MS uniformly regardless of caller's unit choice.
+    const normalizedInput = { ...input, message_date: toMs(input.message_date) };
+    const normalizedState = { ...state, reviewing_opened_at: toMs(state.reviewing_opened_at) };
+    input = normalizedInput;
+    state = normalizedState;
     const open = state.open_proposal_ns || [];
     const n = input.proposal_n;
     const lastAfterRemoval = (removeN) => open.filter(x => x !== removeN);

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -216,6 +216,9 @@ function writeSchoolMd(workDir, sessionObj) {
         `window_days: ${sessionObj.window_days || 7}`,
         `open_proposal_ns: [${(sessionObj.open_proposal_ns || []).join(', ')}]`,
         `rubric_version: "${sessionObj.rubric_version || '1.0.0'}"`,
+        // reviewing_n tracks the proposal currently under /review N — needed
+        // for school_handle_input to reconstruct state between turns.
+        sessionObj.reviewing_n != null ? `reviewing_n: ${sessionObj.reviewing_n}` : '',
         sessionObj.reviewing_opened_at ? `reviewing_opened_at: ${sessionObj.reviewing_opened_at}` : '',
         '---',
         '',
@@ -226,6 +229,19 @@ function writeSchoolMd(workDir, sessionObj) {
         '',
     ].filter(Boolean).join('\n');
     fs.writeFileSync(schoolMdPath(workDir), frontmatter);
+}
+
+// Reconstruct the state-machine input shape expected by transition() from the
+// flat SCHOOL.md frontmatter. Returns { kind, open_proposal_ns, reviewing_n,
+// reviewing_opened_at } — the exact shape transition() reads.
+function schoolStateFromFrontmatter(fm) {
+    if (!fm) return null;
+    return {
+        kind: fm.state || 'scanning',
+        open_proposal_ns: fm.open_proposal_ns || [],
+        reviewing_n: (fm.reviewing_n != null && !isNaN(fm.reviewing_n)) ? fm.reviewing_n : undefined,
+        reviewing_opened_at: fm.reviewing_opened_at || null,
+    };
 }
 
 function readSchoolMd(workDir) {
@@ -241,7 +257,7 @@ function readSchoolMd(workDir) {
         const [, k, v] = kv;
         if (k === 'open_proposal_ns') {
             fm[k] = v.replace(/[\[\]]/g, '').split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
-        } else if (k === 'started_at' || k === 'reviewing_opened_at' || k === 'window_days') {
+        } else if (k === 'started_at' || k === 'reviewing_opened_at' || k === 'window_days' || k === 'reviewing_n') {
             fm[k] = parseInt(v, 10);
         } else {
             fm[k] = v.replace(/^["']|["']$/g, '');
@@ -324,10 +340,14 @@ async function writeSkillFile({ workDir, mode, relPath, body, evidence }) {
         const existing = fs.readFileSync(fullPath, 'utf8');
         const existingSourceMatch = existing.match(/^source:\s*(.+)$/m);
         const existingSource = existingSourceMatch ? existingSourceMatch[1].trim() : 'user';
+        // Inject existing source directly — if the patch body omits `source:`
+        // entirely, the post-hoc .replace() had nothing to match and provenance
+        // was silently lost. injectOrReplaceFrontmatterKeys now both overwrites
+        // an existing source AND adds it if missing.
         finalBody = injectOrReplaceFrontmatterKeys(body, {
+            source: existingSource,
             last_patched_by: 'school', last_patched_at: todayStr(), patch_evidence: evidence,
         });
-        finalBody = finalBody.replace(/^source:\s*.+$/m, `source: ${existingSource}`);
     } else {
         return { ok: false, error: 'invalid_mode' };
     }
@@ -337,4 +357,4 @@ async function writeSkillFile({ workDir, mode, relPath, body, evidence }) {
     return { ok: true, path: relPath, action: mode, sha256: sha };
 }
 
-module.exports = { normalizeTitle, signatureOf, transition, scanLogs, writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath, writeSkillFile };
+module.exports = { normalizeTitle, signatureOf, transition, scanLogs, writeSchoolMd, readSchoolMd, schoolStateFromFrontmatter, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath, writeSkillFile };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -119,4 +119,76 @@ function transition(state, input) {
     return { nextState: state, nextAction: { kind: 'reply_only', template: 'unsupported_state', state: state.kind } };
 }
 
-module.exports = { normalizeTitle, signatureOf, transition };
+const INSUFFICIENT_SIGNAL_MIN_CALLS = 20;
+
+function scanLogs(db, { window_days = 7, min_repetition = 3, now_ms = Date.now(), caps = {} } = {}) {
+    const capPatterns = caps.patterns ?? 5;
+    const capSequences = caps.sequences ?? 10;
+    const capTurns = caps.turns ?? 5;
+    const cutoff = now_ms - window_days * 24 * 3600 * 1000;
+
+    const total = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE created_at > ?`, [cutoff]);
+    const totalCalls = total.length ? total[0].values[0][0] : 0;
+    if (totalCalls < INSUFFICIENT_SIGNAL_MIN_CALLS) {
+        return { window_days, empty: true, reason: 'insufficient_signal', total_tool_calls: totalCalls, suggested_window_days: Math.min(30, window_days * 2) };
+    }
+    const totalTurns = db.exec(`SELECT COUNT(DISTINCT turn_id) FROM tool_call_log WHERE created_at > ?`, [cutoff])[0].values[0][0];
+
+    const repRows = db.exec(`
+        SELECT call_shape, COUNT(*) as cnt, COUNT(DISTINCT DATE(created_at/1000, 'unixepoch')) as distinct_days,
+               GROUP_CONCAT(DISTINCT turn_id) as turns, GROUP_CONCAT(DISTINCT message_id) as msgs
+        FROM tool_call_log
+        WHERE created_at > ?
+        GROUP BY call_shape
+        HAVING cnt >= ?
+        ORDER BY cnt DESC
+        LIMIT ?`, [cutoff, min_repetition, capPatterns]);
+    const repeated_patterns = (repRows[0] ? repRows[0].values : []).map(r => ({
+        call_shape_chain: [r[0]],
+        count: r[1],
+        spans_distinct_days: r[2],
+        sample_turn_ids: String(r[3] || '').split(',').slice(0, 3),
+        sample_message_ids: String(r[4] || '').split(',').slice(0, 3),
+    }));
+
+    const failRows = db.exec(`
+        SELECT tool_name, call_shape, error_kind, COUNT(*) as cnt
+        FROM tool_call_log
+        WHERE created_at > ? AND result_status = 'error'
+        GROUP BY tool_name, call_shape, error_kind
+        HAVING cnt >= ?
+        ORDER BY cnt DESC
+        LIMIT ?`, [cutoff, min_repetition, capSequences]);
+    const failed_sequences = (failRows[0] ? failRows[0].values : []).map(r => ({
+        tool_name: r[0], call_shape: r[1], error_kind: r[2], count: r[3]
+    }));
+
+    const exRows = db.exec(`
+        SELECT turn_id, MIN(message_id), COUNT(*) as tool_count, SUM(latency_ms) as latency_sum
+        FROM tool_call_log
+        WHERE created_at > ?
+        GROUP BY turn_id
+        HAVING tool_count >= 8
+        ORDER BY tool_count DESC, latency_sum DESC
+        LIMIT ?`, [cutoff, capTurns]);
+    const expensive_turns = (exRows[0] ? exRows[0].values : []).map(r => ({
+        turn_id: r[0], message_id: r[1], tool_count: r[2], latency_ms_total: r[3]
+    }));
+
+    const triggeredRows = db.exec(`SELECT DISTINCT skill_name FROM skill_trigger_log WHERE created_at > ?`, [cutoff]);
+    const triggered_skills = (triggeredRows[0] ? triggeredRows[0].values : []).map(r => r[0]);
+
+    return {
+        window_days,
+        empty: false,
+        total_turns: totalTurns,
+        total_tool_calls: totalCalls,
+        repeated_patterns,
+        failed_sequences,
+        expensive_turns,
+        triggered_skills,
+        unused_tools: [],
+    };
+}
+
+module.exports = { normalizeTitle, signatureOf, transition, scanLogs };

--- a/app/src/main/assets/nodejs-project/school.js
+++ b/app/src/main/assets/nodejs-project/school.js
@@ -269,6 +269,19 @@ function readPriorSessions(workDir, limit = 10) {
 
 const MAX_SKILL_BYTES = 64 * 1024;
 
+// Serialize a value as a YAML-safe scalar. Evidence is agent-generated and can
+// contain newlines, colons, # comments, or quotes — all of which would break
+// the simple regex-based frontmatter parser in readSchoolMd. Strip newlines
+// (collapse to spaces) and double-quote if the value contains any reserved
+// character; escape embedded double-quotes.
+function yamlScalar(val) {
+    const s = String(val == null ? '' : val).replace(/\r?\n/g, ' ').trim();
+    if (/[:#"'\[\]{}&*!|>%@`]/.test(s) || s === '' || /^[-?]/.test(s)) {
+        return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    }
+    return s;
+}
+
 function injectOrReplaceFrontmatterKeys(body, keys) {
     const m = body.match(/^---\n([\s\S]+?)\n---/);
     if (!m) throw new Error('no_frontmatter');
@@ -280,7 +293,7 @@ function injectOrReplaceFrontmatterKeys(body, keys) {
         if (kv) { existingMap[kv[1]] = kv[2]; if (!order.includes(kv[1])) order.push(kv[1]); }
     }
     for (const k of Object.keys(keys)) {
-        existingMap[k] = JSON.stringify(keys[k]).replace(/^"|"$/g, '');
+        existingMap[k] = yamlScalar(keys[k]);
         if (!order.includes(k)) order.push(k);
     }
     const newFm = '---\n' + order.map(k => `${k}: ${existingMap[k]}`).join('\n') + '\n---';

--- a/app/src/main/assets/nodejs-project/skills.js
+++ b/app/src/main/assets/nodejs-project/skills.js
@@ -8,6 +8,26 @@ const path = require('path');
 const { SKILLS_DIR, log, config, SHELL_ALLOWLIST } = require('./config');
 
 // ============================================================================
+// SKILL TRIGGER TELEMETRY
+// ============================================================================
+// Wired into the SQL.js database from database.js:initDatabase() via
+// setSkillTriggerDb(). recordSkillTrigger() is called from findMatchingSkills()
+// whenever a skill matches. Feeds the "Go to School" self-improvement loop.
+// Telemetry failures MUST NEVER break message delivery.
+
+let _stlDb = null;
+function setSkillTriggerDb(db) { _stlDb = db; }
+function recordSkillTrigger(skillName, messageId, matchType, createdAt) {
+    if (!_stlDb) return;
+    try {
+        _stlDb.run(
+            `INSERT OR IGNORE INTO skill_trigger_log (skill_name, message_id, match_type, created_at) VALUES (?, ?, ?, ?)`,
+            [skillName, messageId || null, matchType, createdAt]
+        );
+    } catch (e) { /* never fail a message on telemetry */ }
+}
+
+// ============================================================================
 // SKILLS SYSTEM
 // ============================================================================
 
@@ -545,7 +565,7 @@ function loadSkills() {
 // SKILL MATCHING & PROMPT BUILDING
 // ============================================================================
 
-function findMatchingSkills(message) {
+function findMatchingSkills(message, ctx = {}) {
     const skills = loadSkills();
     const lowerMsg = message.toLowerCase();
 
@@ -561,7 +581,12 @@ function findMatchingSkills(message) {
             return regex.test(message);
         });
 
-        if (hasTrigger) matched.push(skill);
+        if (hasTrigger) {
+            matched.push(skill);
+            if (ctx.message_id) {
+                recordSkillTrigger(skill.name, ctx.message_id, 'keyword', ctx.timestamp || Date.now());
+            }
+        }
     }
 
     return matched;
@@ -602,4 +627,6 @@ module.exports = {
     loadSkills,
     findMatchingSkills,
     parseSkillFile,
+    recordSkillTrigger,
+    setSkillTriggerDb,
 };

--- a/app/src/main/assets/nodejs-project/skills.js
+++ b/app/src/main/assets/nodejs-project/skills.js
@@ -17,14 +17,24 @@ const { SKILLS_DIR, log, config, SHELL_ALLOWLIST } = require('./config');
 
 let _stlDb = null;
 function setSkillTriggerDb(db) { _stlDb = db; }
+
+// Defer skill_trigger_log writes off the message hot path via setImmediate.
+// findMatchingSkills() runs synchronously during message handling; doing a
+// SQL.js run() inline adds ~0.5ms per match and can spike on burst traffic.
+// setImmediate yields to the next tick so the message's AI request starts
+// without waiting on telemetry. Errors are swallowed — telemetry MUST NEVER
+// break message delivery.
 function recordSkillTrigger(skillName, messageId, matchType, createdAt) {
     if (!_stlDb) return;
-    try {
-        _stlDb.run(
-            `INSERT OR IGNORE INTO skill_trigger_log (skill_name, message_id, match_type, created_at) VALUES (?, ?, ?, ?)`,
-            [skillName, messageId || null, matchType, createdAt]
-        );
-    } catch (e) { /* never fail a message on telemetry */ }
+    setImmediate(() => {
+        if (!_stlDb) return;  // DB may have been torn down between call and tick
+        try {
+            _stlDb.run(
+                `INSERT OR IGNORE INTO skill_trigger_log (skill_name, message_id, match_type, created_at) VALUES (?, ?, ?, ?)`,
+                [skillName, messageId || null, matchType, createdAt]
+            );
+        } catch (e) { /* never fail a message on telemetry */ }
+    });
 }
 
 // ============================================================================

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -61,16 +61,19 @@ class ToolCallLogger {
         this.flushing = true;
         if (this.buffer.length === 0) { this.flushing = false; return; }
         const batch = this.buffer.splice(0, this.buffer.length);
+        // Declare stmt outside the try so the finally can always free it, even
+        // if stmt.run() throws partway through the batch. Without this, repeated
+        // flush failures would leak SQL.js statement memory over time.
+        let stmt = null;
         try {
             this.db.run('BEGIN TRANSACTION');
-            const stmt = this.db.prepare(`INSERT INTO tool_call_log
+            stmt = this.db.prepare(`INSERT INTO tool_call_log
                 (turn_id, message_id, tool_name, triggered_by_skill, call_shape, result_status, error_kind, latency_ms, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`);
             for (const r of batch) {
                 stmt.run([r.turn_id, r.message_id, r.tool_name, r.triggered_by_skill,
                           r.call_shape, r.result_status, r.error_kind, r.latency_ms, r.created_at]);
             }
-            stmt.free();
             this.db.run('COMMIT');
             // Re-trigger ONLY on success: if buffer grew past threshold while we
             // were flushing, schedule another pass. On the failure path, we fall
@@ -89,6 +92,10 @@ class ToolCallLogger {
             // concurrently during the in-flight flush; enforce same policy as record().
             this._enforceHardCap();
         } finally {
+            // Always free the prepared statement — guards against leaks when
+            // stmt.run() throws mid-batch. Wrapped in try/catch because calling
+            // free() twice (or on an already-errored stmt) would throw.
+            if (stmt) { try { stmt.free(); } catch (_) {} }
             this.flushing = false;
         }
     }

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -1,0 +1,59 @@
+// tool-call-logger.js — in-memory buffer for tool_call_log inserts.
+// Flushes on 5s interval OR 100-row threshold (whichever first).
+// Bypasses the hot path of tool execution; worst case on abrupt kill = 5s of log loss.
+
+class ToolCallLogger {
+    constructor({ db, flushIntervalMs = 5000, maxBufferSize = 100, log = () => {} }) {
+        this.db = db;
+        this.buffer = [];
+        this.flushIntervalMs = flushIntervalMs;
+        this.maxBufferSize = maxBufferSize;
+        this.log = log;
+        this.flushing = false;
+        this.stopped = false;
+        this.timer = setInterval(() => { this.flushNow().catch(() => {}); }, flushIntervalMs);
+        if (this.timer.unref) this.timer.unref();  // don't block Node exit on this timer
+    }
+
+    record(row) {
+        if (this.stopped) return;
+        this.buffer.push(row);
+        if (this.buffer.length >= this.maxBufferSize) {
+            // Fire-and-forget; batch flush on next tick.
+            setImmediate(() => this.flushNow().catch(() => {}));
+        }
+    }
+
+    async flushNow() {
+        if (this.flushing) return;
+        if (this.buffer.length === 0) return;
+        this.flushing = true;
+        const batch = this.buffer.splice(0, this.buffer.length);
+        try {
+            this.db.run('BEGIN TRANSACTION');
+            const stmt = this.db.prepare(`INSERT INTO tool_call_log
+                (turn_id, message_id, tool_name, triggered_by_skill, call_shape, result_status, error_kind, latency_ms, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+            for (const r of batch) {
+                stmt.run([r.turn_id, r.message_id, r.tool_name, r.triggered_by_skill,
+                          r.call_shape, r.result_status, r.error_kind, r.latency_ms, r.created_at]);
+            }
+            stmt.free();
+            this.db.run('COMMIT');
+        } catch (e) {
+            try { this.db.run('ROLLBACK'); } catch (_) {}
+            this.log(`[ToolCallLogger] flush failed: ${e.message}`, 'ERROR');
+            // Put the batch back at the head so we don't lose it silently
+            this.buffer.unshift(...batch);
+        } finally {
+            this.flushing = false;
+        }
+    }
+
+    stop() {
+        this.stopped = true;
+        clearInterval(this.timer);
+    }
+}
+
+module.exports = { ToolCallLogger };

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -4,6 +4,12 @@
 // On persistent flush failure, buffer is capped at 10× maxBufferSize; oldest rows
 // dropped with WARN log (prevents unbounded growth when db is unusable).
 
+// After a failed flush, suppress size-triggered setImmediate flushes for at
+// least this long. The 5s interval still retries — the cooldown just prevents
+// a tight setImmediate loop when the DB is persistently unusable and record()
+// keeps firing (e.g., burst of tool calls during a DB-closed window).
+const FAILED_FLUSH_COOLDOWN_MS = 1000;
+
 class ToolCallLogger {
     constructor({ db, flushIntervalMs = 5000, maxBufferSize = 100, log = () => {} }) {
         this.db = db;
@@ -14,6 +20,7 @@ class ToolCallLogger {
         this.log = log;
         this.flushing = false;
         this.stopped = false;
+        this.lastFlushFailedAt = 0;  // ms; 0 = no recent failure
         this.timer = setInterval(() => { this.flushNow().catch(() => {}); }, flushIntervalMs);
         if (this.timer.unref) this.timer.unref();  // don't block Node exit on this timer
     }
@@ -36,8 +43,13 @@ class ToolCallLogger {
         this.buffer.push(row);
         this._enforceHardCap();
         if (this.buffer.length >= this.maxBufferSize) {
-            // Fire-and-forget; batch flush on next tick.
-            setImmediate(() => this.flushNow().catch(() => {}));
+            // Fire-and-forget; batch flush on next tick. Skip if a recent flush
+            // failed — the 5s interval handles retry, and without this gate a
+            // persistent DB failure + continued tool calls would spam
+            // setImmediate + ERROR logs on the hot path.
+            if (Date.now() - this.lastFlushFailedAt >= FAILED_FLUSH_COOLDOWN_MS) {
+                setImmediate(() => this.flushNow().catch(() => {}));
+            }
         }
     }
 
@@ -80,12 +92,14 @@ class ToolCallLogger {
             // through to the catch + finally — no re-trigger, letting the 5s
             // interval (or the next record() call) handle retry. This prevents
             // a CPU spin loop on persistent db failure.
+            this.lastFlushFailedAt = 0;  // clear cooldown on success
             if (!this.stopped && this.buffer.length >= this.maxBufferSize) {
                 setImmediate(() => this.flushNow().catch(() => {}));
             }
         } catch (e) {
             try { this.db.run('ROLLBACK'); } catch (_) {}
             this.log(`[ToolCallLogger] flush failed: ${e.message}`, 'ERROR');
+            this.lastFlushFailedAt = Date.now();  // start cooldown
             // Put the batch back at the head so we don't lose it silently
             this.buffer.unshift(...batch);
             // Failed unshift may push buffer over hard cap if records accumulated

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -1,6 +1,8 @@
 // tool-call-logger.js — in-memory buffer for tool_call_log inserts.
 // Flushes on 5s interval OR 100-row threshold (whichever first).
 // Bypasses the hot path of tool execution; worst case on abrupt kill = 5s of log loss.
+// On persistent flush failure, buffer is capped at 10× maxBufferSize; oldest rows
+// dropped with WARN log (prevents unbounded growth when db is unusable).
 
 class ToolCallLogger {
     constructor({ db, flushIntervalMs = 5000, maxBufferSize = 100, log = () => {} }) {
@@ -8,6 +10,7 @@ class ToolCallLogger {
         this.buffer = [];
         this.flushIntervalMs = flushIntervalMs;
         this.maxBufferSize = maxBufferSize;
+        this.MAX_BUFFER_HARD_CAP_MULTIPLIER = 10;
         this.log = log;
         this.flushing = false;
         this.stopped = false;
@@ -18,6 +21,16 @@ class ToolCallLogger {
     record(row) {
         if (this.stopped) return;
         this.buffer.push(row);
+        const hardCap = this.maxBufferSize * this.MAX_BUFFER_HARD_CAP_MULTIPLIER;
+        if (this.buffer.length > hardCap) {
+            // Persistent flush failure (e.g. db closed / disk full) will accumulate
+            // unboundedly via unshift on the error path. Drop oldest to prevent
+            // memory leak. Honest tradeoff: we already accept 5s data loss on abrupt
+            // kill; persistent-failure loss is the same tradeoff at a different scale.
+            const drop = this.buffer.length - hardCap;
+            this.buffer.splice(0, drop);
+            this.log(`[ToolCallLogger] buffer hard-cap exceeded; dropped ${drop} oldest rows`, 'WARN');
+        }
         if (this.buffer.length >= this.maxBufferSize) {
             // Fire-and-forget; batch flush on next tick.
             setImmediate(() => this.flushNow().catch(() => {}));
@@ -47,12 +60,19 @@ class ToolCallLogger {
             this.buffer.unshift(...batch);
         } finally {
             this.flushing = false;
+            // If the buffer grew past threshold while we were flushing, re-trigger.
+            if (!this.stopped && this.buffer.length >= this.maxBufferSize) {
+                setImmediate(() => this.flushNow().catch(() => {}));
+            }
         }
     }
 
-    stop() {
+    async stop() {
         this.stopped = true;
         clearInterval(this.timer);
+        // Final drain. If this throws (db already closed, etc.), swallow — we're
+        // shutting down; there's nothing else to do with the rows.
+        try { await this.flushNow(); } catch (_) {}
     }
 }
 

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -38,9 +38,24 @@ class ToolCallLogger {
     }
 
     async flushNow() {
-        if (this.flushing) return;
+        // Join an in-flight flush rather than returning immediately. This matters
+        // for shutdown: database.js's gracefulShutdown awaits flushLoggerNow before
+        // saveDatabase, and must not return while INSERTs are still in flight.
+        while (this._activeFlush) {
+            try { await this._activeFlush; } catch (_) {}
+        }
         if (this.buffer.length === 0) return;
+        const p = this._runFlush();
+        this._activeFlush = p;
+        try { await p; }
+        finally {
+            if (this._activeFlush === p) this._activeFlush = null;
+        }
+    }
+
+    async _runFlush() {
         this.flushing = true;
+        if (this.buffer.length === 0) { this.flushing = false; return; }
         const batch = this.buffer.splice(0, this.buffer.length);
         try {
             this.db.run('BEGIN TRANSACTION');

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -18,19 +18,23 @@ class ToolCallLogger {
         if (this.timer.unref) this.timer.unref();  // don't block Node exit on this timer
     }
 
-    record(row) {
-        if (this.stopped) return;
-        this.buffer.push(row);
+    _enforceHardCap() {
+        // Persistent flush failure (e.g. db closed / disk full) will accumulate
+        // unboundedly via unshift on the error path. Drop oldest to prevent
+        // memory leak. Honest tradeoff: we already accept 5s data loss on abrupt
+        // kill; persistent-failure loss is the same tradeoff at a different scale.
         const hardCap = this.maxBufferSize * this.MAX_BUFFER_HARD_CAP_MULTIPLIER;
         if (this.buffer.length > hardCap) {
-            // Persistent flush failure (e.g. db closed / disk full) will accumulate
-            // unboundedly via unshift on the error path. Drop oldest to prevent
-            // memory leak. Honest tradeoff: we already accept 5s data loss on abrupt
-            // kill; persistent-failure loss is the same tradeoff at a different scale.
             const drop = this.buffer.length - hardCap;
             this.buffer.splice(0, drop);
             this.log(`[ToolCallLogger] buffer hard-cap exceeded; dropped ${drop} oldest rows`, 'WARN');
         }
+    }
+
+    record(row) {
+        if (this.stopped) return;
+        this.buffer.push(row);
+        this._enforceHardCap();
         if (this.buffer.length >= this.maxBufferSize) {
             // Fire-and-forget; batch flush on next tick.
             setImmediate(() => this.flushNow().catch(() => {}));
@@ -81,6 +85,9 @@ class ToolCallLogger {
             this.log(`[ToolCallLogger] flush failed: ${e.message}`, 'ERROR');
             // Put the batch back at the head so we don't lose it silently
             this.buffer.unshift(...batch);
+            // Failed unshift may push buffer over hard cap if records accumulated
+            // concurrently during the in-flight flush; enforce same policy as record().
+            this._enforceHardCap();
         } finally {
             this.flushing = false;
         }

--- a/app/src/main/assets/nodejs-project/tool-call-logger.js
+++ b/app/src/main/assets/nodejs-project/tool-call-logger.js
@@ -53,6 +53,14 @@ class ToolCallLogger {
             }
             stmt.free();
             this.db.run('COMMIT');
+            // Re-trigger ONLY on success: if buffer grew past threshold while we
+            // were flushing, schedule another pass. On the failure path, we fall
+            // through to the catch + finally — no re-trigger, letting the 5s
+            // interval (or the next record() call) handle retry. This prevents
+            // a CPU spin loop on persistent db failure.
+            if (!this.stopped && this.buffer.length >= this.maxBufferSize) {
+                setImmediate(() => this.flushNow().catch(() => {}));
+            }
         } catch (e) {
             try { this.db.run('ROLLBACK'); } catch (_) {}
             this.log(`[ToolCallLogger] flush failed: ${e.message}`, 'ERROR');
@@ -60,10 +68,6 @@ class ToolCallLogger {
             this.buffer.unshift(...batch);
         } finally {
             this.flushing = false;
-            // If the buffer grew past threshold while we were flushing, re-trigger.
-            if (!this.stopped && this.buffer.length >= this.maxBufferSize) {
-                setImmediate(() => this.flushNow().catch(() => {}));
-            }
         }
     }
 

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -1,7 +1,7 @@
 // tools/index.js — Tool registry + executeTool() dispatcher (BAT-470)
 // Merges all domain modules, builds handler dispatch map, routes tool calls.
 
-const { log, CHANNEL } = require('../config');
+const { log, CHANNEL, workDir } = require('../config');
 const channel = require('../channel');
 const { ToolCallLogger } = require('../tool-call-logger');
 const { getShape } = require('../call-shape');
@@ -21,6 +21,54 @@ const androidMod  = require('./android');
 const solanaMod   = require('./solana');
 const telegramMod = CHANNEL === 'telegram' ? require('./telegram') : null;
 const systemMod   = require('./system');
+const schoolMod   = require('./school');
+
+// ── School tools ────────────────────────────────────────────────────────────
+
+const schoolTools = [
+    {
+        name: 'school_begin',
+        description: 'Start or resume a Go-to-School self-improvement session. Creates workspace/SCHOOL.md as a trigger file; if one already exists, returns its parsed state for resumption. Returns session_id + last 10 prior sessions from workspace/school/log.jsonl for dedup.',
+        input_schema: { type: 'object', properties: { reason: { type: 'string', enum: ['on_demand', 'cron', 'resumed'] } }, required: ['reason'] },
+    },
+    {
+        name: 'school_scan',
+        description: 'Pattern-mine the tool_call_log and skill_trigger_log SQL.js tables. Returns structured candidates: repeated_patterns (same call_shape ≥3×), failed_sequences (error_kind repeats), expensive_turns (≥8 tool calls), triggered_skills (for computing unused_skills retire candidates).',
+        input_schema: { type: 'object', properties: { window_days: { type: 'integer', minimum: 1, maximum: 30 }, min_repetition: { type: 'integer' } } },
+    },
+    {
+        name: 'school_write_skill',
+        description: 'Write a new SKILL.md (create mode) or patch an existing one. Tool auto-injects `source: school`, `created`, `evidence` frontmatter on create; preserves existing `source` field + appends `last_patched_by: school` on patch. Enforces path sandbox (workspace/skills/ only), 64KB size cap, valid YAML frontmatter, and non-empty markdown body.',
+        input_schema: { type: 'object', properties: {
+            mode: { type: 'string', enum: ['create', 'patch'] },
+            path: { type: 'string' },
+            body: { type: 'string' },
+            evidence: { type: 'string' },
+        }, required: ['mode', 'path', 'body', 'evidence'] },
+    },
+    {
+        name: 'school_retire_skill',
+        description: 'Move a workspace skill to workspace/school/retired/ (reversible archive, not delete). Bundled skills rejected. User can restore by moving the file back.',
+        input_schema: { type: 'object', properties: { path: { type: 'string' }, reason: { type: 'string' } }, required: ['path'] },
+    },
+    {
+        name: 'school_end',
+        description: 'Finalize a school session: append one JSON line to workspace/school/log.jsonl (rolling 90-day retention), then delete SCHOOL.md. Atomic ordering guarantees crash recovery never re-finalizes a session already logged.',
+        input_schema: { type: 'object', properties: {
+            session_id: { type: 'string' },
+            summary: { type: 'object' },
+        }, required: ['session_id', 'summary'] },
+    },
+    {
+        name: 'school_handle_input',
+        description: 'Advance the school session state machine. Agent calls this for school-relevant inputs (yes/no/review/skip/stop) after classifying user input via the classification rubric in the go-to-school skill. Returns the new state + next_action to execute. NOT called for unrelated messages — those route through normal message handling.',
+        input_schema: { type: 'object', properties: {
+            session_id: { type: 'string' },
+            state: { type: 'object' },
+            input: { type: 'object' },
+        }, required: ['session_id', 'state', 'input'] },
+    },
+];
 
 // ── Merged TOOLS array ───────────────────────────────────────────────────────
 
@@ -35,7 +83,14 @@ const TOOLS = [
     ...solanaMod.tools,
     ...(telegramMod ? telegramMod.tools : []),
     ...systemMod.tools,
+    ...schoolTools,
 ];
+
+// ── School context builder ──────────────────────────────────────────────────
+
+function _schoolCtx(chatId) {
+    return { chatId, workDir, db: getDb() };
+}
 
 // ── Handler dispatch map ─────────────────────────────────────────────────────
 
@@ -50,6 +105,14 @@ const handlerMap = Object.assign({},
     solanaMod.handlers,
     ...(telegramMod ? [telegramMod.handlers] : []),
     systemMod.handlers,
+    {
+        school_begin: (input, chatId) => schoolMod.schoolBeginHandler(input, _schoolCtx(chatId)),
+        school_scan: (input, chatId) => schoolMod.schoolScanHandler(input, _schoolCtx(chatId)),
+        school_write_skill: (input, chatId) => schoolMod.schoolWriteSkillHandler(input, _schoolCtx(chatId)),
+        school_retire_skill: (input, chatId) => schoolMod.schoolRetireSkillHandler(input, _schoolCtx(chatId)),
+        school_end: (input, chatId) => schoolMod.schoolEndHandler(input, _schoolCtx(chatId)),
+        school_handle_input: (input, chatId) => schoolMod.schoolHandleInputHandler(input, _schoolCtx(chatId)),
+    },
 );
 
 // ── Shared state ─────────────────────────────────────────────────────────────

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -7,6 +7,7 @@ const { ToolCallLogger } = require('../tool-call-logger');
 const { getShape } = require('../call-shape');
 const { getDb } = require('../database');
 const { redactSecrets } = require('../security');
+const { classifyError } = require('../error-classifier');
 
 // ── Domain modules ───────────────────────────────────────────────────────────
 
@@ -212,18 +213,18 @@ async function executeTool(name, input, chatId, messageId = null) {
     try {
         result = await executeToolInner(normalizedName, input, chatId);
         // Some tool handlers return { error: '...' } on non-exception failures.
-        // redactSecrets masks API keys / wallet / token patterns; path-like strings may still appear.
-        // Low-cardinality bucketing (e.g. file_not_found, http_404) is a future enhancement.
+        // classifyError maps into low-cardinality buckets (file_not_found, http_404, etc.)
+        // so tool_call_log aggregations are pattern-mineable; fallback is redacted + truncated.
         if (result && typeof result === 'object' && result.error) {
             status = 'error';
-            errorKind = redactSecrets(String(result.error)).slice(0, 60);
+            errorKind = classifyError(String(result.error));
         }
     } catch (e) {
         status = 'error';
         // Prefer e.code → e.message → e.name for richer error kinds.
         // Without e.message, every `new Error('bridge unreachable')` collapses to 'Error'.
         const raw = (e && (e.code || e.message || e.name) || 'exception').toString();
-        errorKind = redactSecrets(raw).slice(0, 60);
+        errorKind = classifyError(raw);
         // Convert to the `{ error }` contract per ARCHITECTURE.md — callers expect no exceptions
         // to escape executeTool(). Returning a synthetic error result keeps the interface consistent.
         // Also redact the user-facing synthetic message — e.message can plausibly contain URLs

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -6,6 +6,7 @@ const channel = require('../channel');
 const { ToolCallLogger } = require('../tool-call-logger');
 const { getShape } = require('../call-shape');
 const { getDb } = require('../database');
+const { redactSecrets } = require('../security');
 
 // ── Domain modules ───────────────────────────────────────────────────────────
 
@@ -202,21 +203,27 @@ async function executeToolInner(name, input, chatId) {
 
 async function executeTool(name, input, chatId) {
     const startedAt = Date.now();
+    // Normalize once — executeToolInner also trims defensively, but we need the
+    // normalized name for consistent tool_name + call_shape in tool_call_log.
+    const normalizedName = typeof name === 'string' ? name.trim() : '';
     let status = 'ok';
     let errorKind = null;
     let result;
     try {
-        result = await executeToolInner(name, input, chatId);
+        result = await executeToolInner(normalizedName, input, chatId);
         // Some tool handlers return { error: '...' } on non-exception failures.
+        // redactSecrets masks API keys / wallet / token patterns; path-like strings may still appear.
+        // Low-cardinality bucketing (e.g. file_not_found, http_404) is a future enhancement.
         if (result && typeof result === 'object' && result.error) {
             status = 'error';
-            errorKind = String(result.error).slice(0, 60);
+            errorKind = redactSecrets(String(result.error)).slice(0, 60);
         }
     } catch (e) {
         status = 'error';
         // Prefer e.code → e.message → e.name for richer error kinds.
         // Without e.message, every `new Error('bridge unreachable')` collapses to 'Error'.
-        errorKind = (e && (e.code || e.message || e.name) || 'exception').toString().slice(0, 60);
+        const raw = (e && (e.code || e.message || e.name) || 'exception').toString();
+        errorKind = redactSecrets(raw).slice(0, 60);
         // Convert to the `{ error }` contract per ARCHITECTURE.md — callers expect no exceptions
         // to escape executeTool(). Returning a synthetic error result keeps the interface consistent.
         result = { error: `Tool execution failed: ${e && e.message ? e.message : 'exception'}` };
@@ -227,9 +234,9 @@ async function executeTool(name, input, chatId) {
                 logger.record({
                     turn_id: chatId != null ? String(chatId) : 'unknown',
                     message_id: null,           // Task A5 scope: message_id plumbing is future work
-                    tool_name: name,
+                    tool_name: normalizedName,
                     triggered_by_skill: null,    // Task A6 will populate
-                    call_shape: getShape(name, input),
+                    call_shape: getShape(normalizedName, input),
                     result_status: status,  // TODO(A6): classify 'timeout' / 'blocked_by_confirmation' upstream
                     error_kind: errorKind,
                     latency_ms: Date.now() - startedAt,

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -212,22 +212,25 @@ async function executeTool(name, input, chatId) {
             status = 'error';
             errorKind = String(result.error).slice(0, 60);
         }
-        return result;
     } catch (e) {
         status = 'error';
-        errorKind = (e && (e.code || e.name) || 'exception').toString().slice(0, 60);
-        throw e;
+        // Prefer e.code → e.message → e.name for richer error kinds.
+        // Without e.message, every `new Error('bridge unreachable')` collapses to 'Error'.
+        errorKind = (e && (e.code || e.message || e.name) || 'exception').toString().slice(0, 60);
+        // Convert to the `{ error }` contract per ARCHITECTURE.md — callers expect no exceptions
+        // to escape executeTool(). Returning a synthetic error result keeps the interface consistent.
+        result = { error: `Tool execution failed: ${e && e.message ? e.message : 'exception'}` };
     } finally {
         try {
             const logger = getLogger();
             if (logger) {
                 logger.record({
-                    turn_id: chatId ? String(chatId) : 'unknown',
+                    turn_id: chatId != null ? String(chatId) : 'unknown',
                     message_id: null,           // Task A5 scope: message_id plumbing is future work
                     tool_name: name,
                     triggered_by_skill: null,    // Task A6 will populate
                     call_shape: getShape(name, input),
-                    result_status: status,
+                    result_status: status,  // TODO(A6): classify 'timeout' / 'blocked_by_confirmation' upstream
                     error_kind: errorKind,
                     latency_ms: Date.now() - startedAt,
                     created_at: startedAt,
@@ -235,6 +238,7 @@ async function executeTool(name, input, chatId) {
             }
         } catch (_) { /* never let logging break a tool call */ }
     }
+    return result;
 }
 
 // ── Re-exported helpers ──────────────────────────────────────────────────────

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -3,6 +3,9 @@
 
 const { log, CHANNEL } = require('../config');
 const channel = require('../channel');
+const { ToolCallLogger } = require('../tool-call-logger');
+const { getShape } = require('../call-shape');
+const { getDb } = require('../database');
 
 // ── Domain modules ───────────────────────────────────────────────────────────
 
@@ -162,9 +165,21 @@ function requestConfirmation(chatId, toolName, input) {
     });
 }
 
+// ── tool-call-log plumbing (see spec §6.3) ───────────────────────────────────
+let _logger = null;
+function getLogger() {
+    if (_logger) return _logger;
+    const db = getDb();
+    if (!db) return null;  // db not yet initialized at very early startup
+    _logger = new ToolCallLogger({ db, log });
+    return _logger;
+}
+async function flushLoggerNow() { const l = getLogger(); if (l) await l.flushNow(); }
+async function stopLogger() { if (_logger) { await _logger.stop(); _logger = null; } }
+
 // ── executeTool() dispatcher ─────────────────────────────────────────────────
 
-async function executeTool(name, input, chatId) {
+async function executeToolInner(name, input, chatId) {
     log(`Executing tool: ${name}`, 'DEBUG');
     // OpenClaw parity: normalize whitespace-padded tool names
     name = typeof name === 'string' ? name.trim() : '';
@@ -185,6 +200,43 @@ async function executeTool(name, input, chatId) {
     return { error: `Unknown tool: ${name}` };
 }
 
+async function executeTool(name, input, chatId) {
+    const startedAt = Date.now();
+    let status = 'ok';
+    let errorKind = null;
+    let result;
+    try {
+        result = await executeToolInner(name, input, chatId);
+        // Some tool handlers return { error: '...' } on non-exception failures.
+        if (result && typeof result === 'object' && result.error) {
+            status = 'error';
+            errorKind = String(result.error).slice(0, 60);
+        }
+        return result;
+    } catch (e) {
+        status = 'error';
+        errorKind = (e && (e.code || e.name) || 'exception').toString().slice(0, 60);
+        throw e;
+    } finally {
+        try {
+            const logger = getLogger();
+            if (logger) {
+                logger.record({
+                    turn_id: chatId ? String(chatId) : 'unknown',
+                    message_id: null,           // Task A5 scope: message_id plumbing is future work
+                    tool_name: name,
+                    triggered_by_skill: null,    // Task A6 will populate
+                    call_shape: getShape(name, input),
+                    result_status: status,
+                    error_kind: errorKind,
+                    latency_ms: Date.now() - startedAt,
+                    created_at: startedAt,
+                });
+            }
+        } catch (_) { /* never let logging break a tool call */ }
+    }
+}
+
 // ── Re-exported helpers ──────────────────────────────────────────────────────
 
 const { listFilesRecursive, formatBytes } = fileMod;
@@ -199,4 +251,5 @@ module.exports = {
     pendingConfirmations, lastToolUseTime,
     listFilesRecursive, formatBytes,
     setMcpExecuteTool, setFullToolRegistry,
+    flushLoggerNow, stopLogger,   // NEW for tool-call-log
 };

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -298,12 +298,16 @@ async function executeTool(name, input, chatId, messageId = null) {
         try {
             const logger = getLogger();
             if (logger) {
+                // Log sentinel for whitespace/empty/non-string tool names so
+                // aggregations stay pattern-mineable instead of collecting
+                // empty strings. User-facing error already returned above.
+                const loggedName = normalizedName || 'unknown_tool';
                 logger.record({
                     turn_id: chatId != null ? String(chatId) : 'unknown',
                     message_id: messageId != null ? String(messageId) : null,
-                    tool_name: normalizedName,
+                    tool_name: loggedName,
                     triggered_by_skill: null,    // Task A6 will populate
-                    call_shape: getShape(normalizedName, input),
+                    call_shape: getShape(loggedName, input),
                     // result_status is 'ok' | 'error' only in PR-A. Spec §6.1 lists
                     // 'timeout' | 'blocked_by_policy' | 'blocked_by_confirmation' which
                     // happen upstream (ai.js confirmation gate, rate limiter) and need

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -201,7 +201,7 @@ async function executeToolInner(name, input, chatId) {
     return { error: `Unknown tool: ${name}` };
 }
 
-async function executeTool(name, input, chatId) {
+async function executeTool(name, input, chatId, messageId = null) {
     const startedAt = Date.now();
     // Normalize once — executeToolInner also trims defensively, but we need the
     // normalized name for consistent tool_name + call_shape in tool_call_log.
@@ -226,14 +226,17 @@ async function executeTool(name, input, chatId) {
         errorKind = redactSecrets(raw).slice(0, 60);
         // Convert to the `{ error }` contract per ARCHITECTURE.md — callers expect no exceptions
         // to escape executeTool(). Returning a synthetic error result keeps the interface consistent.
-        result = { error: `Tool execution failed: ${e && e.message ? e.message : 'exception'}` };
+        // Also redact the user-facing synthetic message — e.message can plausibly contain URLs
+        // with query strings, tokens, or file paths that would otherwise leak through to Telegram.
+        const safeMsg = e && e.message ? redactSecrets(String(e.message)) : 'exception';
+        result = { error: `Tool execution failed: ${safeMsg}` };
     } finally {
         try {
             const logger = getLogger();
             if (logger) {
                 logger.record({
                     turn_id: chatId != null ? String(chatId) : 'unknown',
-                    message_id: null,           // Task A5 scope: message_id plumbing is future work
+                    message_id: messageId != null ? String(messageId) : null,
                     tool_name: normalizedName,
                     triggered_by_skill: null,    // Task A6 will populate
                     call_shape: getShape(normalizedName, input),

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -61,12 +61,12 @@ const schoolTools = [
     },
     {
         name: 'school_handle_input',
-        description: 'Advance the school session state machine. Agent calls this for school-relevant inputs (yes/no/review/skip/stop) after classifying user input via the classification rubric in the go-to-school skill. Returns the new state + next_action to execute. NOT called for unrelated messages — those route through normal message handling.',
+        description: 'Advance the school session state machine. Agent calls this for school-relevant inputs (yes/no/review/skip/stop) after classifying user input via the classification rubric in the go-to-school skill. Returns the new state + next_action to execute. NOT called for unrelated messages — those route through normal message handling. `input.message_date` may be ms or unix-seconds (both accepted; normalized to ms internally). The handler reads authoritative state from workspace/SCHOOL.md; pass `state` only as a first-turn fallback when the session record is not yet written.',
         input_schema: { type: 'object', properties: {
             session_id: { type: 'string' },
             state: { type: 'object' },
             input: { type: 'object' },
-        }, required: ['session_id', 'state', 'input'] },
+        }, required: ['session_id', 'input'] },
     },
 ];
 

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -241,7 +241,12 @@ async function executeTool(name, input, chatId, messageId = null) {
                     tool_name: normalizedName,
                     triggered_by_skill: null,    // Task A6 will populate
                     call_shape: getShape(normalizedName, input),
-                    result_status: status,  // TODO(A6): classify 'timeout' / 'blocked_by_confirmation' upstream
+                    // result_status is 'ok' | 'error' only in PR-A. Spec §6.1 lists
+                    // 'timeout' | 'blocked_by_policy' | 'blocked_by_confirmation' which
+                    // happen upstream (ai.js confirmation gate, rate limiter) and need
+                    // separate instrumentation. Deferred to PR-B where blocked-tool
+                    // analytics feed school_scan; see spec §6.1 "known limitation".
+                    result_status: status,
                     error_kind: errorKind,
                     latency_ms: Date.now() - startedAt,
                     created_at: startedAt,

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -1,7 +1,8 @@
 // tools/school.js — Go-to-School tool handlers.
 const crypto = require('crypto');
 const fs = require('fs');
-const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath, writeSkillFile } = require('../school');
+const pathMod = require('path');
+const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath, writeSkillFile, transition, scanLogs } = require('../school');
 
 function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
 
@@ -71,4 +72,48 @@ async function schoolWriteSkillHandler(args, ctx) {
     });
 }
 
-module.exports = { schoolBeginHandler, schoolEndHandler, schoolWriteSkillHandler };
+async function schoolRetireSkillHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    const relPath = args.path;
+    if (!relPath.startsWith('skills/') || relPath.includes('..')) {
+        return { ok: false, error: 'cannot_retire_bundled' };
+    }
+    const src = pathMod.join(workDir, relPath);
+    if (!fs.existsSync(src)) return { ok: false, error: 'target_missing' };
+    const name = pathMod.basename(relPath);
+    const ts = Date.now();
+    const dst = pathMod.join(workDir, 'school/retired', `${ts}-${name}`);
+    fs.mkdirSync(pathMod.dirname(dst), { recursive: true });
+    fs.renameSync(src, dst);
+    return { ok: true, restored_path: dst.replace(workDir + '/', ''), reason: args.reason || '' };
+}
+
+async function schoolHandleInputHandler(args, ctx) {
+    try {
+        const { nextState, nextAction } = transition(args.state, args.input);
+        return { ok: true, previous_state: args.state.kind, new_state: nextState.kind, next_action: nextAction, open_proposal_ns: nextState.open_proposal_ns || [] };
+    } catch (e) {
+        return { ok: false, error: 'transition_failed', hint: e.message };
+    }
+}
+
+async function schoolScanHandler(args, ctx) {
+    let db = (ctx && ctx.db);
+    if (!db) {
+        try {
+            const { getDb } = require('../database');
+            db = getDb();
+        } catch (_) {
+            db = null;
+        }
+    }
+    if (!db) return { ok: false, error: 'db_unavailable' };
+    try {
+        const res = scanLogs(db, { window_days: args.window_days || 7, min_repetition: args.min_repetition || 3 });
+        return { ok: true, ...res };
+    } catch (e) {
+        return { ok: false, error: 'scan_failed', hint: e.message };
+    }
+}
+
+module.exports = { schoolBeginHandler, schoolEndHandler, schoolWriteSkillHandler, schoolRetireSkillHandler, schoolHandleInputHandler, schoolScanHandler };

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -30,7 +30,21 @@ function buildStaleEndEntry(pre, nowMs) {
 // honored — tool args are agent-controlled and must not steer filesystem roots.
 async function schoolBeginHandler(args, ctx) {
     const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
-    const existing = readSchoolMd(workDir);
+    // readSchoolMd throws on malformed frontmatter. Surface a structured error
+    // so the skill can route the user to /school-reset instead of letting the
+    // exception bubble through executeTool's generic catch as "Tool execution
+    // failed: SCHOOL.md malformed (no YAML frontmatter)".
+    let existing;
+    try {
+        existing = readSchoolMd(workDir);
+    } catch (e) {
+        return {
+            ok: false,
+            error: 'school_md_unreadable',
+            hint: 'SCHOOL.md exists but could not be parsed. Run /school-reset to discard it and start fresh.',
+            detail: e.message,
+        };
+    }
     // If the existing session has gone stale (>48h since started), auto-end it
     // and create a fresh one. Agent's SKILL.md prose explains the combined-message
     // flow; the response flags it with `started_after_cleanup: true` so the agent

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -1,0 +1,64 @@
+// tools/school.js — Go-to-School tool handlers.
+const crypto = require('crypto');
+const fs = require('fs');
+const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath } = require('../school');
+
+function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
+
+async function schoolBeginHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || (typeof args === 'object' && args.workDir) || process.env.WORKDIR;
+    const existing = readSchoolMd(workDir);
+    if (existing) {
+        return {
+            ok: true, resumed: true,
+            session_id: existing.session_id,
+            started_at: existing.started_at,
+            prior_sessions: readPriorSessions(workDir, 10),
+            resumed_state: {
+                session_id: existing.session_id,
+                started_at: existing.started_at,
+                trigger: existing.trigger,
+                state: existing.state,
+                window_days: existing.window_days,
+                open_proposal_ns: existing.open_proposal_ns,
+                proposals: existing.proposals,
+                rubric_version: existing.rubric_version,
+                reviewing_opened_at: existing.reviewing_opened_at || null,
+            },
+        };
+    }
+    const sessionId = newSessionId();
+    const startedAt = Date.now();
+    writeSchoolMd(workDir, {
+        session_id: sessionId, started_at: startedAt, trigger: args.reason || 'on_demand',
+        state: 'scanning', window_days: 7, open_proposal_ns: [], proposals: [], rubric_version: '1.0.0',
+    });
+    return {
+        ok: true, resumed: false,
+        session_id: sessionId,
+        started_at: startedAt,
+        prior_sessions: readPriorSessions(workDir, 10),
+        resumed_state: null,
+    };
+}
+
+async function schoolEndHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    const existing = readSchoolMd(workDir) || {};
+    const entry = {
+        session_id: args.session_id,
+        started_at: existing.started_at || Date.now(),
+        ended_at: Date.now(),
+        trigger: existing.trigger || 'on_demand',
+        window_days: 7,
+        rubric_version: '1.0.0',
+        proposals: args.summary && args.summary.approved
+            ? [...(args.summary.approved || []), ...(args.summary.drafted_but_denied || []), ...(args.summary.skipped || []), ...(args.summary.ignored || []), ...(args.summary.rejected_by_rubric || []), ...(args.summary.rejected_as_duplicate || [])]
+            : [],
+    };
+    appendLogLine(workDir, entry);
+    try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+    return { ok: true };
+}
+
+module.exports = { schoolBeginHandler, schoolEndHandler };

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -2,7 +2,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const pathMod = require('path');
-const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath, writeSkillFile, transition, scanLogs } = require('../school');
+const { writeSchoolMd, readSchoolMd, schoolStateFromFrontmatter, appendLogLine, readPriorSessions, schoolMdPath, writeSkillFile, transition, scanLogs } = require('../school');
 
 function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
 
@@ -116,8 +116,14 @@ async function schoolWriteSkillHandler(args, ctx) {
 async function schoolRetireSkillHandler(args, ctx) {
     const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
     const relPath = args.path;
-    if (!relPath.startsWith('skills/') || relPath.includes('..')) {
-        return { ok: false, error: 'cannot_retire_bundled' };
+    // Two distinct rejection cases. Using separate error codes makes failures
+    // diagnosable — "cannot_retire_bundled" was misleading because bundled-skill
+    // protection lives in the APK assets, not in the workspace path check.
+    if (relPath.includes('..')) {
+        return { ok: false, error: 'path_traversal' };
+    }
+    if (!relPath.startsWith('skills/')) {
+        return { ok: false, error: 'path_outside_workspace_skills' };
     }
     const src = pathMod.join(workDir, relPath);
     if (!fs.existsSync(src)) return { ok: false, error: 'target_missing' };
@@ -130,9 +136,47 @@ async function schoolRetireSkillHandler(args, ctx) {
 }
 
 async function schoolHandleInputHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
     try {
-        const { nextState, nextAction } = transition(args.state, args.input);
-        return { ok: true, previous_state: args.state.kind, new_state: nextState.kind, next_action: nextAction, open_proposal_ns: nextState.open_proposal_ns || [] };
+        // Load persisted state from SCHOOL.md so the state machine operates on
+        // the authoritative session record, not whatever the agent passed in
+        // args.state (which can drift across turns). args.state is still a
+        // useful fallback for first-turn calls before any state is persisted.
+        const fm = readSchoolMd(workDir);
+        const persistedState = schoolStateFromFrontmatter(fm);
+        const prevState = persistedState || args.state;
+        if (!prevState || !prevState.kind) {
+            return { ok: false, error: 'no_session_state', hint: 'SCHOOL.md missing; call school_begin first' };
+        }
+        const { nextState, nextAction } = transition(prevState, args.input);
+        // Persist the new state back to SCHOOL.md. Preserve session metadata
+        // (session_id, started_at, trigger, window_days, rubric_version,
+        // proposals) from the existing record; only the state-machine fields
+        // change per input.
+        if (fm) {
+            writeSchoolMd(workDir, {
+                session_id: fm.session_id,
+                started_at: fm.started_at,
+                trigger: fm.trigger,
+                state: nextState.kind,
+                window_days: fm.window_days,
+                open_proposal_ns: nextState.open_proposal_ns || [],
+                reviewing_n: nextState.reviewing_n,
+                reviewing_opened_at: nextState.reviewing_opened_at,
+                rubric_version: fm.rubric_version,
+                proposals: fm.proposals,
+            });
+        }
+        return {
+            ok: true,
+            session_id: fm ? fm.session_id : args.session_id,
+            previous_state: prevState.kind,
+            new_state: nextState.kind,
+            next_action: nextAction,
+            open_proposal_ns: nextState.open_proposal_ns || [],
+            reviewing_n: nextState.reviewing_n != null ? nextState.reviewing_n : null,
+            reviewing_opened_at: nextState.reviewing_opened_at || null,
+        };
     } catch (e) {
         return { ok: false, error: 'transition_failed', hint: e.message };
     }

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -5,8 +5,11 @@ const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdP
 
 function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
 
+// workDir comes from trusted sources only: ctx (injected by tool dispatcher) or
+// WORKDIR env (set at app startup from config). args.workDir is deliberately NOT
+// honored — tool args are agent-controlled and must not steer filesystem roots.
 async function schoolBeginHandler(args, ctx) {
-    const workDir = (ctx && ctx.workDir) || (typeof args === 'object' && args.workDir) || process.env.WORKDIR;
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
     const existing = readSchoolMd(workDir);
     if (existing) {
         return {

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -1,7 +1,7 @@
 // tools/school.js — Go-to-School tool handlers.
 const crypto = require('crypto');
 const fs = require('fs');
-const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath } = require('../school');
+const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath, writeSkillFile } = require('../school');
 
 function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
 
@@ -64,4 +64,11 @@ async function schoolEndHandler(args, ctx) {
     return { ok: true };
 }
 
-module.exports = { schoolBeginHandler, schoolEndHandler };
+async function schoolWriteSkillHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    return await writeSkillFile({
+        workDir, mode: args.mode, relPath: args.path, body: args.body, evidence: args.evidence,
+    });
+}
+
+module.exports = { schoolBeginHandler, schoolEndHandler, schoolWriteSkillHandler };

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -6,12 +6,53 @@ const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdP
 
 function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
 
+// Stale-session cutoff: if SCHOOL.md hasn't been touched in this long, auto-end
+// it on the next /school invocation instead of silently "resuming" state the
+// user has forgotten about. Exported for main.js boot-time cleanup too.
+const SCHOOL_STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+// Shared entry-builder for auto-end logging. Keeps boot-time cleanup (main.js)
+// and handler-time cleanup (below) using the same shape.
+function buildStaleEndEntry(pre, nowMs) {
+    return {
+        session_id: pre.session_id,
+        started_at: pre.started_at,
+        ended_at: nowMs,
+        trigger: pre.trigger || 'on_demand',
+        window_days: pre.window_days || 7,
+        rubric_version: pre.rubric_version || '1.0.0',
+        proposals: (pre.proposals || []).map(p => ({ ...p, outcome: 'abandoned_stale' })),
+    };
+}
+
 // workDir comes from trusted sources only: ctx (injected by tool dispatcher) or
 // WORKDIR env (set at app startup from config). args.workDir is deliberately NOT
 // honored — tool args are agent-controlled and must not steer filesystem roots.
 async function schoolBeginHandler(args, ctx) {
     const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
     const existing = readSchoolMd(workDir);
+    // If the existing session has gone stale (>48h since started), auto-end it
+    // and create a fresh one. Agent's SKILL.md prose explains the combined-message
+    // flow; the response flags it with `started_after_cleanup: true` so the agent
+    // can surface the cleanup to the user in the same reply as the new scan.
+    if (existing && (Date.now() - (existing.started_at || 0)) > SCHOOL_STALE_THRESHOLD_MS) {
+        appendLogLine(workDir, buildStaleEndEntry(existing, Date.now()));
+        try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+        const sessionId = newSessionId();
+        const startedAt = Date.now();
+        writeSchoolMd(workDir, {
+            session_id: sessionId, started_at: startedAt, trigger: args.reason || 'on_demand',
+            state: 'scanning', window_days: 7, open_proposal_ns: [], proposals: [], rubric_version: '1.0.0',
+        });
+        return {
+            ok: true, resumed: false,
+            session_id: sessionId, started_at: startedAt,
+            prior_sessions: readPriorSessions(workDir, 10),
+            resumed_state: null,
+            started_after_cleanup: true,
+            cleaned_up: { prior_session_id: existing.session_id, prior_started_at: existing.started_at },
+        };
+    }
     if (existing) {
         return {
             ok: true, resumed: true,
@@ -116,4 +157,4 @@ async function schoolScanHandler(args, ctx) {
     }
 }
 
-module.exports = { schoolBeginHandler, schoolEndHandler, schoolWriteSkillHandler, schoolRetireSkillHandler, schoolHandleInputHandler, schoolScanHandler };
+module.exports = { schoolBeginHandler, schoolEndHandler, schoolWriteSkillHandler, schoolRetireSkillHandler, schoolHandleInputHandler, schoolScanHandler, SCHOOL_STALE_THRESHOLD_MS, buildStaleEndEntry };

--- a/app/src/main/assets/nodejs-project/tools/school.js
+++ b/app/src/main/assets/nodejs-project/tools/school.js
@@ -104,13 +104,17 @@ async function schoolBeginHandler(args, ctx) {
 async function schoolEndHandler(args, ctx) {
     const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
     const existing = readSchoolMd(workDir) || {};
+    // Preserve window_days + rubric_version from the active session record so
+    // /school log and dedup comparisons stay accurate across scan-window or
+    // rubric-version changes. Fall back to defaults only when SCHOOL.md is
+    // absent (e.g., mid-shutdown race).
     const entry = {
         session_id: args.session_id,
         started_at: existing.started_at || Date.now(),
         ended_at: Date.now(),
         trigger: existing.trigger || 'on_demand',
-        window_days: 7,
-        rubric_version: '1.0.0',
+        window_days: existing.window_days != null ? existing.window_days : 7,
+        rubric_version: existing.rubric_version != null ? existing.rubric_version : '1.0.0',
         proposals: args.summary && args.summary.approved
             ? [...(args.summary.approved || []), ...(args.summary.drafted_but_denied || []), ...(args.summary.skipped || []), ...(args.summary.ignored || []), ...(args.summary.rejected_by_rubric || []), ...(args.summary.rejected_as_duplicate || [])]
             : [],

--- a/docs/superpowers/plans/2026-04-19-go-to-school.md
+++ b/docs/superpowers/plans/2026-04-19-go-to-school.md
@@ -1,0 +1,2892 @@
+# Go to School Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the SeekerClaw agent a structured reflection feature where it analyzes its own recent tool-call and skill-trigger activity and proposes concrete self-improvements (create / patch / retire skills), gated by a 5-rubric rigor check and a two-gate user approval flow.
+
+**Architecture:** Two PRs landing sequentially. PR-A adds two SQL.js tables (`tool_call_log`, `skill_trigger_log`) with a buffered async logger and retention, plus `call_shape` builders per tool. PR-B adds the `school.js` module (pure state-machine + pattern-mining), 6 new tools in `tools/school.js`, and a bundled `go-to-school` SKILL.md that carries the rubric, proposal format, approval protocol, and input classification rubric. Two-gate approval: `/review N` → user sees drafted SKILL.md → `YES N` writes it. Deterministic JS state machine with 32 transitions; classification echo to the user on every state change.
+
+**Tech Stack:** Node 18 (nodejs-mobile), SQL.js 1.12 (WASM SQLite), plain-JS test harness (no framework; test files exit 0/1), Kotlin UI is untouched by this feature. Spec: [docs/superpowers/specs/2026-04-19-go-to-school-design.md](../specs/2026-04-19-go-to-school-design.md).
+
+---
+
+## File Structure
+
+### New files (PR-A — log infrastructure)
+
+| Path | Responsibility |
+|---|---|
+| `app/src/main/assets/nodejs-project/call-shape.js` | Per-tool `call_shape` builders + `getShape(toolName, args)` entry point. Pure functions. |
+| `app/src/main/assets/nodejs-project/tool-call-logger.js` | In-memory buffered logger + flush. Appends to `tool_call_log` in batches; flushes on 5s OR 100-row threshold. |
+| `tests/nodejs-project/call-shape.test.js` | Unit tests for every tool's shape builder (privacy + stability). |
+| `tests/nodejs-project/tool-call-log.test.js` | Logger buffer, retention, batch insert. |
+| `tests/nodejs-project/skill-trigger-log.test.js` | Skill-trigger table inserts + UNIQUE constraint. |
+
+### Modified files (PR-A)
+
+| Path | What changes |
+|---|---|
+| `app/src/main/assets/nodejs-project/database.js` | Add `CREATE TABLE tool_call_log` and `CREATE TABLE skill_trigger_log` in `initDatabase()`. Add `purgeOldLogs()` retention fn. Export both. |
+| `app/src/main/assets/nodejs-project/tools/index.js` | Wrap `executeTool()` with buffered logger call. |
+| `app/src/main/assets/nodejs-project/skills.js` | One-line `INSERT OR IGNORE` in `findMatchingSkills()` after `matched.push(skill)`. |
+| `app/src/main/assets/nodejs-project/main.js` | Call `purgeOldLogs()` on service start; call `flushToolCallBuffer()` in shutdown path. |
+| `tests/nodejs-project/smoke.js` | Add `call-shape`, `tool-call-logger` to side-effect-free module list. |
+
+### New files (PR-B — school feature)
+
+| Path | Responsibility |
+|---|---|
+| `app/src/main/assets/nodejs-project/school.js` | Pure module: `transition()` state machine, `scanLogs()`, `draftSkillFile()`, `writeSkillFile()`, `retireSkill()`, `readSchoolMd()`, `writeSchoolMd()`, `appendLogLine()`, `normalizeTitle()`, `signatureOf()`, `readPriorSessions()`. |
+| `app/src/main/assets/nodejs-project/tools/school.js` | Thin tool handlers (6 tools): `school_begin`, `school_scan`, `school_write_skill`, `school_retire_skill`, `school_end`, `school_handle_input`. |
+| `app/src/main/assets/default-skills/go-to-school/SKILL.md` | Bundled skill: frontmatter, rubric (5 gates + dedup), proposal format, approval protocol, input classification rubric, classification echo rule. |
+| `tests/nodejs-project/school.test.js` | `normalizeTitle`, `signatureOf`, `scanLogs`, `readSchoolMd` malformed handling. |
+| `tests/nodejs-project/school-state-machine.test.js` | All 32 `(state, input)` transitions from §8.5.1. |
+| `tests/nodejs-project/school-tools.test.js` | Frontmatter marker enforcement, path sandbox, size cap, bundled-skill rejection, patch provenance preservation, stale-session auto-end, write-failure path. |
+| `tests/nodejs-project/school-integration.test.js` | Full happy path on seeded fixtures + crash-recovery + classification echo presence. |
+| `docs/internal/audits/SAB-AUDIT-v23.md` | SAB audit for school feature. Target: 60-100 probe points, 100% post-fix. |
+
+### Modified files (PR-B)
+
+| Path | What changes |
+|---|---|
+| `app/src/main/assets/nodejs-project/tools/index.js` | Import + merge `schoolTools` into `TOOLS`. Route school tool calls to handlers. |
+| `app/src/main/assets/nodejs-project/ai.js` | Add new "Self-Improvement" block to `buildSystemBlocks()`. |
+| `app/src/main/assets/nodejs-project/telegram.js` | Register `/school`, `/school log`, `/school-reset`, `/school-reset-confirm` commands. |
+| `app/src/main/assets/nodejs-project/message-handler.js` | Detect `/school-reset-confirm` pending state (60s TTL) and gate the reset action. |
+| `app/src/main/assets/nodejs-project/main.js` | On startup: detect stale `workspace/SCHOOL.md`, auto-end via `school_end`; detect concurrent-session interaction with `/school`. |
+| `app/src/main/assets/nodejs-project/DIAGNOSTICS.md` | New section on school troubleshooting: stuck SCHOOL.md, empty-log, bundled-skill-rejection, stale-session behavior, `/school-reset` flow. |
+| `CHANGELOG.md` | Add v1.10.0 "Go to School" entry under Added. |
+| `app/build.gradle.kts` | Bump `versionCode` 17 → 18, `versionName` "1.9.0" → "1.10.0". |
+| `tests/nodejs-project/smoke.js` | Add `school` to side-effect-free module list. |
+
+---
+
+# PHASE A — PR-A: Log infrastructure
+
+Ships as **v1.10.0-rc1**. No user-visible behavior change. Soaks in production for 7 days before PR-B merges.
+
+---
+
+### Task A1: `tool_call_log` table migration + unit test
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/database.js`
+- Test: `tests/nodejs-project/tool-call-log.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/nodejs-project/tool-call-log.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// tool-call-log.test.js — schema + insert smoke test for tool_call_log.
+// Run: node tests/nodejs-project/tool-call-log.test.js
+
+const path = require('path');
+
+async function main() {
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    // This will fail until the migration runs. We call the exported migration helper.
+    const { createToolCallLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, message_id, tool_name, triggered_by_skill, call_shape, result_status, error_kind, latency_ms, created_at)
+        VALUES ('t1', 'm1', 'web_fetch', NULL, 'web_fetch:example.com:GET', 'ok', NULL, 45, 1713614400000)`);
+
+    const rows = db.exec('SELECT tool_name, call_shape FROM tool_call_log');
+    if (rows.length !== 1 || rows[0].values.length !== 1 ||
+        rows[0].values[0][0] !== 'web_fetch' || rows[0].values[0][1] !== 'web_fetch:example.com:GET') {
+        console.error('FAIL: expected single row with tool_name=web_fetch');
+        process.exit(1);
+    }
+    console.log('  ✓ tool_call_log schema created + insert roundtrips');
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: FAIL — `createToolCallLogSchema is not a function` (not yet exported).
+
+- [ ] **Step 3: Add the schema function in `database.js`**
+
+In `app/src/main/assets/nodejs-project/database.js`, after the existing `CREATE TABLE api_request_log` block (around line 93), add:
+
+```javascript
+function createToolCallLogSchema(dbInstance) {
+    dbInstance.run(`CREATE TABLE IF NOT EXISTS tool_call_log (
+        id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+        turn_id            TEXT    NOT NULL,
+        message_id         TEXT,
+        tool_name          TEXT    NOT NULL,
+        triggered_by_skill TEXT,
+        call_shape         TEXT    NOT NULL,
+        result_status      TEXT    NOT NULL,
+        error_kind         TEXT,
+        latency_ms         INTEGER,
+        created_at         INTEGER NOT NULL
+    )`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_created ON tool_call_log(created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_tool    ON tool_call_log(tool_name, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_shape   ON tool_call_log(call_shape, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_turn    ON tool_call_log(turn_id)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at)`);
+}
+```
+
+Call it from `initDatabase()` after the existing table creates. Export it from `module.exports` (add `createToolCallLogSchema,`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: PASS — `✓ tool_call_log schema created + insert roundtrips`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/database.js tests/nodejs-project/tool-call-log.test.js
+git commit -m "feat(log): add tool_call_log schema + unit test"
+```
+
+---
+
+### Task A2: `skill_trigger_log` table migration + UNIQUE-constraint test
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/database.js`
+- Test: `tests/nodejs-project/skill-trigger-log.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/nodejs-project/skill-trigger-log.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// skill-trigger-log.test.js — schema + UNIQUE constraint test.
+// Run: node tests/nodejs-project/skill-trigger-log.test.js
+
+const path = require('path');
+
+async function main() {
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    const { createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createSkillTriggerLogSchema(db);
+
+    // First insert succeeds.
+    db.run(`INSERT OR IGNORE INTO skill_trigger_log
+        (skill_name, message_id, match_type, created_at) VALUES ('weather', 'msg-1', 'keyword', 1713614400000)`);
+
+    // Duplicate (skill_name, message_id) is silently ignored.
+    db.run(`INSERT OR IGNORE INTO skill_trigger_log
+        (skill_name, message_id, match_type, created_at) VALUES ('weather', 'msg-1', 'keyword', 1713614400500)`);
+
+    const result = db.exec('SELECT COUNT(*) FROM skill_trigger_log');
+    const count = result[0].values[0][0];
+    if (count !== 1) {
+        console.error(`FAIL: expected 1 row after dedup, got ${count}`);
+        process.exit(1);
+    }
+    console.log('  ✓ skill_trigger_log dedups on (skill_name, message_id)');
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+node tests/nodejs-project/skill-trigger-log.test.js
+```
+Expected: FAIL — `createSkillTriggerLogSchema is not a function`.
+
+- [ ] **Step 3: Add schema fn in `database.js`**
+
+In `database.js`, right after `createToolCallLogSchema`:
+
+```javascript
+function createSkillTriggerLogSchema(dbInstance) {
+    dbInstance.run(`CREATE TABLE IF NOT EXISTS skill_trigger_log (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        skill_name  TEXT    NOT NULL,
+        message_id  TEXT,
+        match_type  TEXT    NOT NULL,
+        created_at  INTEGER NOT NULL,
+        UNIQUE(skill_name, message_id)
+    )`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_stl_skill_created ON skill_trigger_log(skill_name, created_at)`);
+    dbInstance.run(`CREATE INDEX IF NOT EXISTS idx_stl_created       ON skill_trigger_log(created_at)`);
+}
+```
+
+Call it from `initDatabase()`. Export it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+node tests/nodejs-project/skill-trigger-log.test.js
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/database.js tests/nodejs-project/skill-trigger-log.test.js
+git commit -m "feat(log): add skill_trigger_log schema with UNIQUE(skill, msg) dedup"
+```
+
+---
+
+### Task A3: `call-shape.js` — per-tool builders + default
+
+**Files:**
+- Create: `app/src/main/assets/nodejs-project/call-shape.js`
+- Test: `tests/nodejs-project/call-shape.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/nodejs-project/call-shape.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// call-shape.test.js — per-tool shape builders. Must produce structural
+// classifiers without leaking sensitive values (wallets, API keys, user text).
+// Run: node tests/nodejs-project/call-shape.test.js
+
+const path = require('path');
+const { getShape } = require(path.join(__dirname, '../../app/src/main/assets/nodejs-project/call-shape.js'));
+
+let fails = 0;
+function assertEq(actual, expected, msg) {
+    if (actual !== expected) {
+        console.error(`FAIL ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        fails++;
+    } else {
+        console.log(`  ✓ ${msg}`);
+    }
+}
+function assertNotContains(shape, needle, msg) {
+    if (typeof shape === 'string' && shape.includes(needle)) {
+        console.error(`FAIL ${msg}: shape ${JSON.stringify(shape)} contained ${JSON.stringify(needle)}`);
+        fails++;
+    } else {
+        console.log(`  ✓ ${msg}`);
+    }
+}
+
+// web_fetch: host + method only
+assertEq(getShape('web_fetch', { url: 'https://api.anthropic.com/v1/messages?key=secret', method: 'POST' }),
+    'web_fetch:api.anthropic.com:POST', 'web_fetch shape: host+method');
+assertEq(getShape('web_fetch', { url: 'https://example.com/path' }),
+    'web_fetch:example.com:GET', 'web_fetch shape: default GET');
+
+// solana_swap: well-known mints are public; unknown mints → "other"
+assertEq(getShape('solana_swap', { inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' }),
+    'solana_swap:SOL:USDC', 'solana_swap shape: known mint pair');
+assertEq(getShape('solana_swap', { inputMint: 'AbcXyzRandomMintAddress1234567890', outputMint: 'So11111111111111111111111111111111111111112' }),
+    'solana_swap:other:SOL', 'solana_swap shape: unknown input mint → other');
+
+// solana_balance: self vs other
+assertEq(getShape('solana_balance', {}), 'solana_balance:self', 'solana_balance shape: self');
+assertEq(getShape('solana_balance', { address: 'SomeOtherWallet' }), 'solana_balance:other', 'solana_balance shape: other');
+
+// file_read: path pattern
+assertEq(getShape('file_read', { path: 'memory/2026-04-19.md' }), 'file_read:memory/*.md', 'file_read shape: memory daily');
+assertEq(getShape('file_read', { path: 'skills/weather.md' }), 'file_read:skills/*.md', 'file_read shape: skills');
+assertEq(getShape('file_read', { path: 'SOUL.md' }), 'file_read:SOUL.md', 'file_read shape: root md');
+
+// shell_exec: first token only
+assertEq(getShape('shell_exec', { cmd: 'ls -la /tmp' }), 'shell_exec:ls', 'shell_exec shape: first token');
+assertEq(getShape('shell_exec', { cmd: 'cat /etc/passwd' }), 'shell_exec:cat', 'shell_exec shape: cat');
+
+// default — just the tool name
+assertEq(getShape('some_new_unknown_tool', { whatever: 'x' }), 'some_new_unknown_tool',
+    'default shape: just tool name');
+
+// Privacy red-team — sensitive values never appear in shape
+const wallet = 'AbcXyzWallet1234567890xxx';
+const apiKey = 'sk-ant-api03-secret';
+assertNotContains(getShape('solana_balance', { address: wallet }), wallet, 'wallet not in shape');
+assertNotContains(getShape('web_fetch', { url: `https://example.com?key=${apiKey}` }), apiKey, 'api key not in shape');
+assertNotContains(getShape('file_read', { path: 'memory/private-name-here.md' }), 'private-name-here', 'filename not in shape');
+
+// Size cap — 64 chars max
+const huge = 'solana_swap';
+const longMint = 'X'.repeat(100);
+const shape = getShape('solana_swap', { inputMint: longMint, outputMint: longMint });
+if (shape.length > 64) {
+    console.error(`FAIL shape length ${shape.length} > 64: ${shape}`);
+    fails++;
+} else {
+    console.log(`  ✓ shape length capped at 64 chars`);
+}
+
+if (fails > 0) { console.error(`${fails} failures`); process.exit(1); }
+console.log('all tests passed');
+process.exit(0);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+node tests/nodejs-project/call-shape.test.js
+```
+Expected: FAIL — `Cannot find module 'call-shape.js'`.
+
+- [ ] **Step 3: Create `call-shape.js`**
+
+Create `app/src/main/assets/nodejs-project/call-shape.js`:
+
+```javascript
+// call-shape.js — structural classifier per tool for tool_call_log.
+// Pure functions. Never stores sensitive data. Max 64 chars per shape.
+//
+// Each builder receives the tool's args and returns a short string that
+// captures the *class* of the call (e.g. "web_fetch:api.anthropic.com:POST")
+// without any user-specific values.
+
+const KNOWN_MINTS = {
+    'So11111111111111111111111111111111111111112': 'SOL',
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': 'USDC',
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': 'USDT',
+    'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263': 'BONK',
+};
+function mintLabel(mint) {
+    if (!mint) return 'unknown';
+    return KNOWN_MINTS[mint] || 'other';
+}
+
+function hostOf(url) {
+    if (!url || typeof url !== 'string') return 'unknown';
+    try {
+        const u = new URL(url);
+        return u.hostname;
+    } catch (_) {
+        return 'malformed';
+    }
+}
+
+function pathPattern(p) {
+    if (!p || typeof p !== 'string') return 'unknown';
+    // memory/YYYY-MM-DD.md → memory/*.md
+    if (/^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(p)) return 'memory/*.md';
+    if (/^memory\//.test(p)) return 'memory/*';
+    if (/^skills\/[^/]+\.md$/.test(p)) return 'skills/*.md';
+    if (/^skills\//.test(p)) return 'skills/*';
+    if (/^workspace\/school\//.test(p)) return 'workspace/school/*';
+    // Root-level .md files expose filename (safe — SOUL/MEMORY/IDENTITY/USER/HEARTBEAT only)
+    if (/^[A-Z]+\.md$/.test(p)) return p;
+    // Everything else → bucket by depth
+    return p.split('/').slice(0, 2).join('/') + '/*';
+}
+
+const builders = {
+    web_fetch: (args) => `web_fetch:${hostOf(args.url)}:${(args.method || 'GET').toUpperCase()}`,
+    web_search: (args) => `web_search:${args.provider || 'default'}`,
+    solana_swap: (args) => `solana_swap:${mintLabel(args.inputMint)}:${mintLabel(args.outputMint)}`,
+    solana_balance: (args) => args && args.address ? 'solana_balance:other' : 'solana_balance:self',
+    solana_send: (args) => `solana_send:${mintLabel(args && args.mint)}`,
+    solana_price: (args) => `solana_price:${mintLabel(args && args.mint)}`,
+    file_read: (args) => `file_read:${pathPattern(args && args.path)}`,
+    file_write: (args) => `file_write:${pathPattern(args && args.path)}`,
+    file_edit: (args) => `file_edit:${pathPattern(args && args.path)}`,
+    file_delete: (args) => `file_delete:${pathPattern(args && args.path)}`,
+    shell_exec: (args) => {
+        const cmd = (args && args.cmd) || '';
+        const first = cmd.trim().split(/\s+/)[0] || 'empty';
+        return `shell_exec:${first}`;
+    },
+    android_sms: () => 'android_sms',
+    android_call: () => 'android_call',
+    telegram_send: () => 'telegram_send',
+};
+
+function getShape(toolName, args) {
+    const b = builders[toolName];
+    const raw = b ? b(args || {}) : toolName;
+    // Cap to 64 chars with trailing … if truncated
+    if (raw.length <= 64) return raw;
+    return raw.slice(0, 63) + '…';
+}
+
+module.exports = { getShape };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+node tests/nodejs-project/call-shape.test.js
+```
+Expected: PASS — all 14+ cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/call-shape.js tests/nodejs-project/call-shape.test.js
+git commit -m "feat(log): call-shape builders for 14 tools + privacy red-team test"
+```
+
+---
+
+### Task A4: Buffered async tool-call logger
+
+**Files:**
+- Create: `app/src/main/assets/nodejs-project/tool-call-logger.js`
+- Test: extend `tests/nodejs-project/tool-call-log.test.js`
+
+- [ ] **Step 1: Add a failing test for buffering**
+
+Append to `tests/nodejs-project/tool-call-log.test.js` (before the final `console.log('all tests passed')`):
+
+```javascript
+    // Buffered logger test
+    const { ToolCallLogger } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tool-call-logger.js')
+    );
+    const logger = new ToolCallLogger({ db, flushIntervalMs: 50, maxBufferSize: 5 });
+
+    // Log 7 rows — should trigger size-based flush at 5
+    for (let i = 0; i < 7; i++) {
+        logger.record({
+            turn_id: 't2', message_id: `m${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:example.com:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 10, created_at: 1713614400000 + i
+        });
+    }
+    // Wait briefly for interval flush
+    await new Promise(r => setTimeout(r, 80));
+    await logger.flushNow();
+
+    const r = db.exec('SELECT COUNT(*) FROM tool_call_log WHERE turn_id = ?', ['t2']);
+    const c = r[0].values[0][0];
+    if (c !== 7) { console.error(`FAIL buffered logger: expected 7 rows, got ${c}`); process.exit(1); }
+    console.log('  ✓ buffered logger flushes on size + interval');
+    logger.stop();
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: FAIL — `Cannot find module 'tool-call-logger.js'`.
+
+- [ ] **Step 3: Create the logger**
+
+Create `app/src/main/assets/nodejs-project/tool-call-logger.js`:
+
+```javascript
+// tool-call-logger.js — in-memory buffer for tool_call_log inserts.
+// Flushes on 5s interval OR 100-row threshold (whichever first).
+// Bypasses the hot path of tool execution; worst case on abrupt kill = 5s of log loss.
+
+class ToolCallLogger {
+    constructor({ db, flushIntervalMs = 5000, maxBufferSize = 100, log = () => {} }) {
+        this.db = db;
+        this.buffer = [];
+        this.flushIntervalMs = flushIntervalMs;
+        this.maxBufferSize = maxBufferSize;
+        this.log = log;
+        this.flushing = false;
+        this.stopped = false;
+        this.timer = setInterval(() => { this.flushNow().catch(() => {}); }, flushIntervalMs);
+        if (this.timer.unref) this.timer.unref();  // don't block Node exit on this timer
+    }
+
+    record(row) {
+        if (this.stopped) return;
+        this.buffer.push(row);
+        if (this.buffer.length >= this.maxBufferSize) {
+            // Fire-and-forget; batch flush on next tick.
+            setImmediate(() => this.flushNow().catch(() => {}));
+        }
+    }
+
+    async flushNow() {
+        if (this.flushing) return;
+        if (this.buffer.length === 0) return;
+        this.flushing = true;
+        const batch = this.buffer.splice(0, this.buffer.length);
+        try {
+            this.db.run('BEGIN TRANSACTION');
+            const stmt = this.db.prepare(`INSERT INTO tool_call_log
+                (turn_id, message_id, tool_name, triggered_by_skill, call_shape, result_status, error_kind, latency_ms, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+            for (const r of batch) {
+                stmt.run([r.turn_id, r.message_id, r.tool_name, r.triggered_by_skill,
+                          r.call_shape, r.result_status, r.error_kind, r.latency_ms, r.created_at]);
+            }
+            stmt.free();
+            this.db.run('COMMIT');
+        } catch (e) {
+            try { this.db.run('ROLLBACK'); } catch (_) {}
+            this.log(`[ToolCallLogger] flush failed: ${e.message}`, 'ERROR');
+            // Put the batch back at the head so we don't lose it silently
+            this.buffer.unshift(...batch);
+        } finally {
+            this.flushing = false;
+        }
+    }
+
+    stop() {
+        this.stopped = true;
+        clearInterval(this.timer);
+    }
+}
+
+module.exports = { ToolCallLogger };
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: PASS — both schema and buffered-logger cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/tool-call-logger.js tests/nodejs-project/tool-call-log.test.js
+git commit -m "feat(log): buffered async tool-call logger (5s / 100-row flush)"
+```
+
+---
+
+### Task A5: Wire `executeTool` to the logger
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/tools/index.js`
+- Modify: `app/src/main/assets/nodejs-project/main.js`
+
+- [ ] **Step 1: Read current `executeTool` dispatcher**
+
+```bash
+grep -n "executeTool\|function execute\|async function execute" /Users/egod/Dev/SeekerClaw/app/src/main/assets/nodejs-project/tools/index.js | head
+```
+
+Note the exact function signature — the wrap in Step 2 must match.
+
+- [ ] **Step 2: Add logger wrap in `tools/index.js`**
+
+At the top of `tools/index.js`, add imports:
+
+```javascript
+const { ToolCallLogger } = require('../tool-call-logger');
+const { getShape } = require('../call-shape');
+const { getDb } = require('../database');
+```
+
+Add module state (singleton logger, initialized lazily):
+
+```javascript
+let _logger = null;
+function getLogger() {
+    if (!_logger) {
+        const db = getDb();
+        if (!db) return null;
+        _logger = new ToolCallLogger({ db, log });  // `log` comes from existing require('../config')
+    }
+    return _logger;
+}
+function stopLogger() { if (_logger) { _logger.stop(); _logger = null; } }
+```
+
+Wrap the existing tool dispatch. Find the function (likely `executeTool` or similar) and add timing + logger call:
+
+```javascript
+async function executeToolWithLogging(name, args, context) {
+    const startedAt = Date.now();
+    let status = 'ok';
+    let errorKind = null;
+    try {
+        const result = await executeToolInner(name, args, context);  // rename original to executeToolInner
+        if (result && result.isError) { status = 'error'; errorKind = (result.errorKind || 'unknown'); }
+        return result;
+    } catch (e) {
+        status = 'error';
+        errorKind = (e.code || e.name || 'exception').toString().slice(0, 60);
+        throw e;
+    } finally {
+        const logger = getLogger();
+        if (logger) {
+            logger.record({
+                turn_id: (context && context.turn_id) || 'unknown',
+                message_id: (context && context.message_id) || null,
+                tool_name: name,
+                triggered_by_skill: (context && context.activeSkill) || null,
+                call_shape: getShape(name, args),
+                result_status: status,
+                error_kind: errorKind,
+                latency_ms: Date.now() - startedAt,
+                created_at: startedAt,
+            });
+        }
+    }
+}
+```
+
+Export the wrapped version as `executeTool`, keep `executeToolInner` as the dispatcher. Also export `stopLogger`.
+
+- [ ] **Step 3: Flush on shutdown in `main.js`**
+
+In `main.js`, find the shutdown path (look for existing `process.on('SIGTERM'` or similar graceful exit). Add:
+
+```javascript
+// Flush any buffered tool-call logs before exit
+try {
+    const { stopLogger, flushLoggerNow } = require('./tools');
+    if (flushLoggerNow) await flushLoggerNow();
+    if (stopLogger) stopLogger();
+} catch (e) { /* best-effort */ }
+```
+
+Also export `flushLoggerNow` from `tools/index.js`:
+
+```javascript
+async function flushLoggerNow() { const l = getLogger(); if (l) await l.flushNow(); }
+module.exports = { executeTool: executeToolWithLogging, stopLogger, flushLoggerNow, /* ...existing... */ };
+```
+
+- [ ] **Step 4: Smoke-check — run the module-load smoke test**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS — no regex/module-load regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/tools/index.js app/src/main/assets/nodejs-project/main.js
+git commit -m "feat(log): wrap executeTool with buffered call logger + shutdown flush"
+```
+
+---
+
+### Task A6: Skill-trigger instrumentation in `findMatchingSkills`
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/skills.js`
+- Test: extend `tests/nodejs-project/skill-trigger-log.test.js`
+
+- [ ] **Step 1: Add a failing test for instrumentation**
+
+Append to `tests/nodejs-project/skill-trigger-log.test.js` (before final `process.exit(0)`):
+
+```javascript
+    // Verify findMatchingSkills records matches.
+    // We call a helper that simulates the match-and-log path.
+    const { recordSkillTrigger } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/skills.js')
+    );
+    // Seed db on the module
+    const { setSkillTriggerDb } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/skills.js')
+    );
+    setSkillTriggerDb(db);
+
+    recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500000);
+    recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500500);  // duplicate, should be ignored
+
+    const r2 = db.exec('SELECT COUNT(*) FROM skill_trigger_log WHERE message_id = ?', ['msg-42']);
+    const c2 = r2[0].values[0][0];
+    if (c2 !== 1) { console.error(`FAIL recordSkillTrigger dedup: expected 1, got ${c2}`); process.exit(1); }
+    console.log('  ✓ recordSkillTrigger uses INSERT OR IGNORE (no double-count)');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+node tests/nodejs-project/skill-trigger-log.test.js
+```
+Expected: FAIL — `recordSkillTrigger is not a function` OR `setSkillTriggerDb is not a function`.
+
+- [ ] **Step 3: Add the helper + instrument the matcher**
+
+In `app/src/main/assets/nodejs-project/skills.js`, near the top (after existing imports), add:
+
+```javascript
+let _stlDb = null;
+function setSkillTriggerDb(db) { _stlDb = db; }
+function recordSkillTrigger(skillName, messageId, matchType, createdAt) {
+    if (!_stlDb) return;
+    try {
+        _stlDb.run(`INSERT OR IGNORE INTO skill_trigger_log (skill_name, message_id, match_type, created_at) VALUES (?, ?, ?, ?)`,
+            [skillName, messageId || null, matchType, createdAt]);
+    } catch (e) { /* never fail a message on telemetry */ }
+}
+```
+
+In `findMatchingSkills()` (around line 548), after `matched.push(skill)`, add instrumentation — but the function signature is `findMatchingSkills(message)` which has no `message_id`. Change the signature to accept an optional `ctx` arg:
+
+```javascript
+function findMatchingSkills(message, ctx = {}) {
+    const skills = loadSkills();
+    const lowerMsg = message.toLowerCase();
+    const matched = [];
+    for (const skill of skills) {
+        if (matched.length >= 2) break;
+        const hasTrigger = skill.triggers.some(trigger => {
+            if (trigger.includes(' ')) return lowerMsg.includes(trigger);
+            const regex = new RegExp(`\\b${trigger.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+            return regex.test(message);
+        });
+        if (hasTrigger) {
+            matched.push(skill);
+            if (ctx.message_id) {
+                recordSkillTrigger(skill.name, ctx.message_id, 'keyword', ctx.timestamp || Date.now());
+            }
+        }
+    }
+    return matched;
+}
+```
+
+All callers of `findMatchingSkills(msg)` continue to work (ctx defaults to `{}`). Update the call site in `ai.js` (around line 387) and `message-handler.js` to pass `{ message_id, timestamp }` where known.
+
+Export `recordSkillTrigger` and `setSkillTriggerDb` in `module.exports`.
+
+In `database.js` `initDatabase()`, after `createSkillTriggerLogSchema(db)`, wire the db into skills:
+
+```javascript
+const { setSkillTriggerDb } = require('./skills');
+setSkillTriggerDb(db);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+node tests/nodejs-project/skill-trigger-log.test.js
+```
+Expected: PASS — both schema dedup and `recordSkillTrigger` dedup.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/skills.js app/src/main/assets/nodejs-project/database.js app/src/main/assets/nodejs-project/ai.js app/src/main/assets/nodejs-project/message-handler.js tests/nodejs-project/skill-trigger-log.test.js
+git commit -m "feat(log): instrument findMatchingSkills with skill_trigger_log writes"
+```
+
+---
+
+### Task A7: Retention purge on service start
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/database.js`
+- Modify: `app/src/main/assets/nodejs-project/main.js`
+- Test: extend `tests/nodejs-project/tool-call-log.test.js`
+
+- [ ] **Step 1: Add failing test for retention**
+
+Append to `tests/nodejs-project/tool-call-log.test.js`:
+
+```javascript
+    // Retention purge test
+    const { purgeOldLogs } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    const now = 1713614400000;
+    const oldMs = now - (31 * 24 * 60 * 60 * 1000);   // 31 days old
+    const recentMs = now - (5 * 24 * 60 * 60 * 1000); // 5 days old
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+        VALUES ('old', 'web_fetch', 'web_fetch:x:GET', 'ok', 1, ?)`, [oldMs]);
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+        VALUES ('recent', 'web_fetch', 'web_fetch:x:GET', 'ok', 1, ?)`, [recentMs]);
+
+    purgeOldLogs(db, now);
+
+    const oldCount = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE turn_id = 'old'`)[0].values[0][0];
+    const recentCount = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE turn_id = 'recent'`)[0].values[0][0];
+    if (oldCount !== 0) { console.error(`FAIL: old rows not purged, ${oldCount} remain`); process.exit(1); }
+    if (recentCount !== 1) { console.error(`FAIL: recent row purged, expected 1 got ${recentCount}`); process.exit(1); }
+    console.log('  ✓ purgeOldLogs removes rows > 30 days, keeps recent');
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: FAIL — `purgeOldLogs is not a function`.
+
+- [ ] **Step 3: Implement purge fn**
+
+In `database.js`:
+
+```javascript
+const TOOL_CALL_LOG_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;  // 30 days
+const MAX_TOOL_CALL_LOG_ROWS = 50000;
+
+function purgeOldLogs(dbInstance, now = Date.now()) {
+    const cutoff = now - TOOL_CALL_LOG_RETENTION_MS;
+    dbInstance.run(`DELETE FROM tool_call_log WHERE created_at < ?`, [cutoff]);
+    dbInstance.run(`DELETE FROM skill_trigger_log WHERE created_at < ?`, [cutoff]);
+    // Cap row count
+    dbInstance.run(`DELETE FROM tool_call_log WHERE id IN (
+        SELECT id FROM tool_call_log ORDER BY created_at DESC LIMIT -1 OFFSET ?
+    )`, [MAX_TOOL_CALL_LOG_ROWS]);
+}
+```
+
+Export `purgeOldLogs`.
+
+In `main.js`, after `initDatabase()` returns, call:
+
+```javascript
+// Retention purge runs async, off the boot critical path
+setImmediate(() => {
+    try {
+        const { purgeOldLogs, getDb } = require('./database');
+        const db = getDb();
+        if (db) purgeOldLogs(db);
+    } catch (e) { /* best-effort */ }
+});
+```
+
+- [ ] **Step 4: Run test to verify passes**
+
+```bash
+node tests/nodejs-project/tool-call-log.test.js
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/database.js app/src/main/assets/nodejs-project/main.js tests/nodejs-project/tool-call-log.test.js
+git commit -m "feat(log): 30-day retention purge for tool_call_log + skill_trigger_log"
+```
+
+---
+
+### Task A8: Perf budget test
+
+**Files:**
+- Test: `tests/nodejs-project/tool-call-log-perf.test.js`
+
+- [ ] **Step 1: Write the perf test**
+
+Create `tests/nodejs-project/tool-call-log-perf.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// tool-call-log-perf.test.js — ensure the buffered logger doesn't
+// regress p99 tool latency under a 1000-call burst.
+// Target: 1000 records + flush < 200ms wall-clock total. If this
+// fails, the buffered-insert path is slower than expected.
+
+const path = require('path');
+
+async function main() {
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    const { createToolCallLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+
+    const { ToolCallLogger } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tool-call-logger.js')
+    );
+    const logger = new ToolCallLogger({ db, flushIntervalMs: 10000, maxBufferSize: 200 });
+
+    const start = Date.now();
+    for (let i = 0; i < 1000; i++) {
+        logger.record({
+            turn_id: 'perf', message_id: `m${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:x:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 1, created_at: start + i
+        });
+    }
+    await logger.flushNow();
+    const elapsed = Date.now() - start;
+
+    const count = db.exec('SELECT COUNT(*) FROM tool_call_log')[0].values[0][0];
+    if (count !== 1000) { console.error(`FAIL: expected 1000 rows, got ${count}`); process.exit(1); }
+
+    logger.stop();
+
+    if (elapsed > 200) {
+        console.error(`FAIL: 1000-record burst took ${elapsed}ms (budget: 200ms)`);
+        process.exit(1);
+    }
+    console.log(`  ✓ 1000 records + flush = ${elapsed}ms (budget 200ms)`);
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });
+```
+
+- [ ] **Step 2: Run — should pass if logger + schema are correct**
+
+```bash
+node tests/nodejs-project/tool-call-log-perf.test.js
+```
+Expected: PASS with an elapsed time report.
+
+- [ ] **Step 3: If it fails, investigate before committing**
+
+If the budget is exceeded, check:
+- `BEGIN TRANSACTION` / `COMMIT` wrapping the prepared-statement loop
+- `stmt.free()` after use
+- `setImmediate` not accidentally serializing flushes
+
+Tune `maxBufferSize` (200 in the test) to match realistic production size if needed; do NOT relax the 200ms budget silently.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/nodejs-project/tool-call-log-perf.test.js
+git commit -m "test(log): 1000-record burst perf budget (200ms)"
+```
+
+---
+
+### Task A9: Smoke test hookup + PR-A CHANGELOG + tag rc1
+
+**Files:**
+- Modify: `tests/nodejs-project/smoke.js`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add new modules to side-effect-free smoke list**
+
+In `tests/nodejs-project/smoke.js`, find the list of modules that get `require()`'d in Phase 2 (look for `const SIDE_EFFECT_FREE = [...]` or similar). Add:
+
+```javascript
+'call-shape',
+'tool-call-logger',
+```
+
+- [ ] **Step 2: Run the full smoke suite**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS — Phase 1 `--check` all files, Phase 2 `require()` of the side-effect-free list (including new entries).
+
+- [ ] **Step 3: Add CHANGELOG entry under "Unreleased" (pre-PR-B)**
+
+Add a top-of-file section to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added (internal — no user-facing change yet)
+- `tool_call_log` + `skill_trigger_log` tables in SQL.js. Logs every tool invocation (via buffered async logger; 5s/100-row flush) and skill-trigger match. 30-day retention, 50k-row cap. Foundational for upcoming Go to School feature. Zero user-visible behavior change in this release.
+```
+
+- [ ] **Step 4: Commit CHANGELOG + smoke-list update together**
+
+```bash
+git add CHANGELOG.md tests/nodejs-project/smoke.js
+git commit -m "chore(log): add call-shape + tool-call-logger to smoke test; CHANGELOG"
+```
+
+- [ ] **Step 5: Push the feature branch + open PR-A**
+
+```bash
+git push -u origin feature/go-to-school
+gh pr create --title "feat(log): tool-call + skill-trigger logs (PR-A, BAT-XXX)" --body "$(cat <<'EOF'
+## Summary
+
+Phase A of the Go to School feature — log infrastructure.
+
+- Adds `tool_call_log` and `skill_trigger_log` SQL.js tables.
+- Buffered async logger (5s / 100-row flush) — writes off the tool-execution hot path.
+- Per-tool `call_shape` structural classifier (privacy-safe; wallet addresses, URLs with query strings, user text never land in logs).
+- 30-day retention + 50k row cap; purge runs on service start, off the boot critical path.
+- Skill-trigger instrumentation with `UNIQUE(skill_name, message_id)` dedup.
+
+**No user-visible behavior change in this PR.** PR-B (school feature) consumes these tables.
+
+## Design
+
+Spec: [docs/superpowers/specs/2026-04-19-go-to-school-design.md](../blob/feature/go-to-school/docs/superpowers/specs/2026-04-19-go-to-school-design.md). Phase A scope documented in §6 + §15.1 + §15.3.
+
+## Test plan
+
+- [ ] `node tests/nodejs-project/tool-call-log.test.js` passes (schema + buffered logger + retention)
+- [ ] `node tests/nodejs-project/skill-trigger-log.test.js` passes (schema + UNIQUE dedup)
+- [ ] `node tests/nodejs-project/call-shape.test.js` passes (14 tool shapes + privacy red-team)
+- [ ] `node tests/nodejs-project/tool-call-log-perf.test.js` passes (1000-row burst < 200ms)
+- [ ] `node tests/nodejs-project/smoke.js` passes
+- [ ] On a Seeker device: install, run for 2+ days, verify `tool_call_log` accumulates rows and none contain sensitive values (wallet addresses, query-string secrets).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Wait for PR-A to merge + tag `v1.10.0-rc1` + soak 7 days in production before proceeding to Phase B.**
+
+---
+
+# PHASE B — PR-B: School feature
+
+Ships as **v1.10.0** after PR-A soaks for 7 days.
+
+---
+
+### Task B1: `normalizeTitle` + `signatureOf` in `school.js`
+
+**Files:**
+- Create: `app/src/main/assets/nodejs-project/school.js`
+- Test: `tests/nodejs-project/school.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/nodejs-project/school.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// school.test.js — pure functions in school.js.
+// Run: node tests/nodejs-project/school.test.js
+
+const path = require('path');
+const { normalizeTitle, signatureOf } = require(
+    path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+);
+
+let fails = 0;
+function assertEq(actual, expected, msg) {
+    if (actual !== expected) {
+        console.error(`FAIL ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        fails++;
+    } else console.log(`  ✓ ${msg}`);
+}
+
+// normalizeTitle — 4 variants collapse
+assertEq(normalizeTitle('Recipe Scaling'), 'recipe-scaling', 'title spaces');
+assertEq(normalizeTitle('recipe_scaling'), 'recipe-scaling', 'title underscore');
+assertEq(normalizeTitle('recipe-scaling'), 'recipe-scaling', 'title kebab');
+assertEq(normalizeTitle('RECIPE.SCALING!'), 'recipe-scaling', 'title upper+punct');
+assertEq(normalizeTitle('  --recipe scaling--  '), 'recipe-scaling', 'title trimmed');
+
+// Drift → different signature
+if (signatureOf('create', 'Recipe Scaling') === signatureOf('create', 'recipe-scaling-v2')) {
+    console.error(`FAIL signatureOf: v2 variant should differ from original`);
+    fails++;
+} else console.log('  ✓ signatureOf distinguishes v2 variant');
+
+// Same title → same sig across cases
+if (signatureOf('create', 'Recipe Scaling') !== signatureOf('create', 'RECIPE.SCALING!')) {
+    console.error(`FAIL signatureOf: same normalized title should produce same sig`);
+    fails++;
+} else console.log('  ✓ signatureOf stable across case+punctuation');
+
+if (fails > 0) process.exit(1);
+console.log('all tests passed');
+process.exit(0);
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school.test.js
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `school.js` with the two pure fns**
+
+Create `app/src/main/assets/nodejs-project/school.js`:
+
+```javascript
+// school.js — pure module for Go to School feature.
+// Provides state-machine transition, pattern mining, skill file writers,
+// and persistent-log helpers. No side effects at module load.
+
+const crypto = require('crypto');
+
+function normalizeTitle(raw) {
+    return String(raw || '')
+        .toLowerCase()
+        .replace(/[_\s.]+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+function signatureOf(type, title) {
+    const norm = normalizeTitle(title);
+    return 'sha256:' + crypto.createHash('sha256').update(`${type}|${norm}`).digest('hex');
+}
+
+module.exports = { normalizeTitle, signatureOf };
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+```bash
+node tests/nodejs-project/school.test.js
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/school.js tests/nodejs-project/school.test.js
+git commit -m "feat(school): normalizeTitle + signatureOf with dedup tests"
+```
+
+---
+
+### Task B2: State-machine `transition()` function + full 32-row test
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/school.js`
+- Test: `tests/nodejs-project/school-state-machine.test.js`
+
+- [ ] **Step 1: Write the failing test (all 32 transitions)**
+
+Create `tests/nodejs-project/school-state-machine.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// school-state-machine.test.js — all 32 (state, input) transitions per spec §8.5.1.
+// Run: node tests/nodejs-project/school-state-machine.test.js
+
+const path = require('path');
+const { transition } = require(
+    path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+);
+
+let fails = 0;
+function assertMatch(result, expectedKind, expectedActionKind, msg) {
+    const actualKind = result && result.nextState && result.nextState.kind;
+    const actualAction = result && result.nextAction && result.nextAction.kind;
+    const ok = actualKind === expectedKind && actualAction === expectedActionKind;
+    if (!ok) {
+        console.error(`FAIL ${msg}: expected state=${expectedKind} action=${expectedActionKind}, got state=${actualKind} action=${actualAction}`);
+        fails++;
+    } else console.log(`  ✓ ${msg}`);
+}
+
+// Shared state factory
+const approve = { kind: 'awaiting_approval', open_proposal_ns: [1, 3, 4] };
+const review3 = { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [1, 3, 4], reviewing_opened_at: 1000 };
+
+// awaiting_approval + /review 3 (valid) → reviewing_<3>
+assertMatch(transition(approve, { kind: 'review', proposal_n: 3, message_date: 2000 }),
+    'reviewing_<N>', 'send_review_artifact', 'aa + /review 3 valid → reviewing_<3>');
+
+// awaiting_approval + /review 7 (invalid) → awaiting_approval, reply_only
+assertMatch(transition(approve, { kind: 'review', proposal_n: 7, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + /review 7 invalid → reply_only');
+
+// awaiting_approval + /skip 3 → awaiting_approval (2 remaining)
+assertMatch(transition(approve, { kind: 'skip', proposal_n: 3, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + /skip 3 → awaiting_approval');
+
+// awaiting_approval + /stop → done
+assertMatch(transition(approve, { kind: 'stop', message_date: 2000 }),
+    'done', 'end_session', 'aa + /stop → done');
+
+// awaiting_approval + yes (ambiguous — no review open) → awaiting_approval, reply_only
+assertMatch(transition(approve, { kind: 'yes', message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + bare yes → reply_only (no review open)');
+
+// reviewing_<3> + YES 3 (explicit) → awaiting_approval, write_skill
+assertMatch(transition(review3, { kind: 'yes', proposal_n: 3, message_date: 1030 }),
+    'awaiting_approval', 'write_skill', 'reviewing_3 + YES 3 → write_skill');
+
+// reviewing_<3> + bare YES within 60s → awaiting_approval, write_skill
+assertMatch(transition(review3, { kind: 'yes', message_date: 1030 }),
+    'awaiting_approval', 'write_skill', 'reviewing_3 + bare YES (<60s) → write_skill');
+
+// reviewing_<3> + bare YES > 60s → reviewing_<3>, reply_only (ambiguous)
+assertMatch(transition(review3, { kind: 'yes', message_date: 100000 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + bare YES (>60s) → ambiguous');
+
+// reviewing_<3> + YES 7 (mismatch) → reviewing_<3>, reply_only
+assertMatch(transition(review3, { kind: 'yes', proposal_n: 7, message_date: 1030 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + YES 7 (mismatch) → reject');
+
+// reviewing_<3> + NO 3 → awaiting_approval, reply_only (drafted_but_denied logged)
+assertMatch(transition(review3, { kind: 'no', proposal_n: 3, message_date: 1030 }),
+    'awaiting_approval', 'reply_only', 'reviewing_3 + NO 3 → awaiting_approval');
+
+// reviewing_<3> + /review 1 → reviewing_<1>
+assertMatch(transition(review3, { kind: 'review', proposal_n: 1, message_date: 2000 }),
+    'reviewing_<N>', 'send_review_artifact', 'reviewing_3 + /review 1 → reviewing_<1>');
+
+// reviewing_<3> + /skip 1 (M≠N) → reviewing_<3>
+assertMatch(transition(review3, { kind: 'skip', proposal_n: 1, message_date: 2000 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + /skip 1 → stay reviewing_3');
+
+// reviewing_<3> + /skip 3 (current) → awaiting_approval
+assertMatch(transition(review3, { kind: 'skip', proposal_n: 3, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'reviewing_3 + /skip 3 → awaiting_approval');
+
+// reviewing_<3> + /stop → done
+assertMatch(transition(review3, { kind: 'stop', message_date: 2000 }),
+    'done', 'end_session', 'reviewing_3 + /stop → done');
+
+// Edge: last open proposal + skip → done
+const lastOne = { kind: 'awaiting_approval', open_proposal_ns: [5] };
+assertMatch(transition(lastOne, { kind: 'skip', proposal_n: 5, message_date: 2000 }),
+    'done', 'end_session', 'aa last proposal + /skip → done');
+
+// Edge: YES on last reviewing → done
+const reviewLast = { kind: 'reviewing_<N>', reviewing_n: 5, open_proposal_ns: [5], reviewing_opened_at: 1000 };
+assertMatch(transition(reviewLast, { kind: 'yes', proposal_n: 5, message_date: 1030 }),
+    'done', 'write_skill', 'reviewing_5 last + YES 5 → done (after write)');
+
+if (fails > 0) process.exit(1);
+console.log('all tests passed');
+process.exit(0);
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school-state-machine.test.js
+```
+Expected: FAIL — `transition is not a function`.
+
+- [ ] **Step 3: Implement `transition()`**
+
+In `school.js`, add:
+
+```javascript
+const STALE_BARE_YES_MS = 60 * 1000;
+
+// transition(state, input) — pure function, no I/O.
+// state: { kind: 'awaiting_approval' | 'reviewing_<N>' | 'done' | 'scanning', open_proposal_ns: int[], reviewing_n?: int, reviewing_opened_at?: ms }
+// input: { kind: 'yes'|'no'|'review'|'skip'|'stop', proposal_n?: int, message_date: ms, raw_text?: string }
+// returns: { nextState, nextAction: { kind, ...details } }
+function transition(state, input) {
+    const open = state.open_proposal_ns || [];
+    const n = input.proposal_n;
+    const lastAfterRemoval = (removeN) => open.filter(x => x !== removeN);
+
+    if (state.kind === 'awaiting_approval') {
+        if (input.kind === 'review') {
+            if (!open.includes(n)) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'proposal_not_open', open } };
+            }
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: n, open_proposal_ns: open, reviewing_opened_at: input.message_date },
+                nextAction: { kind: 'send_review_artifact', proposal_n: n },
+            };
+        }
+        if (input.kind === 'skip') {
+            const remaining = lastAfterRemoval(n);
+            if (remaining.length === 0) {
+                return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', skipped: [n] } };
+            }
+            return {
+                nextState: { kind: 'awaiting_approval', open_proposal_ns: remaining },
+                nextAction: { kind: 'reply_only', template: 'skipped', n, remaining },
+            };
+        }
+        if (input.kind === 'stop') {
+            return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', ignored: open } };
+        }
+        if (input.kind === 'yes' || input.kind === 'no') {
+            return { nextState: state, nextAction: { kind: 'reply_only', template: 'yes_no_outside_review' } };
+        }
+        return { nextState: state, nextAction: { kind: 'reply_only', template: 'unknown_input' } };
+    }
+
+    if (state.kind === 'reviewing_<N>') {
+        const cur = state.reviewing_n;
+        if (input.kind === 'yes' || input.kind === 'no') {
+            // Disambiguation
+            let targetN = n;
+            if (targetN === undefined) {
+                const elapsed = input.message_date - (state.reviewing_opened_at || 0);
+                if (elapsed <= STALE_BARE_YES_MS) targetN = cur;
+                else return { nextState: state, nextAction: { kind: 'reply_only', template: 'ambiguous_bare_yes_no' } };
+            }
+            if (targetN !== cur) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'invalid_proposal_n', got: targetN, expected: cur } };
+            }
+            if (input.kind === 'no') {
+                return {
+                    nextState: { kind: 'awaiting_approval', open_proposal_ns: open },
+                    nextAction: { kind: 'reply_only', template: 'drafted_but_denied', n: cur },
+                };
+            }
+            // yes
+            const remaining = lastAfterRemoval(cur);
+            const next = remaining.length === 0
+                ? { kind: 'done', open_proposal_ns: [] }
+                : { kind: 'awaiting_approval', open_proposal_ns: remaining };
+            return { nextState: next, nextAction: { kind: 'write_skill', n: cur } };
+        }
+        if (input.kind === 'review') {
+            if (!open.includes(n)) {
+                return { nextState: state, nextAction: { kind: 'reply_only', template: 'proposal_not_open', open } };
+            }
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: n, open_proposal_ns: open, reviewing_opened_at: input.message_date },
+                nextAction: { kind: 'send_review_artifact', proposal_n: n, skipped_n: cur },
+            };
+        }
+        if (input.kind === 'skip') {
+            if (n === cur) {
+                const remaining = lastAfterRemoval(n);
+                if (remaining.length === 0) {
+                    return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', skipped: [n] } };
+                }
+                return {
+                    nextState: { kind: 'awaiting_approval', open_proposal_ns: remaining },
+                    nextAction: { kind: 'reply_only', template: 'skipped', n, remaining },
+                };
+            }
+            // skip M where M ≠ N — stay reviewing, log M as skipped if open
+            return {
+                nextState: { kind: 'reviewing_<N>', reviewing_n: cur, open_proposal_ns: lastAfterRemoval(n), reviewing_opened_at: state.reviewing_opened_at },
+                nextAction: { kind: 'reply_only', template: 'skipped_other', n, cur },
+            };
+        }
+        if (input.kind === 'stop') {
+            return { nextState: { kind: 'done', open_proposal_ns: [] }, nextAction: { kind: 'end_session', drafted_but_denied: [cur], ignored: lastAfterRemoval(cur) } };
+        }
+        return { nextState: state, nextAction: { kind: 'reply_only', template: 'unknown_input' } };
+    }
+
+    // scanning / done — transitional states owned by school_begin / school_end
+    return { nextState: state, nextAction: { kind: 'reply_only', template: 'unsupported_state', state: state.kind } };
+}
+
+module.exports = { ...module.exports, transition };
+```
+
+(Merge into existing exports.)
+
+- [ ] **Step 4: Run — verify all 16+ transitions pass**
+
+```bash
+node tests/nodejs-project/school-state-machine.test.js
+```
+Expected: PASS — all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/school.js tests/nodejs-project/school-state-machine.test.js
+git commit -m "feat(school): deterministic transition() state machine + 16 transition tests"
+```
+
+---
+
+### Task B3: `scanLogs()` — pattern mining from tool_call_log + skill_trigger_log
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/school.js`
+- Test: extend `tests/nodejs-project/school.test.js`
+
+- [ ] **Step 1: Add failing test for scanLogs**
+
+Append to `tests/nodejs-project/school.test.js` (before the final `process.exit(0)`):
+
+```javascript
+(async () => {
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+    const { createToolCallLogSchema, createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+    createSkillTriggerLogSchema(db);
+
+    const now = 1713614400000;
+    const day = 24 * 3600 * 1000;
+    // Strong-signal: same call_shape 4x over 3 different days
+    for (let i = 0; i < 4; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('t', 'recipe_calc', 'shell_exec:calc', 'ok', 5, ?)`, [now - i * day]);
+    }
+    // Failed sequence: solana_swap with bridge_unreachable x3
+    for (let i = 0; i < 3; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, error_kind, latency_ms, created_at)
+            VALUES ('u', 'solana_swap', 'solana_swap:SOL:USDC', 'error', 'bridge_unreachable', 15, ?)`, [now - i * 3600000]);
+    }
+
+    const { scanLogs } = require(path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js'));
+    const result = scanLogs(db, { window_days: 7, min_repetition: 3, now_ms: now });
+
+    if (result.empty) { console.error('FAIL: expected non-empty scan'); process.exit(1); }
+    const rp = (result.repeated_patterns || []).find(p => (p.call_shape_chain && p.call_shape_chain[0] === 'shell_exec:calc'));
+    if (!rp || rp.count !== 4) { console.error('FAIL: expected repeated_patterns shell_exec:calc count=4', rp); process.exit(1); }
+    console.log('  ✓ scanLogs finds repeated_patterns');
+    const fs2 = (result.failed_sequences || []).find(f => f.error_kind === 'bridge_unreachable');
+    if (!fs2 || fs2.count !== 3) { console.error('FAIL: expected failed_sequences count=3', fs2); process.exit(1); }
+    console.log('  ✓ scanLogs finds failed_sequences');
+
+    // Empty-log behavior
+    const db2 = new SQL.Database();
+    createToolCallLogSchema(db2); createSkillTriggerLogSchema(db2);
+    const emptyRes = scanLogs(db2, { window_days: 7, min_repetition: 3, now_ms: now });
+    if (!emptyRes.empty) { console.error('FAIL: expected empty:true on empty log'); process.exit(1); }
+    console.log('  ✓ scanLogs returns empty:true on insufficient data');
+})();
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school.test.js
+```
+Expected: FAIL — `scanLogs is not a function`.
+
+- [ ] **Step 3: Implement `scanLogs()`**
+
+In `school.js`:
+
+```javascript
+const INSUFFICIENT_SIGNAL_MIN_CALLS = 20;
+
+function scanLogs(db, { window_days = 7, min_repetition = 3, now_ms = Date.now(), caps = {} } = {}) {
+    const capPatterns = caps.patterns ?? 5;
+    const capSequences = caps.sequences ?? 10;
+    const capTurns = caps.turns ?? 5;
+    const capUnused = caps.unused ?? 20;
+    const cutoff = now_ms - window_days * 24 * 3600 * 1000;
+
+    const total = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE created_at > ?`, [cutoff]);
+    const totalCalls = total.length ? total[0].values[0][0] : 0;
+    if (totalCalls < INSUFFICIENT_SIGNAL_MIN_CALLS) {
+        return { window_days, empty: true, reason: 'insufficient_signal', total_tool_calls: totalCalls, suggested_window_days: Math.min(30, window_days * 2) };
+    }
+    const totalTurns = db.exec(`SELECT COUNT(DISTINCT turn_id) FROM tool_call_log WHERE created_at > ?`, [cutoff])[0].values[0][0];
+
+    // Repeated patterns — same call_shape ≥ min_repetition, capture distinct days
+    const repRows = db.exec(`
+        SELECT call_shape, COUNT(*) as cnt, COUNT(DISTINCT DATE(created_at/1000, 'unixepoch')) as distinct_days,
+               GROUP_CONCAT(DISTINCT turn_id) as turns, GROUP_CONCAT(DISTINCT message_id) as msgs
+        FROM tool_call_log
+        WHERE created_at > ?
+        GROUP BY call_shape
+        HAVING cnt >= ?
+        ORDER BY cnt DESC
+        LIMIT ?`, [cutoff, min_repetition, capPatterns]);
+    const repeated_patterns = (repRows[0] ? repRows[0].values : []).map(r => ({
+        call_shape_chain: [r[0]],
+        count: r[1],
+        spans_distinct_days: r[2],
+        sample_turn_ids: String(r[3] || '').split(',').slice(0, 3),
+        sample_message_ids: String(r[4] || '').split(',').slice(0, 3),
+    }));
+
+    const failRows = db.exec(`
+        SELECT tool_name, call_shape, error_kind, COUNT(*) as cnt
+        FROM tool_call_log
+        WHERE created_at > ? AND result_status = 'error'
+        GROUP BY tool_name, call_shape, error_kind
+        HAVING cnt >= ?
+        ORDER BY cnt DESC
+        LIMIT ?`, [cutoff, min_repetition, capSequences]);
+    const failed_sequences = (failRows[0] ? failRows[0].values : []).map(r => ({
+        tool_name: r[0], call_shape: r[1], error_kind: r[2], count: r[3]
+    }));
+
+    const exRows = db.exec(`
+        SELECT turn_id, MIN(message_id), COUNT(*) as tool_count, SUM(latency_ms) as latency_sum
+        FROM tool_call_log
+        WHERE created_at > ?
+        GROUP BY turn_id
+        HAVING tool_count >= 8
+        ORDER BY tool_count DESC, latency_sum DESC
+        LIMIT ?`, [cutoff, capTurns]);
+    const expensive_turns = (exRows[0] ? exRows[0].values : []).map(r => ({
+        turn_id: r[0], message_id: r[1], tool_count: r[2], latency_ms_total: r[3]
+    }));
+
+    // Unused skills — skills with 0 triggers in window
+    // Caller injects the full skill list for comparison (pure-ish)
+    // For test purposes we query what IS triggered and let caller subtract
+    const triggeredRows = db.exec(`SELECT DISTINCT skill_name FROM skill_trigger_log WHERE created_at > ?`, [cutoff]);
+    const triggered_skills = (triggeredRows[0] ? triggeredRows[0].values : []).map(r => r[0]);
+
+    return {
+        window_days,
+        empty: false,
+        total_turns: totalTurns,
+        total_tool_calls: totalCalls,
+        repeated_patterns,
+        failed_sequences,
+        expensive_turns,
+        triggered_skills,  // caller subtracts from full skill list for unused_skills
+        unused_tools: [],  // caller computes
+    };
+}
+
+module.exports = { ...module.exports, scanLogs };
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+```bash
+node tests/nodejs-project/school.test.js
+```
+Expected: PASS including `scanLogs finds repeated_patterns`, `scanLogs finds failed_sequences`, `scanLogs returns empty:true on insufficient data`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/school.js tests/nodejs-project/school.test.js
+git commit -m "feat(school): scanLogs — pattern mining from tool_call_log + skill_trigger_log"
+```
+
+---
+
+### Task B4: `school_begin` + `school_end` tool handlers + SCHOOL.md I/O
+
+**Files:**
+- Create: `app/src/main/assets/nodejs-project/tools/school.js`
+- Modify: `app/src/main/assets/nodejs-project/school.js` (add `readSchoolMd`, `writeSchoolMd`, `appendLogLine`, stale-detection helpers)
+- Test: `tests/nodejs-project/school-tools.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/nodejs-project/school-tools.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// school-tools.test.js — tool handler behavior.
+// Run: node tests/nodejs-project/school-tools.test.js
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+let fails = 0;
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'school-tools-'));
+process.env.WORKDIR = tmp;  // school.js reads workDir via config; plan author: verify this or inject explicitly
+
+(async () => {
+    const { schoolBeginHandler, schoolEndHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+
+    // school_begin — fresh, creates SCHOOL.md
+    const beginRes = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!beginRes.ok || !beginRes.session_id) { console.error('FAIL begin fresh', beginRes); process.exit(1); }
+    console.log('  ✓ school_begin creates new session + SCHOOL.md');
+
+    const sch = fs.readFileSync(path.join(tmp, 'SCHOOL.md'), 'utf8');
+    if (!sch.includes(beginRes.session_id)) { console.error('FAIL SCHOOL.md missing session_id'); process.exit(1); }
+    console.log('  ✓ SCHOOL.md contains session_id');
+
+    // school_begin again — should detect concurrent session
+    const beginRes2 = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (beginRes2.ok && !beginRes2.resumed) { console.error('FAIL: expected concurrent-session return', beginRes2); process.exit(1); }
+    console.log('  ✓ school_begin detects existing SCHOOL.md (resumed or rejected)');
+
+    // school_end — deletes SCHOOL.md, appends log
+    const endRes = await schoolEndHandler({
+        session_id: beginRes.session_id,
+        summary: { patterns_found: 0, proposals_made: 0, approved: [], drafted_but_denied: [], skipped: [], ignored: [], rejected_by_rubric: [], rejected_as_duplicate: [] }
+    }, { workDir: tmp });
+    if (!endRes.ok) { console.error('FAIL end', endRes); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'SCHOOL.md'))) { console.error('FAIL: SCHOOL.md not deleted after end'); process.exit(1); }
+    console.log('  ✓ school_end deletes SCHOOL.md');
+
+    const logPath = path.join(tmp, 'school', 'log.jsonl');
+    const logContent = fs.readFileSync(logPath, 'utf8').trim();
+    const parsed = JSON.parse(logContent);
+    if (parsed.session_id !== beginRes.session_id) { console.error('FAIL: log entry session_id mismatch'); process.exit(1); }
+    console.log('  ✓ school_end appends log.jsonl entry');
+})().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+    if (fails > 0) process.exit(1);
+    console.log('all tests passed');
+    process.exit(0);
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: FAIL — `tools/school.js` not found.
+
+- [ ] **Step 3: Implement begin/end — extend `school.js` first**
+
+In `school.js`, add:
+
+```javascript
+const fs = require('fs');
+const pathMod = require('path');
+
+function schoolDir(workDir) { return pathMod.join(workDir, 'school'); }
+function schoolMdPath(workDir) { return pathMod.join(workDir, 'SCHOOL.md'); }
+function schoolLogPath(workDir) { return pathMod.join(workDir, 'school', 'log.jsonl'); }
+
+function ensureSchoolDir(workDir) {
+    const d = schoolDir(workDir);
+    fs.mkdirSync(d, { recursive: true });
+    fs.mkdirSync(pathMod.join(d, 'drafts'), { recursive: true });
+    fs.mkdirSync(pathMod.join(d, 'retired'), { recursive: true });
+}
+
+function writeSchoolMd(workDir, sessionObj) {
+    ensureSchoolDir(workDir);
+    const frontmatter = [
+        '---',
+        `session_id: ${sessionObj.session_id}`,
+        `started_at: ${sessionObj.started_at}`,
+        `trigger: ${sessionObj.trigger || 'on_demand'}`,
+        `state: ${sessionObj.state || 'scanning'}`,
+        `window_days: ${sessionObj.window_days || 7}`,
+        `open_proposal_ns: [${(sessionObj.open_proposal_ns || []).join(', ')}]`,
+        `rubric_version: "${sessionObj.rubric_version || '1.0.0'}"`,
+        sessionObj.reviewing_opened_at ? `reviewing_opened_at: ${sessionObj.reviewing_opened_at}` : '',
+        '---',
+        '',
+        `# School Session — ${new Date(sessionObj.started_at).toISOString()}`,
+        '',
+        '## Proposals',
+        JSON.stringify(sessionObj.proposals || [], null, 2),
+        '',
+    ].filter(Boolean).join('\n');
+    fs.writeFileSync(schoolMdPath(workDir), frontmatter);
+}
+
+function readSchoolMd(workDir) {
+    const p = schoolMdPath(workDir);
+    if (!fs.existsSync(p)) return null;
+    const content = fs.readFileSync(p, 'utf8');
+    const m = content.match(/^---\n([\s\S]+?)\n---/);
+    if (!m) throw new Error('SCHOOL.md malformed (no YAML frontmatter)');
+    const fm = {};
+    for (const line of m[1].split('\n')) {
+        const kv = line.match(/^(\w+):\s*(.+)$/);
+        if (!kv) continue;
+        const [, k, v] = kv;
+        if (k === 'open_proposal_ns') {
+            fm[k] = v.replace(/[\[\]]/g, '').split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
+        } else if (k === 'started_at' || k === 'reviewing_opened_at' || k === 'window_days') {
+            fm[k] = parseInt(v, 10);
+        } else {
+            fm[k] = v.replace(/^["']|["']$/g, '');
+        }
+    }
+    // Extract proposals JSON block
+    let proposals = [];
+    const pm = content.match(/## Proposals\n(\[[\s\S]*?\])\n/);
+    if (pm) {
+        try { proposals = JSON.parse(pm[1]); } catch (_) { proposals = []; }
+    }
+    return { ...fm, proposals, raw: content };
+}
+
+function appendLogLine(workDir, obj) {
+    ensureSchoolDir(workDir);
+    fs.appendFileSync(schoolLogPath(workDir), JSON.stringify(obj) + '\n');
+}
+
+function readPriorSessions(workDir, limit = 10) {
+    const p = schoolLogPath(workDir);
+    if (!fs.existsSync(p)) return [];
+    const lines = fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean);
+    return lines.slice(-limit).map(l => { try { return JSON.parse(l); } catch (_) { return null; } }).filter(Boolean);
+}
+
+module.exports = { ...module.exports, writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, ensureSchoolDir, schoolMdPath, schoolLogPath };
+```
+
+- [ ] **Step 4: Implement `tools/school.js` with begin + end**
+
+Create `app/src/main/assets/nodejs-project/tools/school.js`:
+
+```javascript
+// tools/school.js — Go-to-School tool handlers.
+const crypto = require('crypto');
+const fs = require('fs');
+const { writeSchoolMd, readSchoolMd, appendLogLine, readPriorSessions, schoolMdPath } = require('../school');
+
+function newSessionId() { return crypto.randomBytes(8).toString('hex'); }
+
+async function schoolBeginHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || (typeof args === 'object' && args.workDir) || process.env.WORKDIR;
+    const existing = readSchoolMd(workDir);
+    if (existing) {
+        return {
+            ok: true, resumed: true,
+            session_id: existing.session_id,
+            started_at: existing.started_at,
+            prior_sessions: readPriorSessions(workDir, 10),
+            resumed_state: {
+                session_id: existing.session_id,
+                started_at: existing.started_at,
+                trigger: existing.trigger,
+                state: existing.state,
+                window_days: existing.window_days,
+                open_proposal_ns: existing.open_proposal_ns,
+                proposals: existing.proposals,
+                rubric_version: existing.rubric_version,
+                reviewing_opened_at: existing.reviewing_opened_at || null,
+            },
+        };
+    }
+    const sessionId = newSessionId();
+    const startedAt = Date.now();
+    writeSchoolMd(workDir, {
+        session_id: sessionId, started_at: startedAt, trigger: args.reason || 'on_demand',
+        state: 'scanning', window_days: 7, open_proposal_ns: [], proposals: [], rubric_version: '1.0.0',
+    });
+    return {
+        ok: true, resumed: false,
+        session_id: sessionId,
+        started_at: startedAt,
+        prior_sessions: readPriorSessions(workDir, 10),
+        resumed_state: null,
+    };
+}
+
+async function schoolEndHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    const entry = {
+        session_id: args.session_id,
+        started_at: (readSchoolMd(workDir) || {}).started_at || Date.now(),
+        ended_at: Date.now(),
+        trigger: (readSchoolMd(workDir) || {}).trigger || 'on_demand',
+        window_days: 7,
+        rubric_version: '1.0.0',
+        proposals: args.summary && args.summary.approved
+            ? [...(args.summary.approved || []), ...(args.summary.drafted_but_denied || []), ...(args.summary.skipped || []), ...(args.summary.ignored || []), ...(args.summary.rejected_by_rubric || []), ...(args.summary.rejected_as_duplicate || [])]
+            : [],
+    };
+    appendLogLine(workDir, entry);
+    try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+    return { ok: true };
+}
+
+module.exports = { schoolBeginHandler, schoolEndHandler };
+```
+
+- [ ] **Step 5: Run — verify pass**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: PASS — begin/end smoke case.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/school.js app/src/main/assets/nodejs-project/tools/school.js tests/nodejs-project/school-tools.test.js
+git commit -m "feat(school): school_begin + school_end tool handlers with SCHOOL.md I/O"
+```
+
+---
+
+### Task B5: `school_write_skill` — frontmatter enforcement + path sandbox
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/school.js` (add `writeSkillFile`)
+- Modify: `app/src/main/assets/nodejs-project/tools/school.js` (add handler)
+- Test: extend `tests/nodejs-project/school-tools.test.js`
+
+- [ ] **Step 1: Append failing tests for write behavior**
+
+In `tests/nodejs-project/school-tools.test.js`, inside the `async () => {}` IIFE before the end:
+
+```javascript
+    const { schoolWriteSkillHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+
+    // create mode — auto-injects frontmatter marker
+    const createRes = await schoolWriteSkillHandler({
+        mode: 'create',
+        path: 'skills/recipe-scaling.md',
+        body: `---\nname: recipe-scaling\ndescription: "Scale recipes"\nversion: "1.0.0"\n---\n\n# Recipe Scaling\n\nInstructions.\n`,
+        evidence: 'user asked 4x since Apr 13',
+    }, { workDir: tmp });
+    if (!createRes.ok) { console.error('FAIL create', createRes); process.exit(1); }
+    const written = fs.readFileSync(path.join(tmp, 'skills/recipe-scaling.md'), 'utf8');
+    if (!written.includes('source: school')) { console.error('FAIL: missing source: school marker'); process.exit(1); }
+    if (!written.includes('evidence:')) { console.error('FAIL: missing evidence field'); process.exit(1); }
+    console.log('  ✓ school_write_skill (create) injects school frontmatter marker');
+
+    // Path traversal rejection
+    const traversalRes = await schoolWriteSkillHandler({
+        mode: 'create', path: '../evil.md', body: `---\nname: evil\n---\n\n# evil\n`, evidence: 'x',
+    }, { workDir: tmp });
+    if (traversalRes.ok) { console.error('FAIL: traversal should be rejected'); process.exit(1); }
+    console.log('  ✓ school_write_skill rejects path traversal');
+
+    // Oversize rejection
+    const huge = 'A'.repeat(70 * 1024);
+    const overRes = await schoolWriteSkillHandler({
+        mode: 'create', path: 'skills/too-big.md',
+        body: `---\nname: too-big\n---\n\n# too-big\n${huge}`,
+        evidence: 'x',
+    }, { workDir: tmp });
+    if (overRes.ok) { console.error('FAIL: oversize should be rejected'); process.exit(1); }
+    console.log('  ✓ school_write_skill rejects > 64KB');
+
+    // Patch preserves source
+    fs.writeFileSync(path.join(tmp, 'skills/user-authored.md'),
+        `---\nname: user-authored\nsource: user\nversion: "1.0.0"\n---\n\n# user\n`);
+    const patchRes = await schoolWriteSkillHandler({
+        mode: 'patch', path: 'skills/user-authored.md',
+        body: `---\nname: user-authored\nsource: user\nversion: "1.0.0"\n---\n\n# user patched\n`,
+        evidence: 'fix',
+    }, { workDir: tmp });
+    if (!patchRes.ok) { console.error('FAIL patch', patchRes); process.exit(1); }
+    const patched = fs.readFileSync(path.join(tmp, 'skills/user-authored.md'), 'utf8');
+    if (!patched.includes('source: user')) { console.error('FAIL: patch must preserve source: user'); process.exit(1); }
+    if (!patched.includes('last_patched_by: school')) { console.error('FAIL: patch must add last_patched_by'); process.exit(1); }
+    console.log('  ✓ school_write_skill (patch) preserves source + adds last_patched_by');
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: FAIL — `schoolWriteSkillHandler is not a function`.
+
+- [ ] **Step 3: Implement in `school.js` + `tools/school.js`**
+
+In `school.js`:
+
+```javascript
+const MAX_SKILL_BYTES = 64 * 1024;
+
+function injectOrReplaceFrontmatterKeys(body, keys) {
+    // keys: { source: 'school', created: 'YYYY-MM-DD', evidence: '...' }  (create mode)
+    // or:   { last_patched_by: 'school', last_patched_at: 'YYYY-MM-DD', patch_evidence: '...' }  (patch mode)
+    const m = body.match(/^---\n([\s\S]+?)\n---/);
+    if (!m) throw new Error('no_frontmatter');
+    const existing = m[1].split('\n');
+    const existingMap = {};
+    const order = [];
+    for (const line of existing) {
+        const kv = line.match(/^(\w[\w-]*):\s*(.+)$/);
+        if (kv) { existingMap[kv[1]] = kv[2]; if (!order.includes(kv[1])) order.push(kv[1]); }
+    }
+    // For create: overwrite source/created/evidence; for patch: never touch existing `source`, just append last_patched_*
+    for (const k of Object.keys(keys)) {
+        existingMap[k] = JSON.stringify(keys[k]).replace(/^"|"$/g, '');  // unquote simple strings
+        if (!order.includes(k)) order.push(k);
+    }
+    const newFm = '---\n' + order.map(k => `${k}: ${existingMap[k]}`).join('\n') + '\n---';
+    return body.replace(/^---\n[\s\S]+?\n---/, newFm);
+}
+
+function todayStr() { return new Date().toISOString().slice(0, 10); }
+
+async function writeSkillFile({ workDir, mode, relPath, body, evidence }) {
+    if (!relPath.startsWith('skills/') || relPath.includes('..')) {
+        return { ok: false, error: 'path_outside_workspace_skills' };
+    }
+    if (Buffer.byteLength(body, 'utf8') > MAX_SKILL_BYTES) {
+        return { ok: false, error: 'oversize', limit_bytes: MAX_SKILL_BYTES };
+    }
+    if (!body.startsWith('---\n')) return { ok: false, error: 'missing_frontmatter' };
+    if (!/^#\s+.+/m.test(body.replace(/^---\n[\s\S]+?\n---\n/, ''))) {
+        return { ok: false, error: 'missing_body_heading' };
+    }
+    const fullPath = pathMod.join(workDir, relPath);
+    let finalBody;
+    if (mode === 'create') {
+        finalBody = injectOrReplaceFrontmatterKeys(body, {
+            source: 'school', created: todayStr(), evidence,
+        });
+    } else if (mode === 'patch') {
+        if (!fs.existsSync(fullPath)) return { ok: false, error: 'patch_target_missing' };
+        // Check existing file's source — if it's part of the bundled default-skills/ seed, reject.
+        // Here we only check workspace/skills/ files — bundled are never patchable because they live outside workspace.
+        const existing = fs.readFileSync(fullPath, 'utf8');
+        const existingSourceMatch = existing.match(/^source:\s*(.+)$/m);
+        const existingSource = existingSourceMatch ? existingSourceMatch[1].trim() : 'user';
+        finalBody = injectOrReplaceFrontmatterKeys(body, {
+            last_patched_by: 'school', last_patched_at: todayStr(), patch_evidence: evidence,
+        });
+        // Preserve existing source field explicitly
+        finalBody = finalBody.replace(/^source:\s*.+$/m, `source: ${existingSource}`);
+    } else {
+        return { ok: false, error: 'invalid_mode' };
+    }
+    fs.mkdirSync(pathMod.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, finalBody);
+    const sha = crypto.createHash('sha256').update(finalBody).digest('hex');
+    return { ok: true, path: relPath, action: mode, sha256: sha };
+}
+
+module.exports = { ...module.exports, writeSkillFile };
+```
+
+In `tools/school.js`:
+
+```javascript
+const { writeSkillFile } = require('../school');
+
+async function schoolWriteSkillHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    return await writeSkillFile({
+        workDir, mode: args.mode, relPath: args.path, body: args.body, evidence: args.evidence,
+    });
+}
+module.exports = { ...module.exports, schoolWriteSkillHandler };
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: PASS — all new cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/school.js app/src/main/assets/nodejs-project/tools/school.js tests/nodejs-project/school-tools.test.js
+git commit -m "feat(school): school_write_skill with frontmatter marker + sandbox + size cap"
+```
+
+---
+
+### Task B6: `school_retire_skill` + `school_handle_input` + `school_scan` tool wrappers
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/tools/school.js`
+- Test: extend `tests/nodejs-project/school-tools.test.js`
+
+- [ ] **Step 1: Append tests**
+
+```javascript
+    // retire
+    fs.writeFileSync(path.join(tmp, 'skills/to-retire.md'),
+        `---\nname: to-retire\nsource: school\n---\n\n# gone\n`);
+    const { schoolRetireSkillHandler, schoolHandleInputHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+    const retRes = await schoolRetireSkillHandler({ path: 'skills/to-retire.md', reason: 'unused' }, { workDir: tmp });
+    if (!retRes.ok) { console.error('FAIL retire', retRes); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'skills/to-retire.md'))) { console.error('FAIL: file not moved'); process.exit(1); }
+    const retiredFiles = fs.readdirSync(path.join(tmp, 'school/retired'));
+    if (!retiredFiles.some(f => f.includes('to-retire.md'))) { console.error('FAIL: no retired file found'); process.exit(1); }
+    console.log('  ✓ school_retire_skill moves to retired/ reversibly');
+
+    // handle_input — YES on reviewing_<3>
+    const hiRes = await schoolHandleInputHandler({
+        session_id: 'test', state: { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [3], reviewing_opened_at: 1000 },
+        input: { kind: 'yes', proposal_n: 3, message_date: 1020, raw_text: 'YES 3' }
+    }, { workDir: tmp });
+    if (!hiRes.ok || hiRes.next_action.kind !== 'write_skill') { console.error('FAIL handle_input yes', hiRes); process.exit(1); }
+    console.log('  ✓ school_handle_input returns write_skill next_action on YES');
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: FAIL — handlers not defined.
+
+- [ ] **Step 3: Implement handlers**
+
+Append to `tools/school.js`:
+
+```javascript
+const { transition } = require('../school');
+const pathMod = require('path');
+
+async function schoolRetireSkillHandler(args, ctx) {
+    const workDir = (ctx && ctx.workDir) || process.env.WORKDIR;
+    const relPath = args.path;
+    if (!relPath.startsWith('skills/') || relPath.includes('..')) {
+        return { ok: false, error: 'cannot_retire_bundled' };
+    }
+    const src = pathMod.join(workDir, relPath);
+    if (!fs.existsSync(src)) return { ok: false, error: 'target_missing' };
+    const name = pathMod.basename(relPath);
+    const ts = Date.now();
+    const dst = pathMod.join(workDir, 'school/retired', `${ts}-${name}`);
+    fs.mkdirSync(pathMod.dirname(dst), { recursive: true });
+    fs.renameSync(src, dst);
+    return { ok: true, restored_path: dst.replace(workDir + '/', ''), reason: args.reason || '' };
+}
+
+async function schoolHandleInputHandler(args, ctx) {
+    try {
+        const { nextState, nextAction } = transition(args.state, args.input);
+        return { ok: true, previous_state: args.state.kind, new_state: nextState.kind, next_action: nextAction, open_proposal_ns: nextState.open_proposal_ns || [] };
+    } catch (e) {
+        return { ok: false, error: 'transition_failed', hint: e.message };
+    }
+}
+
+module.exports = { ...module.exports, schoolRetireSkillHandler, schoolHandleInputHandler };
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+```bash
+node tests/nodejs-project/school-tools.test.js
+```
+Expected: PASS — all cases.
+
+- [ ] **Step 5: Add `schoolScanHandler` wrapper**
+
+In `tools/school.js`:
+
+```javascript
+const { scanLogs } = require('../school');
+const { getDb } = require('../database');
+
+async function schoolScanHandler(args, ctx) {
+    const db = (ctx && ctx.db) || getDb();
+    if (!db) return { ok: false, error: 'db_unavailable' };
+    try {
+        const res = scanLogs(db, { window_days: args.window_days || 7, min_repetition: args.min_repetition || 3 });
+        return { ok: true, ...res };
+    } catch (e) {
+        return { ok: false, error: 'scan_failed', hint: e.message };
+    }
+}
+
+module.exports = { ...module.exports, schoolScanHandler };
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/tools/school.js tests/nodejs-project/school-tools.test.js
+git commit -m "feat(school): school_retire_skill + school_handle_input + school_scan handlers"
+```
+
+---
+
+### Task B7: Register school tools in `tools/index.js`
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/tools/index.js`
+
+- [ ] **Step 1: Add the 6 school tool entries**
+
+In `tools/index.js`, after `const systemMod = require('./system');`, add:
+
+```javascript
+const schoolMod = require('./school');
+```
+
+In the `TOOLS` array (already has `...webMod.tools, ...memoryMod.tools, ...`), add:
+
+```javascript
+    // School tools — Go-to-School feature
+    {
+        name: 'school_begin',
+        description: 'Start or resume a Go-to-School self-improvement session. Creates workspace/SCHOOL.md as a trigger file; if one already exists, returns its parsed state for resumption. Returns session_id + last 10 prior sessions from workspace/school/log.jsonl for dedup.',
+        input_schema: { type: 'object', properties: { reason: { type: 'string', enum: ['on_demand', 'cron', 'resumed'] } }, required: ['reason'] },
+    },
+    {
+        name: 'school_scan',
+        description: 'Pattern-mine the tool_call_log and skill_trigger_log SQL.js tables. Returns structured candidates: repeated_patterns (same call_shape ≥3×), failed_sequences (error_kind repeats), expensive_turns (≥8 tool calls), triggered_skills (for computing unused_skills retire candidates).',
+        input_schema: { type: 'object', properties: { window_days: { type: 'integer', minimum: 1, maximum: 30 }, min_repetition: { type: 'integer' } } },
+    },
+    {
+        name: 'school_write_skill',
+        description: 'Write a new SKILL.md (create mode) or patch an existing one. Tool auto-injects `source: school`, `created`, `evidence` frontmatter on create; preserves existing `source` field + appends `last_patched_by: school` on patch. Enforces path sandbox (workspace/skills/ only), 64KB size cap, valid YAML frontmatter, and non-empty markdown body.',
+        input_schema: { type: 'object', properties: {
+            mode: { type: 'string', enum: ['create', 'patch'] },
+            path: { type: 'string' },
+            body: { type: 'string' },
+            evidence: { type: 'string' },
+        }, required: ['mode', 'path', 'body', 'evidence'] },
+    },
+    {
+        name: 'school_retire_skill',
+        description: 'Move a workspace skill to workspace/school/retired/ (reversible archive, not delete). Bundled skills rejected. User can restore by moving the file back.',
+        input_schema: { type: 'object', properties: { path: { type: 'string' }, reason: { type: 'string' } }, required: ['path'] },
+    },
+    {
+        name: 'school_end',
+        description: 'Finalize a school session: append one JSON line to workspace/school/log.jsonl (rolling 90-day retention), then delete SCHOOL.md. Atomic ordering guarantees crash recovery never re-finalizes a session already logged.',
+        input_schema: { type: 'object', properties: {
+            session_id: { type: 'string' },
+            summary: { type: 'object' },
+        }, required: ['session_id', 'summary'] },
+    },
+    {
+        name: 'school_handle_input',
+        description: 'Advance the school session state machine. Agent calls this for school-relevant inputs (yes/no/review/skip/stop) after classifying user input via the classification rubric in the go-to-school skill. Returns the new state + next_action to execute. NOT called for unrelated messages — those route through normal message handling.',
+        input_schema: { type: 'object', properties: {
+            session_id: { type: 'string' },
+            state: { type: 'object' },
+            input: { type: 'object' },
+        }, required: ['session_id', 'state', 'input'] },
+    },
+```
+
+Also in the dispatch map that routes tool calls (look for a switch or handlers object mapping tool name → handler):
+
+```javascript
+    school_begin: (args, ctx) => schoolMod.schoolBeginHandler(args, ctx),
+    school_scan: (args, ctx) => schoolMod.schoolScanHandler(args, ctx),
+    school_write_skill: (args, ctx) => schoolMod.schoolWriteSkillHandler(args, ctx),
+    school_retire_skill: (args, ctx) => schoolMod.schoolRetireSkillHandler(args, ctx),
+    school_end: (args, ctx) => schoolMod.schoolEndHandler(args, ctx),
+    school_handle_input: (args, ctx) => schoolMod.schoolHandleInputHandler(args, ctx),
+```
+
+- [ ] **Step 2: Run smoke**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS — no module-load regressions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/tools/index.js
+git commit -m "feat(school): register 6 school_* tools in the dispatcher"
+```
+
+---
+
+### Task B8: Bundled `go-to-school` SKILL.md
+
+**Files:**
+- Create: `app/src/main/assets/default-skills/go-to-school/SKILL.md`
+
+- [ ] **Step 1: Author the SKILL.md**
+
+Create `app/src/main/assets/default-skills/go-to-school/SKILL.md`:
+
+```markdown
+---
+name: go-to-school
+description: "Analyze recent activity and propose new skills, skill patches, or skill retirements. Triggered by /school command or phrases like 'go to school', 'run school', 'study time'. Challenges its own findings with a 5-gate rubric; surfaces rejections so the user can audit the thinking. Two-gate approval: /review N → YES N writes the file."
+version: "1.0.0"
+emoji: "🎓"
+requires:
+  bins: []
+  env: []
+allowed-tools:
+  - school_begin
+  - school_scan
+  - school_write_skill
+  - school_retire_skill
+  - school_end
+  - school_handle_input
+  - file_read
+  - file_write
+  - telegram_send
+---
+
+# Go to School — Structured Self-Reflection
+
+When the user invokes /school (or a natural-language trigger), you analyze your own recent behavior and propose concrete self-improvements. Your output is a ranked list of proposals, each passing a 5-gate rubric. The user approves per-proposal in two steps (/review N → YES N).
+
+## Session flow
+
+1. Call `school_begin({ reason: "on_demand" })`.
+   - If `resumed: true`: you're picking up a prior session. Use `resumed_state` and continue in the state it's in.
+   - Else: proceed to scanning.
+2. Call `school_scan({ window_days: 7, min_repetition: 3 })`.
+   - If `empty: true`: send one message "Not enough signal to propose anything — try again after more activity." and call `school_end` with empty summary. Stop.
+3. Read memory files for context:
+   - `file_read(MEMORY.md)` and the 7 most recent `memory/YYYY-MM-DD.md` daily notes.
+4. Apply the rubric (below) to every candidate pattern from `school_scan`. Build proposals.
+5. Apply the dedup gate against `prior_sessions` (also from `school_begin`).
+6. Send the proposals message (format below) to the user via `telegram_send`.
+7. For each user input, CLASSIFY it per the Input Classification Rubric. For school-relevant inputs, call `school_handle_input`. Execute the `next_action` it returns.
+8. When all proposals are resolved (state=done), call `school_end` with the final summary.
+
+## The rubric (5 gates)
+
+Every candidate pattern must pass **all 5** before it's shown as a proposal.
+
+| Gate | Type | Test |
+|---|---|---|
+| **Repetition** | Quantitative | `scan.repeated_patterns[i].count >= 3` (or failed/unused counts ≥ 3) |
+| **Permanence** | Quantitative | `scan.repeated_patterns[i].spans_distinct_days >= 2` |
+| **Gap** | Qualitative (requires artifact) | Produce a `coverage_check` block listing every existing tool/bundled-skill/workspace-skill considered and one line each on why it doesn't cover this pattern. No list → fail. |
+| **Utility** | Qualitative (honest yes/no) | Answer yes/no with one sentence referencing scan data: "Will this skill fire often enough to earn its prompt-size cost?" FORBIDDEN: fake arithmetic. |
+| **Actionable** | Structural | Draft the **When to Use** section inline, with concrete trigger keywords + specific tools + output format. If the draft reduces to "be smarter about X", fail. Soft-warning keyword check (`smarter`, `better`, `improved` without a concrete mechanism) flags for extra scrutiny. |
+
+### Dedup gate (pre-rubric)
+
+For each candidate, compute the signature `sha256(type + normalize(title))`. If it matches any entry in `prior_sessions` with `outcome` in `{drafted_but_denied, skipped, ignored, rejected_by_rubric, abandoned_stale, rejected_as_duplicate}` from the last 30 days, drop as `rejected_as_duplicate`.
+
+## Proposal message format
+
+Use HTML (Telegram). ≤ 4096 chars, chunked if longer.
+
+```
+🎓 School — <date> scan (last N days)
+
+📝 CREATE  · <count>
+🔧 PATCH   · <count>
+🗑️ RETIRE  · <count>
+❌ REJECTED · <count>
+
+─── [1] CREATE · <slug> ───
+Evidence: <evidence line>
+Rubric: rep ✓ perm ✓ gap ✓ util ✓ action ✓ (5/5)
+Confidence: N/10
+Skeptical take: <one honest sentence>
+> /review 1
+
+... more proposals ...
+
+─── Rejected (<count>) ───
+· <slug> — fails <GATE>: <reason>
+... more ...
+
+Reply: /review N  |  /skip N  |  /stop
+Reply on review: YES N  |  NO N  (bare YES/NO works if only one review open)
+```
+
+## Input Classification Rubric
+
+An input is **school-relevant** iff it matches exactly one of:
+- Starts with `/review ` + positive integer → `kind: "review"`, `proposal_n: <int>`
+- Starts with `/skip ` + positive integer → `kind: "skip"`, `proposal_n: <int>`
+- Equals `/stop` (exact, trimmed) → `kind: "stop"`
+- Matches `^(YES|NO|Y|N|👍|👎)\s*(\d+)?\s*$` case-insensitive after trim (≤ 120 chars) → `kind: "yes"` or `"no"`, `proposal_n` optional
+- Starts with `YES ` or `NO ` followed by number + non-empty trailing text → YES/NO captured, trailing text routed to normal handling in the same turn.
+
+**Everything else is unrelated** — do NOT call `school_handle_input`. Route through normal message handling. If state is `reviewing_<N>`, append to your normal reply: *"Still awaiting YES/NO on proposal {N}."*
+
+## Classification echo rule
+
+After calling `school_handle_input` with a school-relevant input, the first sentence of your reply MUST echo back your classification — e.g. *"Understood as YES on proposal 3 — writing now."* or *"Taking that as /skip 2 — logged."*
+
+This gives the user a visible correction hook. The state machine is deterministic from `school_handle_input` onwards, but input classification is still your judgment.
+
+## Write-failure handling
+
+If `next_action.kind` is `write_skill` or `retire_skill` and the follow-up tool call fails, do NOT proceed as if it succeeded. State stays at `reviewing_<N>`. Surface the error to the user: *"Couldn't write proposal {N}: {error}. Reply YES {N} to retry, NO {N} to decline, or /stop to end."* No log entry is written until the write succeeds or the user explicitly declines.
+
+## Silent exit
+
+If `school_scan` returns `empty: true` or all candidates fail the rubric + dedup, send one line — *"Not enough signal to propose anything — try again after more activity."* — and call `school_end` cleanly. No filler proposals.
+
+## Post-approval note
+
+Append to the success message after any write: *"Live on next turn."* — confirms no manual restart is needed; the existing `loadSkills()` live-read picks up new skills automatically.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/main/assets/default-skills/go-to-school/
+git commit -m "feat(school): bundled go-to-school SKILL.md with rubric + classification"
+```
+
+---
+
+### Task B9: Agent self-awareness — `buildSystemBlocks()` Self-Improvement block
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/ai.js`
+
+- [ ] **Step 1: Locate `buildSystemBlocks()`**
+
+```bash
+grep -n "buildSystemBlocks\|function buildSystemBlocks" /Users/egod/Dev/SeekerClaw/app/src/main/assets/nodejs-project/ai.js | head
+```
+
+- [ ] **Step 2: Add Self-Improvement section**
+
+Inside `buildSystemBlocks()`, add a new section where other capability blocks live (near the Tooling / Skills sections):
+
+```javascript
+    blocks.push(`## Self-Improvement (Go to School)
+
+You have a /school command that triggers a structured self-reflection session: analyze your recent tool-call history (from the `tool_call_log` SQL.js table) and skill-trigger history (from `skill_trigger_log`), then propose concrete changes to your skill set — new skills, patches to existing ones, retirements of unused ones.
+
+**Tools (6):**
+- \`school_begin\` — start or resume a session. Creates workspace/SCHOOL.md trigger file.
+- \`school_scan\` — pattern-mine the logs. Returns repeated_patterns (call_shape ≥ 3×), failed_sequences, expensive_turns, and triggered_skills.
+- \`school_write_skill\` — write or patch a SKILL.md. Auto-injects school frontmatter marker on create; preserves existing source field on patch.
+- \`school_retire_skill\` — move a workspace skill to workspace/school/retired/ (reversible).
+- \`school_end\` — append one JSON line to workspace/school/log.jsonl, delete SCHOOL.md.
+- \`school_handle_input\` — advance the state machine for YES/NO/review/skip/stop inputs.
+
+**Rubric (5 gates — all must pass):** Repetition (≥ 3 occurrences), Permanence (≥ 2 distinct days), Gap (no existing capability covers it), Utility (honest yes/no on whether it earns its prompt cost), Actionable (concrete playbook, not "be smarter about X").
+
+**Two-gate approval:** /review N shows the user the drafted SKILL.md; YES N writes it. Bundled skills cannot be patched or retired (return error, suggest filing a GitHub issue instead).
+
+**Effect timing:** Newly-written skills are picked up on the next agent turn automatically — the existing loadSkills() reads the filesystem fresh on every message, so no service restart is needed.
+
+**Rate limit:** 1 /school invocation per 5 minutes, max 10 per 24 hours. Exceeding replies "School ran recently — next available at {time}."
+
+**State machine is deterministic JS** in school.js; you do NOT drive it directly. You classify user input per the classification rubric in the go-to-school SKILL.md, call school_handle_input, then execute the next_action it returns. Echo your classification back in every state-changing reply so the user can catch misclassifications.
+`);
+```
+
+- [ ] **Step 3: Run smoke**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/ai.js
+git commit -m "feat(school): Self-Improvement block in buildSystemBlocks() (agent self-awareness)"
+```
+
+---
+
+### Task B10: Telegram commands + `/school-reset` two-step
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/telegram.js`
+- Modify: `app/src/main/assets/nodejs-project/message-handler.js`
+
+- [ ] **Step 1: Find the existing command registry**
+
+```bash
+grep -n "startsWith\s*('/help'\|startsWith\s*('/status'\|COMMANDS\s*=" /Users/egod/Dev/SeekerClaw/app/src/main/assets/nodejs-project/telegram.js | head
+```
+
+- [ ] **Step 2: Register the new commands**
+
+In `telegram.js` / `message-handler.js` (wherever `/status`, `/help`, `/new` are handled), add:
+
+```javascript
+if (text === '/school') {
+    // Rate-limit check (reuse existing pattern from /swap etc.)
+    // Then route to the go-to-school skill via a synthetic "run go-to-school" instruction
+    return invokeSchool({ reason: 'on_demand' });
+}
+
+if (text === '/school log') {
+    return renderSchoolLog();  // reads workspace/school/log.jsonl tail, formats summary
+}
+
+if (text === '/school-reset') {
+    // Two-step: set pending-reset flag with 60s TTL
+    pendingSchoolReset = { expires_at: Date.now() + 60 * 1000 };
+    return reply('This will discard the current open session and any drafts. Reply `/school-reset-confirm` within 60s to proceed.');
+}
+
+if (text === '/school-reset-confirm') {
+    if (!pendingSchoolReset || pendingSchoolReset.expires_at < Date.now()) {
+        pendingSchoolReset = null;
+        return reply('No pending reset — type `/school-reset` first.');
+    }
+    pendingSchoolReset = null;
+    try { fs.unlinkSync(path.join(workDir, 'SCHOOL.md')); } catch (_) {}
+    try {
+        const draftsDir = path.join(workDir, 'school/drafts');
+        if (fs.existsSync(draftsDir)) for (const f of fs.readdirSync(draftsDir)) fs.unlinkSync(path.join(draftsDir, f));
+    } catch (_) {}
+    return reply('School state cleared.');
+}
+```
+
+Add `let pendingSchoolReset = null;` at module scope.
+
+- [ ] **Step 3: Cancel pending reset on any non-confirm input**
+
+In the command dispatcher, before running any handler:
+
+```javascript
+if (pendingSchoolReset && pendingSchoolReset.expires_at < Date.now()) pendingSchoolReset = null;
+// Any non-/school-reset-confirm input while pending is NOT destructive; the flag simply expires.
+```
+
+- [ ] **Step 4: Rate-limit `/school`**
+
+Reuse the existing rate-limit helper from `solana_swap` / `android_sms`. Add:
+
+```javascript
+const SCHOOL_MIN_INTERVAL_MS = 5 * 60 * 1000;
+const SCHOOL_DAILY_CAP = 10;
+const schoolRateState = { lastInvokedAt: 0, invokesToday: 0, dayStart: 0 };
+
+function checkSchoolRateLimit(now = Date.now()) {
+    // Reset daily counter on day boundary
+    if (new Date(schoolRateState.dayStart).toDateString() !== new Date(now).toDateString()) {
+        schoolRateState.invokesToday = 0;
+        schoolRateState.dayStart = now;
+    }
+    if (now - schoolRateState.lastInvokedAt < SCHOOL_MIN_INTERVAL_MS) {
+        const nextAt = new Date(schoolRateState.lastInvokedAt + SCHOOL_MIN_INTERVAL_MS).toLocaleTimeString();
+        return { ok: false, reason: `throttled`, message: `School ran recently. Next available at ${nextAt}.` };
+    }
+    if (schoolRateState.invokesToday >= SCHOOL_DAILY_CAP) {
+        return { ok: false, reason: 'daily_cap', message: `School daily cap (${SCHOOL_DAILY_CAP}) reached. Try again tomorrow.` };
+    }
+    schoolRateState.lastInvokedAt = now;
+    schoolRateState.invokesToday++;
+    return { ok: true };
+}
+```
+
+Gate `/school` invocation on `checkSchoolRateLimit()`.
+
+- [ ] **Step 5: Run smoke**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/telegram.js app/src/main/assets/nodejs-project/message-handler.js
+git commit -m "feat(school): /school, /school log, /school-reset two-step, rate limit"
+```
+
+---
+
+### Task B11: Stale-session auto-end + combined-message flow on new `/school`
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/main.js`
+- Modify: `app/src/main/assets/nodejs-project/tools/school.js`
+
+- [ ] **Step 1: Extend `school_begin` to handle stale detection**
+
+In `tools/school.js`, inside `schoolBeginHandler`, before the `if (existing)` block:
+
+```javascript
+    const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+    const pre = readSchoolMd(workDir);
+    if (pre && (Date.now() - pre.started_at) > STALE_THRESHOLD_MS) {
+        // Auto-end stale session, start fresh
+        appendLogLine(workDir, {
+            session_id: pre.session_id, started_at: pre.started_at, ended_at: Date.now(),
+            trigger: pre.trigger || 'on_demand', window_days: pre.window_days || 7,
+            rubric_version: pre.rubric_version || '1.0.0',
+            proposals: (pre.proposals || []).map(p => ({ ...p, outcome: 'abandoned_stale' })),
+        });
+        try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+        // Fall through to fresh session creation with combined-message flag
+        const sessionId = newSessionId();
+        const startedAt = Date.now();
+        writeSchoolMd(workDir, {
+            session_id: sessionId, started_at: startedAt, trigger: args.reason || 'on_demand',
+            state: 'scanning', window_days: 7, open_proposal_ns: [], proposals: [], rubric_version: '1.0.0',
+        });
+        return {
+            ok: true, resumed: false,
+            session_id: sessionId, started_at: startedAt,
+            prior_sessions: readPriorSessions(workDir, 10),
+            resumed_state: null,
+            started_after_cleanup: true,
+            cleaned_up: { prior_session_id: pre.session_id, prior_started_at: pre.started_at },
+        };
+    }
+```
+
+- [ ] **Step 2: Boot-time stale detection in `main.js`**
+
+In `main.js` startup sequence, after skills load:
+
+```javascript
+// Stale-school-session cleanup on boot (no new session started)
+try {
+    const { readSchoolMd, appendLogLine, schoolMdPath } = require('./school');
+    const pre = readSchoolMd(workDir);
+    const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+    if (pre && (Date.now() - pre.started_at) > STALE_THRESHOLD_MS) {
+        appendLogLine(workDir, {
+            session_id: pre.session_id, started_at: pre.started_at, ended_at: Date.now(),
+            trigger: pre.trigger || 'on_demand', window_days: pre.window_days || 7,
+            rubric_version: pre.rubric_version || '1.0.0',
+            proposals: (pre.proposals || []).map(p => ({ ...p, outcome: 'abandoned_stale' })),
+        });
+        try { fs.unlinkSync(schoolMdPath(workDir)); } catch (_) {}
+        // Send Telegram notice — user wasn't asking for a session, just inform.
+        // Use existing telegram send helper.
+        sendMessage(`Cleaned up stale school session from ${new Date(pre.started_at).toLocaleString()}.`);
+    }
+} catch (e) { log(`[school] stale cleanup failed: ${e.message}`, 'WARN'); }
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/tools/school.js app/src/main/assets/nodejs-project/main.js
+git commit -m "feat(school): stale-session auto-end (48h) + seamless combined-message flow"
+```
+
+---
+
+### Task B12: DIAGNOSTICS.md school section
+
+**Files:**
+- Modify: `app/src/main/assets/nodejs-project/DIAGNOSTICS.md`
+
+- [ ] **Step 1: Add a "Go to School troubleshooting" section**
+
+Append to `DIAGNOSTICS.md`:
+
+```markdown
+## Go to School troubleshooting
+
+**Symptom: `/school` replies "School session already open"**
+- An active session exists (workspace/SCHOOL.md). Reply `/stop` to end it, or `/review N` / `/skip N` to resolve open proposals.
+- If truly stuck: `/school-reset` (then `/school-reset-confirm` within 60s).
+
+**Symptom: /school returns "Not enough signal to propose anything"**
+- Fewer than 20 tool calls recorded in the last window. Normal on a new install or after a quiet week. Use the agent for a few days, then try `/school` again.
+
+**Symptom: Proposal rejected with "fails GAP"**
+- An existing capability (tool, bundled skill, workspace skill) already covers the pattern. The rubric's coverage_check artifact in the rejection reason names which existing capability it considered.
+
+**Symptom: "Cannot patch bundled skill"**
+- Bundled skills (in the APK) are read-only. File a GitHub issue for improvements to bundled skills.
+
+**Symptom: Stale session message on service start**
+- A prior session crossed the 48h threshold without resolution. Normal cleanup. Run `/school` to start fresh.
+
+**Symptom: Same proposal keeps appearing weekly even though I rejected it**
+- Check workspace/school/log.jsonl — the proposal's signature may differ across runs due to title drift. If so, file a bug.
+
+**Symptom: "Ambiguous YES/NO"**
+- More than 60 seconds elapsed since the most recent /review, or multiple reviews were opened. Reply `YES N` or `NO N` with the specific proposal number.
+
+**Symptom: Write-skill failed — retry prompt**
+- Disk full, security-detector rejection, or concurrent write. Check the error message, resolve (free disk / revise body via NO N then new session), then retry.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+git commit -m "docs(school): DIAGNOSTICS.md troubleshooting section"
+```
+
+---
+
+### Task B13: Full happy-path integration test
+
+**Files:**
+- Create: `tests/nodejs-project/school-integration.test.js`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/nodejs-project/school-integration.test.js`:
+
+```javascript
+#!/usr/bin/env node
+// school-integration.test.js — end-to-end happy path on a seeded fixture.
+// Structural invariants (no exact-count assertions — rubric is LLM-driven in
+// real flow; here we exercise the deterministic plumbing only).
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+(async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'school-int-'));
+    process.env.WORKDIR = tmp;
+    fs.mkdirSync(path.join(tmp, 'skills'));
+
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const SQL = await require(SQL_PATH)({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+    const { createToolCallLogSchema, createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js'));
+    createToolCallLogSchema(db); createSkillTriggerLogSchema(db);
+
+    const now = Date.now();
+    // Seed a strong-signal repetition across 3 days
+    for (let i = 0; i < 5; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('t' || ?, 'shell_exec', 'shell_exec:calc', 'ok', 3, ?)`,
+            [i, now - i * 24 * 3600 * 1000]);
+    }
+
+    const { schoolBeginHandler, schoolEndHandler, schoolScanHandler, schoolWriteSkillHandler, schoolHandleInputHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js'));
+
+    // 1. begin
+    const bR = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!bR.ok) { console.error('FAIL begin', bR); process.exit(1); }
+    console.log('  ✓ begin returns ok');
+
+    // 2. scan
+    const sR = await schoolScanHandler({ window_days: 7, min_repetition: 3 }, { workDir: tmp, db });
+    if (!sR.ok || !sR.repeated_patterns || sR.repeated_patterns.length === 0) {
+        console.error('FAIL scan — expected repeated_patterns', sR); process.exit(1);
+    }
+    console.log('  ✓ scan produces ≥ 1 repeated_pattern on strong-signal fixture');
+
+    // 3. write a drafted skill (simulating YES approval)
+    const writeR = await schoolWriteSkillHandler({
+        mode: 'create', path: 'skills/calc-automation.md',
+        body: `---\nname: calc-automation\ndescription: "Automate calc invocations"\nversion: "1.0.0"\n---\n\n# Calc Automation\n\nUse calc tool.\n`,
+        evidence: 'shell_exec:calc × 5 across 3 days',
+    }, { workDir: tmp });
+    if (!writeR.ok) { console.error('FAIL write', writeR); process.exit(1); }
+    const written = fs.readFileSync(path.join(tmp, 'skills/calc-automation.md'), 'utf8');
+    if (!written.includes('source: school')) { console.error('FAIL missing source'); process.exit(1); }
+    if (!written.includes('evidence:')) { console.error('FAIL missing evidence'); process.exit(1); }
+    console.log('  ✓ written skill has school frontmatter marker');
+
+    // 4. end
+    const eR = await schoolEndHandler({
+        session_id: bR.session_id,
+        summary: { patterns_found: 1, proposals_made: 1, approved: [{ n: 1, type: 'create', title: 'calc-automation' }],
+                   drafted_but_denied: [], skipped: [], ignored: [], rejected_by_rubric: [], rejected_as_duplicate: [] }
+    }, { workDir: tmp });
+    if (!eR.ok) { console.error('FAIL end', eR); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'SCHOOL.md'))) { console.error('FAIL SCHOOL.md not deleted'); process.exit(1); }
+    const logLine = fs.readFileSync(path.join(tmp, 'school/log.jsonl'), 'utf8').trim();
+    if (!logLine.includes(bR.session_id)) { console.error('FAIL log missing session_id'); process.exit(1); }
+    console.log('  ✓ end appends log + deletes SCHOOL.md');
+
+    // 5. Crash-recovery check: re-begin with an already-stale SCHOOL.md
+    const oldSession = Date.now() - 72 * 3600 * 1000;  // 72h ago, stale
+    fs.writeFileSync(path.join(tmp, 'SCHOOL.md'),
+        `---\nsession_id: stale-xyz\nstarted_at: ${oldSession}\ntrigger: on_demand\nstate: awaiting_approval\nwindow_days: 7\nopen_proposal_ns: [1]\nrubric_version: "1.0.0"\n---\n\n# Stale\n\n## Proposals\n[]\n`);
+    const bR2 = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!bR2.ok) { console.error('FAIL begin on stale', bR2); process.exit(1); }
+    if (!bR2.started_after_cleanup) { console.error('FAIL expected started_after_cleanup', bR2); process.exit(1); }
+    console.log('  ✓ stale session auto-ends + seamless new session start');
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    console.log('all tests passed');
+    process.exit(0);
+})().catch(e => { console.error('FAIL', e); process.exit(1); });
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+node tests/nodejs-project/school-integration.test.js
+```
+Expected: PASS — all structural invariants hold.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/nodejs-project/school-integration.test.js
+git commit -m "test(school): happy-path integration + crash-recovery + stale-session"
+```
+
+---
+
+### Task B14: Smoke test add + CHANGELOG + version bump
+
+**Files:**
+- Modify: `tests/nodejs-project/smoke.js`
+- Modify: `CHANGELOG.md`
+- Modify: `app/build.gradle.kts`
+
+- [ ] **Step 1: Add `school` to smoke's side-effect-free list**
+
+In `tests/nodejs-project/smoke.js`, find the `SIDE_EFFECT_FREE` array and add `'school'`.
+
+Note: do NOT add `tools/school.js` — it requires `database.js` which has startup side effects.
+
+- [ ] **Step 2: Run smoke**
+
+```bash
+node tests/nodejs-project/smoke.js
+```
+Expected: PASS — including `require('./school')` at the end.
+
+- [ ] **Step 3: Update CHANGELOG**
+
+Replace the `## [Unreleased]` section in `CHANGELOG.md` with:
+
+```markdown
+## [1.10.0] - 2026-XX-XX
+
+### Added
+- **Go to School** — The agent can now analyze its own recent activity (tool-call log, skill-trigger log, memory files) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric (Repetition, Permanence, Gap, Utility, Actionable), and proposals the rubric rejects are surfaced with reasons. Two-gate approval: `/review N` → `YES N` writes the file. Trigger with `/school`; recurring via `cron_create`. Rate-limited to 1 per 5 min, 10 per 24h. Newly-written skills take effect on the next turn.
+- `tool_call_log` + `skill_trigger_log` SQL.js tables with buffered async logger (5s / 100-row flush). 30-day rolling retention, 50k-row cap. Per-tool `call_shape` structural classifier — pattern-mines repeated CLASSES of calls, not byte-identical calls. Privacy-safe: wallets, URLs with query strings, user text never land in logs.
+
+### Internal
+- New bundled skill: `go-to-school`.
+- New tools: `school_begin`, `school_scan`, `school_write_skill`, `school_retire_skill`, `school_end`, `school_handle_input`.
+- New commands: `/school`, `/school log`, `/school-reset`, `/school-reset-confirm`.
+- New workspace artifacts: `workspace/SCHOOL.md` (transient trigger file), `workspace/school/log.jsonl` (90-day rolling), `workspace/school/drafts/`, `workspace/school/retired/`.
+```
+
+- [ ] **Step 4: Version bump in `app/build.gradle.kts`**
+
+```kotlin
+versionCode = 18
+versionName = "1.10.0"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/nodejs-project/smoke.js CHANGELOG.md app/build.gradle.kts
+git commit -m "chore(school): smoke test add + CHANGELOG + bump v1.10.0 (code 18)"
+```
+
+---
+
+### Task B15: SAB-AUDIT-v23 + PR-B submission
+
+**Files:**
+- Create: `docs/internal/audits/SAB-AUDIT-v23.md`
+
+- [ ] **Step 1: Author the SAB audit**
+
+Following prior audit structure (SAB-AUDIT-v19, v20, etc. — look at `docs/internal/audits/` for the shape). At minimum cover:
+
+- Identity & Self-Awareness — 10 probe points on the Self-Improvement block's content (each of the 6 tools, rate limit, effect timing, classification rule, etc.)
+- Tooling — 15 probe points across the 6 school tools (when to call each, argument semantics, error returns)
+- Memory Recall — 5 probe points on how school reads MEMORY.md + daily notes + how this integrates with dedup against `prior_sessions`
+- Workspace — 10 probe points: SCHOOL.md lifecycle, log.jsonl shape, drafts/ vs retired/ directories, stale-session behavior
+- Runtime info — 5 probe points: 48h stale threshold, 30-day log retention, 60s bare-YES window, rate limits
+- Silent Replies — 3 probe points on silent-exit behavior and "Not enough signal" path
+- Rubric self-explanation — 10 probe points, one per gate + dedup + rubric_version semantics
+- Crash recovery — 5 probe points: SCHOOL.md precedence, log-tail-matches-session-id handling, resume message
+- User-facing classification — 7 probe points: input classification rubric, classification echo rule, ambiguous YES/NO handling, disambiguation forms
+- Bundled vs workspace skills — 5 probe points: patch/retire rejection, error hint suggesting GitHub issue, frontmatter marker policy differences
+
+Target: 75 probe points. Score honestly pre-fix; fix gaps; rescore to 100% post-fix. Attach the audit doc to PR-B description.
+
+- [ ] **Step 2: Run the full test suite before push**
+
+```bash
+node tests/nodejs-project/smoke.js
+node tests/nodejs-project/tool-call-log.test.js
+node tests/nodejs-project/skill-trigger-log.test.js
+node tests/nodejs-project/call-shape.test.js
+node tests/nodejs-project/tool-call-log-perf.test.js
+node tests/nodejs-project/school.test.js
+node tests/nodejs-project/school-state-machine.test.js
+node tests/nodejs-project/school-tools.test.js
+node tests/nodejs-project/school-integration.test.js
+node tests/nodejs-project/silent-reply.test.js
+```
+All must exit 0.
+
+- [ ] **Step 3: Device acceptance run**
+
+Install the built APK on a Solana Seeker:
+```bash
+./gradlew assembleDappStoreDebug
+adb install -r app/build/outputs/apk/dappStore/debug/app-dappStore-debug.apk
+```
+
+From Telegram:
+1. Run `/school`. Expect either a proposals message or the silent-exit line.
+2. If proposals: `/review 1`. Expect the drafted SKILL.md in a `<pre>` block + *"Write to workspace? Reply YES N or NO N."*
+3. Reply `YES 1`. Expect *"Understood as YES on proposal 1 — writing now. ... Live on next turn."*
+4. Run `/school log`. Expect compact history summary including the session.
+5. Run `/school-reset`. Expect confirmation prompt. Do NOT confirm; wait > 60s; verify next input proceeds normally.
+6. Run `/school-reset` → `/school-reset-confirm` within 60s → expect *"School state cleared."*
+
+Capture a transcript (scrub personal info).
+
+- [ ] **Step 4: Commit audit + transcript**
+
+```bash
+git add docs/internal/audits/SAB-AUDIT-v23.md
+git commit -m "docs(school): SAB-AUDIT-v23 — 75 probes, 100% post-fix"
+```
+
+- [ ] **Step 5: Push + open PR-B**
+
+```bash
+git push
+gh pr create --title "feat(school): Go to School self-improvement (PR-B, BAT-XXX)" --body "$(cat <<'EOF'
+## Summary
+
+Phase B of the Go to School feature — the user-facing capability.
+
+- Bundled `go-to-school` skill with 5-gate rubric, dedup, proposal format, two-gate approval protocol, input classification rubric.
+- 6 new tools: `school_begin`, `school_scan`, `school_write_skill`, `school_retire_skill`, `school_end`, `school_handle_input`.
+- Deterministic JS state machine (32 transitions tested).
+- New commands: `/school`, `/school log`, `/school-reset` (two-step confirmation).
+- Stale-session auto-end (48h), rate limit (1/5min, 10/24h).
+- Skills created by school take effect on the next turn via existing `loadSkills()` live-read.
+
+## Design
+
+Spec: [docs/superpowers/specs/2026-04-19-go-to-school-design.md](../blob/feature/go-to-school/docs/superpowers/specs/2026-04-19-go-to-school-design.md) (7 design revisions; fully verified against the codebase).
+
+## SAB-AUDIT-v23
+
+Attached: [docs/internal/audits/SAB-AUDIT-v23.md](../blob/feature/go-to-school/docs/internal/audits/SAB-AUDIT-v23.md) — 75 probe points, 100% post-fix.
+
+## Test plan
+
+- [x] `node tests/nodejs-project/smoke.js`
+- [x] `node tests/nodejs-project/school.test.js`
+- [x] `node tests/nodejs-project/school-state-machine.test.js` (16 transitions, covers all 4 states × key inputs)
+- [x] `node tests/nodejs-project/school-tools.test.js`
+- [x] `node tests/nodejs-project/school-integration.test.js`
+- [x] Device run on Solana Seeker: `/school`, `/review N`, `YES N`, `/school log`, `/school-reset` two-step. Transcript attached to release notes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Wait for PR-B to merge + tag `v1.10.0-rc2`. After 3 days clean on RC → tag `v1.10.0`. Google Play staged 10/50/100% over 72h.**
+
+---
+
+## Self-Review
+
+**Spec coverage:** every section in [the design spec](../specs/2026-04-19-go-to-school-design.md) maps to at least one task above. §6 → Tasks A1-A2 (schemas) + A3 (shape) + A4-A5 (logger) + A6 (skill-trigger instrumentation) + A7 (retention). §7 → Tasks B4-B7. §8 → Task B8 (bundled skill body). §9 → Tasks B4 (SCHOOL.md + log.jsonl) + B11 (stale). §10 → Task B10. §11 (security) is implicit in tool-level enforcement (B5) + existing `security.js` reuse (tested via B5's oversize/traversal cases). §12 → Tasks B9 (buildSystemBlocks) + B12 (DIAGNOSTICS). §13 → Tasks A1-A8 + B1-B3 + B13 (all test matrices). §14 → Task B15 (SAB audit). §15 → Tasks A9 + B14 + B15 (rollout). §16 acceptance criteria map 1:1 to test assertions in tasks.
+
+**Placeholder scan:** no TBDs or "figure out later" phrases. Every code block is complete. One pragmatic note: Task A5 says "find the existing `executeTool` dispatcher" and wraps it — the exact surgery depends on the current function shape; plan author may need to adjust naming (e.g., rename the current `executeTool` to `executeToolInner` and export the wrapped version). This is a common refactor pattern, not an evasion.
+
+**Type consistency:** `call_shape` is a string everywhere. `transition()` returns `{nextState, nextAction}` everywhere. `schoolBeginHandler` / `schoolEndHandler` etc. use camelCase with `Handler` suffix consistently. `workDir` is the context parameter name throughout.
+
+**Plan-phase items from v4-v7 spec** (5-9 flagged as plan-phase):
+- Item 5 (`/school-reset` confirmation): Task B10 (two-step with 60s TTL).
+- Item 6 (`rubric_version` semantics): stamped as skill version `"1.0.0"` hardcoded in v1; agent reads from bundled skill frontmatter.
+- Item 7 (`resumed_state` shape): Task B4 returns full parsed structure.
+- Item 8 (`workspace/skills/` missing): Task B5 uses `fs.mkdirSync(recursive: true)` before write.
+- Item 9 (injection-during-session test): not explicitly tested in B13; reuses existing `security.js` suspicious-pattern detector at `school_write_skill` — the test in B5 (oversize/traversal) covers the sandbox but NOT the injection pattern rejection. **Plan author should add a test case in school-tools.test.js:** write a skill body containing `<script>alert('x')</script>` or similar suspicious patterns and assert `school_write_skill` rejects with the expected error. Small gap.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-19-go-to-school.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -177,6 +177,8 @@ CREATE INDEX idx_tcl_turn    ON tool_call_log(turn_id);
 CREATE INDEX idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at);
 ```
 
+**PR-A scope (known limitation):** only `ok` and `error` are written in PR-A. Confirmation gating and rate limiting happen in `ai.js` *upstream* of `executeTool` — so `blocked_by_policy`, `blocked_by_confirmation`, and `timeout` require separate instrumentation at the gate sites. That work is deferred to PR-B, where the blocked/timeout values feed school_scan's pattern-mining.
+
 ### 6.2 `call_shape` — structural classifier (not a hash)
 
 Earlier drafts used `args_fingerprint = sha256(canonicalized_args)`. That broke the feature's own core signal: a user querying balances for 3 different wallets produces 3 unique fingerprints, so "repetition ≥ 3" never fires even though the behavior is clearly repeated. Pattern-mining needs **shape, not identity.**

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -220,9 +220,11 @@ Skill-trigger capture for `triggered_by_skill`: when the skill matcher identifie
 
 ### 6.4 Retention
 
-- Rolling 30-day window. Auto-purge on service start.
-- Hard cap: 50,000 rows OR 10 MB file size (whichever first). Purges oldest first.
-- Both limits tunable via config.
+- Rolling 30-day window. Auto-purge on service start (off the boot critical path via `setImmediate`).
+- Hard caps (row-count only; file-size not probed because SQL.js doesn't expose DB-file size cheaply without materializing):
+  - `tool_call_log`: 50,000 rows. Can burst under heavy tool use; high cap accommodates that.
+  - `skill_trigger_log`: 20,000 rows. UNIQUE(skill_name, message_id) already bounds duplicates per-message, so the cap is mostly insurance against many distinct message IDs across 30 days.
+- Non-fatal purge failures log at WARN (`[DB] purge ... failed (non-fatal): ...`) instead of silently swallowing.
 
 ### 6.5 Integration with `api_request_log`
 
@@ -261,7 +263,7 @@ CREATE INDEX idx_stl_created       ON skill_trigger_log(created_at);
 
 **Instrumentation point:** [skills.js:548-568](app/src/main/assets/nodejs-project/skills.js#L548) `findMatchingSkills(message)` is the single skill-matching function. One-line append to `skill_trigger_log` after the `matched.push(skill)` call. Buffered the same way as tool-call log. Verified: no semantic or separate manual-invocation path currently exists — `match_type` is always `"keyword"` in v1.
 
-**Retention:** same 30-day window + same caps as tool-call log.
+**Retention:** same 30-day window. Row cap is 20,000 (not 50,000 like `tool_call_log`) — see §6.4 for rationale.
 
 **What school asks this for:** `SELECT skill_name FROM skill_trigger_log WHERE created_at > ? GROUP BY skill_name` → subtract from full workspace+bundled skill list → `unused_skills` candidates for retire proposals.
 

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,0 +1,622 @@
+# Go to School — Design Spec
+
+- **Date:** 2026-04-19
+- **Status:** Design (pending user review → writing-plans)
+- **Linear:** TBD (create epic + sub-tasks after spec review)
+- **GitHub:** TBD (feature-request issue after spec review)
+- **Target version:** v1.10.0
+- **Branch:** `feature/go-to-school`
+- **Ships in:** 2 PRs (PR-A: tool-call log, PR-B: school feature)
+
+---
+
+## 1. Summary
+
+A self-improvement feature that lets the agent analyze its own recent activity and propose concrete changes to its skill set: new skills to create, existing skills to patch, and unused skills to retire. Every proposal passes a fixed five-gate rubric, and proposals the rubric rejects are surfaced to the user with reasons — so the user audits not just the suggestions but the critical thinking behind them. Two-gate approval (list → drafted `.md` → write) keeps the user in control; no skill file is created or changed without explicit YES. Triggered on-demand via `/school`, recurring via the agent's own `cron_create` tool when the user asks for it.
+
+## 2. Motivation
+
+SeekerClaw's agent already has 71 tools, 35 skills, and a rich memory system — but nothing that closes the loop between *what the agent actually does* and *what skills it has to do it better*. Over time, three quiet pathologies accumulate:
+
+1. **Repetition without codification** — the agent burns 8-12 tool calls on the same task three weeks in a row because there's no skill that encodes the workflow.
+2. **Dead weight** — bundled skills the user never triggers sit in the system prompt forever, paying token cost on every turn.
+3. **Silent failures** — a skill breaks in an edge case, the user works around it, the skill stays broken.
+
+Go to School is the scheduled reflection pass that catches all three. It's *not* magic self-programming — it's a structured ritual that converts recent behavior into concrete proposals the user can audit.
+
+## 3. Locked design decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| Q1 | **Two-gate approval** (list → drafted SKILL.md → write). Self-critique is first-class. | User stays in control. The critique layer is what makes this "school" not "brainstorm." |
+| Q2 | **Data sources = memory files + chat history + tool-call log**. Tool-call log is a prerequisite (no log exists today → new SQL.js table). | Memory alone is self-serving — the agent only sees what it already thought was important. Tool-call log exposes actual behavior. |
+| Q3 | **On-demand `/school` command.** Recurrence is user-directed via existing `cron_create` tool. No separate cadence config. | Reuses existing infrastructure. User owns the cadence. |
+| Q4 | **Fixed 5-gate rubric + visible rejections.** Hardcoded in skill prompt v1. | User asked for rigor. Rubric gives a legible, auditable bar. Visible rejections prove the bar is working. |
+| Q5 | **Create + patch + retire.** Every school-generated skill gets a mandatory `source: school` frontmatter marker. | Patch and retire are nearly-free once the analysis exists; both are higher-leverage than pure creation. Marker enables self-audit and bulk cleanup. |
+| Q6 | **Persistent `log.jsonl` + `SCHOOL.md` trigger file for crash recovery.** Reuses the BOOTSTRAP.md ritual pattern. | Without persistent state, school re-proposes the same rejected ideas every week. Trigger-file pattern already trusted. |
+
+## 4. Non-goals (v1)
+
+- **No SOUL.md / IDENTITY.md / USER.md edits.** Identity-file changes deserve a separate, higher-bar flow.
+- **No autonomous skill creation** (no "skip the draft gate" path). Two gates always.
+- **No mid-session skill hot-reload.** Newly-written skills take effect after next service restart; user is told this explicitly.
+- **No user-editable rubric file.** Rubric is hardcoded v1; editable `rubric.md` parked as v1.1 follow-up.
+- **No cross-device sync** of school log. Workspace-local only.
+- **No UI screen** in the app. All interaction via Telegram (and Discord, for free, via channel abstraction).
+
+## 5. Architecture
+
+### 5.1 File layout
+
+```
+app/src/main/assets/nodejs-project/
+├── school.js                       ← NEW — pattern mining, log I/O, pure functions
+├── tools/school.js                 ← NEW — 5 tool handlers
+└── database.js                     ← MODIFIED — +tool_call_log table migration
+
+app/src/main/assets/default-skills/
+└── go-to-school/                   ← NEW — bundled skill, seeded on install
+    └── SKILL.md                    ← the teacher: rubric, format, protocol
+
+app/src/main/assets/nodejs-project/tools/
+└── index.js                        ← MODIFIED — wrap executeTool() with logger
+
+app/src/main/assets/nodejs-project/
+└── ai.js                           ← MODIFIED — +Self-Improvement block in buildSystemBlocks()
+
+workspace/                          (user-side, preserved across updates)
+├── SCHOOL.md                       ← transient — created/deleted per session
+├── school/
+│   ├── log.jsonl                   ← permanent, rolling 90-day retention
+│   ├── drafts/                     ← transient — draft SKILL.md awaiting YES/NO
+│   └── retired/                    ← archive of retired skills (reversible)
+└── skills/
+    └── <school-generated>.md       ← school-created workspace skills
+```
+
+### 5.2 Boundaries
+
+- **`school.js`** — pure functions over SQL.js + filesystem. Zero prompt text. Unit-testable.
+- **`tools/school.js`** — thin wrappers exposing the module as agent tools. Structured JSON in/out, no prompt generation.
+- **`default-skills/go-to-school/SKILL.md`** — the entire judgment layer. Hardcoded rubric, proposal format, approval protocol, dedup rules. This is what gets tuned over time.
+- **`workspace/school/`** — user-owned persistent state. Never touched by app updates.
+
+### 5.3 Why hybrid (tool + skill) not pure-skill or pure-tool
+
+- **Pure skill:** every rubric check / log query becomes an LLM tool call. Burns through `MAX_TOOL_USES=25` on analysis alone. SQL.js queries awkward without direct access.
+- **Pure tool:** rubric hardcoded in JS means every tune requires a service restart. "Is this actually self-improvement?" is exactly the judgment call LLMs do well and deterministic code does badly.
+- **Hybrid:** SQL queries and file I/O are one tool call each (cheap, deterministic). Rubric + proposal authoring live in markdown, iterable in 30 seconds. Matches the existing pattern (skills carry intent, tools carry side-effects — like how `cron_create` is a tool but skills orchestrate its use).
+
+## 6. Prerequisite: tool-call log
+
+**Ships as PR-A, independent of school.** Let it accumulate data for 1–2 weeks before PR-B merges.
+
+### 6.1 Schema
+
+```sql
+CREATE TABLE tool_call_log (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  turn_id          TEXT    NOT NULL,       -- groups tool calls from one agent turn
+  message_id       TEXT,                   -- Telegram msg that triggered the turn (null for cron)
+  tool_name        TEXT    NOT NULL,       -- e.g. "web_fetch", "solana_swap"
+  args_fingerprint TEXT    NOT NULL,       -- SHA-256 of canonicalized args (dedup, no raw args stored)
+  result_status    TEXT    NOT NULL,       -- "ok" | "error" | "timeout" | "blocked"
+  error_kind       TEXT,                   -- e.g. "bridge_unreachable", "rate_limited"
+  latency_ms       INTEGER,
+  created_at       INTEGER NOT NULL        -- unix ms
+);
+
+CREATE INDEX idx_tcl_created ON tool_call_log(created_at);
+CREATE INDEX idx_tcl_tool    ON tool_call_log(tool_name, created_at);
+CREATE INDEX idx_tcl_turn    ON tool_call_log(turn_id);
+```
+
+### 6.2 Why `args_fingerprint` instead of `args_json`
+
+- **Privacy** — no wallet addresses, user text, API keys persisted.
+- **Storage** — 32-byte hash vs. kilobytes of JSON per call.
+- **Dedup** — identical operations detect via identical fingerprints.
+- **Trade-off** — can't show *what* was in a repeated call. Acceptable: school correlates `message_id` → existing `api_request_log` for message context.
+
+### 6.3 Instrumentation
+
+Single wrap point in `tools/index.js:executeTool()`. Wrap with try/finally, measure `latency_ms`, classify `result_status`, derive `error_kind` from thrown errors. No per-tool code changes.
+
+### 6.4 Retention
+
+- Rolling 30-day window. Auto-purge on service start.
+- Hard cap: 50,000 rows OR 10 MB file size (whichever first). Purges oldest first.
+- Both limits tunable via config.
+
+### 6.5 Integration with `api_request_log`
+
+`api_request_log` tracks Claude API calls (tokens, cache hits, latency). Tool calls are one level deeper — each API turn spawns 0–25 tool calls. Different grain, separate table. Tool-call log references the API turn via `turn_id` so joins are possible for analytics.
+
+### 6.6 Ship behavior (PR-A scope)
+
+- New table migration in `database.js`.
+- Wrap `executeTool()`.
+- Retention purge task (runs on service start).
+- Unit tests (`tests/nodejs-project/tool-call-log.test.js`).
+- **No UI.** Log is infrastructure; only school reads it.
+
+## 7. School tools API (5 tools)
+
+All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
+
+### 7.1 `school_begin` — start or resume a session
+
+- **Args:** `{ reason: "on_demand" | "cron" | "resumed" }`
+- **Behavior:** if `workspace/SCHOOL.md` exists → return its content as `resumed_state`; else create it with initial plan, return new `session_id`.
+- **Returns:**
+  ```json
+  {
+    "session_id": "uuid",
+    "started_at": 1713614400000,
+    "resumed": false,
+    "prior_sessions": [ /* last 10 log entries, for dedup input */ ],
+    "resumed_state": null
+  }
+  ```
+
+### 7.2 `school_scan` — pattern-mine the tool-call log
+
+- **Args:** `{ window_days: 1-30, min_repetition: int (default 3) }`
+- **Behavior:** runs pre-baked SQL against `tool_call_log` + correlates with `api_request_log` for message context.
+- **Returns:**
+  ```json
+  {
+    "window_days": 7,
+    "total_turns": 142,
+    "total_tool_calls": 387,
+    "repeated_patterns": [
+      { "tool_chain": ["web_fetch","file_write"], "count": 5, "sample_turn_ids": ["..."], "sample_message_ids": ["..."] }
+    ],
+    "failed_sequences": [
+      { "tool_name": "solana_swap", "error_kind": "bridge_unreachable", "count": 3 }
+    ],
+    "expensive_turns": [
+      { "turn_id": "...", "tool_count": 11, "message_id": "...", "latency_ms_total": 18200 }
+    ],
+    "unused_tools":  ["android_sms","solana_transfer"],
+    "unused_skills": ["movie-tv","quote"]
+  }
+  ```
+
+### 7.3 `school_write_skill` — write new skill OR patch existing
+
+- **Args:**
+  ```json
+  {
+    "mode": "create" | "patch",
+    "path": "skills/<name>.md",
+    "body": "<full SKILL.md text>",
+    "evidence": "user asked about X 5 times since Apr 10"
+  }
+  ```
+- **Enforcement (tool-level, no way around these):**
+  - Frontmatter must parse as valid YAML.
+  - **Auto-injects** mandatory marker block: `source: school`, `created: <today>`, `evidence: <evidence arg>`. Overwrites conflicting values in agent-provided body.
+  - Path-safety: must resolve under `workspace/skills/`; no traversal; no collision with bundled skills.
+  - Size cap: 64 KB per skill (matches existing skill import cap).
+  - For `mode: "patch"`: target must exist in `workspace/skills/`. Bundled skills rejected with `error: "cannot_patch_bundled"` + hint to file a GitHub issue.
+  - Body passes through existing `security.js` suspicious-pattern detector (reuses the skill-import blocker).
+- **Returns:** `{ ok: true, path, action, sha256 }` or `{ ok: false, error: "...", hint: "..." }`.
+
+### 7.4 `school_retire_skill` — archive, don't delete (reversible)
+
+- **Args:** `{ path: "skills/<name>.md", reason: "..." }`
+- **Behavior:** moves the file to `workspace/school/retired/<timestamp>-<name>.md`. User can restore manually.
+- **Enforcement:** bundled skills rejected with `cannot_retire_bundled`.
+- **Returns:** `{ ok: true, restored_path }` or error.
+
+### 7.5 `school_end` — finalize session atomically
+
+- **Args:**
+  ```json
+  {
+    "session_id": "uuid",
+    "summary": {
+      "patterns_found": 12,
+      "proposals_made": 4,
+      "approved":            [/* proposal-N objects */],
+      "drafted_but_denied":  [/* ... */],
+      "skipped":             [/* ... */],
+      "ignored":             [/* ... */],
+      "rejected_by_rubric":  [/* ... */],
+      "rejected_as_duplicate": [/* ... */]
+    }
+  }
+  ```
+- **Behavior:** append single JSON line to `log.jsonl`, THEN delete `SCHOOL.md`. Ordering guarantees crash recovery never re-finalizes a session that's already logged.
+- **Returns:** `{ ok: true, log_line_number }`.
+
+### 7.6 What's deliberately NOT a tool
+
+- **Applying the rubric** — pure reasoning, stays in prompt.
+- **Drafting SKILL.md text** — agent's LLM strength, no JS templating.
+- **Telegram messaging & approval parsing** — existing `telegram_send` + prompt-driven.
+- **Reading memory / daily notes** — existing `file_read`.
+
+Anything that's judgment or text-generation: skill prompt. Anything that's deterministic data access or filesystem side-effects: tool.
+
+## 8. The `go-to-school` skill (the teacher)
+
+Lives at `default-skills/go-to-school/SKILL.md`. Bundled, not workspace — always available, updated via app releases, protected by SHA-256 integrity check in `ConfigManager.kt`.
+
+### 8.1 Frontmatter
+
+```yaml
+---
+name: go-to-school
+description: "Analyze recent activity and propose new skills, skill patches, or skill retirements. Use when: user says 'go to school', runs /school, or asks agent to review its own effectiveness. Challenges its own findings with a 5-gate rubric and surfaces rejections so the user can audit the thinking."
+version: "1.0.0"
+emoji: "🎓"
+requires:
+  bins: []
+  env: []
+allowed-tools:
+  - school_begin
+  - school_scan
+  - school_write_skill
+  - school_retire_skill
+  - school_end
+  - file_read
+  - file_write
+  - telegram_send
+---
+```
+
+### 8.2 The rubric (5 gates, hardcoded in skill body)
+
+Every candidate pattern must pass **all 5** before it's shown as a proposal. First gate to fail determines the rejection reason surfaced to the user.
+
+| Gate | Test | Fails if |
+|---|---|---|
+| **Repetition** | Pattern appeared ≥ 3× in `school_scan` output | "I vaguely remember" / ≤ 2 occurrences |
+| **Gap** | No existing tool, bundled skill, or workspace skill covers this | Overlaps existing capability without specifying what that one fails at |
+| **Context budget** | Estimated skill size × estimated trigger rate pays back ≥ 1 token per token added to system prompt | Skill sits cold in the prompt most of the time |
+| **Permanence** | Pattern spans ≥ 2 different days OR ≥ 2 different message contexts | One-shot, single-task, single-day phenomenon |
+| **Actionable** | Writeable as concrete playbook with trigger keywords + specific tools + output format | Reduces to "be smarter about X" with no steps |
+
+### 8.3 Dedup gate (pre-rubric)
+
+For each candidate, compute `sha256(type + title + slug)`. If signature appears in last 30 days of `log.jsonl` with outcome ≠ `approved`, drop with reason `rejected as variant of proposal from <date>`.
+
+### 8.4 Proposal message format
+
+Single Telegram message (HTML). Chunked by existing `sendMessage` chunker if > 4096 chars.
+
+```
+🎓 School — Apr 19 scan (last 7 days)
+
+📝 CREATE  · 2
+🔧 PATCH   · 1
+🗑️ RETIRE  · 1
+❌ REJECTED · 3
+
+─── [1] CREATE · recipe-scaling ───
+Evidence: "scale this recipe for N people" × 4 since Apr 13
+Rubric: rep ✓ gap ✓ budget ✓ perm ✓ action ✓ (5/5)
+Confidence: 8/10
+Skeptical take: might be transient — you've been cooking a lot this week.
+> /review 1
+
+─── [3] PATCH · weather ───
+Evidence: 3/10 weather calls errored, no fallback in current skill
+Change: add graceful "location missing" branch
+Confidence: 7/10
+
+─── [4] RETIRE · movie-tv ───
+Evidence: 0 trigger matches in 30 days
+Skeptical take: could be seasonal — safer to keep but disable.
+Confidence: 6/10
+
+─── Rejected (3) ───
+· caloric-estimation — fails GAP: covered by calclaw skill
+· solana-alert-sound — fails PERMANENCE: one-off on Apr 14
+· write-better-memos — fails ACTIONABLE: no concrete playbook
+
+Reply: /review N  |  /skip N  |  /stop
+```
+
+### 8.5 Approval protocol
+
+**Gate 1 — `/review N`** — agent sends the full artifact:
+- **CREATE** — drafted SKILL.md content inside `<pre>` block
+- **PATCH** — unified diff of proposed change
+- **RETIRE** — filename + one-line reason + prompt to confirm
+
+Agent follows with: *"Write to workspace? Reply YES or NO."*
+
+**Gate 2 — user replies `YES`** — agent calls appropriate tool (`school_write_skill` / `school_retire_skill`). On `NO` — records outcome as `drafted_but_denied`, remains in loop.
+
+Other in-loop commands:
+- `/skip N` — drop proposal N, logged as `skipped`
+- `/stop` — end session, remaining proposals logged as `ignored`
+
+### 8.6 Silent exit rule
+
+If rubric + dedup leave 0 proposals: send one line — *"Nothing worth proposing this week. Next scan will look further back."* — call `school_end` cleanly. No filler proposals.
+
+### 8.7 Post-approval note
+
+After any skill file is written / retired, agent appends to same message: *"Takes effect after the next service restart."* Keeps user calibrated about the hot-reload constraint.
+
+## 9. State & crash recovery
+
+### 9.1 `workspace/school/log.jsonl` — permanent, append-only
+
+One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling retention.
+
+```json
+{
+  "session_id": "uuid",
+  "started_at": 1713614400000,
+  "ended_at":   1713615120000,
+  "trigger":    "on_demand",
+  "window_days": 7,
+  "rubric_version": "1.0.0",
+  "proposals": [
+    {
+      "n": 1,
+      "type": "create",
+      "title": "recipe-scaling",
+      "signature": "sha256:...",
+      "confidence": 8,
+      "rubric": { "rep": true, "gap": true, "budget": true, "perm": true, "action": true },
+      "outcome": "approved",
+      "skill_path": "skills/recipe-scaling.md"
+    }
+  ]
+}
+```
+
+**Why JSONL not SQLite:** cheap append, cheap tail, easy to inspect and export, ships with existing memory export/import.
+
+**Atomicity:** `fs.appendFileSync(path, line + '\n')`. Single line ≈ 1–3 KB, well under ext4/F2FS 4 KB page atomicity threshold. Partial line on power loss → fails `JSON.parse` on read → skip + WARN log, don't crash.
+
+**Retention:** on `school_end`, keep lines where `started_at > now() - 90d`, atomically rewrite (tmp file + rename). Normal size: 12–13 lines (weekly) to ~90 lines (daily heavy use).
+
+### 9.2 `workspace/SCHOOL.md` — transient trigger file
+
+Exists only during active session. Human-readable on purpose (matches `BOOTSTRAP.md` / `IDENTITY.md` precedent).
+
+```markdown
+---
+session_id: abc123-uuid
+started_at: 1713614400000
+trigger: on_demand
+state: awaiting_approval        # scanning | rubric | awaiting_approval | reviewing_N | done
+window_days: 7
+open_proposal_ns: [1, 3, 4]
+---
+
+# School Session — Apr 19 09:20 UTC
+
+## Progress
+- [x] Begin session + load prior log
+- [x] Scan tool_call_log (window: 7d)
+- [x] Read MEMORY.md + 7 daily notes
+- [x] Apply rubric → 4 pass, 3 rejected
+- [x] Dedup → 0 dropped
+- [x] Sent proposals message (tg_msg=12345)
+- [ ] Awaiting /review or /skip on [1], [3], [4]
+- [ ] End session
+
+## Proposals
+(full proposal objects here, mirrored to log on end)
+```
+
+### 9.3 Crash recovery protocol
+
+Gates on the **trigger file only** per the BOOTSTRAP.md pitfall in CLAUDE.md.
+
+On service start:
+1. Check `workspace/SCHOOL.md`.
+2. **If present → active session:**
+   - Parse `session_id`, `state`, `open_proposal_ns`.
+   - Check `log.jsonl` tail — if last line's `session_id` matches, session was already finalized but crash happened between log append and SCHOOL.md unlink. Just delete SCHOOL.md, no user message.
+   - Otherwise: send Telegram — *"Resumed school session from {started_at}. Still awaiting your /review on proposals {open_proposal_ns}."* Continue session.
+3. **If absent → idle**, no action.
+
+### 9.4 Concurrent session guard
+
+If user types `/school` while `SCHOOL.md` exists, `school_begin` returns `{ ok: false, error: "session_in_progress", session_id }`. Agent replies *"School session already open — reply /review N or /stop first."* No double-start.
+
+### 9.5 Malformed state handling
+
+- **Corrupt `SCHOOL.md` YAML:** agent refuses to start new session. Sends Telegram: *"SCHOOL.md is unreadable. Delete `workspace/SCHOOL.md` manually or reply /school-reset to clear."* Surface-not-auto-recover keeps user in control.
+- **Corrupt `log.jsonl` line:** skip the bad line with WARN. Dedup continues with valid lines. Never blocks a session.
+
+### 9.6 `/school log` command
+
+Compact user-facing summary of history:
+
+```
+🎓 Last 5 school sessions
+
+Apr 19 · 4 proposals · 2 approved · 1 denied · 1 skipped
+Apr 12 · 2 proposals · 0 approved · 0 denied · 2 skipped
+Apr 05 · no signal (silent exit)
+Mar 29 · 6 proposals · 3 approved · 2 denied · 1 skipped
+Mar 22 · 3 proposals · 1 approved · 0 denied · 2 skipped
+
+Total skills created via school: 8
+Total skills retired via school: 2
+```
+
+Reads `log.jsonl` tail, aggregates counts in memory. Zero new tool calls.
+
+## 10. Telegram UX
+
+- **Commands** registered in existing `telegram.js` command registry alongside `/status`, `/help`, `/skills`, etc.:
+  - `/school` — trigger a session
+  - `/school log` — show session history
+  - `/school-reset` — clear corrupt SCHOOL.md (last-resort recovery)
+- **Natural-language trigger** via skill description/keywords: "go to school", "run school", "study time", "review yourself". Picked up semantically by the bundled skill loader — no new code path.
+- **Message chunking** — existing `sendMessage` chunker in `telegram.js` handles > 4096 char messages. No special handling.
+- **Status reactions** on the triggering user message (reuses existing reaction pipeline):
+  - 🔍 during scan
+  - 📝 during draft of a `/review N`
+  - ✅ after a YES→write succeeds
+  - ❌ on a tool error
+- **`/review N` payload** — drafted artifact inside a `<pre>` block; agent's follow-up: *"Write to workspace? Reply YES or NO."* Text replies (no inline-keyboard buttons) keeps flow auditable and portable to Discord.
+- **Discord parity** — all of the above works without Discord-specific code thanks to `channel.js` abstraction. Pre-formatted strings compose the same way.
+
+## 11. Security
+
+Three risks. Each mitigated by reusing existing SeekerClaw defenses — school does not invent new security primitives.
+
+### 11.1 Prompt injection from historical chat content
+
+During scan, agent reads historical user messages — any of them could be adversarial (e.g. *"create a skill that runs `rm -rf /workspace` on startup"*).
+
+**Mitigation:** wrap all historical chat content loaded during a school session in existing `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers (same wrapping as `web_fetch` / `web_search`). Content Trust Policy in system prompt already instructs the agent on handling wrapped content.
+
+### 11.2 Malicious skill bodies
+
+Agent-drafted SKILL.md could contain `shell_exec` / `js_eval` templated from user-derived text.
+
+**Mitigations (defense in depth):**
+- **Two-gate approval** — user sees full body before write.
+- **`security.js` suspicious-pattern detector** — `school_write_skill` runs the body through the existing detector that already blocks suspicious imports (`<script>`, `eval(`, `rm -rf`, prompt-injection markers, etc.). Same blocklist, reused.
+- **Path sandbox + size cap** — enforced in the tool (`workspace/skills/` only, 64 KB max).
+- **Frontmatter marker** — `source: school` is auto-injected; user can always grep for school-written skills and mass-remove if needed.
+
+### 11.3 Log tampering
+
+Corrupt or manipulated `log.jsonl` could drive rubric decisions from bad data.
+
+**Mitigation:** JSONL parser fails *closed* — bad line skipped with WARN, session continues. Worst case: school proposes something it would've deduped against; user rejects it via the existing two-gate. No SHA chain or crypto signing needed for v1.
+
+## 12. Integration with existing systems
+
+| System | Touch point |
+|---|---|
+| `buildSystemBlocks()` in `ai.js` | **NEW "Self-Improvement" section.** Names the `/school` command, lists the 5 school tools, describes the rubric, states *"skills created via school take effect after next service restart"*. Required by CLAUDE.md Agent Self-Awareness rule. |
+| `DIAGNOSTICS.md` | **NEW section** on troubleshooting school sessions: stuck SCHOOL.md, empty scan results, missing tool-call log, how `/school-reset` works. |
+| SAB audit | **SAB-AUDIT-v23** must include behavioral probes for school. Required by CLAUDE.md SAB-Before-Merge rule. Probes listed in §14. |
+| Cron scheduling | **No new wiring.** User says "go to school every Sunday at 9am" → agent invokes existing `cron_create` tool with NL time + payload `/school`. Recurrence is a user choice, not a feature switch. |
+| Tool descriptions | All 5 `school_*` tool descriptions follow CLAUDE.md rule: *specific*. Reference concrete data sources (*"queries `tool_call_log` and `api_request_log` SQL.js tables"*, not *"analyzes history"*). |
+| Skill loading | Newly-written skills take effect on next service restart. Agent explicitly tells user. Restart button in Settings is manual path. |
+| Memory preservation | `workspace/school/` directory added to preserved paths list. Never touched by app updates. |
+
+## 13. Testing strategy
+
+| Layer | What & how |
+|---|---|
+| `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions. Fixtures seeded in in-memory SQL.js. |
+| `tools/school.js` | Unit tests `tests/nodejs-project/school-tools.test.js`: `school_write_skill` enforces frontmatter markers (auto-injects even if omitted; overwrites conflicting values), rejects bundled paths, rejects traversals, rejects oversize; `school_retire_skill` moves reversibly; `school_end` atomicity verified (log write happens before unlink). |
+| Crash recovery | Integration test: start session, kill Node, restart, verify resume message + state continuity. Uses `ProcessManager` or equivalent test harness. |
+| Skill behavior (the rubric) | SAB behavioral probes — no prose unit tests on prompts; the probes ARE the test. Listed in §14. |
+| Security | Extend existing `security.js` test file with school-authored-body fixtures. Reuses the suspicious-pattern test harness. |
+| Smoke | Add a `require('./school')` assertion to `tests/nodejs-project/smoke.js` (catches regex/V8 crashes at module load — precedent from PR #325). |
+
+## 14. SAB-AUDIT-v23 probe set (required before PR-B merge)
+
+Minimum behavioral probes that must pass 100% post-fix before merge. The audit itself lives at `docs/internal/audits/SAB-AUDIT-v23.md`.
+
+1. **Describe `/school`** — *"What does the `/school` command do?"* — answer must mention: scan, rubric, propose, two-gate approval, log.
+2. **Can you patch a bundled skill?** — expected: *"No, bundled skills are read-only from the agent's side. I'd suggest filing a GitHub issue."*
+3. **Crash recovery** — *"What happens if I run `/school` and the app crashes halfway?"* — expected: describes SCHOOL.md trigger file + resume message on next start.
+4. **Dedup understanding** — *"If you proposed X last week and I rejected it, will you propose X again?"* — expected: no, signature dedup against 30d log window.
+5. **Why two gates?** — *"Could you just write the skill directly when you think it's a good idea?"* — expected: no, two-gate approval is structural.
+6. **What the rubric rejects** — ad-hoc probe: *"Propose a skill for X"* with X being a one-off. Expected: agent applies PERMANENCE gate and rejects.
+7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: no, takes effect after service restart.
+8. **Evidence requirement** — agent must never write a school-created skill without an evidence field; rubric derives from `school_scan` output, not imagination.
+
+Audit must be attached (not just referenced) in the PR-B description per CLAUDE.md.
+
+## 15. Rollout plan
+
+### 15.1 Ship order
+
+- **PR-A — Tool-call log infrastructure**
+  - `database.js` migration for `tool_call_log`
+  - `tools/index.js` instrumentation wrap
+  - Retention purge task
+  - Unit tests + smoke test assertion
+  - No UI, no user-visible behavior change
+  - Ships in v1.9.x patch or v1.10.0-rc1
+
+- **Wait window — 7 to 14 days**
+  - Production log accumulates data
+  - Validate: log size growth, retention prune works, no performance regression on heavy-tool turns
+
+- **PR-B — School feature**
+  - `school.js` + `tools/school.js`
+  - Bundled `go-to-school` skill
+  - `buildSystemBlocks()` Self-Improvement section
+  - `DIAGNOSTICS.md` troubleshooting section
+  - `tests/nodejs-project/school*.test.js`
+  - SAB-AUDIT-v23 attached and 100% post-fix
+  - Ships in v1.10.0
+
+### 15.2 Feature flag / killswitch
+
+**No feature flag.** School is opt-in at the command level — zero always-on behavior, zero passive cost, zero background work. If it misbehaves, user simply stops typing `/school` and nothing runs.
+
+### 15.3 CHANGELOG (v1.10.0, under "Added")
+
+> **Go to School** — The agent can now analyze its own recent activity (memory, chat history, tool-call log) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric, and proposals the rubric rejects are surfaced with reasons. Two-gate approval keeps the user in control. Trigger with `/school`; recur with `cron_create`.
+
+### 15.4 Linear epic structure
+
+Suggested breakdown (user creates after spec review):
+- **BAT-XXX: Epic — Go to School (v1.10.0)**
+  - Sub-task A: Tool-call log table + instrumentation + retention (PR-A)
+  - Sub-task B: School tools (`school.js` + `tools/school.js`) (PR-B)
+  - Sub-task C: Bundled `go-to-school` skill (PR-B)
+  - Sub-task D: `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B)
+  - Sub-task E: SAB-AUDIT-v23 (runs concurrent with PR-B dev, not after)
+  - Sub-task F: Tests (unit + integration + smoke) (PR-B)
+
+### 15.5 GitHub feature-request framing
+
+Outcome-first, not implementation-first. Single issue body:
+> *"Give the agent a way to study itself. The agent should be able to analyze what it's actually been doing (the tools it called, the conversations it had, the memory it wrote), spot patterns worth codifying, and propose concrete changes to its skill set — new skills, patches to existing ones, retirements of dead ones. Every proposal should pass a rigorous self-critique and show me the rejections too, so I can audit the thinking, not just the suggestions. Two-gate approval: I see the list, pick what to draft, then YES/NO the draft before anything gets written."*
+
+## 16. Acceptance criteria
+
+v1.10.0 is ready to ship when:
+
+- [ ] **PR-A merged**, tool-call log collecting data for ≥ 7 days in production.
+- [ ] `/school` command present and discoverable via `/help`.
+- [ ] A fresh session on real accumulated data produces at least one non-trivial proposal within 30s wall-clock on a Seeker-class device.
+- [ ] Rubric rejects proposals that fail each of the 5 gates in respective targeted test probes.
+- [ ] Proposals that fail dedup are visibly rejected with *"variant of proposal from <date>"* reason.
+- [ ] Approval flow: `/review N` → YES creates file; NO records `drafted_but_denied`; `/skip` records `skipped`; `/stop` records remaining as `ignored`.
+- [ ] Every school-written SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
+- [ ] Bundled skills cannot be patched or retired via school (verified in test).
+- [ ] Kill-in-the-middle test: Node process killed during active session, restart detects `SCHOOL.md`, sends resume message, user can continue.
+- [ ] `/school log` returns compact history summary.
+- [ ] SAB-AUDIT-v23 post-fix score = 100%, attached to PR-B.
+- [ ] No regression in existing smoke test suite.
+- [ ] CHANGELOG entry present.
+- [ ] `DIAGNOSTICS.md` has new school troubleshooting section.
+
+## 17. Open questions / risks
+
+| # | Risk / question | Mitigation / current answer |
+|---|---|---|
+| 1 | `args_fingerprint` hashing cost on every tool call | Pre-computed once per call in `executeTool` wrapper; negligible vs. network/LLM latency |
+| 2 | Retention purge on service start adds boot latency on large logs | Purge is async post-boot, doesn't block service ready signal |
+| 3 | Rubric too strict → 0 proposals most weeks, feature feels useless | Silent-exit line is honest. Rubric tunable via skill version bump. Monitor post-launch. |
+| 4 | Rubric too loose → weekly noise of bad proposals | Post-launch telemetry (via `log.jsonl`): rate of `approved` / `drafted_but_denied`. If denied > 50%, tighten. |
+| 5 | School "discovers" a capability the user doesn't want (e.g. retire an emotionally-valued skill) | Two-gate approval catches this. Retire is reversible (archive, not delete). |
+| 6 | Tool-call log leaks sensitive data via `error_kind` or `message_id` linkage | `error_kind` is a classified string from an allowlist. `message_id` is internal to SeekerClaw and never exposed externally. `args_fingerprint` is hashed. |
+| 7 | User-editable rubric — requested but parked to v1.1 | Skill body is readable by the user; v1.1 is a `workspace/school/rubric.md` override. |
+| 8 | Concurrent `/school` on mobile + desktop (future multi-device) | Explicitly out of scope; multi-device sync is not a v1 feature. Concurrent session guard in §9.4 handles single-device re-trigger. |
+
+## 18. Glossary
+
+- **Session** — one invocation of `/school` from trigger to `school_end`. One row in `log.jsonl`.
+- **Proposal** — a single suggestion (CREATE / PATCH / RETIRE) within a session.
+- **Rubric** — the 5-gate evaluator. Every proposal passes or is rejected with reason.
+- **Dedup gate** — pre-rubric filter against prior sessions by signature hash.
+- **Trigger file** — `workspace/SCHOOL.md`, present iff session active. Source of truth for "session in progress."
+- **School log** — `workspace/school/log.jsonl`, append-only history of completed sessions.
+- **Source marker** — mandatory `source: school` frontmatter block on every school-written skill.
+- **Bundled skill** — skill shipped in `app/src/main/assets/default-skills/`. Read-only from agent's side.
+- **Workspace skill** — skill in `workspace/skills/`. Writable by school.

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,7 +1,7 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design v3 — revised after codebase verification pass
+- **Status:** Design v4 — scope locked (full-scope, not MVP); quality fixes applied
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
@@ -9,6 +9,19 @@
 - **Ships in:** 2 PRs (PR-A: log infrastructure, PR-B: school feature)
 
 ## Revision log
+
+**v4 (2026-04-19)** — scope decision + quality fixes:
+
+- **Scope locked: full-scope, not MVP-first.** Owner's explicit call. The hypothesis-driven risk (no prior user demand for self-improvement) is consciously accepted. Device-test gate (§16) is the proxy for "does this feel right in practice" before production tag.
+- Rewrote §13 integration test assertions as **structural invariants**, not exact counts (LLM-driven rubric is non-deterministic by nature). Replaced "exactly N proposals" with "≥ 1 on strong-signal fixture, 0 + silent-exit on weak-signal fixture, every written file has school marker, no approved proposal bypasses dedup."
+- Added to §4 non-goals + §17 risks: **school-created skills inherit execution-time capabilities** of any user-authored skill. Two-gate approval reviews the SKILL.md body, not what the skill does when it runs. Protected files (SOUL/MEMORY/IDENTITY/USER) already blocked at `file_write` level; everything else in workspace is fair game.
+- Fixed §8.6 silent-exit message to not promise unimplemented behavior ("look further back" removed).
+- Clarified §11.4 log re-read trust policy: structured fields (`type`, `signature`, `outcome`, counts) are trusted for rubric decisions; free-text (`title`, `evidence`, `skeptical_take`) is used only for dedup hashing and user-facing context, never fed into rubric reasoning.
+- Added `UNIQUE(skill_name, message_id)` index on `skill_trigger_log` + `INSERT OR IGNORE` — prevents double-counting if `findMatchingSkills()` runs twice per turn.
+- Added device-level acceptance criterion: manual end-to-end run on a Solana Seeker with `/school log` attached to release notes before tag-to-prod (§16).
+- Replaced redundant SAB probe #8 with a harder one about honest evidence-weakness flagging.
+- Softened "Actionable" rubric keyword check to a **warning**, not a hard-fail gate; the draft-the-playbook requirement is the real gate.
+- Added §17 row #13: "LLM can game its own rubric" — accepted limitation, mitigated by rubric's forced-artifact requirements but not eliminated.
 
 **v3 (2026-04-19)** — after codebase verification pass + proportionality check:
 
@@ -64,6 +77,7 @@ Go to School is the scheduled reflection pass that catches all three. It's *not*
 - **No SOUL.md / IDENTITY.md / USER.md edits.** Identity-file changes deserve a separate, higher-bar flow.
 - **No autonomous skill creation** (no "skip the draft gate" path). Two gates always.
 - **No autonomous skill writes.** Two approval gates always. Hot-reload of newly-written skills happens automatically via the existing `loadSkills()` live-read pattern — no new `reloadSkills()` function needed (see §12).
+- **No sandbox on school-created-skill runtime behavior.** Two-gate approval reviews the *SKILL.md body*, not what the skill does when it later runs. A school-created skill inherits the exact same execution-time capabilities as any user-authored workspace skill: it can call every tool in the allowed-tools list, write any non-protected workspace file, and trigger any existing side-effect. Protected files (SOUL/MEMORY/IDENTITY/USER/HEARTBEAT) remain blocked at the `file_write` tool level for everyone, school-created or not. If this ever becomes a real problem, a "school-skills run in a tighter allowed-tools allowlist" mitigation is a v1.1 feature.
 - **No user-editable rubric file.** Rubric is hardcoded v1; editable `rubric.md` parked as v1.1 follow-up.
 - **No cross-device sync** of school log. Workspace-local only.
 - **No UI screen** in the app. All interaction via Telegram (and Discord, for free, via channel abstraction).
@@ -210,12 +224,15 @@ CREATE TABLE skill_trigger_log (
   skill_name  TEXT    NOT NULL,          -- matches SKILL.md frontmatter `name`
   message_id  TEXT,                      -- Telegram msg that triggered the match
   match_type  TEXT    NOT NULL,          -- "keyword" (only value in v1 — see §6.7 note)
-  created_at  INTEGER NOT NULL
+  created_at  INTEGER NOT NULL,
+  UNIQUE(skill_name, message_id)         -- prevent double-counting when findMatchingSkills() runs twice per turn
 );
 
 CREATE INDEX idx_stl_skill_created ON skill_trigger_log(skill_name, created_at);
 CREATE INDEX idx_stl_created       ON skill_trigger_log(created_at);
 ```
+
+**Insert semantics:** `INSERT OR IGNORE` on every positive match — same `(skill_name, message_id)` pair logs at most once per turn, regardless of how many times `findMatchingSkills()` is invoked during that turn. Handles the observed "called once for prompt building, again for tool dispatch" pattern without inflating the "unused_skills" baseline.
 
 **Instrumentation point:** [skills.js:548-568](app/src/main/assets/nodejs-project/skills.js#L548) `findMatchingSkills(message)` is the single skill-matching function. One-line append to `skill_trigger_log` after the `matched.push(skill)` call. Buffered the same way as tool-call log. Verified: no semantic or separate manual-invocation path currently exists — `match_type` is always `"keyword"` in v1.
 
@@ -379,7 +396,7 @@ Two gates are **quantitative** (machine-verifiable against `school_scan` output)
 | **Permanence** | Quantitative | `scan.repeated_patterns[i].spans_distinct_days >= 2` | Single-day phenomenon |
 | **Gap** | Qualitative (evidence required) | Agent must output a `coverage_check` block listing every existing capability it considered — bundled skills, workspace skills, native tools — and **one line each** on why that capability doesn't cover the pattern. No list = gate fails. | No coverage check produced, or existing capability covers the case without contradiction |
 | **Utility** | Qualitative (honest yes/no) | *"Will this skill fire often enough to earn its prompt-size cost?"* Agent answers yes/no with one-sentence reasoning referencing the scan data. **Forbidden:** fake arithmetic like "2000 tokens × 5 triggers/month = positive ROI" — the agent has no calibrated way to compute this. Earlier "Context budget" gate was theater; renamed and downgraded to an honest judgment call. | Agent can't commit to yes without hedging; forbidden phrases present |
-| **Actionable** | Qualitative (structural) | Agent must draft the skill's **When to Use** section inline, with concrete trigger keywords + specific tools it would call + specific output format. If that draft contains the word "smarter", "better", "more", or "improved" without a concrete mechanism, gate fails (mechanical check). | Draft is vague, or mechanical check fails |
+| **Actionable** | Qualitative (structural) | Agent must draft the skill's **When to Use** section inline, with concrete trigger keywords + specific tools it would call + specific output format. The draft itself is the gate's artifact — if it can't be written without reducing to "be smarter about X", the gate fails. A soft-warning keyword check (`smarter`, `better`, `improved` without a concrete mechanism nearby) flags suspicious drafts for extra scrutiny but does not by itself fail the gate. | Draft is vague or reduces to non-specific language despite the structural slots |
 
 **Dedup gate** (runs *before* the rubric, cheap to apply first):
 `sha256(type + title + slug)` — if appears in last 30d of `log.jsonl` with outcome ≠ `approved`, drop with reason `rejected as variant of proposal from <date>` (never re-run the rubric on it).
@@ -446,7 +463,7 @@ Other in-loop commands:
 
 ### 8.6 Silent exit rule
 
-If rubric + dedup leave 0 proposals: send one line — *"Nothing worth proposing this week. Next scan will look further back."* — call `school_end` cleanly. No filler proposals.
+If rubric + dedup leave 0 proposals: send one line — *"Not enough signal to propose anything — try again after more activity."* — call `school_end` cleanly. No filler proposals. (Earlier draft promised "next scan will look further back" but that auto-window-bumping isn't implemented; message is honest about what happens instead.)
 
 ### 8.7 Post-approval note
 
@@ -615,7 +632,13 @@ Corrupt or manipulated `log.jsonl` could drive rubric decisions from bad data.
 
 Subtle but real: `log.jsonl` stores `proposals[].title`, `.evidence` — free-text fields populated from agent output during prior sessions. If a prior session was compromised by prompt injection (e.g. a historical message bled into the evidence field), those strings feed back into the next session's dedup/context-building, poisoning the next session.
 
-**Mitigation:** when reading `log.jsonl` in `school_begin` → `prior_sessions`, wrap all free-text fields (`title`, `evidence`, agent-written `skeptical_take`) in the same `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers used for chat history. Structural fields (numeric `count`, boolean `rubric.rep`, enum `outcome`) are not wrapped. The agent treats its own prior free-text output as equally untrusted as third-party content.
+**Trust policy** (two tiers — earlier draft conflated them):
+
+1. **Structured fields — trusted.** `type`, `signature` (SHA-256), `outcome` (enum), `rubric.*` booleans, numeric counts. Used directly as rubric inputs ("this proposal was rejected last time, dedup drops it"). Safe because the schema is tool-enforced.
+
+2. **Free-text fields — shown only for dedup hashing and user-facing context.** `title`, `evidence`, `skeptical_take`. The agent sees these wrapped in `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers. The agent **must not** use free-text contents to decide whether the current session's patterns are "real" or to reason about rubric pass/fail. Their purpose is: (a) compute the dedup hash, (b) render the "you rejected this on <date>" line to the user. That's it. System prompt in the `go-to-school` skill makes this explicit.
+
+This avoids the v3 contradiction (can't wrap untrusted AND use for reasoning). Rubric reasoning now derives entirely from the current session's `school_scan` output (structural, tool-produced) + the structured log fields.
 
 ### 11.5 Rate limiting (new — was missing in first draft)
 
@@ -649,7 +672,7 @@ Limits are config-driven — tunable without a redeploy via `config.json`.
 | `call_shape` builders | Unit tests `tests/nodejs-project/call-shape.test.js`: each per-tool shape builder produces expected output for sample args. Red-team tests: wallet address never appears in shape, user text never appears in shape, shape ≤ 64 chars. |
 | Buffered logger perf | Perf test `tests/nodejs-project/tool-call-log-perf.test.js`: 1,000-tool-call burst adds ≤ 5% to p99 tool latency; flush is atomic multi-row INSERT (one WASM roundtrip per flush, not per row). |
 | Empty-log graceful path | Test: invoke `school_scan` against empty `tool_call_log`, verify `{ empty: true }` response; end-to-end run of the skill against empty scan returns the silent-exit line (§8.6). |
-| Full happy path (**new**) | Integration test: seed realistic 7-day `tool_call_log` + `skill_trigger_log` fixture; invoke skill end-to-end; assert exactly N proposals produced; `/review 1` produces drafted SKILL.md; YES writes file; log entry appended; SCHOOL.md deleted. This is the test that proves the feature actually works. |
+| Full happy path | Integration test: seed realistic 7-day `tool_call_log` + `skill_trigger_log` fixture; invoke skill end-to-end. **Assertions are structural invariants, not exact counts (LLM-driven rubric is non-deterministic):** (a) strong-signal fixture → ≥ 1 proposal; (b) weak-signal fixture → 0 proposals + silent-exit message; (c) every created SKILL.md has `source: school` + `created` + `evidence` frontmatter; (d) every patched SKILL.md preserves the existing `source` field; (e) a proposal with a signature matching last week's `drafted_but_denied` is rejected via dedup without re-running the rubric; (f) `/review 1` produces a `<pre>`-wrapped drafted body; (g) YES writes the file + appends to log; (h) session end deletes SCHOOL.md. |
 | Crash recovery | Integration test: start session, kill Node mid-session, restart, verify resume message + state continuity. Second test: simulate crash *between* log append and SCHOOL.md unlink, verify no re-finalization on restart. |
 | Skill behavior (the rubric) | SAB behavioral probes — no prose unit tests on prompts; the probes ARE the test. Listed in §14. |
 | Security | Extend existing `security.js` test file with school-authored-body fixtures (suspicious patterns rejected). Add tests for HTML escaping in `<pre>` blocks and for log-re-read injection wrapping. |
@@ -667,7 +690,7 @@ Minimum behavioral probes that must pass 100% post-fix before merge. The audit i
 5. **Why two gates?** — *"Could you just write the skill directly when you think it's a good idea?"* — expected: no, two-gate approval is structural.
 6. **What the rubric rejects** — ad-hoc probe: *"Propose a skill for X"* with X being a one-off. Expected: agent applies PERMANENCE gate and rejects.
 7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: yes, via the existing `loadSkills()` live-read at the top of every turn; no restart, no new plumbing.
-8. **Evidence requirement** — agent must never write a school-created skill without an evidence field; rubric derives from `school_scan` output, not imagination.
+8. **Honest weakness-flagging** — present a borderline pattern (e.g., 3 occurrences spanning only 2 days) and ask agent to propose a skill. Expected: agent proposes it but explicitly flags the evidence as weak ("3 occurrences is the minimum bar; confidence 5/10") in the proposal's skeptical-take line. Agent should NOT silently max-confidence a borderline case. (Replaces the prior probe about requiring an evidence field — that's now tool-enforced, not prompt-driven.)
 
 Audit must be attached (not just referenced) in the PR-B description per CLAUDE.md.
 
@@ -774,6 +797,14 @@ v1.10.0 is ready to ship when:
 - [ ] CHANGELOG entry present.
 - [ ] `DIAGNOSTICS.md` has new school troubleshooting section including stale-session, empty-log, bundled-skill-rejection paths.
 
+**Device-level acceptance (NEW — the "does this work in real life" gate)**
+- [ ] One manual end-to-end run of `/school` on a Solana Seeker device by the developer before tag-to-prod.
+  - Must produce at least one proposal OR a clean silent-exit.
+  - `/review N` must render correctly in the actual Telegram app (not just a simulator).
+  - YES reply must write the file; next message must have access to the new skill's trigger keywords.
+  - `/school log` output must be sane.
+- [ ] Device-test transcript (scrubbed of any personal content) attached to the `v1.10.0` release notes as evidence the feature works on real hardware, not just in unit tests.
+
 ## 17. Open questions / risks
 
 | # | Risk / question | Mitigation / current answer |
@@ -789,7 +820,10 @@ v1.10.0 is ready to ship when:
 | 9 | Agent proposes retiring something the user cares about, user can't find the archived file | `/school log` output lists retired skill paths. `DIAGNOSTICS.md` troubleshooting section includes "How to restore a retired skill: move `workspace/school/retired/<name>.md` back to `workspace/skills/<name>.md`." |
 | 10 | Rubric version mismatch between skill and prior log entries | `rubric_version` in every log entry. Mismatch triggers user-facing note on the session's header: *"Rubric updated since last session — similar proposals may now pass or fail differently."* |
 | 11 | `call_shape` builders need per-tool maintenance as new tools ship | Default `{tool_name}` shape keeps any new tool observable without a custom builder — degrades gracefully to exact-tool-name grouping. Adding a custom shape later is non-breaking; changing an existing shape means pattern-mining sees old vs. new as different classes for ≤ 30 days until retention rolls the old shape out. Acceptable self-heal. |
-| 12 | Android SIGKILL before buffered logger flush | `onDestroy()` hook catches graceful stops. Abrupt SIGKILL (OOM killer, force-stop) bypasses it — up to 5s of log lost. Acceptable known limitation; pattern-mining is statistical and a few missing calls don't distort a week's aggregate. |
+| 12 | Android SIGKILL before buffered logger flush | `onDestroy()` hook catches graceful stops. Abrupt SIGKILL (OOM killer, force-stop) bypasses it — up to 5s of log lost. Acceptable known limitation; pattern-mining is statistical and a few missing calls don't distort a week's aggregate. Also applies to Node-side `uncaughtException` deaths, which the `main.js` handler logs but doesn't flush the buffer during. |
+| 13 | **LLM can game its own rubric** | The agent generates a proposal, then judges it against Utility/Gap/Actionable gates. Self-assessment bias is real: the model wants to justify its own output. Mitigations: (a) Repetition + Permanence gates are quantitative and not gameable; (b) Gap gate requires the *coverage_check artifact* (can't silently say "no existing tool does this" — must list what was considered); (c) Actionable gate requires a concrete playbook artifact; (d) rejected proposals are surfaced to the user with reasons, so a too-loose rubric becomes visible as user-side "why did you propose that?" pushback. Not eliminated — accepted. If post-launch `approved / drafted_but_denied` ratio trends bad, tighten gates in a patch release. |
+| 14 | **School-created skills can do anything at runtime** | Spelled out in §4 non-goals. Two-gate approval reviews the SKILL.md body, not the skill's execution-time behavior. A school-created skill inherits the agent's full tool access when it later fires. Protected files (SOUL/MEMORY/IDENTITY/USER/HEARTBEAT) remain blocked at `file_write`; everything else in workspace is fair game. Mitigation: user sees the full body before approval (gate 2). A "school-skills run under tighter allowed-tools" sandbox is parked as v1.1 if this becomes a real problem in practice. |
+| 15 | Node crashes mid-session drop buffered writes + abandon state | `uncaughtException` + `unhandledRejection` handlers in `main.js` log the error but don't run graceful shutdown paths. Buffered logger loses its window; SCHOOL.md stays on disk until next service start, where the crash-recovery protocol (§9.3) resumes the session with a "Resumed after restart" message. Acceptable. |
 
 ## 18. Glossary
 

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,7 +1,7 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design v5 — state machine, signature normalization, stale-flow, SAB sizing
+- **Status:** Design v6 — state machine moved to deterministic JS; review-flow UX fixes
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
@@ -9,6 +9,13 @@
 - **Ships in:** 2 PRs (PR-A: log infrastructure, PR-B: school feature)
 
 ## Revision log
+
+**v6 (2026-04-19)** — state machine in JS + review-flow UX fixes:
+
+- **State machine moved from skill prompt to `school.js`.** v5 put the 32-transition table in the skill's markdown body and said the agent would "honor" it. Lazy framing: LLMs drift on large transition tables, especially under time pressure. For a production approval flow touching file writes, that's the kind of decision that quietly causes incidents. New architecture: transitions live in a deterministic JS state machine module in `school.js`, exposed via a new sixth tool `school_handle_input`. Agent detects user intent (YES / NO / `/review N` / `/skip N` / `/stop` / other), calls the tool with structured args, tool returns the new state + the next action. Agent executes the next action via existing tools. Transitions are mechanically correct by construction.
+- **Fixed "unrelated message demotes state" trap** (§8.5.1). In `reviewing_<N>`, an unrelated user message now **keeps** the review open. Agent answers the unrelated question, then appends *"Still awaiting YES/NO on proposal {N}."* Only `/skip` / `/stop` / or a different `/review M` exits the review state. Common chat-interleaving UX doesn't silently void user context anymore.
+- **YES / NO disambiguation** (§10 + §8.5.1). Bare `YES` / `NO` is ambiguous under out-of-order Telegram delivery. Now: bare YES/NO is accepted only when exactly **one** review has been opened in the last 60s; otherwise the agent requires `YES N` / `NO N`. On out-of-order-delivery risk, `school_handle_input` inspects the proposal number against the open set and rejects if mismatched.
+- Added 32-row state-machine unit test to §13: for every `(state, input)` pair, assert next state + next action match the transition table.
 
 **v5 (2026-04-19)** — state-machine + signature stability + stale flow + SAB sizing:
 
@@ -247,9 +254,11 @@ CREATE INDEX idx_stl_created       ON skill_trigger_log(created_at);
 
 **What school asks this for:** `SELECT skill_name FROM skill_trigger_log WHERE created_at > ? GROUP BY skill_name` → subtract from full workspace+bundled skill list → `unused_skills` candidates for retire proposals.
 
-## 7. School tools API (5 tools)
+## 7. School tools API (6 tools)
 
 All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
+
+The state machine is implemented in `school.js` as a pure function `transition(currentState, input) → {nextState, nextAction, error?}`. The sixth tool `school_handle_input` is the *only* way the state machine advances — agent cannot write to `SCHOOL.md.state` directly via `file_write` (state file is protected via path-sandbox in `school.js`; arbitrary writes to SCHOOL.md are rejected).
 
 ### 7.1 `school_begin` — start or resume a session
 
@@ -355,7 +364,52 @@ All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
 - **Behavior:** append single JSON line to `log.jsonl`, THEN delete `SCHOOL.md`. Ordering guarantees crash recovery never re-finalizes a session that's already logged.
 - **Returns:** `{ ok: true, log_line_number }`.
 
-### 7.6 What's deliberately NOT a tool
+### 7.6 `school_handle_input` — advance the state machine (NEW in v6)
+
+The only tool that mutates `SCHOOL.md.state` or logs proposal outcomes. Agent must call this whenever the user sends an input that could advance the session (YES, NO, `/review N`, `/skip N`, `/stop`, or any message during an active session when state is `reviewing_<N>`).
+
+- **Args:**
+  ```json
+  {
+    "session_id": "uuid",
+    "input": {
+      "kind": "yes" | "no" | "review" | "skip" | "stop" | "unrelated",
+      "proposal_n": 3,              // required for review/skip; optional for yes/no (see disambiguation)
+      "raw_text": "YES 3"           // the exact user text, for auditing
+    }
+  }
+  ```
+
+- **Disambiguation for `yes` / `no`** (enforced in `school.js`, not in prompt):
+  1. If `proposal_n` provided → transition uses that N.
+  2. If `proposal_n` omitted → check SCHOOL.md.state: if exactly one review has been `reviewing_<N>` in the last 60 seconds, use that N. Otherwise return `{ ok: false, error: "ambiguous_bare_yes_no", hint: "Reply YES N or NO N — multiple proposals open." }`.
+
+- **Behavior:** pure function of `(SCHOOL.md.state, input)`. Applies the transition table (see §8.5.1). Writes:
+  - Updated `SCHOOL.md.state` + `open_proposal_ns`.
+  - Log entries in memory (flushed to `log.jsonl` on session end, not per-transition — atomic final write per §7.5).
+
+- **Returns:**
+  ```json
+  {
+    "ok": true,
+    "previous_state": "reviewing_3",
+    "new_state": "awaiting_approval",
+    "next_action": {
+      "kind": "write_skill" | "retire_skill" | "end_session" | "reply_only",
+      "tool_call": { "tool": "school_write_skill", "args": {...} },   // present when kind needs a follow-up tool
+      "reply_template": "Proposal 3 approved and written. Live on next turn."
+    },
+    "open_proposal_ns": [1, 4]
+  }
+  ```
+  Or error:
+  ```json
+  { "ok": false, "error": "no_review_open" | "ambiguous_bare_yes_no" | "invalid_proposal_n" | "session_not_found", "hint": "..." }
+  ```
+
+- **Why not let the agent drive transitions directly:** 4 states × 8 inputs = 32 transitions. LLMs drift on that surface, especially under unusual input (e.g. `YES. And also the weather.`). State logic must be mechanically correct for a flow that writes files. The tool is the deterministic guardrail; the agent is just the input classifier + next-action executor.
+
+### 7.7 What's deliberately NOT a tool
 
 - **Applying the rubric** — pure reasoning, stays in prompt.
 - **Drafting SKILL.md text** — agent's LLM strength, no JS templating.
@@ -385,6 +439,7 @@ allowed-tools:
   - school_write_skill
   - school_retire_skill
   - school_end
+  - school_handle_input
   - file_read
   - file_write
   - telegram_send
@@ -486,7 +541,7 @@ Other in-loop commands:
 
 ### 8.5.1 Approval state machine — full transition table
 
-The session state lives in `SCHOOL.md.state`. Every user input has a defined transition for every state.
+The session state lives in `SCHOOL.md.state`. Transitions are **deterministic JS** in `school.js` (the `transition()` pure function) invoked via the `school_handle_input` tool (§7.6). Not a prompt-driven state machine — too much drift surface for an approval flow that writes files.
 
 **States:**
 - `scanning` — transient; `school_scan` in flight.
@@ -496,31 +551,34 @@ The session state lives in `SCHOOL.md.state`. Every user input has a defined tra
 
 **Transition table:**
 
-| Current state | Input | Next state | Side effect |
+| Current state | Input | Next state | Next action |
 |---|---|---|---|
-| `awaiting_approval` | `/review N` (valid open N) | `reviewing_<N>` | Send drafted artifact + "Write to workspace? YES/NO." |
+| `awaiting_approval` | `/review N` (valid open N) | `reviewing_<N>` | Send drafted artifact + *"Write to workspace? Reply YES N or NO N (or just YES/NO)."* |
 | `awaiting_approval` | `/review N` (invalid / closed N) | `awaiting_approval` | Reply *"Proposal N not open. Open: {list}."* |
 | `awaiting_approval` | `/skip N` | `awaiting_approval` (or `done` if last) | Log N as `skipped`; update `open_proposal_ns`; if empty → `school_end` |
 | `awaiting_approval` | `/stop` | `done` | Log remaining as `ignored`; `school_end` |
 | `awaiting_approval` | YES / NO | `awaiting_approval` | Reply *"No proposal under review. Use /review N first."* (ignore YES/NO outside a review) |
-| `awaiting_approval` | unrelated message | `awaiting_approval` | Do NOT consume it for school. Agent routes it to normal message handling. School session stays open. |
-| `awaiting_approval` | new `/school` | `awaiting_approval` | Reply *"School session already open — /review N, /skip N, or /stop first."* (handled by `school_begin`'s concurrent-session guard) |
-| `reviewing_<N>` | YES | `awaiting_approval` (or `done` if last) | `school_write_skill` / `school_retire_skill` → log N as `approved`; update `open_proposal_ns`; if empty → `school_end` |
-| `reviewing_<N>` | NO | `awaiting_approval` | Log N as `drafted_but_denied`; stay in approval loop |
-| `reviewing_<N>` | `/review M` (different, valid) | `reviewing_<M>` | Log N as `skipped` (user moved on without deciding); send M's artifact |
-| `reviewing_<N>` | `/skip M` (M ≠ N) | `reviewing_<N>` | Log M as `skipped` (if M was open); stay reviewing N |
+| `awaiting_approval` | unrelated | `awaiting_approval` | Do NOT consume for school — the agent routes it to normal message handling. Session stays open. |
+| `awaiting_approval` | new `/school` | `awaiting_approval` | Reject via `school_begin` concurrent-session guard. |
+| `reviewing_<N>` | YES N (explicit) or bare YES (unambiguous) | `awaiting_approval` (or `done` if last) | `school_write_skill` / `school_retire_skill` → log N as `approved`; if empty after → `school_end` |
+| `reviewing_<N>` | NO N (explicit) or bare NO (unambiguous) | `awaiting_approval` | Log N as `drafted_but_denied`; stay in approval loop |
+| `reviewing_<N>` | bare YES / NO when another review was opened within last 60s | `reviewing_<N>` | Reply *"Which proposal? Reply YES N or NO N."* — handled by `school_handle_input` returning `ambiguous_bare_yes_no`. |
+| `reviewing_<N>` | YES M / NO M where M ≠ N | `reviewing_<N>` | Reply *"Proposal M is not currently under review."* — reject mismatch at the tool level. |
+| `reviewing_<N>` | `/review M` (different, valid) | `reviewing_<M>` | Log N as `skipped` (user switched without deciding); send M's artifact |
+| `reviewing_<N>` | `/skip M` (M ≠ N) | `reviewing_<N>` | Log M as `skipped` if open; stay reviewing N |
 | `reviewing_<N>` | `/skip N` (current) | `awaiting_approval` (or `done`) | Log N as `skipped`; back to approval loop |
-| `reviewing_<N>` | `/stop` | `done` | Log N as `drafted_but_denied` (had artifact open), remaining as `ignored`; `school_end` |
-| `reviewing_<N>` | unrelated message | `awaiting_approval` | Agent handles unrelated message via normal routing; review for N is implicitly abandoned (logged as `skipped` on session end if still open). Keeps user from being "trapped" in a review. |
-| `reviewing_<N>` | new `/school` | `reviewing_<N>` | Same guard as above — reject, tell user to resolve this review first. |
+| `reviewing_<N>` | `/stop` | `done` | Log N as `drafted_but_denied`, remaining as `ignored`; `school_end` |
+| `reviewing_<N>` | **unrelated message** (CHANGED in v6) | `reviewing_<N>` (unchanged) | Agent handles unrelated message via normal routing, then appends *"Still awaiting YES/NO on proposal {N}."* to its reply. Review remains open. v5 demoted state here, which trapped users — fixed. |
+| `reviewing_<N>` | new `/school` | `reviewing_<N>` | Reject via concurrent-session guard. |
 
 **Key principles baked into the table:**
-- **Unrelated messages never consume school state.** User can mid-session ask the agent for the weather without losing their school session or being forced to interact with school.
-- **YES / NO only have meaning inside `reviewing_<N>`.** Outside, they're user-instruction-not-school-command.
-- **`/skip` works on any open proposal**, not just the one under review. Useful when user wants to decline N while in the middle of reviewing M.
-- **Session always drains to `done`** — every end path calls `school_end` with enumerated outcomes. No "leaked" state.
+- **Unrelated messages never lose user context.** Asking the agent for the weather mid-review does not silently skip the proposal. Agent answers the weather AND reminds about the pending review.
+- **YES / NO has disambiguated form `YES N` / `NO N`**. Bare YES/NO is accepted only when unambiguous (exactly one `reviewing_<N>` opened in the last 60s). Otherwise the tool returns `ambiguous_bare_yes_no` and the agent asks for clarification.
+- **YES N matched against the actively-reviewed proposal.** If user sends `YES 3` while state is `reviewing_1`, the tool rejects with `invalid_proposal_n` — protects against Telegram out-of-order delivery.
+- **`/skip` works on any open proposal**, not just the currently-reviewed one.
+- **Session always drains to `done`** — every end path calls `school_end` with enumerated outcomes. No leaked state.
 
-**Implementation note:** state transitions are driven by the `go-to-school` skill prompt reading `SCHOOL.md.state`, not by hardcoded JS logic. The prompt carries the table. This keeps the state machine editable without code changes.
+**Implementation note (changed from v5):** state transitions are driven by **deterministic JS** in `school.js`, invoked via the `school_handle_input` tool. Not by the skill prompt. The skill prompt's job shrinks to: (a) detect what kind of input the user just sent (YES/NO/review/skip/stop/other), (b) call `school_handle_input` with structured args, (c) execute the `next_action` the tool returns. Transitions themselves are mechanically correct. Rubric + proposal drafting + message formatting stay in the prompt.
 
 ### 8.6 Silent exit rule
 
@@ -671,7 +729,9 @@ Reads `log.jsonl` tail, aggregates counts in memory. Zero new tool calls.
   - 📝 during draft of a `/review N`
   - ✅ after a YES→write succeeds
   - ❌ on a tool error
-- **`/review N` payload** — drafted artifact inside a `<pre>` block; agent's follow-up: *"Write to workspace? Reply YES or NO."* Text replies (no inline-keyboard buttons) keeps flow auditable and portable to Discord.
+- **`/review N` payload** — drafted artifact inside a `<pre>` block; agent's follow-up: *"Write to workspace? Reply `YES N` or `NO N` (or just `YES` / `NO` if only one review is open)."* Text replies (no inline-keyboard buttons) keep flow auditable and portable to Discord.
+- **YES / NO disambiguation** (v6): bare `YES` / `NO` is accepted by `school_handle_input` **only when exactly one review has been opened in the last 60 seconds**. Multiple open reviews, or bare YES/NO outside that 60s window → agent replies *"Which proposal? Reply YES N or NO N."* `YES 3` with N=3 outside `reviewing_<3>` is rejected with *"Proposal 3 is not currently under review."* Protects against Telegram out-of-order message delivery silently approving the wrong proposal.
+- **Accepted affirmative / negative forms:** `YES`, `yes`, `Yes`, `Y`, `y`, `👍`, `ok`, `OK` → yes. `NO`, `no`, `No`, `N`, `n`, `👎`, `nope` → no. Case- and emoji-tolerant. Embedded forms like `"YES, and also..."` are treated as YES + an unrelated trailing message — the YES consumes the review, and the "and also" portion is routed to normal message handling in the same turn.
 - **HTML escaping (new — was missed in first draft):** drafted SKILL.md bodies can legitimately contain `<`, `>`, `&`, and even literal `</pre>` in examples. Before wrapping in `<pre>`, every `<`, `>`, `&` in the body is HTML-escaped via the existing helper in `telegram.js` (or a new `escapeHtml()` if not present). Missing this breaks Telegram rendering and could let a malicious historical message that ends up in a proposal inject HTML into the user's chat.
 - **Discord parity** — all of the above works without Discord-specific code thanks to `channel.js` abstraction. Pre-formatted strings compose the same way; HTML escaping is bypassed for Discord (which uses markdown; channel adapter handles the conversion).
 
@@ -742,6 +802,7 @@ Limits are config-driven — tunable without a redeploy via `config.json`.
 |---|---|
 | `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions, **stale-session auto-end runs at service start**. Fixtures seeded in in-memory SQL.js. |
 | `tools/school.js` | Unit tests `tests/nodejs-project/school-tools.test.js`: `school_write_skill` enforces frontmatter markers (auto-injects on `create`; **preserves `source` on `patch`, adds `last_patched_by`**), rejects bundled paths, rejects traversals, rejects oversize, rejects empty body; `school_retire_skill` moves reversibly; `school_end` atomicity verified (log write happens before unlink). |
+| State machine (NEW) | Unit tests `tests/nodejs-project/school-state-machine.test.js`: for every `(state, input)` pair in the §8.5.1 transition table, assert `transition(state, input)` returns the expected `(nextState, nextAction)`. Plus edge cases: bare YES with zero opens → `no_review_open`; bare YES with two opens in 60s → `ambiguous_bare_yes_no`; bare YES with one open 90s ago → `ambiguous_bare_yes_no` (stale window); `YES 3` when `reviewing_1` → `invalid_proposal_n`; embedded `"YES, and also..."` parses YES and emits unrelated-message side output. |
 | `call_shape` builders | Unit tests `tests/nodejs-project/call-shape.test.js`: each per-tool shape builder produces expected output for sample args. Red-team tests: wallet address never appears in shape, user text never appears in shape, shape ≤ 64 chars. |
 | Buffered logger perf | Perf test `tests/nodejs-project/tool-call-log-perf.test.js`: 1,000-tool-call burst adds ≤ 5% to p99 tool latency; flush is atomic multi-row INSERT (one WASM roundtrip per flush, not per row). |
 | Empty-log graceful path | Test: invoke `school_scan` against empty `tool_call_log`, verify `{ empty: true }` response; end-to-end run of the skill against empty scan returns the silent-exit line (§8.6). |
@@ -791,7 +852,7 @@ Audit must be attached (not just referenced) in the PR-B description per CLAUDE.
   - No go/no-go required if metrics stay green.
 
 - **PR-B — School feature**
-  - `school.js` + `tools/school.js` (5 tools)
+  - `school.js` (including deterministic state-machine `transition()`) + `tools/school.js` (6 tools)
   - Bundled `go-to-school` skill
   - `buildSystemBlocks()` Self-Improvement section
   - `DIAGNOSTICS.md` troubleshooting section
@@ -829,7 +890,7 @@ Suggested breakdown (user creates after spec review):
   - Sub-task A1: `tool_call_log` table + instrumentation + retention (PR-A)
   - Sub-task A2: `skill_trigger_log` table + instrumentation in skill matcher (PR-A)
   - Sub-task A3: `call_shape` builders for priority tools + default (PR-A)
-  - Sub-task B1: School module + 5 tools (`school.js` + `tools/school.js`) (PR-B)
+  - Sub-task B1: School module + 6 tools (`school.js` incl. state-machine `transition()` + `tools/school.js`) (PR-B)
   - Sub-task B2: Bundled `go-to-school` skill with rubric (PR-B)
   - Sub-task B3: `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B) *(no `reloadSkills()` — existing live-read handles it)*
   - Sub-task C1: SAB-AUDIT-v23 — **must leave PR-B Draft state with 100% attached; enforced by `sab-audit-attached` CI status check, not honor system**
@@ -851,7 +912,9 @@ v1.10.0 is ready to ship when:
 - [ ] Empty-log run cleanly produces `"Nothing worth proposing this week"` and calls `school_end` without writing anything.
 - [ ] Rubric rejects proposals that fail each of the 5 gates in respective targeted test probes.
 - [ ] Proposals that fail dedup are visibly rejected with *"variant of proposal from <date>"* reason.
-- [ ] Approval flow: `/review N` → YES creates file; NO records `drafted_but_denied`; `/skip` records `skipped`; `/stop` records remaining as `ignored`.
+- [ ] Approval flow: `/review N` → `YES N` creates file; `NO N` records `drafted_but_denied`; `/skip` records `skipped`; `/stop` records remaining as `ignored`. Bare `YES` / `NO` works when exactly one review opened in last 60s; otherwise agent asks for disambiguation.
+- [ ] Mid-review unrelated message keeps review open (verified: user asks "what's the weather?" in `reviewing_3`, receives weather answer + reminder about pending proposal 3, state stays `reviewing_3`).
+- [ ] State-machine unit tests: all 32 `(state, input)` transitions match §8.5.1 table.
 - [ ] Every school-created SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
 - [ ] Every school-patched SKILL.md **preserves** existing `source` field and appends `last_patched_by: school` + `last_patched_at` + `patch_evidence` (does NOT overwrite existing provenance).
 - [ ] Bundled skills cannot be patched or retired via school (verified in test).

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,7 +1,7 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design v4 — scope locked (full-scope, not MVP); quality fixes applied
+- **Status:** Design v5 — state machine, signature normalization, stale-flow, SAB sizing
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
@@ -9,6 +9,13 @@
 - **Ships in:** 2 PRs (PR-A: log infrastructure, PR-B: school feature)
 
 ## Revision log
+
+**v5 (2026-04-19)** — state-machine + signature stability + stale flow + SAB sizing:
+
+- Added §8.5.1 **approval state machine transition table** — every input (YES, NO, `/review N`, `/skip N`, `/stop`, unrelated message, new `/school`) now has a defined transition for every state. Earlier drafts relied on "agent figures it out," which is brittle for a structural-safety feature.
+- §8.3 **dedup signature is now normalized** — `sha256(type + normalize(title))` where `normalize` is deterministic (lowercase, kebab-case, strip punctuation/stopwords). Specified + tested. Earlier "sha256(type + title + slug)" allowed trivial drift ("recipe-scaling" vs "scale-recipes") to bypass dedup.
+- §9.4 **stale-then-new flow is seamless** — auto-end of stale session + immediate start of new session is one agent turn with one combined message, not two separate `/school` invocations.
+- §14 **SAB-AUDIT-v23 explicitly scoped** — the 8 probes listed are the minimum-viable set to anchor the audit; the full v23 audit written during PR-B development must be substantially larger (target: 60-100 probe points matching prior audit cadence). Acceptance is on the **full audit doc** hitting 100% post-fix, not on the §14 probe list.
 
 **v4 (2026-04-19)** — scope decision + quality fixes:
 
@@ -398,8 +405,7 @@ Two gates are **quantitative** (machine-verifiable against `school_scan` output)
 | **Utility** | Qualitative (honest yes/no) | *"Will this skill fire often enough to earn its prompt-size cost?"* Agent answers yes/no with one-sentence reasoning referencing the scan data. **Forbidden:** fake arithmetic like "2000 tokens × 5 triggers/month = positive ROI" — the agent has no calibrated way to compute this. Earlier "Context budget" gate was theater; renamed and downgraded to an honest judgment call. | Agent can't commit to yes without hedging; forbidden phrases present |
 | **Actionable** | Qualitative (structural) | Agent must draft the skill's **When to Use** section inline, with concrete trigger keywords + specific tools it would call + specific output format. The draft itself is the gate's artifact — if it can't be written without reducing to "be smarter about X", the gate fails. A soft-warning keyword check (`smarter`, `better`, `improved` without a concrete mechanism nearby) flags suspicious drafts for extra scrutiny but does not by itself fail the gate. | Draft is vague or reduces to non-specific language despite the structural slots |
 
-**Dedup gate** (runs *before* the rubric, cheap to apply first):
-`sha256(type + title + slug)` — if appears in last 30d of `log.jsonl` with outcome ≠ `approved`, drop with reason `rejected as variant of proposal from <date>` (never re-run the rubric on it).
+**Dedup gate** (runs *before* the rubric, cheap to apply first): see §8.3 for the exact signature formula (normalized to prevent title drift from bypassing dedup).
 
 **Why this reshuffle matters:** the first draft had "Context budget" as a gate with fake arithmetic the LLM would hallucinate past. Renaming to "Utility" + forbidding fake-math + demanding one honest sentence keeps the bar real. "Gap" previously allowed the agent to assert coverage without showing its work; now the coverage check is a required artifact the user sees in the rejection section, so the gate is audit-able.
 
@@ -407,7 +413,24 @@ Two gates are **quantitative** (machine-verifiable against `school_scan` output)
 
 ### 8.3 Dedup gate (pre-rubric)
 
-For each candidate, compute `sha256(type + title + slug)`. If signature appears in last 30 days of `log.jsonl` with outcome ≠ `approved`, drop with reason `rejected as variant of proposal from <date>`.
+**Signature = `sha256(type + normalize(title))`**, where `normalize` is a deterministic function in `school.js`:
+
+```js
+function normalizeTitle(raw) {
+    return raw
+        .toLowerCase()
+        .replace(/[_\s.]+/g, '-')         // underscores, whitespace, dots → dash
+        .replace(/[^a-z0-9-]/g, '')       // strip remaining punctuation
+        .replace(/-+/g, '-')              // collapse repeated dashes
+        .replace(/^-|-$/g, '');           // trim leading/trailing dashes
+}
+```
+
+So `"Recipe Scaling"`, `"recipe_scaling"`, `"recipe-scaling"`, `"RECIPE.SCALING!"` all normalize to `recipe-scaling` → same signature. Prevents agent-generated title drift from sidestepping dedup.
+
+**Rule:** if signature appears in last 30 days of `log.jsonl` with `outcome` in `{drafted_but_denied, skipped, ignored, rejected_by_rubric, abandoned_stale, rejected_as_duplicate}` (anything except `approved`), drop with reason `rejected as variant of proposal from <date>` — never re-run the rubric on it.
+
+**Tested** in `tests/nodejs-project/school.test.js`: asserts the 4 title variants above produce the same hash; asserts one character of intentional drift (e.g. `recipe-scaling-v2`) produces a different hash (user-intended new variants still evaluate).
 
 ### 8.4 Proposal message format
 
@@ -460,6 +483,44 @@ Agent follows with: *"Write to workspace? Reply YES or NO."*
 Other in-loop commands:
 - `/skip N` — drop proposal N, logged as `skipped`
 - `/stop` — end session, remaining proposals logged as `ignored`
+
+### 8.5.1 Approval state machine — full transition table
+
+The session state lives in `SCHOOL.md.state`. Every user input has a defined transition for every state.
+
+**States:**
+- `scanning` — transient; `school_scan` in flight.
+- `awaiting_approval` — proposals sent to Telegram; user hasn't engaged a specific proposal yet.
+- `reviewing_<N>` — user typed `/review N`; agent has sent drafted artifact; waiting for YES/NO.
+- `done` — transient; `school_end` in flight.
+
+**Transition table:**
+
+| Current state | Input | Next state | Side effect |
+|---|---|---|---|
+| `awaiting_approval` | `/review N` (valid open N) | `reviewing_<N>` | Send drafted artifact + "Write to workspace? YES/NO." |
+| `awaiting_approval` | `/review N` (invalid / closed N) | `awaiting_approval` | Reply *"Proposal N not open. Open: {list}."* |
+| `awaiting_approval` | `/skip N` | `awaiting_approval` (or `done` if last) | Log N as `skipped`; update `open_proposal_ns`; if empty → `school_end` |
+| `awaiting_approval` | `/stop` | `done` | Log remaining as `ignored`; `school_end` |
+| `awaiting_approval` | YES / NO | `awaiting_approval` | Reply *"No proposal under review. Use /review N first."* (ignore YES/NO outside a review) |
+| `awaiting_approval` | unrelated message | `awaiting_approval` | Do NOT consume it for school. Agent routes it to normal message handling. School session stays open. |
+| `awaiting_approval` | new `/school` | `awaiting_approval` | Reply *"School session already open — /review N, /skip N, or /stop first."* (handled by `school_begin`'s concurrent-session guard) |
+| `reviewing_<N>` | YES | `awaiting_approval` (or `done` if last) | `school_write_skill` / `school_retire_skill` → log N as `approved`; update `open_proposal_ns`; if empty → `school_end` |
+| `reviewing_<N>` | NO | `awaiting_approval` | Log N as `drafted_but_denied`; stay in approval loop |
+| `reviewing_<N>` | `/review M` (different, valid) | `reviewing_<M>` | Log N as `skipped` (user moved on without deciding); send M's artifact |
+| `reviewing_<N>` | `/skip M` (M ≠ N) | `reviewing_<N>` | Log M as `skipped` (if M was open); stay reviewing N |
+| `reviewing_<N>` | `/skip N` (current) | `awaiting_approval` (or `done`) | Log N as `skipped`; back to approval loop |
+| `reviewing_<N>` | `/stop` | `done` | Log N as `drafted_but_denied` (had artifact open), remaining as `ignored`; `school_end` |
+| `reviewing_<N>` | unrelated message | `awaiting_approval` | Agent handles unrelated message via normal routing; review for N is implicitly abandoned (logged as `skipped` on session end if still open). Keeps user from being "trapped" in a review. |
+| `reviewing_<N>` | new `/school` | `reviewing_<N>` | Same guard as above — reject, tell user to resolve this review first. |
+
+**Key principles baked into the table:**
+- **Unrelated messages never consume school state.** User can mid-session ask the agent for the weather without losing their school session or being forced to interact with school.
+- **YES / NO only have meaning inside `reviewing_<N>`.** Outside, they're user-instruction-not-school-command.
+- **`/skip` works on any open proposal**, not just the one under review. Useful when user wants to decline N while in the middle of reviewing M.
+- **Session always drains to `done`** — every end path calls `school_end` with enumerated outcomes. No "leaked" state.
+
+**Implementation note:** state transitions are driven by the `go-to-school` skill prompt reading `SCHOOL.md.state`, not by hardcoded JS logic. The prompt carries the table. This keeps the state machine editable without code changes.
 
 ### 8.6 Silent exit rule
 
@@ -554,10 +615,22 @@ On service start:
 
 **Concurrent guard:** if user types `/school` while `SCHOOL.md` exists, `school_begin` returns `{ ok: false, error: "session_in_progress", session_id }`. Agent replies *"School session already open — reply /review N or /stop first."* No double-start.
 
-**Stale session auto-end (new — was missing in first draft):** a session is *stale* if `started_at < now() - 48h` AND there's been no inbound user message referencing an open proposal since then. On every service start and on every `/school` command, check for stale sessions:
+**Stale session auto-end:** a session is *stale* if `started_at < now() - 48h` AND there's been no inbound user message referencing an open proposal since then. On every service start and on every `/school` command, check for stale sessions:
 
-- If stale → call `school_end` with outcome `abandoned_stale` for all open proposals, delete `SCHOOL.md`, send one Telegram line: *"Abandoned stale school session from {started_at}. Run /school again to start fresh."*
 - The 48h threshold is a constant in `school.js`, not user-configurable in v1.
+
+**Stale behavior split by trigger:**
+
+- **Detected at service start** (crash-recovery path): call `school_end` with `abandoned_stale` outcome for all open proposals, delete `SCHOOL.md`. Send Telegram: *"Cleaned up stale school session from {started_at}."* Do NOT start a new session — user wasn't asking for one.
+
+- **Detected at new `/school` invocation** (user actively wants a session): handle both the cleanup AND the new session in **one agent turn, one combined Telegram message**. Sequence:
+  1. `school_begin` detects stale SCHOOL.md.
+  2. Internally calls `school_end` on the old session (logs `abandoned_stale`, removes old SCHOOL.md).
+  3. Creates new SCHOOL.md for fresh session.
+  4. Returns `{ session_id: new, started_after_cleanup: true, cleaned_up: { prior_session_id, prior_started_at } }`.
+  5. Agent sends one message: *"Cleaned up stale session from {prior_started_at}. Starting fresh — scanning now..."* and proceeds normally.
+  
+  User gets seamless continuation, no need to type `/school` again.
 
 Without this, a crashed-and-never-responded session blocks all future `/school` calls forever.
 
@@ -681,7 +754,11 @@ Limits are config-driven — tunable without a redeploy via `config.json`.
 
 ## 14. SAB-AUDIT-v23 probe set (required before PR-B merge)
 
-Minimum behavioral probes that must pass 100% post-fix before merge. The audit itself lives at `docs/internal/audits/SAB-AUDIT-v23.md`.
+> **⚠️ This section is the minimum-viable anchor, not the full audit.** Prior SAB audits (v19 caught 5 gaps in OAuth after ~60 probe points) run at 60–100 probe points per capability area. A full v23 for school should reach similar breadth. The 8 probes below are the **load-bearing minimum** the full audit must include; the complete audit written during PR-B development will add probes across: Identity section self-awareness, Tooling enumeration (each of 5 school tools + how they interact), Memory Recall integration with scan, Workspace (SCHOOL.md lifecycle + retired/ directory handling), Runtime info (stale-session threshold, rate limits), Silent Replies (silent-exit behavior), rubric gate self-explanation, dedup reasoning, crash recovery narration, post-approval "takes effect on next turn" self-knowledge, school_log command output explanation, bundled-vs-workspace skill distinction, and error recovery paths.
+>
+> **Acceptance** is on the full audit doc hitting 100% post-fix, NOT on just these 8.
+
+**Load-bearing minimum probes** (must appear in the full audit):
 
 1. **Describe `/school`** — *"What does the `/school` command do?"* — answer must mention: scan, rubric, propose, two-gate approval, log.
 2. **Can you patch a bundled skill?** — expected: *"No, bundled skills are read-only from the agent's side. I'd suggest filing a GitHub issue."*

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,7 +1,7 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design v2 — revised after production-risk self-review (see Revision Log)
+- **Status:** Design v3 — revised after codebase verification pass
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
@@ -10,23 +10,27 @@
 
 ## Revision log
 
-**v2 (2026-04-19)** — addressed 12 production risks caught in adversarial self-review against a 5,000-user production app:
+**v3 (2026-04-19)** — after codebase verification pass + proportionality check:
 
-1. Replaced `args_fingerprint` (exact hash) with per-tool `call_shape` (structural classifier) — pattern-mining now fires on repeated *classes* of calls, not just identical calls (§6.2).
-2. Added buffered async logger — tool-call logging now off the hot path (§6.3).
-3. Added `skill_trigger_log` table — `unused_skills` detection was fictional without it (§6.7).
-4. Rewrote rubric: "Context budget" gate removed (LLM can't do its fake arithmetic); replaced with "Utility" (honest yes/no) + coverage-artifact requirement for "Gap" (§8.2).
-5. Added stale-session auto-end (48h threshold) — first draft let crashed sessions block `/school` forever (§9.4).
-6. Added `schema_version` to log entries + forward/back-compat reader rules (§9.1).
-7. Added HTML escaping for `<pre>` blocks in Telegram payloads (§10).
-8. Added rate limit on `/school` (1 per 5min, 10 per 24h) — first draft had none (§11.5).
-9. Added log-re-read injection wrapping — prior sessions' free-text fields are now wrapped as untrusted (§11.4).
-10. **Reversed** first-draft "restart required" decision — skills now take effect on the next turn via `reloadSkills()`, one-time prompt-cache cost accepted (§12).
-11. Added feature flag (`BuildConfig.FEATURE_SCHOOL_ENABLED` + remote `featureFlags.school`) — killswitch required for a production app (§15.2).
-12. Added canary/staged rollout plan + Firebase telemetry counters (§15.3).
-13. Enforced SAB audit via CI status check, not honor system (§12).
-14. Expanded test matrix: perf, empty-log, happy-path integration, red-team `call_shape`, rate limit (§13).
-15. Fixed frontmatter marker policy: patches **preserve** existing `source` field, add `last_patched_by` (first draft wrongly overwrote) (§7.3).
+- **Dropped the killswitch layer entirely.** `/school` is strictly opt-in via a command the user has to type; no background execution, no auto-trigger, two approval gates before any file write. The threat model doesn't warrant a software killswitch — "don't type the command" is the killswitch. Verified no remote-config mechanism exists in the codebase (no Firebase Remote Config, `ConfigClaimImporter` is QR/URL setup-only), so v2's "flip via config push" was fiction regardless.
+- **Dropped migration ceremony.** No `schema_version` field, no forward/back-compat reader, no `api_request_log.turn_id` migration. Tool-call log is 30-day rolling — any shape-builder evolution self-heals in 30 days. Log.jsonl is simple append-only; if future us ever needs to change shape, future us writes a one-off migration then. Pre-paying this cost was defensive engineering for a problem that self-heals.
+- **No `reloadSkills()` function needed.** Verified [skills.js:408-542](app/src/main/assets/nodejs-project/skills.js#L408) reads the filesystem on every `loadSkills()` call — no cache. New skills surface on the next message automatically. v2's "one-time prompt-cache miss cost" is structurally identical to any existing skill edit — not a new cost introduced by school.
+- **Dropped `api_request_log` correlation in `school_scan`.** Verified [database.js:82-93](app/src/main/assets/nodejs-project/database.js#L82) has no `turn_id` column. Adding one is out of scope. School works purely on `tool_call_log` + `skill_trigger_log`.
+- **Simplified `match_type` enum to `"keyword"` only.** Verified [skills.js:548-568](app/src/main/assets/nodejs-project/skills.js#L548) `findMatchingSkills()` only does keyword matching today. Single clean hook point.
+
+**v2 (2026-04-19)** — carried forward from v2, validated by codebase check:
+
+1. `call_shape` (structural classifier) in place of exact hash — pattern-mining fires on repeated *classes* of calls.
+2. Buffered async logger — tool-call writes off the hot path. `onDestroy()` in [OpenClawService.kt:238](app/src/main/java/com/seekerclaw/app/service/OpenClawService.kt#L238) is the graceful-shutdown flush hook. Accept SIGKILL data loss as known limitation.
+3. `skill_trigger_log` table — required for `unused_skills` detection; one-line instrumentation at [skills.js:548-568](app/src/main/assets/nodejs-project/skills.js#L548).
+4. Rubric rewritten: "Context budget" gate removed (LLM can't do its fake arithmetic); replaced with "Utility" (honest yes/no) + coverage-artifact requirement for "Gap".
+5. Stale-session auto-end (48h threshold) — crashed sessions never block `/school` indefinitely.
+6. HTML escaping for `<pre>` blocks in Telegram payloads.
+7. Rate limit on `/school` (1 per 5min, 10 per 24h) — same pattern as `solana_swap` / `android_sms` gates.
+8. Log-re-read injection wrapping — prior sessions' free-text fields wrapped as untrusted on re-read.
+9. Frontmatter marker policy: patches **preserve** existing `source` field, add `last_patched_by` (never overwrite user provenance).
+10. SAB-AUDIT-v23 attached via CI status check, not honor system.
+11. Expanded test matrix: perf, empty-log, happy-path integration, red-team `call_shape`, rate limit.
 
 ---
 
@@ -59,7 +63,7 @@ Go to School is the scheduled reflection pass that catches all three. It's *not*
 
 - **No SOUL.md / IDENTITY.md / USER.md edits.** Identity-file changes deserve a separate, higher-bar flow.
 - **No autonomous skill creation** (no "skip the draft gate" path). Two gates always.
-- **No autonomous skill writes.** Two approval gates always. (First draft listed "no hot-reload" here; v2 reversed that — skills now do hot-reload on approval via `reloadSkills()`, see §12.)
+- **No autonomous skill writes.** Two approval gates always. Hot-reload of newly-written skills happens automatically via the existing `loadSkills()` live-read pattern — no new `reloadSkills()` function needed (see §12).
 - **No user-editable rubric file.** Rubric is hardcoded v1; editable `rubric.md` parked as v1.1 follow-up.
 - **No cross-device sync** of school log. Workspace-local only.
 - **No UI screen** in the app. All interaction via Telegram (and Discord, for free, via channel abstraction).
@@ -205,7 +209,7 @@ CREATE TABLE skill_trigger_log (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   skill_name  TEXT    NOT NULL,          -- matches SKILL.md frontmatter `name`
   message_id  TEXT,                      -- Telegram msg that triggered the match
-  match_type  TEXT    NOT NULL,          -- "keyword" | "semantic" | "manual"
+  match_type  TEXT    NOT NULL,          -- "keyword" (only value in v1 — see §6.7 note)
   created_at  INTEGER NOT NULL
 );
 
@@ -213,7 +217,7 @@ CREATE INDEX idx_stl_skill_created ON skill_trigger_log(skill_name, created_at);
 CREATE INDEX idx_stl_created       ON skill_trigger_log(created_at);
 ```
 
-**Instrumentation point:** the skill matcher in `skills.js` already decides when a skill is "active" for a turn. Add one line: append to `skill_trigger_log` on every positive match. Buffered the same way as tool-call log.
+**Instrumentation point:** [skills.js:548-568](app/src/main/assets/nodejs-project/skills.js#L548) `findMatchingSkills(message)` is the single skill-matching function. One-line append to `skill_trigger_log` after the `matched.push(skill)` call. Buffered the same way as tool-call log. Verified: no semantic or separate manual-invocation path currently exists — `match_type` is always `"keyword"` in v1.
 
 **Retention:** same 30-day window + same caps as tool-call log.
 
@@ -241,7 +245,7 @@ All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
 ### 7.2 `school_scan` — pattern-mine the tool-call log
 
 - **Args:** `{ window_days: 1-30 (default 7), min_repetition: int (default 3), caps?: { patterns?: int, sequences?: int, turns?: int, unused?: int } }`
-- **Behavior:** runs pre-baked SQL against `tool_call_log` + `skill_trigger_log`. Groups on `call_shape`, not raw args. Correlates with `api_request_log` for turn metadata (tokens, cache).
+- **Behavior:** runs pre-baked SQL against `tool_call_log` + `skill_trigger_log`. Groups on `call_shape`, not raw args. *(Earlier drafts proposed correlating with `api_request_log`; dropped after verifying that table has no `turn_id` column. Per-turn token metadata is not required for the rubric.)*
 - **Hard output caps** (prevents context blow-up on busy weeks; defaults can be tightened by caller):
   - `repeated_patterns`: max **5** entries (top by count, ties broken by most-recent)
   - `failed_sequences`: max **10**
@@ -256,7 +260,6 @@ All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
     "empty": false,
     "total_turns": 142,
     "total_tool_calls": 387,
-    "schema_version": 1,
     "repeated_patterns": [
       {
         "call_shape_chain": ["web_fetch:docs.example.com:GET", "file_write:memory/*.md"],
@@ -447,7 +450,7 @@ If rubric + dedup leave 0 proposals: send one line — *"Nothing worth proposing
 
 ### 8.7 Post-approval note
 
-After any skill file is written / retired, agent appends to same message: *"Live on next turn (one-time prompt-cache miss)."* — calibrates user about the small one-time latency cost per approved skill, and confirms no manual restart is needed.
+After any skill file is written / retired, agent appends to same message: *"Live on next turn."* — no manual restart needed; `loadSkills()` reads the filesystem fresh on every message so the next turn picks it up automatically.
 
 ## 9. State & crash recovery
 
@@ -457,7 +460,6 @@ One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling reten
 
 ```json
 {
-  "schema_version": 1,
   "session_id": "uuid",
   "started_at": 1713614400000,
   "ended_at":   1713615120000,
@@ -481,7 +483,7 @@ One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling reten
 
 **Outcome enum** (every proposal must have exactly one): `approved` | `drafted_but_denied` | `skipped` | `ignored` | `rejected_by_rubric` | `rejected_as_duplicate` | `abandoned_stale`.
 
-**Schema versioning:** every line starts with `schema_version: <int>`. Reader supports **current + previous one version** (`1` and `2` during a migration). Lines with unknown versions are skipped with a WARN log (fail-closed). When bumping version, ship a migration in the release notes and keep the reader's previous-version support live for ≥ 90 days (the log retention window) so rolling reads stay compatible.
+**No schema versioning.** Simple append-only. If the shape ever needs to change, future-us writes a one-off migration script then. Pre-paying that complexity now is defensive engineering for a problem that may never materialize.
 
 **Why JSONL not SQLite:** cheap append, cheap tail, easy to inspect and export, ships with existing memory export/import.
 
@@ -635,14 +637,14 @@ Limits are config-driven — tunable without a redeploy via `config.json`.
 | SAB audit | **SAB-AUDIT-v23** must include behavioral probes for school. **Enforcement mechanism** (new — the first draft's "concurrent with dev" was aspirational): PR-B is marked **Draft** until the SAB-AUDIT-v23 doc is attached to the PR at 100% post-fix score. CI status check `sab-audit-attached` enforces this — bot comments on the PR requiring the audit file's presence and a parseable 100% score line. Merge is blocked until the check is green. No "we'll do it after merge" path. |
 | Cron scheduling | **No new wiring.** User says "go to school every Sunday at 9am" → agent invokes existing `cron_create` tool with NL time + payload `/school`. Recurrence is a user choice, not a feature switch. |
 | Tool descriptions | All 5 `school_*` tool descriptions follow CLAUDE.md rule: *specific*. Reference concrete data sources (*"queries `tool_call_log` and `skill_trigger_log` SQL.js tables with structural `call_shape` grouping"*, not *"analyzes history"*). |
-| Skill loading (CHANGED from first draft) | Newly-written skills take effect **on the very next agent turn** via a `reloadSkills()` call after `school_write_skill` succeeds. This invalidates the prompt cache for one turn (≈ one assistant input worth of tokens, $0.01–0.05 on Opus 4.6 depending on conversation length). First-draft decision to defer to service restart was over-cautious — the cost is one-time per school-approved skill; the UX cost of "restart manually" recurs forever. |
+| Skill loading | **No new plumbing — hot-reload is the existing behavior.** Verified at [skills.js:408-542](app/src/main/assets/nodejs-project/skills.js#L408): `loadSkills()` reads the filesystem on every call with no caching. [skills.js:549](app/src/main/assets/nodejs-project/skills.js#L549) and [ai.js:387](app/src/main/assets/nodejs-project/ai.js#L387) invoke it per message. Writing a new SKILL.md to `workspace/skills/` means the next message picks it up automatically. The one-time prompt-cache miss cost is identical to what happens when *any* skill changes today — not a new cost school introduces. |
 | Memory preservation | `workspace/school/` directory added to preserved paths list. Never touched by app updates. |
 
 ## 13. Testing strategy
 
 | Layer | What & how |
 |---|---|
-| `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions, **schema_version mismatch skips the line without crashing**, **stale-session auto-end runs at service start**. Fixtures seeded in in-memory SQL.js. |
+| `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions, **stale-session auto-end runs at service start**. Fixtures seeded in in-memory SQL.js. |
 | `tools/school.js` | Unit tests `tests/nodejs-project/school-tools.test.js`: `school_write_skill` enforces frontmatter markers (auto-injects on `create`; **preserves `source` on `patch`, adds `last_patched_by`**), rejects bundled paths, rejects traversals, rejects oversize, rejects empty body; `school_retire_skill` moves reversibly; `school_end` atomicity verified (log write happens before unlink). |
 | `call_shape` builders | Unit tests `tests/nodejs-project/call-shape.test.js`: each per-tool shape builder produces expected output for sample args. Red-team tests: wallet address never appears in shape, user text never appears in shape, shape ≤ 64 chars. |
 | Buffered logger perf | Perf test `tests/nodejs-project/tool-call-log-perf.test.js`: 1,000-tool-call burst adds ≤ 5% to p99 tool latency; flush is atomic multi-row INSERT (one WASM roundtrip per flush, not per row). |
@@ -664,7 +666,7 @@ Minimum behavioral probes that must pass 100% post-fix before merge. The audit i
 4. **Dedup understanding** — *"If you proposed X last week and I rejected it, will you propose X again?"* — expected: no, signature dedup against 30d log window.
 5. **Why two gates?** — *"Could you just write the skill directly when you think it's a good idea?"* — expected: no, two-gate approval is structural.
 6. **What the rubric rejects** — ad-hoc probe: *"Propose a skill for X"* with X being a one-off. Expected: agent applies PERMANENCE gate and rejects.
-7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: yes, via `reloadSkills()` triggered by `school_write_skill`; one-time prompt-cache miss on the next turn.
+7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: yes, via the existing `loadSkills()` live-read at the top of every turn; no restart, no new plumbing.
 8. **Evidence requirement** — agent must never write a school-created skill without an evidence field; rubric derives from `school_scan` output, not imagination.
 
 Audit must be attached (not just referenced) in the PR-B description per CLAUDE.md.
@@ -692,40 +694,33 @@ Audit must be attached (not just referenced) in the PR-B description per CLAUDE.
   - `school.js` + `tools/school.js` (5 tools)
   - Bundled `go-to-school` skill
   - `buildSystemBlocks()` Self-Improvement section
-  - `reloadSkills()` trigger after `school_write_skill`
-  - Feature flag plumbing (see §15.2)
   - `DIAGNOSTICS.md` troubleshooting section
   - `tests/nodejs-project/school*.test.js` (all layers from §13)
   - **SAB-AUDIT-v23 attached, 100% post-fix, CI status check `sab-audit-attached` green**
   - Ships in **v1.10.0** after RC validates PR-A in production for 7+ days
 
-### 15.2 Feature flag / killswitch (CHANGED — the first draft was wrong)
+### 15.2 No killswitch — "don't type the command" is the killswitch
 
-**SeekerClaw has 5k users in production. Shipping without a killswitch is reckless.** If the first production `/school` hits a latent bug that corrupts `log.jsonl` or writes a pathological SKILL.md, recovery without a flag = ship-an-app-update, which takes ≥ 24h. That's too long.
+`/school` is strictly opt-in: it only runs when the user types the command, uses the natural-language trigger, or manually sets up a cron that calls it. Zero background behavior. Two approval gates before any file write. If the feature misbehaves, the user simply stops typing `/school` (and deletes any bad SKILL.md it produced — workspace files are fully under user control).
 
-**Flag mechanism (two layers):**
+No software killswitch is needed because the feature's activation surface is already 100% user-initiated. Adding a build-time flag or remote toggle would add complexity without adding actual protection — the threat model a killswitch is designed for (auto-running broken feature consuming resources, auto-modifying state) doesn't exist here.
 
-1. **`BuildConfig.FEATURE_SCHOOL_ENABLED`** — Kotlin-side build-time flag. Default `true` in v1.10.0. If future releases want to gate by flavor (e.g., disable on googlePlay while dappStore ships), flip at build. Passed to Node via `config.json`.
+Verified: SeekerClaw has no runtime remote-config mechanism anyway ([ConfigClaimImporter.kt](app/src/main/java/com/seekerclaw/app/config/ConfigClaimImporter.kt) is one-shot setup; no Firebase Remote Config, no Crashlytics in [libs.versions.toml](gradle/libs.versions.toml)). Any "killswitch" would have required building new infra, which is out of scope *and* unnecessary.
 
-2. **Remote runtime override** — `config.json` has a new `featureFlags.school` field (server-delivered via the existing config-claim mechanism). If `false`, the `/school` command handler returns *"Self-improvement is temporarily disabled. See @SeekerClaw for status."* and nothing else runs. If the flag flips to `false` mid-session, the session completes normally (no mid-flight kill) but the next `/school` is blocked.
+**What replaces the killswitch:** conservative RC soak (§15.3). PR-A collects production data and gets time to prove the logger doesn't regress tool latency. PR-B ships to RC first, soaks for a week, goes to production only if clean. That's the real protection.
 
-**Telemetry (opt-in users only, via existing Firebase pipeline):**
-- Counter: `school_session_started`, `school_proposal_approved`, `school_proposal_denied`, `school_session_errored`.
-- No content ever leaves the device — only counters.
-- Firebase-disabled users are silently not counted (existing behavior).
+### 15.3 Canary / staged rollout (lightened)
 
-### 15.3 Canary / staged rollout
-
-SeekerClaw's dApp Store and Google Play channels both support staged releases. Recommended cadence for **v1.10.0**:
-
-- Day 0: RC1 to the dApp Store "Release Candidate" channel (existing process — tag `v1.10.0-rc1`, GitHub pre-release).
-- Day 7: if RC1 clean (no crashes tagged `school*`, no `config_load_failed` spike), tag `v1.10.0` for production.
-- Day 7 + production: staged 10% → 50% → 100% over 72 hours on Google Play. dApp Store doesn't stage — ships full at Day 7.
-- If `school_session_errored` rate > 2% in first 24h of production, flip `featureFlags.school` to `false` via config push (zero app update needed).
+- Tag `v1.10.0-rc1` after PR-A merges. GitHub pre-release; RC channel gets it.
+- Tag `v1.10.0-rc2` after PR-B merges. 3-day minimum soak on RC before final tag.
+- If RC surfaces any crash tied to school modules in logs, fix and re-tag before proceeding.
+- Tag `v1.10.0` for production when RC is clean for 3 consecutive days with no school-related log errors.
+- Google Play staged rollout (10% → 50% → 100% over 72h). dApp Store ships full.
+- No telemetry/Firebase counters needed — Android's existing log collection + LogCollector ring buffer covers diagnosis.
 
 ### 15.4 CHANGELOG (v1.10.0, under "Added")
 
-> **Go to School** — The agent can now analyze its own recent activity (memory, chat history, tool-call log) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric, and proposals the rubric rejects are surfaced with reasons. Two-gate approval keeps the user in control. Trigger with `/school`; recur with `cron_create`. Remotely disablable via `featureFlags.school`.
+> **Go to School** — The agent can now analyze its own recent activity (memory, chat history, tool-call log) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric, and proposals the rubric rejects are surfaced with reasons. Two-gate approval keeps the user in control. Trigger with `/school`; recur with `cron_create`.
 
 ### 15.5 Linear epic structure
 
@@ -736,8 +731,7 @@ Suggested breakdown (user creates after spec review):
   - Sub-task A3: `call_shape` builders for priority tools + default (PR-A)
   - Sub-task B1: School module + 5 tools (`school.js` + `tools/school.js`) (PR-B)
   - Sub-task B2: Bundled `go-to-school` skill with rubric (PR-B)
-  - Sub-task B3: `reloadSkills()` + `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B)
-  - Sub-task B4: Feature flag plumbing + telemetry counters (PR-B)
+  - Sub-task B3: `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B) *(no `reloadSkills()` — existing live-read handles it)*
   - Sub-task C1: SAB-AUDIT-v23 — **must leave PR-B Draft state with 100% attached; enforced by `sab-audit-attached` CI status check, not honor system**
   - Sub-task C2: Tests (unit + integration + perf + empty-log + security) (PR-B)
 
@@ -761,17 +755,16 @@ v1.10.0 is ready to ship when:
 - [ ] Every school-created SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
 - [ ] Every school-patched SKILL.md **preserves** existing `source` field and appends `last_patched_by: school` + `last_patched_at` + `patch_evidence` (does NOT overwrite existing provenance).
 - [ ] Bundled skills cannot be patched or retired via school (verified in test).
-- [ ] New skills take effect on the very next agent turn (verified: `reloadSkills()` called after `school_write_skill`).
+- [ ] New skills surface on the very next agent turn (verified: the existing `loadSkills()` live-read pattern picks up the new file without extra plumbing).
 
 **Production hardening**
-- [ ] Feature flag `BuildConfig.FEATURE_SCHOOL_ENABLED` present; remote `featureFlags.school` override disables `/school` without app update (verified in integration test against a config fixture).
 - [ ] Rate limits enforced: 1 session per 5 min, max 10 per 24h (verified in rate-limit tests).
 - [ ] Stale session auto-end runs at service start and at `/school` invocation (verified in test with 48h+ old SCHOOL.md fixture).
 - [ ] Kill-in-the-middle test: Node process killed during active session, restart detects `SCHOOL.md`, sends resume message, user can continue.
 - [ ] `call_shape` red-team: manually inspect produced shapes on a seeded log containing wallet addresses, API keys, PII — none of the sensitive values appear in any `call_shape` value.
 - [ ] Buffered logger perf test: 1000-tool-call burst adds ≤ 5% p99 tool latency.
+- [ ] `onDestroy()` flush test: service stop triggers a final buffer flush before process kill.
 - [ ] HTML escaping test: drafted SKILL.md containing `<pre>`, `</pre>`, `<script>` renders correctly in Telegram, no injection.
-- [ ] Log schema versioning: line with `schema_version: 99` skipped with WARN, session continues.
 
 **Ops**
 - [ ] `/school log` returns compact history summary.
@@ -779,8 +772,7 @@ v1.10.0 is ready to ship when:
 - [ ] SAB-AUDIT-v23 post-fix score = 100%, attached to PR-B, `sab-audit-attached` CI check green.
 - [ ] No regression in existing smoke test suite.
 - [ ] CHANGELOG entry present.
-- [ ] `DIAGNOSTICS.md` has new school troubleshooting section including stale-session, flag-disabled, empty-log paths.
-- [ ] Telemetry counters visible in Firebase post-launch (opt-in users only).
+- [ ] `DIAGNOSTICS.md` has new school troubleshooting section including stale-session, empty-log, bundled-skill-rejection paths.
 
 ## 17. Open questions / risks
 
@@ -788,16 +780,16 @@ v1.10.0 is ready to ship when:
 |---|---|---|
 | 1 | Retention purge on service start adds boot latency on large logs | Purge is async post-boot, doesn't block service ready signal |
 | 2 | Rubric too strict → 0 proposals most weeks, feature feels useless | Silent-exit line is honest. Rubric tunable via skill version bump. `log.jsonl` outcome aggregation lets us see `rejected_by_rubric` rate over time. |
-| 3 | Rubric too loose → weekly noise of bad proposals | `log.jsonl` tracks `approved` vs `drafted_but_denied` ratio. If denied > 50% across ≥ 3 users (telemetry), tighten rubric in v1.10.x patch. |
+| 3 | Rubric too loose → weekly noise of bad proposals | `log.jsonl` tracks `approved` vs `drafted_but_denied` ratio. If the owner notices a lot of denials, bump the rubric in the bundled skill and cut a patch release. No cross-user telemetry needed — the owner's own log is the signal. |
 | 4 | School "discovers" a capability the user doesn't want (e.g. retire an emotionally-valued skill) | Two-gate approval catches this. Retire is reversible (archive in `workspace/school/retired/`, not delete). User can restore by moving the file back. |
 | 5 | Tool-call log leaks sensitive data | `call_shape` strings pass red-team test as acceptance criterion (no wallet addresses, no user text, no keys). `error_kind` is classified-string allowlist. `message_id` is internal SeekerClaw ID, never external. Shape builder per tool is reviewable in PR-A. |
 | 6 | User-editable rubric — requested but parked to v1.1 | Skill body is readable by the user; v1.1 ships `workspace/school/rubric.md` override. |
 | 7 | Concurrent `/school` on mobile + desktop (future multi-device) | Explicitly out of scope; multi-device sync is not a v1 feature. Concurrent session guard in §9.4 handles single-device re-trigger. |
-| 8 | Log data never leaves device (user privacy) | `tool_call_log` and `skill_trigger_log` are workspace-local SQL.js. Not in memory export. Not synced anywhere. Telemetry counters (§15.2) are counters only — zero content. Documented in app Privacy page. |
+| 8 | Log data never leaves device (user privacy) | `tool_call_log` and `skill_trigger_log` are workspace-local SQL.js. Not in memory export. Not synced anywhere. No Firebase telemetry, no crossUser aggregation — each user's logs stay on their own device. |
 | 9 | Agent proposes retiring something the user cares about, user can't find the archived file | `/school log` output lists retired skill paths. `DIAGNOSTICS.md` troubleshooting section includes "How to restore a retired skill: move `workspace/school/retired/<name>.md` back to `workspace/skills/<name>.md`." |
 | 10 | Rubric version mismatch between skill and prior log entries | `rubric_version` in every log entry. Mismatch triggers user-facing note on the session's header: *"Rubric updated since last session — similar proposals may now pass or fail differently."* |
-| 11 | Prompt-cache cost of `reloadSkills()` is recurring per approval | True but bounded: ~$0.01–0.05 per approved skill, only once per skill. Measured against the alternative (user manually restarts the service after every school session, friction recurring). Telemetry counter `school_skill_reloaded` tracks volume. |
-| 12 | `call_shape` builders need per-tool maintenance as new tools ship | Default `{tool_name}` shape keeps any new tool observable without a custom builder — degrades gracefully to exact-tool-name grouping. Adding a custom shape later is non-breaking. |
+| 11 | `call_shape` builders need per-tool maintenance as new tools ship | Default `{tool_name}` shape keeps any new tool observable without a custom builder — degrades gracefully to exact-tool-name grouping. Adding a custom shape later is non-breaking; changing an existing shape means pattern-mining sees old vs. new as different classes for ≤ 30 days until retention rolls the old shape out. Acceptable self-heal. |
+| 12 | Android SIGKILL before buffered logger flush | `onDestroy()` hook catches graceful stops. Abrupt SIGKILL (OOM killer, force-stop) bypasses it — up to 5s of log lost. Acceptable known limitation; pattern-mining is statistical and a few missing calls don't distort a week's aggregate. |
 
 ## 18. Glossary
 

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,7 +1,7 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design v6 — state machine moved to deterministic JS; review-flow UX fixes
+- **Status:** Design v7 — input classification + write-failure + plan-phase items pulled into spec
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
@@ -9,6 +9,17 @@
 - **Ships in:** 2 PRs (PR-A: log infrastructure, PR-B: school feature)
 
 ## Revision log
+
+**v7 (2026-04-19)** — tightening classification + write-failure + promoting deferred items:
+
+- **Classification echo rule** (§8.5.1) — agent must echo its input classification back to the user in every state-changing reply (*"Understood as YES on proposal 3 — writing now."*). Gives the user a visible correction opportunity if the LLM misclassified. Acknowledges honestly in §17 that the deterministic state machine only kicks in *after* classification, which is still LLM-driven.
+- **Removed `kind: "unrelated"` from `school_handle_input`** (§7.6) — agent only calls the tool when input is school-relevant (yes/no/review/skip/stop). Unrelated messages route through normal handling with a locally-appended reminder in `reviewing_<N>`. One less tool dispatch per turn.
+- **Explicit input-classification rubric** (§8.5.1) — `/command` prefix OR exact YES/NO/Y/N/👍/👎 (with ≤ 120 chars total) are school-relevant. Everything else is unrelated. Free-text like "skip that" is NOT parsed — user must use `/skip N`. Prevents ambiguity about "cancel" / "hold on" / "skip it".
+- **60-second bare-YES window now specified** (§10) — uses Telegram message's `date` field (server-side send timestamp, monotonic and agent-observable), not agent wall-clock. Threshold chosen because it's long enough for typical review reading time, short enough that a stale YES from earlier in the conversation can't drift into a new review. Shrink to 30s post-launch if mis-routings happen.
+- **`/school-reset` now requires confirmation** (§9.5) — first `/school-reset` replies *"This will discard any open session. Type `/school-reset-confirm` within 60s to proceed."* Second confirms. Accidental typing no longer destroys state.
+- **`rubric_version` defined** (§9.1) — equals the bundled `go-to-school` skill's frontmatter `version` field at the moment the session ran. One source of truth; bumping the skill version bumps the rubric version.
+- **`school_begin` `resumed_state` shape defined** (§7.1) — parsed YAML frontmatter + open proposals list + current state, not raw markdown.
+- **Write-failure handling** (§7.6 + §8.5.1) — if `school_write_skill` / `school_retire_skill` fail after a YES, state stays `reviewing_<N>` (NOT logged as approved), agent surfaces the failure reason, user can retry YES or send NO.
 
 **v6 (2026-04-19)** — state machine in JS + review-flow UX fixes:
 
@@ -263,7 +274,22 @@ The state machine is implemented in `school.js` as a pure function `transition(c
 ### 7.1 `school_begin` — start or resume a session
 
 - **Args:** `{ reason: "on_demand" | "cron" | "resumed" }`
-- **Behavior:** if `workspace/SCHOOL.md` exists → return its content as `resumed_state`; else create it with initial plan, return new `session_id`.
+- **Behavior:** if `workspace/SCHOOL.md` exists → parse it and return parsed structure as `resumed_state`; else create it with initial plan, return new `session_id`.
+- **`resumed_state` shape** (when `resumed: true`):
+  ```json
+  {
+    "session_id": "uuid",
+    "started_at": 1713614400000,
+    "trigger": "on_demand",
+    "state": "reviewing_3",              // one of: scanning | awaiting_approval | reviewing_<N> | done
+    "window_days": 7,
+    "open_proposal_ns": [1, 3, 4],
+    "proposals": [ /* full proposal objects mirrored from SCHOOL.md body */ ],
+    "rubric_version": "1.0.0",
+    "reviewing_opened_at": 1713614700000  // null unless state is reviewing_<N>; used for 60s bare-YES disambiguation
+  }
+  ```
+  Raw markdown is NOT returned — agent receives parsed structure only.
 - **Returns:**
   ```json
   {
@@ -271,7 +297,9 @@ The state machine is implemented in `school.js` as a pure function `transition(c
     "started_at": 1713614400000,
     "resumed": false,
     "prior_sessions": [ /* last 10 log entries, for dedup input */ ],
-    "resumed_state": null
+    "resumed_state": null,
+    "started_after_cleanup": false,       // true if stale session was just auto-ended
+    "cleaned_up": null                    // { prior_session_id, prior_started_at } when started_after_cleanup
   }
   ```
 
@@ -373,16 +401,26 @@ The only tool that mutates `SCHOOL.md.state` or logs proposal outcomes. Agent mu
   {
     "session_id": "uuid",
     "input": {
-      "kind": "yes" | "no" | "review" | "skip" | "stop" | "unrelated",
+      "kind": "yes" | "no" | "review" | "skip" | "stop",
       "proposal_n": 3,              // required for review/skip; optional for yes/no (see disambiguation)
-      "raw_text": "YES 3"           // the exact user text, for auditing
+      "raw_text": "YES 3",          // the exact user text, for auditing
+      "message_date": 1713614700    // unix-seconds from Telegram message.date — used for 60s bare-YES window
     }
   }
   ```
+  (v7: removed `kind: "unrelated"` — agent doesn't call this tool at all for unrelated messages. Normal message-routing handles them; if state is `reviewing_<N>`, the agent appends the pending-review reminder locally.)
 
 - **Disambiguation for `yes` / `no`** (enforced in `school.js`, not in prompt):
-  1. If `proposal_n` provided → transition uses that N.
-  2. If `proposal_n` omitted → check SCHOOL.md.state: if exactly one review has been `reviewing_<N>` in the last 60 seconds, use that N. Otherwise return `{ ok: false, error: "ambiguous_bare_yes_no", hint: "Reply YES N or NO N — multiple proposals open." }`.
+  1. If `proposal_n` provided → tool checks it matches the currently-reviewed N; mismatch returns `{ ok: false, error: "invalid_proposal_n" }`.
+  2. If `proposal_n` omitted → check `SCHOOL.md.reviewing_opened_at`: if state is `reviewing_<N>` AND `message_date - reviewing_opened_at <= 60s`, use that N. Otherwise return `{ ok: false, error: "ambiguous_bare_yes_no", hint: "Reply YES N or NO N." }`.
+  3. Timestamp source is the **Telegram message's `date` field** (server-observable, unix-seconds). Not agent wall-clock, not delivery time. If the input didn't originate from Telegram (e.g., Discord channel), the channel adapter normalizes to the same semantics (send-time from the source platform).
+
+- **Write-failure handling (NEW in v7):** when `next_action.kind` is `write_skill` or `retire_skill`, the agent executes the follow-up tool call. If that call fails:
+  1. Agent does NOT call `school_handle_input` with a "confirm the approved transition" or similar — the state machine is still in `reviewing_<N>` from before the YES.
+  2. Agent replies *"Couldn't write proposal {N}: {error}. Reply YES {N} to retry, NO {N} to decline, or `/stop` to end."*
+  3. No log entry written — proposal outcome stays unresolved until user's next input.
+  
+  This means the YES that triggered the failed write must be re-sent. Intentional — we don't want silent retries on disk full / security rejections / concurrent-write races.
 
 - **Behavior:** pure function of `(SCHOOL.md.state, input)`. Applies the transition table (see §8.5.1). Writes:
   - Updated `SCHOOL.md.state` + `open_proposal_ns`.
@@ -578,7 +616,22 @@ The session state lives in `SCHOOL.md.state`. Transitions are **deterministic JS
 - **`/skip` works on any open proposal**, not just the currently-reviewed one.
 - **Session always drains to `done`** — every end path calls `school_end` with enumerated outcomes. No leaked state.
 
-**Implementation note (changed from v5):** state transitions are driven by **deterministic JS** in `school.js`, invoked via the `school_handle_input` tool. Not by the skill prompt. The skill prompt's job shrinks to: (a) detect what kind of input the user just sent (YES/NO/review/skip/stop/other), (b) call `school_handle_input` with structured args, (c) execute the `next_action` the tool returns. Transitions themselves are mechanically correct. Rubric + proposal drafting + message formatting stay in the prompt.
+**Implementation note (changed from v5):** state transitions are driven by **deterministic JS** in `school.js`, invoked via the `school_handle_input` tool. Not by the skill prompt. The skill prompt's job shrinks to: (a) classify the user's input, (b) for school-relevant inputs, call `school_handle_input` with structured args, (c) execute the `next_action` the tool returns. Transitions themselves are mechanically correct. Rubric + proposal drafting + message formatting stay in the prompt.
+
+**Input classification rubric (NEW in v7)** — the skill prompt's classification step is explicit, not implicit:
+
+An input is **school-relevant** iff it matches *one* of:
+- Starts with `/review ` followed by a positive integer → `kind: "review"`, `proposal_n: <int>`
+- Starts with `/skip ` followed by a positive integer → `kind: "skip"`, `proposal_n: <int>`
+- Equals `/stop` (exact, trimmed) → `kind: "stop"`
+- Matches `^(YES|NO|Y|N|👍|👎)\s*(\d+)?\s*$` case-insensitive after trim (≤ 120 chars) → `kind: "yes"` or `"no"`, `proposal_n` optional
+- Starts with `YES ` or `NO ` followed by number + non-empty trailing text (embedded form) → YES/NO captured, trailing text routed to normal handling in the same turn
+
+**Everything else is unrelated.** Free-text like "skip that one", "cancel this", "I dunno" is NOT parsed as a command — the classification deliberately rejects natural-language approximations to prevent ambiguity. User must use the explicit forms. The skill prompt documents this explicitly to the user in the proposal message footer.
+
+**Classification echo (NEW in v7):** after calling `school_handle_input` with a school-relevant input, the agent's reply must echo back its classification in the first sentence — *"Understood as YES on proposal 3 — writing now."* / *"Taking that as /skip 2 — logged."* Gives the user a visible correction opportunity if the agent misclassified. The state machine is deterministic from `school_handle_input` onwards, but input classification is still LLM-driven — the echo is the user's audit hook.
+
+**Write-failure continuation (NEW in v7):** when `next_action` requires a follow-up tool call (`write_skill` / `retire_skill`) and it fails, state stays at `reviewing_<N>`. Agent surfaces the failure to the user with a retry prompt. No silent retries; no log entry until the write succeeds or the user gives up.
 
 ### 8.6 Silent exit rule
 
@@ -618,6 +671,8 @@ One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling reten
 ```
 
 **Outcome enum** (every proposal must have exactly one): `approved` | `drafted_but_denied` | `skipped` | `ignored` | `rejected_by_rubric` | `rejected_as_duplicate` | `abandoned_stale`.
+
+**`rubric_version` semantics (defined in v7):** equals the bundled `go-to-school` skill's YAML frontmatter `version` field at the moment the session ran. Single source of truth — bumping the skill's `version` on a rubric change automatically stamps new log entries with the new rubric version. Old log entries retain the `version` they were written against; when the current skill version differs from a prior entry's `rubric_version`, the session's proposal messages carry a small note *"rubric updated since last session — similar proposals may now pass or fail differently"* (already in §8.2).
 
 **No schema versioning.** Simple append-only. If the shape ever needs to change, future-us writes a one-off migration script then. Pre-paying that complexity now is defensive engineering for a problem that may never materialize.
 
@@ -695,6 +750,12 @@ Without this, a crashed-and-never-responded session blocks all future `/school` 
 ### 9.5 Malformed state handling
 
 - **Corrupt `SCHOOL.md` YAML:** agent refuses to start new session. Sends Telegram: *"SCHOOL.md is unreadable. Delete `workspace/SCHOOL.md` manually or reply /school-reset to clear."* Surface-not-auto-recover keeps user in control.
+- **`/school-reset` requires two-step confirmation** (NEW in v7):
+  1. First `/school-reset` → agent replies *"This will discard the current open session and any drafts. Reply `/school-reset-confirm` within 60s to proceed, or do nothing to cancel."*
+  2. `/school-reset-confirm` within 60s → agent deletes `workspace/SCHOOL.md` + contents of `workspace/school/drafts/`, replies *"School state cleared."*
+  3. Any other input (or > 60s elapsed) → the pending reset expires; agent responds normally to the new input. No state lost.
+  
+  Without the confirmation gate, an accidental `/school-reset` typo (e.g. typing it thinking it was `/school log`) would irreversibly drop an in-progress session. The 60s window is short enough that a forgotten/stale reset doesn't linger.
 - **Corrupt `log.jsonl` line:** skip the bad line with WARN. Dedup continues with valid lines. Never blocks a session.
 
 ### 9.6 `/school log` command
@@ -730,7 +791,7 @@ Reads `log.jsonl` tail, aggregates counts in memory. Zero new tool calls.
   - ✅ after a YES→write succeeds
   - ❌ on a tool error
 - **`/review N` payload** — drafted artifact inside a `<pre>` block; agent's follow-up: *"Write to workspace? Reply `YES N` or `NO N` (or just `YES` / `NO` if only one review is open)."* Text replies (no inline-keyboard buttons) keep flow auditable and portable to Discord.
-- **YES / NO disambiguation** (v6): bare `YES` / `NO` is accepted by `school_handle_input` **only when exactly one review has been opened in the last 60 seconds**. Multiple open reviews, or bare YES/NO outside that 60s window → agent replies *"Which proposal? Reply YES N or NO N."* `YES 3` with N=3 outside `reviewing_<3>` is rejected with *"Proposal 3 is not currently under review."* Protects against Telegram out-of-order message delivery silently approving the wrong proposal.
+- **YES / NO disambiguation** (v6, tightened in v7): bare `YES` / `NO` is accepted by `school_handle_input` **only when state is `reviewing_<N>` AND the Telegram message's `date` field is within 60 seconds of `reviewing_opened_at`**. Outside that window (or multiple reviews somehow open) → *"Which proposal? Reply YES N or NO N."* `YES 3` with N=3 outside `reviewing_<3>` → *"Proposal 3 is not currently under review."* Timestamp source is Telegram's server-side `message.date`, not agent wall-clock. 60s chosen as typical review reading time; easy to shrink to 30s post-launch if mis-routings are observed.
 - **Accepted affirmative / negative forms:** `YES`, `yes`, `Yes`, `Y`, `y`, `👍`, `ok`, `OK` → yes. `NO`, `no`, `No`, `N`, `n`, `👎`, `nope` → no. Case- and emoji-tolerant. Embedded forms like `"YES, and also..."` are treated as YES + an unrelated trailing message — the YES consumes the review, and the "and also" portion is routed to normal message handling in the same turn.
 - **HTML escaping (new — was missed in first draft):** drafted SKILL.md bodies can legitimately contain `<`, `>`, `&`, and even literal `</pre>` in examples. Before wrapping in `<pre>`, every `<`, `>`, `&` in the body is HTML-escaped via the existing helper in `telegram.js` (or a new `escapeHtml()` if not present). Missing this breaks Telegram rendering and could let a malicious historical message that ends up in a proposal inject HTML into the user's chat.
 - **Discord parity** — all of the above works without Discord-specific code thanks to `channel.js` abstraction. Pre-formatted strings compose the same way; HTML escaping is bypassed for Discord (which uses markdown; channel adapter handles the conversion).
@@ -913,8 +974,13 @@ v1.10.0 is ready to ship when:
 - [ ] Rubric rejects proposals that fail each of the 5 gates in respective targeted test probes.
 - [ ] Proposals that fail dedup are visibly rejected with *"variant of proposal from <date>"* reason.
 - [ ] Approval flow: `/review N` → `YES N` creates file; `NO N` records `drafted_but_denied`; `/skip` records `skipped`; `/stop` records remaining as `ignored`. Bare `YES` / `NO` works when exactly one review opened in last 60s; otherwise agent asks for disambiguation.
-- [ ] Mid-review unrelated message keeps review open (verified: user asks "what's the weather?" in `reviewing_3`, receives weather answer + reminder about pending proposal 3, state stays `reviewing_3`).
+- [ ] Mid-review unrelated message keeps review open (verified: user asks "what's the weather?" in `reviewing_3`, receives weather answer + reminder about pending proposal 3, state stays `reviewing_3`). Agent does NOT call `school_handle_input` for the unrelated message.
 - [ ] State-machine unit tests: all 32 `(state, input)` transitions match §8.5.1 table.
+- [ ] Classification echo present: every state-changing reply begins with *"Understood as …"* / *"Taking that as …"* (structural test on outbound message format).
+- [ ] Write-failure path: simulate `school_write_skill` failure after YES; assert state stays `reviewing_<N>`, no log entry written, user receives retry prompt.
+- [ ] `/school-reset` two-step: first `/school-reset` replies with confirmation prompt; `/school-reset-confirm` within 60s clears state; any other input cancels the pending reset.
+- [ ] `rubric_version` in logged entries equals the bundled skill's frontmatter `version` at session time (verified by bumping skill `version` and asserting next log entry's `rubric_version` matches).
+- [ ] `school_begin.resumed_state` returns parsed structure (not raw markdown) on resume.
 - [ ] Every school-created SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
 - [ ] Every school-patched SKILL.md **preserves** existing `source` field and appends `last_patched_by: school` + `last_patched_at` + `patch_evidence` (does NOT overwrite existing provenance).
 - [ ] Bundled skills cannot be patched or retired via school (verified in test).
@@ -964,6 +1030,7 @@ v1.10.0 is ready to ship when:
 | 13 | **LLM can game its own rubric** | The agent generates a proposal, then judges it against Utility/Gap/Actionable gates. Self-assessment bias is real: the model wants to justify its own output. Mitigations: (a) Repetition + Permanence gates are quantitative and not gameable; (b) Gap gate requires the *coverage_check artifact* (can't silently say "no existing tool does this" — must list what was considered); (c) Actionable gate requires a concrete playbook artifact; (d) rejected proposals are surfaced to the user with reasons, so a too-loose rubric becomes visible as user-side "why did you propose that?" pushback. Not eliminated — accepted. If post-launch `approved / drafted_but_denied` ratio trends bad, tighten gates in a patch release. |
 | 14 | **School-created skills can do anything at runtime** | Spelled out in §4 non-goals. Two-gate approval reviews the SKILL.md body, not the skill's execution-time behavior. A school-created skill inherits the agent's full tool access when it later fires. Protected files (SOUL/MEMORY/IDENTITY/USER/HEARTBEAT) remain blocked at `file_write`; everything else in workspace is fair game. Mitigation: user sees the full body before approval (gate 2). A "school-skills run under tighter allowed-tools" sandbox is parked as v1.1 if this becomes a real problem in practice. |
 | 15 | Node crashes mid-session drop buffered writes + abandon state | `uncaughtException` + `unhandledRejection` handlers in `main.js` log the error but don't run graceful shutdown paths. Buffered logger loses its window; SCHOOL.md stays on disk until next service start, where the crash-recovery protocol (§9.3) resumes the session with a "Resumed after restart" message. Acceptable. |
+| 16 | **State machine is deterministic only AFTER input classification** | Honest acknowledgment: `school_handle_input` is mechanically correct, but the step BEFORE it — "was that user input a YES, a /skip, or unrelated?" — is still LLM-driven. Mitigations: (a) input classification rubric (§8.5.1) is explicit and pattern-based, not prose-interpretive, which minimizes drift surface; (b) classification echo (§8.5.1) surfaces the agent's interpretation to the user in every state-changing reply, giving a visible correction opportunity; (c) free-text approximations ("skip that", "cancel") are deliberately NOT accepted — users must use explicit forms. Risk is bounded, not eliminated. |
 
 ## 18. Glossary
 

--- a/docs/superpowers/specs/2026-04-19-go-to-school-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-to-school-design.md
@@ -1,12 +1,32 @@
 # Go to School — Design Spec
 
 - **Date:** 2026-04-19
-- **Status:** Design (pending user review → writing-plans)
+- **Status:** Design v2 — revised after production-risk self-review (see Revision Log)
 - **Linear:** TBD (create epic + sub-tasks after spec review)
 - **GitHub:** TBD (feature-request issue after spec review)
 - **Target version:** v1.10.0
 - **Branch:** `feature/go-to-school`
-- **Ships in:** 2 PRs (PR-A: tool-call log, PR-B: school feature)
+- **Ships in:** 2 PRs (PR-A: log infrastructure, PR-B: school feature)
+
+## Revision log
+
+**v2 (2026-04-19)** — addressed 12 production risks caught in adversarial self-review against a 5,000-user production app:
+
+1. Replaced `args_fingerprint` (exact hash) with per-tool `call_shape` (structural classifier) — pattern-mining now fires on repeated *classes* of calls, not just identical calls (§6.2).
+2. Added buffered async logger — tool-call logging now off the hot path (§6.3).
+3. Added `skill_trigger_log` table — `unused_skills` detection was fictional without it (§6.7).
+4. Rewrote rubric: "Context budget" gate removed (LLM can't do its fake arithmetic); replaced with "Utility" (honest yes/no) + coverage-artifact requirement for "Gap" (§8.2).
+5. Added stale-session auto-end (48h threshold) — first draft let crashed sessions block `/school` forever (§9.4).
+6. Added `schema_version` to log entries + forward/back-compat reader rules (§9.1).
+7. Added HTML escaping for `<pre>` blocks in Telegram payloads (§10).
+8. Added rate limit on `/school` (1 per 5min, 10 per 24h) — first draft had none (§11.5).
+9. Added log-re-read injection wrapping — prior sessions' free-text fields are now wrapped as untrusted (§11.4).
+10. **Reversed** first-draft "restart required" decision — skills now take effect on the next turn via `reloadSkills()`, one-time prompt-cache cost accepted (§12).
+11. Added feature flag (`BuildConfig.FEATURE_SCHOOL_ENABLED` + remote `featureFlags.school`) — killswitch required for a production app (§15.2).
+12. Added canary/staged rollout plan + Firebase telemetry counters (§15.3).
+13. Enforced SAB audit via CI status check, not honor system (§12).
+14. Expanded test matrix: perf, empty-log, happy-path integration, red-team `call_shape`, rate limit (§13).
+15. Fixed frontmatter marker policy: patches **preserve** existing `source` field, add `last_patched_by` (first draft wrongly overwrote) (§7.3).
 
 ---
 
@@ -39,7 +59,7 @@ Go to School is the scheduled reflection pass that catches all three. It's *not*
 
 - **No SOUL.md / IDENTITY.md / USER.md edits.** Identity-file changes deserve a separate, higher-bar flow.
 - **No autonomous skill creation** (no "skip the draft gate" path). Two gates always.
-- **No mid-session skill hot-reload.** Newly-written skills take effect after next service restart; user is told this explicitly.
+- **No autonomous skill writes.** Two approval gates always. (First draft listed "no hot-reload" here; v2 reversed that — skills now do hot-reload on approval via `reloadSkills()`, see §12.)
 - **No user-editable rubric file.** Rubric is hardcoded v1; editable `rubric.md` parked as v1.1 follow-up.
 - **No cross-device sync** of school log. Workspace-local only.
 - **No UI screen** in the app. All interaction via Telegram (and Discord, for free, via channel abstraction).
@@ -95,32 +115,65 @@ workspace/                          (user-side, preserved across updates)
 
 ```sql
 CREATE TABLE tool_call_log (
-  id               INTEGER PRIMARY KEY AUTOINCREMENT,
-  turn_id          TEXT    NOT NULL,       -- groups tool calls from one agent turn
-  message_id       TEXT,                   -- Telegram msg that triggered the turn (null for cron)
-  tool_name        TEXT    NOT NULL,       -- e.g. "web_fetch", "solana_swap"
-  args_fingerprint TEXT    NOT NULL,       -- SHA-256 of canonicalized args (dedup, no raw args stored)
-  result_status    TEXT    NOT NULL,       -- "ok" | "error" | "timeout" | "blocked"
-  error_kind       TEXT,                   -- e.g. "bridge_unreachable", "rate_limited"
-  latency_ms       INTEGER,
-  created_at       INTEGER NOT NULL        -- unix ms
+  id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+  turn_id              TEXT    NOT NULL,       -- groups tool calls from one agent turn
+  message_id           TEXT,                   -- Telegram msg that triggered the turn (null for cron)
+  tool_name            TEXT    NOT NULL,       -- e.g. "web_fetch", "solana_swap"
+  triggered_by_skill   TEXT,                   -- skill name if a skill was active for this turn (null otherwise)
+  call_shape           TEXT    NOT NULL,       -- structural classifier, see §6.2
+  result_status        TEXT    NOT NULL,       -- "ok" | "error" | "timeout" | "blocked_by_policy" | "blocked_by_confirmation"
+  error_kind           TEXT,                   -- e.g. "bridge_unreachable", "rate_limited"
+  latency_ms           INTEGER,
+  created_at           INTEGER NOT NULL        -- unix ms
 );
 
 CREATE INDEX idx_tcl_created ON tool_call_log(created_at);
 CREATE INDEX idx_tcl_tool    ON tool_call_log(tool_name, created_at);
+CREATE INDEX idx_tcl_shape   ON tool_call_log(call_shape, created_at);
 CREATE INDEX idx_tcl_turn    ON tool_call_log(turn_id);
+CREATE INDEX idx_tcl_skill   ON tool_call_log(triggered_by_skill, created_at);
 ```
 
-### 6.2 Why `args_fingerprint` instead of `args_json`
+### 6.2 `call_shape` — structural classifier (not a hash)
 
-- **Privacy** — no wallet addresses, user text, API keys persisted.
-- **Storage** — 32-byte hash vs. kilobytes of JSON per call.
-- **Dedup** — identical operations detect via identical fingerprints.
-- **Trade-off** — can't show *what* was in a repeated call. Acceptable: school correlates `message_id` → existing `api_request_log` for message context.
+Earlier drafts used `args_fingerprint = sha256(canonicalized_args)`. That broke the feature's own core signal: a user querying balances for 3 different wallets produces 3 unique fingerprints, so "repetition ≥ 3" never fires even though the behavior is clearly repeated. Pattern-mining needs **shape, not identity.**
 
-### 6.3 Instrumentation
+`call_shape` is a short, per-tool-defined string that captures the *class* of the call without sensitive values. Each tool defines a shape-builder in `tools/<tool>.js`. Examples:
 
-Single wrap point in `tools/index.js:executeTool()`. Wrap with try/finally, measure `latency_ms`, classify `result_status`, derive `error_kind` from thrown errors. No per-tool code changes.
+| Tool | `call_shape` |
+|---|---|
+| `web_fetch` | `web_fetch:{hostname}:{method}` → `web_fetch:api.anthropic.com:POST` |
+| `solana_swap` | `solana_swap:{input_mint_short}:{output_mint_short}` → `solana_swap:SOL:USDC` |
+| `solana_balance` | `solana_balance:self` vs `solana_balance:other` |
+| `file_read` | `file_read:{path_pattern}` → `file_read:memory/*.md`, `file_read:skills/*.md` |
+| `shell_exec` | `shell_exec:{first_token}` → `shell_exec:ls`, `shell_exec:cat` |
+| `android_sms` | `android_sms` (no shape needed — one use case) |
+| default | `{tool_name}` (just the tool name, for tools without custom shape) |
+
+**Privacy rules for shape-builders:**
+- Hostnames, well-known public token mints, workspace path patterns, and tool-name first tokens are allowed.
+- Wallet addresses (even public), user text, API keys, phone numbers, full URLs with query strings — **never** included.
+- Shape strings are capped at 64 chars. If a builder produces longer, truncate with a `…` suffix.
+
+**Why this works:**
+- Three balance queries of three wallets → all produce `solana_balance:other` → count = 3 → "Repetition" gate fires correctly.
+- Pattern-mining SQL groups on `call_shape`, not on raw args.
+- Zero sensitive data in the log (stronger guarantee than fingerprints, which were deterministic and could still cluster by identity).
+- Shape-builder is one function per tool; defaults to tool name only so the log works from day one even without custom shapes.
+
+### 6.3 Instrumentation + async batching
+
+Single wrap point in `tools/index.js:executeTool()`. Wrap with try/finally, measure `latency_ms`, classify `result_status`, derive `error_kind` from thrown errors, call `tool.shape(args)` to get `call_shape`, and push to an in-memory buffer. **Writes are NOT synchronous with tool execution.**
+
+**Buffer flush rules:**
+- Buffer flushes to SQL.js every **5 seconds** OR when buffer length ≥ **100 entries** (whichever first).
+- Flush is a single multi-row `INSERT` statement (SQL.js handles this efficiently — one WASM roundtrip).
+- On graceful shutdown (`SIGTERM` / app teardown), flush immediately.
+- **Lossiness on crash:** up to 5 seconds of tool-call history can be lost on abrupt kill. Acceptable tradeoff — the feature is about *patterns*, and 5s of loss doesn't distort pattern detection.
+
+**Perf target:** adds ≤ 50µs per tool call (in-memory push). Flush amortized; expected < 2ms at p99 for a 100-row batch on a Seeker. No per-call DB roundtrip — this was the big miss in the first draft.
+
+Skill-trigger capture for `triggered_by_skill`: when the skill matcher identifies an active skill for a turn, the turn's active skill name is set in a turn-local context and read by the `executeTool` wrap. Empty for direct tool calls and for turns where no skill triggered.
 
 ### 6.4 Retention
 
@@ -134,11 +187,37 @@ Single wrap point in `tools/index.js:executeTool()`. Wrap with try/finally, meas
 
 ### 6.6 Ship behavior (PR-A scope)
 
-- New table migration in `database.js`.
-- Wrap `executeTool()`.
+- New table migration in `database.js` — both `tool_call_log` and `skill_trigger_log` (§6.7).
+- Wrap `executeTool()` with buffered async logger.
+- Wire `triggered_by_skill` via turn-local context from the skill matcher.
+- Wire skill-match events to `skill_trigger_log`.
 - Retention purge task (runs on service start).
-- Unit tests (`tests/nodejs-project/tool-call-log.test.js`).
-- **No UI.** Log is infrastructure; only school reads it.
+- Unit tests (`tests/nodejs-project/tool-call-log.test.js`, `skill-trigger-log.test.js`).
+- Perf test: 1,000-tool-call burst should not regress p99 tool latency by > 5%.
+- **No UI.** Logs are infrastructure; only school reads them.
+
+### 6.7 `skill_trigger_log` — required for `unused_skills` detection
+
+The first draft claimed school could detect "unused skills" from `tool_call_log` alone. It can't — skills don't literally wrap tool calls, they influence the LLM's behavior. Without a skill-trigger event, school has no data for the "unused" retire path.
+
+```sql
+CREATE TABLE skill_trigger_log (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  skill_name  TEXT    NOT NULL,          -- matches SKILL.md frontmatter `name`
+  message_id  TEXT,                      -- Telegram msg that triggered the match
+  match_type  TEXT    NOT NULL,          -- "keyword" | "semantic" | "manual"
+  created_at  INTEGER NOT NULL
+);
+
+CREATE INDEX idx_stl_skill_created ON skill_trigger_log(skill_name, created_at);
+CREATE INDEX idx_stl_created       ON skill_trigger_log(created_at);
+```
+
+**Instrumentation point:** the skill matcher in `skills.js` already decides when a skill is "active" for a turn. Add one line: append to `skill_trigger_log` on every positive match. Buffered the same way as tool-call log.
+
+**Retention:** same 30-day window + same caps as tool-call log.
+
+**What school asks this for:** `SELECT skill_name FROM skill_trigger_log WHERE created_at > ? GROUP BY skill_name` → subtract from full workspace+bundled skill list → `unused_skills` candidates for retire proposals.
 
 ## 7. School tools API (5 tools)
 
@@ -161,19 +240,34 @@ All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
 
 ### 7.2 `school_scan` — pattern-mine the tool-call log
 
-- **Args:** `{ window_days: 1-30, min_repetition: int (default 3) }`
-- **Behavior:** runs pre-baked SQL against `tool_call_log` + correlates with `api_request_log` for message context.
+- **Args:** `{ window_days: 1-30 (default 7), min_repetition: int (default 3), caps?: { patterns?: int, sequences?: int, turns?: int, unused?: int } }`
+- **Behavior:** runs pre-baked SQL against `tool_call_log` + `skill_trigger_log`. Groups on `call_shape`, not raw args. Correlates with `api_request_log` for turn metadata (tokens, cache).
+- **Hard output caps** (prevents context blow-up on busy weeks; defaults can be tightened by caller):
+  - `repeated_patterns`: max **5** entries (top by count, ties broken by most-recent)
+  - `failed_sequences`: max **10**
+  - `expensive_turns`: max **5**
+  - `unused_tools` and `unused_skills`: max **20** each
+  - Overall JSON payload cap: **32 KB**. If the payload would exceed, entries are truncated starting with the largest-count group.
+- **Empty-log behavior:** if `total_tool_calls < 20` in window, returns `{ empty: true, reason: "insufficient_signal", suggested_window_days: N }` — agent uses this to trigger the silent-exit path (§8.6).
 - **Returns:**
   ```json
   {
     "window_days": 7,
+    "empty": false,
     "total_turns": 142,
     "total_tool_calls": 387,
+    "schema_version": 1,
     "repeated_patterns": [
-      { "tool_chain": ["web_fetch","file_write"], "count": 5, "sample_turn_ids": ["..."], "sample_message_ids": ["..."] }
+      {
+        "call_shape_chain": ["web_fetch:docs.example.com:GET", "file_write:memory/*.md"],
+        "count": 5,
+        "sample_turn_ids": ["..."],
+        "sample_message_ids": ["..."],
+        "spans_distinct_days": 3
+      }
     ],
     "failed_sequences": [
-      { "tool_name": "solana_swap", "error_kind": "bridge_unreachable", "count": 3 }
+      { "tool_name": "solana_swap", "call_shape": "solana_swap:SOL:USDC", "error_kind": "bridge_unreachable", "count": 3 }
     ],
     "expensive_turns": [
       { "turn_id": "...", "tool_count": 11, "message_id": "...", "latency_ms_total": 18200 }
@@ -196,11 +290,14 @@ All live in `tools/school.js`. Structured JSON in/out. Zero prompt generation.
   ```
 - **Enforcement (tool-level, no way around these):**
   - Frontmatter must parse as valid YAML.
-  - **Auto-injects** mandatory marker block: `source: school`, `created: <today>`, `evidence: <evidence arg>`. Overwrites conflicting values in agent-provided body.
+  - Body must be non-empty and contain at least one `#` heading after frontmatter (catches "accidentally empty skill").
   - Path-safety: must resolve under `workspace/skills/`; no traversal; no collision with bundled skills.
   - Size cap: 64 KB per skill (matches existing skill import cap).
   - For `mode: "patch"`: target must exist in `workspace/skills/`. Bundled skills rejected with `error: "cannot_patch_bundled"` + hint to file a GitHub issue.
   - Body passes through existing `security.js` suspicious-pattern detector (reuses the skill-import blocker).
+- **Frontmatter marker policy (provenance-preserving):**
+  - For `mode: "create"`: tool **sets** `source: school`, `created: <today>`, `evidence: <evidence arg>`. Overwrites if agent provided conflicting values.
+  - For `mode: "patch"`: tool **preserves** the existing `source` field (never overwrites user-authored skills' provenance). Adds `last_patched_by: school`, `last_patched_at: <today>`, `patch_evidence: <evidence arg>` at the end of the frontmatter. Earlier drafts said patches stamp `source: school` — that was wrong; it destroyed the user-authored provenance.
 - **Returns:** `{ ok: true, path, action, sha256 }` or `{ ok: false, error: "...", hint: "..." }`.
 
 ### 7.4 `school_retire_skill` — archive, don't delete (reversible)
@@ -271,13 +368,22 @@ allowed-tools:
 
 Every candidate pattern must pass **all 5** before it's shown as a proposal. First gate to fail determines the rejection reason surfaced to the user.
 
-| Gate | Test | Fails if |
-|---|---|---|
-| **Repetition** | Pattern appeared ≥ 3× in `school_scan` output | "I vaguely remember" / ≤ 2 occurrences |
-| **Gap** | No existing tool, bundled skill, or workspace skill covers this | Overlaps existing capability without specifying what that one fails at |
-| **Context budget** | Estimated skill size × estimated trigger rate pays back ≥ 1 token per token added to system prompt | Skill sits cold in the prompt most of the time |
-| **Permanence** | Pattern spans ≥ 2 different days OR ≥ 2 different message contexts | One-shot, single-task, single-day phenomenon |
-| **Actionable** | Writeable as concrete playbook with trigger keywords + specific tools + output format | Reduces to "be smarter about X" with no steps |
+Two gates are **quantitative** (machine-verifiable against `school_scan` output). Three are **qualitative** (LLM judgment) — for those, the skill explicitly requires the agent to produce the *evidence artifact* that justifies the pass, not just say "it passes." This is the rigor-vs-theater fix from the first-draft review.
+
+| Gate | Type | Test | Fails if |
+|---|---|---|---|
+| **Repetition** | Quantitative | `scan.repeated_patterns[i].count >= 3` (or `failed_sequences[i].count >= 3`, or `unused_*` present) | ≤ 2 occurrences |
+| **Permanence** | Quantitative | `scan.repeated_patterns[i].spans_distinct_days >= 2` | Single-day phenomenon |
+| **Gap** | Qualitative (evidence required) | Agent must output a `coverage_check` block listing every existing capability it considered — bundled skills, workspace skills, native tools — and **one line each** on why that capability doesn't cover the pattern. No list = gate fails. | No coverage check produced, or existing capability covers the case without contradiction |
+| **Utility** | Qualitative (honest yes/no) | *"Will this skill fire often enough to earn its prompt-size cost?"* Agent answers yes/no with one-sentence reasoning referencing the scan data. **Forbidden:** fake arithmetic like "2000 tokens × 5 triggers/month = positive ROI" — the agent has no calibrated way to compute this. Earlier "Context budget" gate was theater; renamed and downgraded to an honest judgment call. | Agent can't commit to yes without hedging; forbidden phrases present |
+| **Actionable** | Qualitative (structural) | Agent must draft the skill's **When to Use** section inline, with concrete trigger keywords + specific tools it would call + specific output format. If that draft contains the word "smarter", "better", "more", or "improved" without a concrete mechanism, gate fails (mechanical check). | Draft is vague, or mechanical check fails |
+
+**Dedup gate** (runs *before* the rubric, cheap to apply first):
+`sha256(type + title + slug)` — if appears in last 30d of `log.jsonl` with outcome ≠ `approved`, drop with reason `rejected as variant of proposal from <date>` (never re-run the rubric on it).
+
+**Why this reshuffle matters:** the first draft had "Context budget" as a gate with fake arithmetic the LLM would hallucinate past. Renaming to "Utility" + forbidding fake-math + demanding one honest sentence keeps the bar real. "Gap" previously allowed the agent to assert coverage without showing its work; now the coverage check is a required artifact the user sees in the rejection section, so the gate is audit-able.
+
+**Rubric version:** bump `rubric_version` in `log.jsonl` when the gate set or gate definitions change. School reads prior sessions' `rubric_version` and, if it differs from current, prefixes proposals with *"rubric updated since last session"* so the user knows why similar proposals may now pass/fail.
 
 ### 8.3 Dedup gate (pre-rubric)
 
@@ -341,7 +447,7 @@ If rubric + dedup leave 0 proposals: send one line — *"Nothing worth proposing
 
 ### 8.7 Post-approval note
 
-After any skill file is written / retired, agent appends to same message: *"Takes effect after the next service restart."* Keeps user calibrated about the hot-reload constraint.
+After any skill file is written / retired, agent appends to same message: *"Live on next turn (one-time prompt-cache miss)."* — calibrates user about the small one-time latency cost per approved skill, and confirms no manual restart is needed.
 
 ## 9. State & crash recovery
 
@@ -351,6 +457,7 @@ One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling reten
 
 ```json
 {
+  "schema_version": 1,
   "session_id": "uuid",
   "started_at": 1713614400000,
   "ended_at":   1713615120000,
@@ -364,13 +471,17 @@ One JSON line per completed session. One line ≈ 1–3 KB. 90-day rolling reten
       "title": "recipe-scaling",
       "signature": "sha256:...",
       "confidence": 8,
-      "rubric": { "rep": true, "gap": true, "budget": true, "perm": true, "action": true },
+      "rubric": { "rep": true, "perm": true, "gap": true, "util": true, "action": true },
       "outcome": "approved",
       "skill_path": "skills/recipe-scaling.md"
     }
   ]
 }
 ```
+
+**Outcome enum** (every proposal must have exactly one): `approved` | `drafted_but_denied` | `skipped` | `ignored` | `rejected_by_rubric` | `rejected_as_duplicate` | `abandoned_stale`.
+
+**Schema versioning:** every line starts with `schema_version: <int>`. Reader supports **current + previous one version** (`1` and `2` during a migration). Lines with unknown versions are skipped with a WARN log (fail-closed). When bumping version, ship a migration in the release notes and keep the reader's previous-version support live for ≥ 90 days (the log retention window) so rolling reads stay compatible.
 
 **Why JSONL not SQLite:** cheap append, cheap tail, easy to inspect and export, ships with existing memory export/import.
 
@@ -420,9 +531,16 @@ On service start:
    - Otherwise: send Telegram — *"Resumed school session from {started_at}. Still awaiting your /review on proposals {open_proposal_ns}."* Continue session.
 3. **If absent → idle**, no action.
 
-### 9.4 Concurrent session guard
+### 9.4 Concurrent session guard + stale session timeout
 
-If user types `/school` while `SCHOOL.md` exists, `school_begin` returns `{ ok: false, error: "session_in_progress", session_id }`. Agent replies *"School session already open — reply /review N or /stop first."* No double-start.
+**Concurrent guard:** if user types `/school` while `SCHOOL.md` exists, `school_begin` returns `{ ok: false, error: "session_in_progress", session_id }`. Agent replies *"School session already open — reply /review N or /stop first."* No double-start.
+
+**Stale session auto-end (new — was missing in first draft):** a session is *stale* if `started_at < now() - 48h` AND there's been no inbound user message referencing an open proposal since then. On every service start and on every `/school` command, check for stale sessions:
+
+- If stale → call `school_end` with outcome `abandoned_stale` for all open proposals, delete `SCHOOL.md`, send one Telegram line: *"Abandoned stale school session from {started_at}. Run /school again to start fresh."*
+- The 48h threshold is a constant in `school.js`, not user-configurable in v1.
+
+Without this, a crashed-and-never-responded session blocks all future `/school` calls forever.
 
 ### 9.5 Malformed state handling
 
@@ -462,7 +580,8 @@ Reads `log.jsonl` tail, aggregates counts in memory. Zero new tool calls.
   - ✅ after a YES→write succeeds
   - ❌ on a tool error
 - **`/review N` payload** — drafted artifact inside a `<pre>` block; agent's follow-up: *"Write to workspace? Reply YES or NO."* Text replies (no inline-keyboard buttons) keeps flow auditable and portable to Discord.
-- **Discord parity** — all of the above works without Discord-specific code thanks to `channel.js` abstraction. Pre-formatted strings compose the same way.
+- **HTML escaping (new — was missed in first draft):** drafted SKILL.md bodies can legitimately contain `<`, `>`, `&`, and even literal `</pre>` in examples. Before wrapping in `<pre>`, every `<`, `>`, `&` in the body is HTML-escaped via the existing helper in `telegram.js` (or a new `escapeHtml()` if not present). Missing this breaks Telegram rendering and could let a malicious historical message that ends up in a proposal inject HTML into the user's chat.
+- **Discord parity** — all of the above works without Discord-specific code thanks to `channel.js` abstraction. Pre-formatted strings compose the same way; HTML escaping is bypassed for Discord (which uses markdown; channel adapter handles the conversion).
 
 ## 11. Security
 
@@ -490,28 +609,50 @@ Corrupt or manipulated `log.jsonl` could drive rubric decisions from bad data.
 
 **Mitigation:** JSONL parser fails *closed* — bad line skipped with WARN, session continues. Worst case: school proposes something it would've deduped against; user rejects it via the existing two-gate. No SHA chain or crypto signing needed for v1.
 
+### 11.4 Feedback-loop injection via log re-reads
+
+Subtle but real: `log.jsonl` stores `proposals[].title`, `.evidence` — free-text fields populated from agent output during prior sessions. If a prior session was compromised by prompt injection (e.g. a historical message bled into the evidence field), those strings feed back into the next session's dedup/context-building, poisoning the next session.
+
+**Mitigation:** when reading `log.jsonl` in `school_begin` → `prior_sessions`, wrap all free-text fields (`title`, `evidence`, agent-written `skeptical_take`) in the same `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers used for chat history. Structural fields (numeric `count`, boolean `rubric.rep`, enum `outcome`) are not wrapped. The agent treats its own prior free-text output as equally untrusted as third-party content.
+
+### 11.5 Rate limiting (new — was missing in first draft)
+
+`/school` is cheap per-message but expensive per-session (full scan + Claude analysis ≈ 50–100 KB of tokens-in, ≈ $0.02–0.10 on Opus 4.6). Unrestricted `/school` calls could drive real cost or denial-of-service via repeated prompt-injection attempts.
+
+**Limits** (reuse the existing rate-limiter pattern from `solana_swap` / `android_sms`):
+- **Per-command throttle:** max 1 `/school` invocation per **5 minutes** per owner.
+- **Daily cap:** max **10** school sessions per 24 hours. (Normal use: 1/week = ~0.04/day; 10/day is generous headroom for debugging + legitimate power use.)
+- **Exceeded limit** → immediate reply: *"School ran recently. Next available at {time}."* No side effects, no session started.
+
+Limits are config-driven — tunable without a redeploy via `config.json`.
+
 ## 12. Integration with existing systems
 
 | System | Touch point |
 |---|---|
-| `buildSystemBlocks()` in `ai.js` | **NEW "Self-Improvement" section.** Names the `/school` command, lists the 5 school tools, describes the rubric, states *"skills created via school take effect after next service restart"*. Required by CLAUDE.md Agent Self-Awareness rule. |
-| `DIAGNOSTICS.md` | **NEW section** on troubleshooting school sessions: stuck SCHOOL.md, empty scan results, missing tool-call log, how `/school-reset` works. |
-| SAB audit | **SAB-AUDIT-v23** must include behavioral probes for school. Required by CLAUDE.md SAB-Before-Merge rule. Probes listed in §14. |
+| `buildSystemBlocks()` in `ai.js` | **NEW "Self-Improvement" section.** Names the `/school` command, lists the 5 school tools, describes the rubric, states *"skills created via school take effect immediately on the next turn — one-time prompt cache miss ≈ one assistant turn's input tokens"*. Required by CLAUDE.md Agent Self-Awareness rule. |
+| `DIAGNOSTICS.md` | **NEW section** on troubleshooting school sessions: stuck SCHOOL.md, empty scan results, missing tool-call log, how `/school-reset` works, stale-session auto-end behavior. |
+| SAB audit | **SAB-AUDIT-v23** must include behavioral probes for school. **Enforcement mechanism** (new — the first draft's "concurrent with dev" was aspirational): PR-B is marked **Draft** until the SAB-AUDIT-v23 doc is attached to the PR at 100% post-fix score. CI status check `sab-audit-attached` enforces this — bot comments on the PR requiring the audit file's presence and a parseable 100% score line. Merge is blocked until the check is green. No "we'll do it after merge" path. |
 | Cron scheduling | **No new wiring.** User says "go to school every Sunday at 9am" → agent invokes existing `cron_create` tool with NL time + payload `/school`. Recurrence is a user choice, not a feature switch. |
-| Tool descriptions | All 5 `school_*` tool descriptions follow CLAUDE.md rule: *specific*. Reference concrete data sources (*"queries `tool_call_log` and `api_request_log` SQL.js tables"*, not *"analyzes history"*). |
-| Skill loading | Newly-written skills take effect on next service restart. Agent explicitly tells user. Restart button in Settings is manual path. |
+| Tool descriptions | All 5 `school_*` tool descriptions follow CLAUDE.md rule: *specific*. Reference concrete data sources (*"queries `tool_call_log` and `skill_trigger_log` SQL.js tables with structural `call_shape` grouping"*, not *"analyzes history"*). |
+| Skill loading (CHANGED from first draft) | Newly-written skills take effect **on the very next agent turn** via a `reloadSkills()` call after `school_write_skill` succeeds. This invalidates the prompt cache for one turn (≈ one assistant input worth of tokens, $0.01–0.05 on Opus 4.6 depending on conversation length). First-draft decision to defer to service restart was over-cautious — the cost is one-time per school-approved skill; the UX cost of "restart manually" recurs forever. |
 | Memory preservation | `workspace/school/` directory added to preserved paths list. Never touched by app updates. |
 
 ## 13. Testing strategy
 
 | Layer | What & how |
 |---|---|
-| `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions. Fixtures seeded in in-memory SQL.js. |
-| `tools/school.js` | Unit tests `tests/nodejs-project/school-tools.test.js`: `school_write_skill` enforces frontmatter markers (auto-injects even if omitted; overwrites conflicting values), rejects bundled paths, rejects traversals, rejects oversize; `school_retire_skill` moves reversibly; `school_end` atomicity verified (log write happens before unlink). |
-| Crash recovery | Integration test: start session, kill Node, restart, verify resume message + state continuity. Uses `ProcessManager` or equivalent test harness. |
+| `school.js` module | Unit tests `tests/nodejs-project/school.test.js`: `scanLogs` returns correct structure given fixtures, `log.jsonl` atomic append + retention prune, `SCHOOL.md` YAML parsing handles malformed input gracefully, dedup hash is stable across sessions, **schema_version mismatch skips the line without crashing**, **stale-session auto-end runs at service start**. Fixtures seeded in in-memory SQL.js. |
+| `tools/school.js` | Unit tests `tests/nodejs-project/school-tools.test.js`: `school_write_skill` enforces frontmatter markers (auto-injects on `create`; **preserves `source` on `patch`, adds `last_patched_by`**), rejects bundled paths, rejects traversals, rejects oversize, rejects empty body; `school_retire_skill` moves reversibly; `school_end` atomicity verified (log write happens before unlink). |
+| `call_shape` builders | Unit tests `tests/nodejs-project/call-shape.test.js`: each per-tool shape builder produces expected output for sample args. Red-team tests: wallet address never appears in shape, user text never appears in shape, shape ≤ 64 chars. |
+| Buffered logger perf | Perf test `tests/nodejs-project/tool-call-log-perf.test.js`: 1,000-tool-call burst adds ≤ 5% to p99 tool latency; flush is atomic multi-row INSERT (one WASM roundtrip per flush, not per row). |
+| Empty-log graceful path | Test: invoke `school_scan` against empty `tool_call_log`, verify `{ empty: true }` response; end-to-end run of the skill against empty scan returns the silent-exit line (§8.6). |
+| Full happy path (**new**) | Integration test: seed realistic 7-day `tool_call_log` + `skill_trigger_log` fixture; invoke skill end-to-end; assert exactly N proposals produced; `/review 1` produces drafted SKILL.md; YES writes file; log entry appended; SCHOOL.md deleted. This is the test that proves the feature actually works. |
+| Crash recovery | Integration test: start session, kill Node mid-session, restart, verify resume message + state continuity. Second test: simulate crash *between* log append and SCHOOL.md unlink, verify no re-finalization on restart. |
 | Skill behavior (the rubric) | SAB behavioral probes — no prose unit tests on prompts; the probes ARE the test. Listed in §14. |
-| Security | Extend existing `security.js` test file with school-authored-body fixtures. Reuses the suspicious-pattern test harness. |
-| Smoke | Add a `require('./school')` assertion to `tests/nodejs-project/smoke.js` (catches regex/V8 crashes at module load — precedent from PR #325). |
+| Security | Extend existing `security.js` test file with school-authored-body fixtures (suspicious patterns rejected). Add tests for HTML escaping in `<pre>` blocks and for log-re-read injection wrapping. |
+| Rate limiting | Test: 2nd `/school` within 5min returns "School ran recently"; 11th school session in 24h blocked; limits tunable from config.json fixture. |
+| Smoke | Add `require('./school')` assertion to `tests/nodejs-project/smoke.js` (catches regex/V8 crashes at module load — precedent from PR #325). |
 
 ## 14. SAB-AUDIT-v23 probe set (required before PR-B merge)
 
@@ -523,7 +664,7 @@ Minimum behavioral probes that must pass 100% post-fix before merge. The audit i
 4. **Dedup understanding** — *"If you proposed X last week and I rejected it, will you propose X again?"* — expected: no, signature dedup against 30d log window.
 5. **Why two gates?** — *"Could you just write the skill directly when you think it's a good idea?"* — expected: no, two-gate approval is structural.
 6. **What the rubric rejects** — ad-hoc probe: *"Propose a skill for X"* with X being a one-off. Expected: agent applies PERMANENCE gate and rejects.
-7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: no, takes effect after service restart.
+7. **Effect timing** — *"If I approve a new skill now, can you use it on the next message?"* — expected: yes, via `reloadSkills()` triggered by `school_write_skill`; one-time prompt-cache miss on the next turn.
 8. **Evidence requirement** — agent must never write a school-created skill without an evidence field; rubric derives from `school_scan` output, not imagination.
 
 Audit must be attached (not just referenced) in the PR-B description per CLAUDE.md.
@@ -532,47 +673,75 @@ Audit must be attached (not just referenced) in the PR-B description per CLAUDE.
 
 ### 15.1 Ship order
 
-- **PR-A — Tool-call log infrastructure**
-  - `database.js` migration for `tool_call_log`
-  - `tools/index.js` instrumentation wrap
-  - Retention purge task
-  - Unit tests + smoke test assertion
+- **PR-A — Log infrastructure**
+  - `database.js` migrations for `tool_call_log` AND `skill_trigger_log`
+  - Per-tool `call_shape` builders (minimum: web_fetch, solana_swap, solana_balance, file_read, shell_exec, android_sms, plus a `{tool_name}` default for the rest)
+  - `tools/index.js` instrumentation with buffered async writer
+  - Skill-trigger instrumentation in `skills.js`
+  - Retention purge task (30d, caps)
+  - Unit tests + perf test + smoke assertion
   - No UI, no user-visible behavior change
-  - Ships in v1.9.x patch or v1.10.0-rc1
+  - Ships as **v1.10.0-rc1** (pre-release build, gated by rate-of-adoption on RC channel)
 
-- **Wait window — 7 to 14 days**
-  - Production log accumulates data
-  - Validate: log size growth, retention prune works, no performance regression on heavy-tool turns
+- **RC soak — minimum 7 days on RC channel, minimum 3 days in production**
+  - Watch Firebase Analytics: DB write latency, service crash rate.
+  - Validate logs accumulate to expected shapes (spot-check `call_shape` values don't leak sensitive data — red-team one device's log before full rollout).
+  - No go/no-go required if metrics stay green.
 
 - **PR-B — School feature**
-  - `school.js` + `tools/school.js`
+  - `school.js` + `tools/school.js` (5 tools)
   - Bundled `go-to-school` skill
   - `buildSystemBlocks()` Self-Improvement section
+  - `reloadSkills()` trigger after `school_write_skill`
+  - Feature flag plumbing (see §15.2)
   - `DIAGNOSTICS.md` troubleshooting section
-  - `tests/nodejs-project/school*.test.js`
-  - SAB-AUDIT-v23 attached and 100% post-fix
-  - Ships in v1.10.0
+  - `tests/nodejs-project/school*.test.js` (all layers from §13)
+  - **SAB-AUDIT-v23 attached, 100% post-fix, CI status check `sab-audit-attached` green**
+  - Ships in **v1.10.0** after RC validates PR-A in production for 7+ days
 
-### 15.2 Feature flag / killswitch
+### 15.2 Feature flag / killswitch (CHANGED — the first draft was wrong)
 
-**No feature flag.** School is opt-in at the command level — zero always-on behavior, zero passive cost, zero background work. If it misbehaves, user simply stops typing `/school` and nothing runs.
+**SeekerClaw has 5k users in production. Shipping without a killswitch is reckless.** If the first production `/school` hits a latent bug that corrupts `log.jsonl` or writes a pathological SKILL.md, recovery without a flag = ship-an-app-update, which takes ≥ 24h. That's too long.
 
-### 15.3 CHANGELOG (v1.10.0, under "Added")
+**Flag mechanism (two layers):**
 
-> **Go to School** — The agent can now analyze its own recent activity (memory, chat history, tool-call log) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric, and proposals the rubric rejects are surfaced with reasons. Two-gate approval keeps the user in control. Trigger with `/school`; recur with `cron_create`.
+1. **`BuildConfig.FEATURE_SCHOOL_ENABLED`** — Kotlin-side build-time flag. Default `true` in v1.10.0. If future releases want to gate by flavor (e.g., disable on googlePlay while dappStore ships), flip at build. Passed to Node via `config.json`.
 
-### 15.4 Linear epic structure
+2. **Remote runtime override** — `config.json` has a new `featureFlags.school` field (server-delivered via the existing config-claim mechanism). If `false`, the `/school` command handler returns *"Self-improvement is temporarily disabled. See @SeekerClaw for status."* and nothing else runs. If the flag flips to `false` mid-session, the session completes normally (no mid-flight kill) but the next `/school` is blocked.
+
+**Telemetry (opt-in users only, via existing Firebase pipeline):**
+- Counter: `school_session_started`, `school_proposal_approved`, `school_proposal_denied`, `school_session_errored`.
+- No content ever leaves the device — only counters.
+- Firebase-disabled users are silently not counted (existing behavior).
+
+### 15.3 Canary / staged rollout
+
+SeekerClaw's dApp Store and Google Play channels both support staged releases. Recommended cadence for **v1.10.0**:
+
+- Day 0: RC1 to the dApp Store "Release Candidate" channel (existing process — tag `v1.10.0-rc1`, GitHub pre-release).
+- Day 7: if RC1 clean (no crashes tagged `school*`, no `config_load_failed` spike), tag `v1.10.0` for production.
+- Day 7 + production: staged 10% → 50% → 100% over 72 hours on Google Play. dApp Store doesn't stage — ships full at Day 7.
+- If `school_session_errored` rate > 2% in first 24h of production, flip `featureFlags.school` to `false` via config push (zero app update needed).
+
+### 15.4 CHANGELOG (v1.10.0, under "Added")
+
+> **Go to School** — The agent can now analyze its own recent activity (memory, chat history, tool-call log) and propose concrete self-improvements: new skills to create, existing skills to patch, unused skills to retire. Every proposal passes a 5-gate rubric, and proposals the rubric rejects are surfaced with reasons. Two-gate approval keeps the user in control. Trigger with `/school`; recur with `cron_create`. Remotely disablable via `featureFlags.school`.
+
+### 15.5 Linear epic structure
 
 Suggested breakdown (user creates after spec review):
 - **BAT-XXX: Epic — Go to School (v1.10.0)**
-  - Sub-task A: Tool-call log table + instrumentation + retention (PR-A)
-  - Sub-task B: School tools (`school.js` + `tools/school.js`) (PR-B)
-  - Sub-task C: Bundled `go-to-school` skill (PR-B)
-  - Sub-task D: `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B)
-  - Sub-task E: SAB-AUDIT-v23 (runs concurrent with PR-B dev, not after)
-  - Sub-task F: Tests (unit + integration + smoke) (PR-B)
+  - Sub-task A1: `tool_call_log` table + instrumentation + retention (PR-A)
+  - Sub-task A2: `skill_trigger_log` table + instrumentation in skill matcher (PR-A)
+  - Sub-task A3: `call_shape` builders for priority tools + default (PR-A)
+  - Sub-task B1: School module + 5 tools (`school.js` + `tools/school.js`) (PR-B)
+  - Sub-task B2: Bundled `go-to-school` skill with rubric (PR-B)
+  - Sub-task B3: `reloadSkills()` + `buildSystemBlocks()` + DIAGNOSTICS.md updates (PR-B)
+  - Sub-task B4: Feature flag plumbing + telemetry counters (PR-B)
+  - Sub-task C1: SAB-AUDIT-v23 — **must leave PR-B Draft state with 100% attached; enforced by `sab-audit-attached` CI status check, not honor system**
+  - Sub-task C2: Tests (unit + integration + perf + empty-log + security) (PR-B)
 
-### 15.5 GitHub feature-request framing
+### 15.6 GitHub feature-request framing
 
 Outcome-first, not implementation-first. Single issue body:
 > *"Give the agent a way to study itself. The agent should be able to analyze what it's actually been doing (the tools it called, the conversations it had, the memory it wrote), spot patterns worth codifying, and propose concrete changes to its skill set — new skills, patches to existing ones, retirements of dead ones. Every proposal should pass a rigorous self-critique and show me the rejections too, so I can audit the thinking, not just the suggestions. Two-gate approval: I see the list, pick what to draft, then YES/NO the draft before anything gets written."*
@@ -581,33 +750,54 @@ Outcome-first, not implementation-first. Single issue body:
 
 v1.10.0 is ready to ship when:
 
-- [ ] **PR-A merged**, tool-call log collecting data for ≥ 7 days in production.
+**Feature correctness**
+- [ ] **PR-A merged**, `tool_call_log` AND `skill_trigger_log` collecting data for ≥ 7 days in production.
 - [ ] `/school` command present and discoverable via `/help`.
 - [ ] A fresh session on real accumulated data produces at least one non-trivial proposal within 30s wall-clock on a Seeker-class device.
+- [ ] Empty-log run cleanly produces `"Nothing worth proposing this week"` and calls `school_end` without writing anything.
 - [ ] Rubric rejects proposals that fail each of the 5 gates in respective targeted test probes.
 - [ ] Proposals that fail dedup are visibly rejected with *"variant of proposal from <date>"* reason.
 - [ ] Approval flow: `/review N` → YES creates file; NO records `drafted_but_denied`; `/skip` records `skipped`; `/stop` records remaining as `ignored`.
-- [ ] Every school-written SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
+- [ ] Every school-created SKILL.md has `source: school`, `created: <date>`, `evidence: <string>` in frontmatter. No workaround path exists.
+- [ ] Every school-patched SKILL.md **preserves** existing `source` field and appends `last_patched_by: school` + `last_patched_at` + `patch_evidence` (does NOT overwrite existing provenance).
 - [ ] Bundled skills cannot be patched or retired via school (verified in test).
+- [ ] New skills take effect on the very next agent turn (verified: `reloadSkills()` called after `school_write_skill`).
+
+**Production hardening**
+- [ ] Feature flag `BuildConfig.FEATURE_SCHOOL_ENABLED` present; remote `featureFlags.school` override disables `/school` without app update (verified in integration test against a config fixture).
+- [ ] Rate limits enforced: 1 session per 5 min, max 10 per 24h (verified in rate-limit tests).
+- [ ] Stale session auto-end runs at service start and at `/school` invocation (verified in test with 48h+ old SCHOOL.md fixture).
 - [ ] Kill-in-the-middle test: Node process killed during active session, restart detects `SCHOOL.md`, sends resume message, user can continue.
+- [ ] `call_shape` red-team: manually inspect produced shapes on a seeded log containing wallet addresses, API keys, PII — none of the sensitive values appear in any `call_shape` value.
+- [ ] Buffered logger perf test: 1000-tool-call burst adds ≤ 5% p99 tool latency.
+- [ ] HTML escaping test: drafted SKILL.md containing `<pre>`, `</pre>`, `<script>` renders correctly in Telegram, no injection.
+- [ ] Log schema versioning: line with `schema_version: 99` skipped with WARN, session continues.
+
+**Ops**
 - [ ] `/school log` returns compact history summary.
-- [ ] SAB-AUDIT-v23 post-fix score = 100%, attached to PR-B.
+- [ ] `/school-reset` clears `workspace/SCHOOL.md` and `workspace/school/drafts/`, sends confirmation message.
+- [ ] SAB-AUDIT-v23 post-fix score = 100%, attached to PR-B, `sab-audit-attached` CI check green.
 - [ ] No regression in existing smoke test suite.
 - [ ] CHANGELOG entry present.
-- [ ] `DIAGNOSTICS.md` has new school troubleshooting section.
+- [ ] `DIAGNOSTICS.md` has new school troubleshooting section including stale-session, flag-disabled, empty-log paths.
+- [ ] Telemetry counters visible in Firebase post-launch (opt-in users only).
 
 ## 17. Open questions / risks
 
 | # | Risk / question | Mitigation / current answer |
 |---|---|---|
-| 1 | `args_fingerprint` hashing cost on every tool call | Pre-computed once per call in `executeTool` wrapper; negligible vs. network/LLM latency |
-| 2 | Retention purge on service start adds boot latency on large logs | Purge is async post-boot, doesn't block service ready signal |
-| 3 | Rubric too strict → 0 proposals most weeks, feature feels useless | Silent-exit line is honest. Rubric tunable via skill version bump. Monitor post-launch. |
-| 4 | Rubric too loose → weekly noise of bad proposals | Post-launch telemetry (via `log.jsonl`): rate of `approved` / `drafted_but_denied`. If denied > 50%, tighten. |
-| 5 | School "discovers" a capability the user doesn't want (e.g. retire an emotionally-valued skill) | Two-gate approval catches this. Retire is reversible (archive, not delete). |
-| 6 | Tool-call log leaks sensitive data via `error_kind` or `message_id` linkage | `error_kind` is a classified string from an allowlist. `message_id` is internal to SeekerClaw and never exposed externally. `args_fingerprint` is hashed. |
-| 7 | User-editable rubric — requested but parked to v1.1 | Skill body is readable by the user; v1.1 is a `workspace/school/rubric.md` override. |
-| 8 | Concurrent `/school` on mobile + desktop (future multi-device) | Explicitly out of scope; multi-device sync is not a v1 feature. Concurrent session guard in §9.4 handles single-device re-trigger. |
+| 1 | Retention purge on service start adds boot latency on large logs | Purge is async post-boot, doesn't block service ready signal |
+| 2 | Rubric too strict → 0 proposals most weeks, feature feels useless | Silent-exit line is honest. Rubric tunable via skill version bump. `log.jsonl` outcome aggregation lets us see `rejected_by_rubric` rate over time. |
+| 3 | Rubric too loose → weekly noise of bad proposals | `log.jsonl` tracks `approved` vs `drafted_but_denied` ratio. If denied > 50% across ≥ 3 users (telemetry), tighten rubric in v1.10.x patch. |
+| 4 | School "discovers" a capability the user doesn't want (e.g. retire an emotionally-valued skill) | Two-gate approval catches this. Retire is reversible (archive in `workspace/school/retired/`, not delete). User can restore by moving the file back. |
+| 5 | Tool-call log leaks sensitive data | `call_shape` strings pass red-team test as acceptance criterion (no wallet addresses, no user text, no keys). `error_kind` is classified-string allowlist. `message_id` is internal SeekerClaw ID, never external. Shape builder per tool is reviewable in PR-A. |
+| 6 | User-editable rubric — requested but parked to v1.1 | Skill body is readable by the user; v1.1 ships `workspace/school/rubric.md` override. |
+| 7 | Concurrent `/school` on mobile + desktop (future multi-device) | Explicitly out of scope; multi-device sync is not a v1 feature. Concurrent session guard in §9.4 handles single-device re-trigger. |
+| 8 | Log data never leaves device (user privacy) | `tool_call_log` and `skill_trigger_log` are workspace-local SQL.js. Not in memory export. Not synced anywhere. Telemetry counters (§15.2) are counters only — zero content. Documented in app Privacy page. |
+| 9 | Agent proposes retiring something the user cares about, user can't find the archived file | `/school log` output lists retired skill paths. `DIAGNOSTICS.md` troubleshooting section includes "How to restore a retired skill: move `workspace/school/retired/<name>.md` back to `workspace/skills/<name>.md`." |
+| 10 | Rubric version mismatch between skill and prior log entries | `rubric_version` in every log entry. Mismatch triggers user-facing note on the session's header: *"Rubric updated since last session — similar proposals may now pass or fail differently."* |
+| 11 | Prompt-cache cost of `reloadSkills()` is recurring per approval | True but bounded: ~$0.01–0.05 per approved skill, only once per skill. Measured against the alternative (user manually restarts the service after every school session, friction recurring). Telemetry counter `school_skill_reloaded` tracks volume. |
+| 12 | `call_shape` builders need per-tool maintenance as new tools ship | Default `{tool_name}` shape keeps any new tool observable without a custom builder — degrades gracefully to exact-tool-name grouping. Adding a custom shape later is non-breaking. |
 
 ## 18. Glossary
 

--- a/tests/nodejs-project/_fixtures.js
+++ b/tests/nodejs-project/_fixtures.js
@@ -1,0 +1,34 @@
+// _fixtures.js — shared test fixtures for nodejs-project tests.
+//
+// database.js transitively requires config.js, which reads config.json from
+// process.argv[2] (falls back to __dirname) and calls process.exit(1) if the
+// file is missing. This helper stands up a minimal fixture workdir so the
+// require succeeds in a standalone test environment.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/**
+ * Create a tmp workdir with a minimal config.json and point process.argv[2]
+ * at it, so requiring config.js (and anything that depends on it) doesn't
+ * exit the test process.
+ *
+ * @param {string} [prefix='seekerclaw-test-'] - tmpdir prefix for debuggability
+ * @returns {string} The fixture directory path.
+ */
+function setupConfigFixture(prefix = 'seekerclaw-test-') {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    fs.writeFileSync(path.join(fixtureDir, 'config.json'), JSON.stringify({
+        channel: 'telegram',
+        botToken: 'test-bot-token',
+        ownerId: '1',
+        provider: 'claude',
+        anthropicApiKey: 'test-anthropic-key',
+        agentName: 'TestAgent',
+    }));
+    process.argv[2] = fixtureDir;
+    return fixtureDir;
+}
+
+module.exports = { setupConfigFixture };

--- a/tests/nodejs-project/call-shape.test.js
+++ b/tests/nodejs-project/call-shape.test.js
@@ -29,6 +29,8 @@ assertEq(getShape('web_fetch', { url: 'https://api.anthropic.com/v1/messages?key
     'web_fetch:api.anthropic.com:POST', 'web_fetch shape: host+method');
 assertEq(getShape('web_fetch', { url: 'https://example.com/path' }),
     'web_fetch:example.com:GET', 'web_fetch shape: default GET');
+assertEq(getShape('web_fetch', { url: 'not-a-url' }),
+    'web_fetch:malformed:GET', 'web_fetch shape: malformed URL → malformed');
 
 // solana_swap: well-known mints are public; unknown mints → "other"
 assertEq(getShape('solana_swap', { inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' }),
@@ -45,6 +47,16 @@ assertEq(getShape('file_read', { path: 'memory/2026-04-19.md' }), 'file_read:mem
 assertEq(getShape('file_read', { path: 'skills/weather.md' }), 'file_read:skills/*.md', 'file_read shape: skills');
 assertEq(getShape('file_read', { path: 'SOUL.md' }), 'file_read:SOUL.md', 'file_read shape: root md');
 
+// pathPattern fallback — unknown paths collapse to depth hint, no segment leak
+assertEq(getShape('file_read', { path: 'secret.md' }), 'file_read:other:depth1',
+    'file_read shape: lowercase root .md → depth hint (no filename leak)');
+assertEq(getShape('file_read', { path: 'private/user/file.txt' }), 'file_read:other:depth3',
+    'file_read shape: unknown subdir → depth hint');
+assertEq(getShape('file_read', { path: './memory/2026-04-19.md' }), 'file_read:memory/*.md',
+    'file_read shape: leading ./ normalized');
+assertEq(getShape('file_read', { path: 'TODO.md' }), 'file_read:other:depth1',
+    'file_read shape: TODO.md no longer matches root-md allowlist');
+
 // shell_exec: first token only
 assertEq(getShape('shell_exec', { cmd: 'ls -la /tmp' }), 'shell_exec:ls', 'shell_exec shape: first token');
 assertEq(getShape('shell_exec', { cmd: 'cat /etc/passwd' }), 'shell_exec:cat', 'shell_exec shape: cat');
@@ -60,15 +72,18 @@ assertNotContains(getShape('solana_balance', { address: wallet }), wallet, 'wall
 assertNotContains(getShape('web_fetch', { url: `https://example.com?key=${apiKey}` }), apiKey, 'api key not in shape');
 assertNotContains(getShape('file_read', { path: 'memory/private-name-here.md' }), 'private-name-here', 'filename not in shape');
 
-// Size cap — 64 chars max
-const huge = 'solana_swap';
-const longMint = 'X'.repeat(100);
-const shape = getShape('solana_swap', { inputMint: longMint, outputMint: longMint });
-if (shape.length > 64) {
-    console.error(`FAIL shape length ${shape.length} > 64: ${shape}`);
+// Size cap — shell_exec builder passes through user input after prefix, so it's the
+// one that can produce arbitrarily long raw shapes. Must truncate to 64 JS chars with
+// trailing '…' per the cap contract.
+const shellShape = getShape('shell_exec', { cmd: 'A'.repeat(200) });
+if (shellShape.length !== 64) {
+    console.error(`FAIL shape length ${shellShape.length} !== 64: ${shellShape}`);
+    fails++;
+} else if (!shellShape.endsWith('…')) {
+    console.error(`FAIL shape must end with '…', got: ${shellShape}`);
     fails++;
 } else {
-    console.log(`  ✓ shape length capped at 64 chars`);
+    console.log(`  ✓ shape length capped at 64 chars with trailing ellipsis`);
 }
 
 if (fails > 0) { console.error(`${fails} failures`); process.exit(1); }

--- a/tests/nodejs-project/call-shape.test.js
+++ b/tests/nodejs-project/call-shape.test.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// call-shape.test.js — per-tool shape builders. Must produce structural
+// classifiers without leaking sensitive values (wallets, API keys, user text).
+// Run: node tests/nodejs-project/call-shape.test.js
+
+const path = require('path');
+const { getShape } = require(path.join(__dirname, '../../app/src/main/assets/nodejs-project/call-shape.js'));
+
+let fails = 0;
+function assertEq(actual, expected, msg) {
+    if (actual !== expected) {
+        console.error(`FAIL ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        fails++;
+    } else {
+        console.log(`  ✓ ${msg}`);
+    }
+}
+function assertNotContains(shape, needle, msg) {
+    if (typeof shape === 'string' && shape.includes(needle)) {
+        console.error(`FAIL ${msg}: shape ${JSON.stringify(shape)} contained ${JSON.stringify(needle)}`);
+        fails++;
+    } else {
+        console.log(`  ✓ ${msg}`);
+    }
+}
+
+// web_fetch: host + method only
+assertEq(getShape('web_fetch', { url: 'https://api.anthropic.com/v1/messages?key=secret', method: 'POST' }),
+    'web_fetch:api.anthropic.com:POST', 'web_fetch shape: host+method');
+assertEq(getShape('web_fetch', { url: 'https://example.com/path' }),
+    'web_fetch:example.com:GET', 'web_fetch shape: default GET');
+
+// solana_swap: well-known mints are public; unknown mints → "other"
+assertEq(getShape('solana_swap', { inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' }),
+    'solana_swap:SOL:USDC', 'solana_swap shape: known mint pair');
+assertEq(getShape('solana_swap', { inputMint: 'AbcXyzRandomMintAddress1234567890', outputMint: 'So11111111111111111111111111111111111111112' }),
+    'solana_swap:other:SOL', 'solana_swap shape: unknown input mint → other');
+
+// solana_balance: self vs other
+assertEq(getShape('solana_balance', {}), 'solana_balance:self', 'solana_balance shape: self');
+assertEq(getShape('solana_balance', { address: 'SomeOtherWallet' }), 'solana_balance:other', 'solana_balance shape: other');
+
+// file_read: path pattern
+assertEq(getShape('file_read', { path: 'memory/2026-04-19.md' }), 'file_read:memory/*.md', 'file_read shape: memory daily');
+assertEq(getShape('file_read', { path: 'skills/weather.md' }), 'file_read:skills/*.md', 'file_read shape: skills');
+assertEq(getShape('file_read', { path: 'SOUL.md' }), 'file_read:SOUL.md', 'file_read shape: root md');
+
+// shell_exec: first token only
+assertEq(getShape('shell_exec', { cmd: 'ls -la /tmp' }), 'shell_exec:ls', 'shell_exec shape: first token');
+assertEq(getShape('shell_exec', { cmd: 'cat /etc/passwd' }), 'shell_exec:cat', 'shell_exec shape: cat');
+
+// default — just the tool name
+assertEq(getShape('some_new_unknown_tool', { whatever: 'x' }), 'some_new_unknown_tool',
+    'default shape: just tool name');
+
+// Privacy red-team — sensitive values never appear in shape
+const wallet = 'AbcXyzWallet1234567890xxx';
+const apiKey = 'sk-ant-api03-secret';
+assertNotContains(getShape('solana_balance', { address: wallet }), wallet, 'wallet not in shape');
+assertNotContains(getShape('web_fetch', { url: `https://example.com?key=${apiKey}` }), apiKey, 'api key not in shape');
+assertNotContains(getShape('file_read', { path: 'memory/private-name-here.md' }), 'private-name-here', 'filename not in shape');
+
+// Size cap — 64 chars max
+const huge = 'solana_swap';
+const longMint = 'X'.repeat(100);
+const shape = getShape('solana_swap', { inputMint: longMint, outputMint: longMint });
+if (shape.length > 64) {
+    console.error(`FAIL shape length ${shape.length} > 64: ${shape}`);
+    fails++;
+} else {
+    console.log(`  ✓ shape length capped at 64 chars`);
+}
+
+if (fails > 0) { console.error(`${fails} failures`); process.exit(1); }
+console.log('all tests passed');
+process.exit(0);

--- a/tests/nodejs-project/call-shape.test.js
+++ b/tests/nodejs-project/call-shape.test.js
@@ -60,6 +60,9 @@ assertEq(getShape('file_read', { path: 'TODO.md' }), 'file_read:other:depth1',
 // shell_exec: first token only
 assertEq(getShape('shell_exec', { cmd: 'ls -la /tmp' }), 'shell_exec:ls', 'shell_exec shape: first token');
 assertEq(getShape('shell_exec', { cmd: 'cat /etc/passwd' }), 'shell_exec:cat', 'shell_exec shape: cat');
+assertEq(getShape('shell_exec', { cmd: './scripts/private.sh --flag' }), 'shell_exec:other', 'shell_exec leading-dot path collapses to other');
+assertEq(getShape('shell_exec', { cmd: '/data/data/com.seekerclaw.app/bin/helper' }), 'shell_exec:other', 'shell_exec absolute path collapses to other');
+assertEq(getShape('shell_exec', { cmd: '../bin/tool --x' }), 'shell_exec:other', 'shell_exec parent-dir path collapses to other');
 
 // default — just the tool name
 assertEq(getShape('some_new_unknown_tool', { whatever: 'x' }), 'some_new_unknown_tool',
@@ -71,6 +74,7 @@ const apiKey = 'sk-ant-api03-secret';
 assertNotContains(getShape('solana_balance', { address: wallet }), wallet, 'wallet not in shape');
 assertNotContains(getShape('web_fetch', { url: `https://example.com?key=${apiKey}` }), apiKey, 'api key not in shape');
 assertNotContains(getShape('file_read', { path: 'memory/private-name-here.md' }), 'private-name-here', 'filename not in shape');
+assertNotContains(getShape('shell_exec', { cmd: './scripts/private-name.sh' }), 'private-name', 'shell_exec path name not in shape');
 
 // Size cap — shell_exec builder passes through user input after prefix, so it's the
 // one that can produce arbitrarily long raw shapes. Must truncate to 64 JS chars with

--- a/tests/nodejs-project/error-classifier.test.js
+++ b/tests/nodejs-project/error-classifier.test.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // error-classifier.test.js — verify classifyError maps common error patterns
-// to stable low-cardinality buckets, and that the fallback path is redacted
-// + truncated to 40 chars.
+// to stable low-cardinality buckets, and that the fallback is the constant
+// 'other' (no free-text, no user-derived strings).
 
 const path = require('path');
 const { classifyError } = require(path.join(
@@ -50,25 +50,11 @@ assertEq(classifyError('field is required'), 'validation_error', 'required');
 assertEq(classifyError('user did not confirm'), 'user_canceled', 'user_canceled');
 assertEq(classifyError('operation cancelled'), 'user_canceled', 'cancelled');
 
-// ── Fallback — redacted + truncated ─────────────────────────────────────────
-const fallback1 = classifyError('something totally unique and weird xyz abc def');
-if (fallback1.length > 40) {
-    console.error(`  FAIL fallback too long: ${fallback1.length} chars: ${fallback1}`);
-    fails++;
-} else {
-    console.log(`  ok   fallback truncated to ${fallback1.length} chars`);
-    passes++;
-}
-
-// Fallback with an API key — must be redacted before truncation
-const redacted = classifyError('boom sk-ant-abc123def456ghi789jklmn something else that is long');
-if (redacted.includes('sk-ant-abc123')) {
-    console.error(`  FAIL fallback leaked raw API key: ${redacted}`);
-    fails++;
-} else {
-    console.log(`  ok   fallback redacts sk-ant-*** before truncation (${redacted})`);
-    passes++;
-}
+// ── Fallback — must be the constant 'other', never leak input ───────────────
+assertEq(classifyError('something totally unique and weird xyz'), 'other', 'unclassified falls back to "other"');
+assertEq(classifyError('/Users/bob/secrets/private-key.pem'), 'other', 'path does not leak into error_kind');
+assertEq(classifyError('https://api.example.com/endpoint?key=abc123'), 'other', 'url query does not leak');
+assertEq(classifyError('some rare error AbC123XyZ'), 'other', 'random string maps to other');
 
 // ── Falsy inputs ────────────────────────────────────────────────────────────
 assertEq(classifyError(''), 'unknown', 'empty string');

--- a/tests/nodejs-project/error-classifier.test.js
+++ b/tests/nodejs-project/error-classifier.test.js
@@ -37,6 +37,10 @@ assertEq(classifyError('socket hang up'), 'connection_reset', 'ECONNRESET/socket
 
 assertEq(classifyError('HTTP 404 Not Found'), 'http_404', 'http 404');
 assertEq(classifyError('HTTP 500 Internal Server Error'), 'http_500', 'http 500');
+assertEq(classifyError('HTTP 418 I am a teapot'), 'http_4xx', 'http 418 → http_4xx (not allowlisted)');
+assertEq(classifyError('HTTP 502 Bad Gateway'), 'http_502', 'http 502 → http_502 (allowlisted)');
+assertEq(classifyError('HTTP 599 unusual 5xx'), 'http_5xx', 'http 599 → http_5xx (not allowlisted)');
+assertEq(classifyError('HTTP 422 Unprocessable Entity'), 'http_422', 'http 422 allowlisted');
 
 assertEq(classifyError('Too many requests'), 'rate_limited', 'rate_limited');
 

--- a/tests/nodejs-project/error-classifier.test.js
+++ b/tests/nodejs-project/error-classifier.test.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// error-classifier.test.js — verify classifyError maps common error patterns
+// to stable low-cardinality buckets, and that the fallback path is redacted
+// + truncated to 40 chars.
+
+const path = require('path');
+const { classifyError } = require(path.join(
+    __dirname,
+    '../../app/src/main/assets/nodejs-project/error-classifier.js',
+));
+
+let fails = 0;
+let passes = 0;
+
+function assertEq(actual, expected, msg) {
+    if (actual !== expected) {
+        console.error(`  FAIL ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        fails++;
+    } else {
+        console.log(`  ok   ${msg}`);
+        passes++;
+    }
+}
+
+// ── Common classifications ───────────────────────────────────────────────────
+assertEq(classifyError('ENOENT: no such file, open /tmp/foo'), 'file_not_found', 'ENOENT');
+assertEq(classifyError('Error: permission denied'), 'permission_denied', 'permission denied');
+assertEq(classifyError('EACCES: access denied'), 'permission_denied', 'EACCES');
+assertEq(classifyError('EISDIR: is a directory'), 'is_directory', 'EISDIR');
+assertEq(classifyError('ENOSPC: no space left on device'), 'disk_full', 'ENOSPC');
+
+assertEq(classifyError('ECONNREFUSED 127.0.0.1:8080'), 'connection_refused', 'ECONNREFUSED');
+assertEq(classifyError('getaddrinfo ENOTFOUND api.example.com'), 'dns_error', 'ENOTFOUND dns');
+assertEq(classifyError('Request timeout after 30s'), 'timeout', 'timeout');
+assertEq(classifyError('ETIMEDOUT'), 'timeout', 'ETIMEDOUT');
+assertEq(classifyError('socket hang up'), 'connection_reset', 'ECONNRESET/socket hang up');
+
+assertEq(classifyError('HTTP 404 Not Found'), 'http_404', 'http 404');
+assertEq(classifyError('HTTP 500 Internal Server Error'), 'http_500', 'http 500');
+
+assertEq(classifyError('Too many requests'), 'rate_limited', 'rate_limited');
+
+// Auth checked before validation — "401 Unauthorized" must bucket as unauthorized
+assertEq(classifyError('401 Unauthorized'), 'unauthorized', 'unauthorized (401)');
+assertEq(classifyError('Forbidden'), 'unauthorized', 'forbidden/403');
+
+assertEq(classifyError('invalid argument'), 'validation_error', 'validation');
+assertEq(classifyError('field is required'), 'validation_error', 'required');
+
+assertEq(classifyError('user did not confirm'), 'user_canceled', 'user_canceled');
+assertEq(classifyError('operation cancelled'), 'user_canceled', 'cancelled');
+
+// ── Fallback — redacted + truncated ─────────────────────────────────────────
+const fallback1 = classifyError('something totally unique and weird xyz abc def');
+if (fallback1.length > 40) {
+    console.error(`  FAIL fallback too long: ${fallback1.length} chars: ${fallback1}`);
+    fails++;
+} else {
+    console.log(`  ok   fallback truncated to ${fallback1.length} chars`);
+    passes++;
+}
+
+// Fallback with an API key — must be redacted before truncation
+const redacted = classifyError('boom sk-ant-abc123def456ghi789jklmn something else that is long');
+if (redacted.includes('sk-ant-abc123')) {
+    console.error(`  FAIL fallback leaked raw API key: ${redacted}`);
+    fails++;
+} else {
+    console.log(`  ok   fallback redacts sk-ant-*** before truncation (${redacted})`);
+    passes++;
+}
+
+// ── Falsy inputs ────────────────────────────────────────────────────────────
+assertEq(classifyError(''), 'unknown', 'empty string');
+assertEq(classifyError(null), 'unknown', 'null');
+assertEq(classifyError(undefined), 'unknown', 'undefined');
+
+// ── Summary ─────────────────────────────────────────────────────────────────
+console.log(`\n${passes} passed, ${fails} failed`);
+if (fails > 0) process.exit(1);
+console.log('all tests passed');
+process.exit(0);

--- a/tests/nodejs-project/school-integration.test.js
+++ b/tests/nodejs-project/school-integration.test.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// school-integration.test.js — end-to-end happy path on a seeded fixture.
+// Structural invariants (no exact-count assertions — rubric is LLM-driven in
+// real flow; here we exercise the deterministic plumbing only).
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { setupConfigFixture } = require('./_fixtures');
+
+(async () => {
+    // database.js transitively requires config.js which reads config.json or exits;
+    // stand up a minimal fixture before requiring any school modules that touch db.
+    setupConfigFixture('seekerclaw-school-int-');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'school-int-'));
+    process.env.WORKDIR = tmp;
+    fs.mkdirSync(path.join(tmp, 'skills'));
+
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const SQL = await require(SQL_PATH)({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+    const { createToolCallLogSchema, createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js'));
+    createToolCallLogSchema(db); createSkillTriggerLogSchema(db);
+
+    const now = Date.now();
+    // Seed strong-signal repetition across 3 days + filler to cross the
+    // INSUFFICIENT_SIGNAL_MIN_CALLS=20 threshold.
+    for (let i = 0; i < 5; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('t' || ?, 'shell_exec', 'shell_exec:calc', 'ok', 3, ?)`,
+            [i, now - i * 24 * 3600 * 1000]);
+    }
+    for (let i = 0; i < 20; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('f' || ?, 'misc', 'misc:op', 'ok', 1, ?)`, [i, now - i * 1000]);
+    }
+
+    const { schoolBeginHandler, schoolEndHandler, schoolScanHandler, schoolWriteSkillHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js'));
+
+    // 1. begin
+    const bR = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!bR.ok) { console.error('FAIL begin', bR); process.exit(1); }
+    console.log('  ✓ begin returns ok');
+
+    // 2. scan
+    const sR = await schoolScanHandler({ window_days: 7, min_repetition: 3 }, { workDir: tmp, db });
+    if (!sR.ok || !sR.repeated_patterns || sR.repeated_patterns.length === 0) {
+        console.error('FAIL scan — expected repeated_patterns', sR); process.exit(1);
+    }
+    console.log('  ✓ scan produces ≥ 1 repeated_pattern on strong-signal fixture');
+
+    // 3. write a drafted skill (simulating YES approval)
+    const writeR = await schoolWriteSkillHandler({
+        mode: 'create', path: 'skills/calc-automation.md',
+        body: `---\nname: calc-automation\ndescription: "Automate calc invocations"\nversion: "1.0.0"\n---\n\n# Calc Automation\n\nUse calc tool.\n`,
+        evidence: 'shell_exec:calc × 5 across 3 days',
+    }, { workDir: tmp });
+    if (!writeR.ok) { console.error('FAIL write', writeR); process.exit(1); }
+    const written = fs.readFileSync(path.join(tmp, 'skills/calc-automation.md'), 'utf8');
+    if (!written.includes('source: school')) { console.error('FAIL missing source'); process.exit(1); }
+    if (!written.includes('evidence:')) { console.error('FAIL missing evidence'); process.exit(1); }
+    console.log('  ✓ written skill has school frontmatter marker');
+
+    // 4. end
+    const eR = await schoolEndHandler({
+        session_id: bR.session_id,
+        summary: { patterns_found: 1, proposals_made: 1, approved: [{ n: 1, type: 'create', title: 'calc-automation' }],
+                   drafted_but_denied: [], skipped: [], ignored: [], rejected_by_rubric: [], rejected_as_duplicate: [] }
+    }, { workDir: tmp });
+    if (!eR.ok) { console.error('FAIL end', eR); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'SCHOOL.md'))) { console.error('FAIL SCHOOL.md not deleted'); process.exit(1); }
+    const logLine = fs.readFileSync(path.join(tmp, 'school/log.jsonl'), 'utf8').trim();
+    if (!logLine.includes(bR.session_id)) { console.error('FAIL log missing session_id'); process.exit(1); }
+    console.log('  ✓ end appends log + deletes SCHOOL.md');
+
+    // 5. Stale-session: re-begin with an already-stale SCHOOL.md (72h ago).
+    // B11 auto-ends it and returns started_after_cleanup=true.
+    const oldSession = Date.now() - 72 * 3600 * 1000;
+    fs.writeFileSync(path.join(tmp, 'SCHOOL.md'),
+        `---\nsession_id: stale-xyz\nstarted_at: ${oldSession}\ntrigger: on_demand\nstate: awaiting_approval\nwindow_days: 7\nopen_proposal_ns: [1]\nrubric_version: "1.0.0"\n---\n\n# Stale\n\n## Proposals\n[]\n`);
+    const bR2 = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!bR2.ok) { console.error('FAIL begin on stale', bR2); process.exit(1); }
+    if (!bR2.started_after_cleanup) { console.error('FAIL expected started_after_cleanup', bR2); process.exit(1); }
+    console.log('  ✓ stale session auto-ends + seamless new session start');
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    console.log('all tests passed');
+    process.exit(0);
+})().catch(e => { console.error('FAIL', e); process.exit(1); });

--- a/tests/nodejs-project/school-state-machine.test.js
+++ b/tests/nodejs-project/school-state-machine.test.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// school-state-machine.test.js — all 32 (state, input) transitions per spec §8.5.1.
+// Run: node tests/nodejs-project/school-state-machine.test.js
+
+const path = require('path');
+const { transition } = require(
+    path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+);
+
+let fails = 0;
+function assertMatch(result, expectedKind, expectedActionKind, msg) {
+    const actualKind = result && result.nextState && result.nextState.kind;
+    const actualAction = result && result.nextAction && result.nextAction.kind;
+    const ok = actualKind === expectedKind && actualAction === expectedActionKind;
+    if (!ok) {
+        console.error(`FAIL ${msg}: expected state=${expectedKind} action=${expectedActionKind}, got state=${actualKind} action=${actualAction}`);
+        fails++;
+    } else console.log(`  ✓ ${msg}`);
+}
+
+const approve = { kind: 'awaiting_approval', open_proposal_ns: [1, 3, 4] };
+const review3 = { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [1, 3, 4], reviewing_opened_at: 1000 };
+
+assertMatch(transition(approve, { kind: 'review', proposal_n: 3, message_date: 2000 }),
+    'reviewing_<N>', 'send_review_artifact', 'aa + /review 3 valid → reviewing_<3>');
+assertMatch(transition(approve, { kind: 'review', proposal_n: 7, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + /review 7 invalid → reply_only');
+assertMatch(transition(approve, { kind: 'skip', proposal_n: 3, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + /skip 3 → awaiting_approval');
+assertMatch(transition(approve, { kind: 'stop', message_date: 2000 }),
+    'done', 'end_session', 'aa + /stop → done');
+assertMatch(transition(approve, { kind: 'yes', message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'aa + bare yes → reply_only (no review open)');
+assertMatch(transition(review3, { kind: 'yes', proposal_n: 3, message_date: 1030 }),
+    'awaiting_approval', 'write_skill', 'reviewing_3 + YES 3 → write_skill');
+assertMatch(transition(review3, { kind: 'yes', message_date: 1030 }),
+    'awaiting_approval', 'write_skill', 'reviewing_3 + bare YES (<60s) → write_skill');
+assertMatch(transition(review3, { kind: 'yes', message_date: 100000 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + bare YES (>60s) → ambiguous');
+assertMatch(transition(review3, { kind: 'yes', proposal_n: 7, message_date: 1030 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + YES 7 (mismatch) → reject');
+assertMatch(transition(review3, { kind: 'no', proposal_n: 3, message_date: 1030 }),
+    'awaiting_approval', 'reply_only', 'reviewing_3 + NO 3 → awaiting_approval');
+assertMatch(transition(review3, { kind: 'review', proposal_n: 1, message_date: 2000 }),
+    'reviewing_<N>', 'send_review_artifact', 'reviewing_3 + /review 1 → reviewing_<1>');
+assertMatch(transition(review3, { kind: 'skip', proposal_n: 1, message_date: 2000 }),
+    'reviewing_<N>', 'reply_only', 'reviewing_3 + /skip 1 → stay reviewing_3');
+assertMatch(transition(review3, { kind: 'skip', proposal_n: 3, message_date: 2000 }),
+    'awaiting_approval', 'reply_only', 'reviewing_3 + /skip 3 → awaiting_approval');
+assertMatch(transition(review3, { kind: 'stop', message_date: 2000 }),
+    'done', 'end_session', 'reviewing_3 + /stop → done');
+
+const lastOne = { kind: 'awaiting_approval', open_proposal_ns: [5] };
+assertMatch(transition(lastOne, { kind: 'skip', proposal_n: 5, message_date: 2000 }),
+    'done', 'end_session', 'aa last proposal + /skip → done');
+
+const reviewLast = { kind: 'reviewing_<N>', reviewing_n: 5, open_proposal_ns: [5], reviewing_opened_at: 1000 };
+assertMatch(transition(reviewLast, { kind: 'yes', proposal_n: 5, message_date: 1030 }),
+    'done', 'write_skill', 'reviewing_5 last + YES 5 → done (after write)');
+
+if (fails > 0) process.exit(1);
+console.log('all tests passed');
+process.exit(0);

--- a/tests/nodejs-project/school-state-machine.test.js
+++ b/tests/nodejs-project/school-state-machine.test.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-// school-state-machine.test.js — all 32 (state, input) transitions per spec §8.5.1.
+// school-state-machine.test.js — 16 representative transitions covering every
+// (state, input) cell per spec §8.5.1 (each state × each input kind × key edge
+// cases: stale-bare-YES window, mismatched proposal_n, last-proposal drain).
+// Not exhaustive over every combinatorial (state, input, proposal_n) triple —
+// the rows chosen here catch every distinct code path in transition().
 // Run: node tests/nodejs-project/school-state-machine.test.js
 
 const path = require('path');

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// school-tools.test.js — tool handler behavior.
+// Run: node tests/nodejs-project/school-tools.test.js
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+let fails = 0;
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'school-tools-'));
+process.env.WORKDIR = tmp;
+
+(async () => {
+    const { schoolBeginHandler, schoolEndHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+
+    const beginRes = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (!beginRes.ok || !beginRes.session_id) { console.error('FAIL begin fresh', beginRes); process.exit(1); }
+    console.log('  ✓ school_begin creates new session + SCHOOL.md');
+
+    const sch = fs.readFileSync(path.join(tmp, 'SCHOOL.md'), 'utf8');
+    if (!sch.includes(beginRes.session_id)) { console.error('FAIL SCHOOL.md missing session_id'); process.exit(1); }
+    console.log('  ✓ SCHOOL.md contains session_id');
+
+    const beginRes2 = await schoolBeginHandler({ reason: 'on_demand' }, { workDir: tmp });
+    if (beginRes2.ok && !beginRes2.resumed) { console.error('FAIL: expected concurrent-session return', beginRes2); process.exit(1); }
+    console.log('  ✓ school_begin detects existing SCHOOL.md (resumed or rejected)');
+
+    const endRes = await schoolEndHandler({
+        session_id: beginRes.session_id,
+        summary: { patterns_found: 0, proposals_made: 0, approved: [], drafted_but_denied: [], skipped: [], ignored: [], rejected_by_rubric: [], rejected_as_duplicate: [] }
+    }, { workDir: tmp });
+    if (!endRes.ok) { console.error('FAIL end', endRes); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'SCHOOL.md'))) { console.error('FAIL: SCHOOL.md not deleted after end'); process.exit(1); }
+    console.log('  ✓ school_end deletes SCHOOL.md');
+
+    const logPath = path.join(tmp, 'school', 'log.jsonl');
+    const logContent = fs.readFileSync(logPath, 'utf8').trim();
+    const parsed = JSON.parse(logContent);
+    if (parsed.session_id !== beginRes.session_id) { console.error('FAIL: log entry session_id mismatch'); process.exit(1); }
+    console.log('  ✓ school_end appends log.jsonl entry');
+})().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+    if (fails > 0) process.exit(1);
+    console.log('all tests passed');
+    process.exit(0);
+});

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -87,6 +87,23 @@ process.env.WORKDIR = tmp;
     if (!patched.includes('last_patched_by: school')) { console.error('FAIL: patch must add last_patched_by'); process.exit(1); }
     console.log('  ✓ school_write_skill (patch) preserves source + adds last_patched_by');
 
+    // Patch body that OMITS source: entirely must still have the original source
+    // preserved (provenance contract). Previously the post-hoc regex replace
+    // had nothing to match and source was silently dropped.
+    fs.writeFileSync(path.join(tmp, 'skills/needs-source.md'),
+        `---\nname: needs-source\nsource: user\nversion: "1.0.0"\n---\n\n# needs source\n`);
+    const patchNoSrcRes = await schoolWriteSkillHandler({
+        mode: 'patch', path: 'skills/needs-source.md',
+        body: `---\nname: needs-source\nversion: "1.0.0"\n---\n\n# updated body\n`,
+        evidence: 'refactor',
+    }, { workDir: tmp });
+    if (!patchNoSrcRes.ok) { console.error('FAIL patch-no-src', patchNoSrcRes); process.exit(1); }
+    const patchedNoSrc = fs.readFileSync(path.join(tmp, 'skills/needs-source.md'), 'utf8');
+    if (!patchedNoSrc.includes('source: user')) {
+        console.error('FAIL: patch-no-src must still inject source: user, got:\n', patchedNoSrc); process.exit(1);
+    }
+    console.log('  ✓ school_write_skill (patch) injects source when body omits it');
+
     // Evidence with YAML-hostile chars (newlines, colons, #) must be quoted so the
     // frontmatter stays parseable by readSchoolMd's simple regex.
     const nastyRes = await schoolWriteSkillHandler({
@@ -119,12 +136,48 @@ process.env.WORKDIR = tmp;
     if (!retiredFiles.some(f => f.includes('to-retire.md'))) { console.error('FAIL: no retired file found'); process.exit(1); }
     console.log('  ✓ school_retire_skill moves to retired/ reversibly');
 
+    // Seed SCHOOL.md in the state the handler will read from. After B4's /end
+    // earlier in this test, SCHOOL.md was deleted — reseed for the handler test.
+    const { writeSchoolMd: _writeSchoolMd } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+    );
+    _writeSchoolMd(tmp, {
+        session_id: 'hi-test', started_at: 1000, trigger: 'on_demand',
+        state: 'reviewing_<N>', window_days: 7, open_proposal_ns: [3],
+        reviewing_n: 3, reviewing_opened_at: 1000, rubric_version: '1.0.0',
+        proposals: [],
+    });
     const hiRes = await schoolHandleInputHandler({
-        session_id: 'test', state: { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [3], reviewing_opened_at: 1000 },
+        session_id: 'hi-test',
+        state: { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [3], reviewing_opened_at: 1000 },
         input: { kind: 'yes', proposal_n: 3, message_date: 1020, raw_text: 'YES 3' }
     }, { workDir: tmp });
     if (!hiRes.ok || hiRes.next_action.kind !== 'write_skill') { console.error('FAIL handle_input yes', hiRes); process.exit(1); }
     console.log('  ✓ school_handle_input returns write_skill next_action on YES');
+
+    // Verify state was persisted back to SCHOOL.md. YES on the only open
+    // proposal transitions to `done` with empty open_proposal_ns.
+    const { readSchoolMd: _readSchoolMd } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+    );
+    const fmAfter = _readSchoolMd(tmp);
+    if (!fmAfter || fmAfter.state !== 'done') {
+        console.error('FAIL handle_input must persist new state=done, got:', fmAfter && fmAfter.state); process.exit(1);
+    }
+    if (fmAfter.open_proposal_ns.length !== 0) {
+        console.error('FAIL handle_input must drain open_proposal_ns, got:', fmAfter.open_proposal_ns); process.exit(1);
+    }
+    console.log('  ✓ school_handle_input persists new state back to SCHOOL.md');
+
+    // No-session safety: delete SCHOOL.md + omit args.state; expect clean error.
+    try { fs.unlinkSync(path.join(tmp, 'SCHOOL.md')); } catch (_) {}
+    const hiNoSessRes = await schoolHandleInputHandler({
+        session_id: 'no-sess', input: { kind: 'yes', message_date: 1 }
+    }, { workDir: tmp });
+    if (hiNoSessRes.ok || hiNoSessRes.error !== 'no_session_state') {
+        console.error('FAIL no-session handle_input must return no_session_state, got:', hiNoSessRes); process.exit(1);
+    }
+    console.log('  ✓ school_handle_input rejects when no SCHOOL.md + no args.state');
 })().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
     try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
     if (fails > 0) process.exit(1);

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -86,6 +86,25 @@ process.env.WORKDIR = tmp;
     if (!patched.includes('source: user')) { console.error('FAIL: patch must preserve source: user'); process.exit(1); }
     if (!patched.includes('last_patched_by: school')) { console.error('FAIL: patch must add last_patched_by'); process.exit(1); }
     console.log('  ✓ school_write_skill (patch) preserves source + adds last_patched_by');
+
+    // Evidence with YAML-hostile chars (newlines, colons, #) must be quoted so the
+    // frontmatter stays parseable by readSchoolMd's simple regex.
+    const nastyRes = await schoolWriteSkillHandler({
+        mode: 'create', path: 'skills/nasty.md',
+        body: `---\nname: nasty\ndescription: "nasty"\nversion: "1.0.0"\n---\n\n# nasty\n`,
+        evidence: 'user: said\nfoo: bar # not-a-key',
+    }, { workDir: tmp });
+    if (!nastyRes.ok) { console.error('FAIL nasty', nastyRes); process.exit(1); }
+    const nastyText = fs.readFileSync(path.join(tmp, 'skills/nasty.md'), 'utf8');
+    const nastyFm = nastyText.match(/^---\n([\s\S]+?)\n---/)[1];
+    const evLine = nastyFm.split('\n').find(l => l.startsWith('evidence:'));
+    if (!evLine || !evLine.startsWith('evidence: "')) {
+        console.error('FAIL: nasty evidence must be quoted, got:', evLine); process.exit(1);
+    }
+    if (nastyFm.split('\n').some(l => l.startsWith('foo:'))) {
+        console.error('FAIL: nasty evidence injected a phantom foo: key'); process.exit(1);
+    }
+    console.log('  ✓ school_write_skill quotes YAML-hostile evidence');
 })().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
     try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
     if (fails > 0) process.exit(1);

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -104,6 +104,55 @@ process.env.WORKDIR = tmp;
     }
     console.log('  ✓ school_write_skill (patch) injects source when body omits it');
 
+    // Test nested frontmatter preservation: requires: block + allowed-tools: list
+    // must survive a patch operation (issue: old code dropped nested YAML).
+    const nestedSkillBody = `---
+name: my-skill
+source: user
+version: "1.0.0"
+requires:
+  bins: []
+  env:
+    - OPENAI_KEY
+allowed-tools:
+  - file_read
+  - web_fetch
+---
+
+# My Skill
+
+Instructions.
+`;
+    fs.writeFileSync(path.join(tmp, 'skills/nested-fm.md'), nestedSkillBody);
+    const nestedPatchRes = await schoolWriteSkillHandler({
+        mode: 'patch', path: 'skills/nested-fm.md',
+        body: nestedSkillBody,  // Same shape, triggers injection of last_patched_by
+        evidence: 'fixing X',
+    }, { workDir: tmp });
+    if (!nestedPatchRes.ok) { console.error('FAIL nested patch', nestedPatchRes); process.exit(1); }
+    const nestedPatched = fs.readFileSync(path.join(tmp, 'skills/nested-fm.md'), 'utf8');
+
+    // Assert: requires block is still present
+    if (!/\nrequires:\n {2}bins:/m.test(nestedPatched)) {
+        console.error('FAIL: requires: block was dropped in nested patch, got:\n', nestedPatched); process.exit(1);
+    }
+    // Assert: allowed-tools list items are still present
+    if (!nestedPatched.includes('- file_read')) {
+        console.error('FAIL: allowed-tools list item "file_read" was dropped'); process.exit(1);
+    }
+    if (!nestedPatched.includes('- web_fetch')) {
+        console.error('FAIL: allowed-tools list item "web_fetch" was dropped'); process.exit(1);
+    }
+    // Assert: source: user still present
+    if (!nestedPatched.includes('source: user')) {
+        console.error('FAIL: source: user was not preserved in nested patch'); process.exit(1);
+    }
+    // Assert: last_patched_by: school was added
+    if (!nestedPatched.includes('last_patched_by: school')) {
+        console.error('FAIL: last_patched_by: school was not added'); process.exit(1);
+    }
+    console.log('  ✓ school_write_skill (patch) preserves nested YAML blocks and list items');
+
     // Evidence with YAML-hostile chars (newlines, colons, #) must be quoted so the
     // frontmatter stays parseable by readSchoolMd's simple regex.
     const nastyRes = await schoolWriteSkillHandler({

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -105,6 +105,26 @@ process.env.WORKDIR = tmp;
         console.error('FAIL: nasty evidence injected a phantom foo: key'); process.exit(1);
     }
     console.log('  ✓ school_write_skill quotes YAML-hostile evidence');
+
+    // ========== B6 Assertions (school_retire_skill + school_handle_input + school_scan) ==========
+    fs.writeFileSync(path.join(tmp, 'skills/to-retire.md'),
+        `---\nname: to-retire\nsource: school\n---\n\n# gone\n`);
+    const { schoolRetireSkillHandler, schoolHandleInputHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+    const retRes = await schoolRetireSkillHandler({ path: 'skills/to-retire.md', reason: 'unused' }, { workDir: tmp });
+    if (!retRes.ok) { console.error('FAIL retire', retRes); process.exit(1); }
+    if (fs.existsSync(path.join(tmp, 'skills/to-retire.md'))) { console.error('FAIL: file not moved'); process.exit(1); }
+    const retiredFiles = fs.readdirSync(path.join(tmp, 'school/retired'));
+    if (!retiredFiles.some(f => f.includes('to-retire.md'))) { console.error('FAIL: no retired file found'); process.exit(1); }
+    console.log('  ✓ school_retire_skill moves to retired/ reversibly');
+
+    const hiRes = await schoolHandleInputHandler({
+        session_id: 'test', state: { kind: 'reviewing_<N>', reviewing_n: 3, open_proposal_ns: [3], reviewing_opened_at: 1000 },
+        input: { kind: 'yes', proposal_n: 3, message_date: 1020, raw_text: 'YES 3' }
+    }, { workDir: tmp });
+    if (!hiRes.ok || hiRes.next_action.kind !== 'write_skill') { console.error('FAIL handle_input yes', hiRes); process.exit(1); }
+    console.log('  ✓ school_handle_input returns write_skill next_action on YES');
 })().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
     try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
     if (fails > 0) process.exit(1);

--- a/tests/nodejs-project/school-tools.test.js
+++ b/tests/nodejs-project/school-tools.test.js
@@ -40,6 +40,52 @@ process.env.WORKDIR = tmp;
     const parsed = JSON.parse(logContent);
     if (parsed.session_id !== beginRes.session_id) { console.error('FAIL: log entry session_id mismatch'); process.exit(1); }
     console.log('  ✓ school_end appends log.jsonl entry');
+
+    // ========== B5 Assertions (school_write_skill) ==========
+    const { schoolWriteSkillHandler } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tools/school.js')
+    );
+
+    const createRes = await schoolWriteSkillHandler({
+        mode: 'create',
+        path: 'skills/recipe-scaling.md',
+        body: `---\nname: recipe-scaling\ndescription: "Scale recipes"\nversion: "1.0.0"\n---\n\n# Recipe Scaling\n\nInstructions.\n`,
+        evidence: 'user asked 4x since Apr 13',
+    }, { workDir: tmp });
+    if (!createRes.ok) { console.error('FAIL create', createRes); process.exit(1); }
+    const written = fs.readFileSync(path.join(tmp, 'skills/recipe-scaling.md'), 'utf8');
+    if (!written.includes('source: school')) { console.error('FAIL: missing source: school marker'); process.exit(1); }
+    if (!written.includes('evidence:')) { console.error('FAIL: missing evidence field'); process.exit(1); }
+    console.log('  ✓ school_write_skill (create) injects school frontmatter marker');
+
+    const traversalRes = await schoolWriteSkillHandler({
+        mode: 'create', path: '../evil.md', body: `---\nname: evil\n---\n\n# evil\n`, evidence: 'x',
+    }, { workDir: tmp });
+    if (traversalRes.ok) { console.error('FAIL: traversal should be rejected'); process.exit(1); }
+    console.log('  ✓ school_write_skill rejects path traversal');
+
+    const huge = 'A'.repeat(70 * 1024);
+    const overRes = await schoolWriteSkillHandler({
+        mode: 'create', path: 'skills/too-big.md',
+        body: `---\nname: too-big\n---\n\n# too-big\n${huge}`,
+        evidence: 'x',
+    }, { workDir: tmp });
+    if (overRes.ok) { console.error('FAIL: oversize should be rejected'); process.exit(1); }
+    console.log('  ✓ school_write_skill rejects > 64KB');
+
+    fs.mkdirSync(path.join(tmp, 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'skills/user-authored.md'),
+        `---\nname: user-authored\nsource: user\nversion: "1.0.0"\n---\n\n# user\n`);
+    const patchRes = await schoolWriteSkillHandler({
+        mode: 'patch', path: 'skills/user-authored.md',
+        body: `---\nname: user-authored\nsource: user\nversion: "1.0.0"\n---\n\n# user patched\n`,
+        evidence: 'fix',
+    }, { workDir: tmp });
+    if (!patchRes.ok) { console.error('FAIL patch', patchRes); process.exit(1); }
+    const patched = fs.readFileSync(path.join(tmp, 'skills/user-authored.md'), 'utf8');
+    if (!patched.includes('source: user')) { console.error('FAIL: patch must preserve source: user'); process.exit(1); }
+    if (!patched.includes('last_patched_by: school')) { console.error('FAIL: patch must add last_patched_by'); process.exit(1); }
+    console.log('  ✓ school_write_skill (patch) preserves source + adds last_patched_by');
 })().catch(e => { console.error('FAIL', e); process.exit(1); }).finally(() => {
     try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
     if (fails > 0) process.exit(1);

--- a/tests/nodejs-project/school.test.js
+++ b/tests/nodejs-project/school.test.js
@@ -3,9 +3,7 @@
 // Run: node tests/nodejs-project/school.test.js
 
 const path = require('path');
-const { normalizeTitle, signatureOf } = require(
-    path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
-);
+const { setupConfigFixture } = require(path.join(__dirname, '_fixtures.js'));
 
 let fails = 0;
 function assertEq(actual, expected, msg) {
@@ -15,25 +13,89 @@ function assertEq(actual, expected, msg) {
     } else console.log(`  ✓ ${msg}`);
 }
 
-// normalizeTitle — 4 variants collapse
-assertEq(normalizeTitle('Recipe Scaling'), 'recipe-scaling', 'title spaces');
-assertEq(normalizeTitle('recipe_scaling'), 'recipe-scaling', 'title underscore');
-assertEq(normalizeTitle('recipe-scaling'), 'recipe-scaling', 'title kebab');
-assertEq(normalizeTitle('RECIPE.SCALING!'), 'recipe-scaling', 'title upper+punct');
-assertEq(normalizeTitle('  --recipe scaling--  '), 'recipe-scaling', 'title trimmed');
+async function main() {
+    // Setup config fixture before requiring modules that depend on config.js
+    setupConfigFixture('seekerclaw-school-test-');
 
-// Drift → different signature
-if (signatureOf('create', 'Recipe Scaling') === signatureOf('create', 'recipe-scaling-v2')) {
-    console.error(`FAIL signatureOf: v2 variant should differ from original`);
-    fails++;
-} else console.log('  ✓ signatureOf distinguishes v2 variant');
+    // Now safe to require school.js and database-dependent modules
+    const { normalizeTitle, signatureOf, scanLogs } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+    );
 
-// Same title → same sig across cases
-if (signatureOf('create', 'Recipe Scaling') !== signatureOf('create', 'RECIPE.SCALING!')) {
-    console.error(`FAIL signatureOf: same normalized title should produce same sig`);
-    fails++;
-} else console.log('  ✓ signatureOf stable across case+punctuation');
+    // ========== B1 Assertions (sync) ==========
+    // normalizeTitle — 4 variants collapse
+    assertEq(normalizeTitle('Recipe Scaling'), 'recipe-scaling', 'title spaces');
+    assertEq(normalizeTitle('recipe_scaling'), 'recipe-scaling', 'title underscore');
+    assertEq(normalizeTitle('recipe-scaling'), 'recipe-scaling', 'title kebab');
+    assertEq(normalizeTitle('RECIPE.SCALING!'), 'recipe-scaling', 'title upper+punct');
+    assertEq(normalizeTitle('  --recipe scaling--  '), 'recipe-scaling', 'title trimmed');
 
-if (fails > 0) process.exit(1);
-console.log('all tests passed');
-process.exit(0);
+    // Drift → different signature
+    if (signatureOf('create', 'Recipe Scaling') === signatureOf('create', 'recipe-scaling-v2')) {
+        console.error(`FAIL signatureOf: v2 variant should differ from original`);
+        fails++;
+    } else console.log('  ✓ signatureOf distinguishes v2 variant');
+
+    // Same title → same sig across cases
+    if (signatureOf('create', 'Recipe Scaling') !== signatureOf('create', 'RECIPE.SCALING!')) {
+        console.error(`FAIL signatureOf: same normalized title should produce same sig`);
+        fails++;
+    } else console.log('  ✓ signatureOf stable across case+punctuation');
+
+    // ========== B3 Assertions (async — scanLogs) ==========
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+    const { createToolCallLogSchema, createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+    createSkillTriggerLogSchema(db);
+
+    const now = 1713614400000;
+    const day = 24 * 3600 * 1000;
+    // Populate > INSUFFICIENT_SIGNAL_MIN_CALLS (20) total rows so scan doesn't return empty.
+    // 4 repeated + 3 failed = 7 — need 13+ more. Add filler rows.
+    for (let i = 0; i < 4; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('t', 'recipe_calc', 'shell_exec:calc', 'ok', 5, ?)`, [now - i * day]);
+    }
+    for (let i = 0; i < 3; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, error_kind, latency_ms, created_at)
+            VALUES ('u', 'solana_swap', 'solana_swap:SOL:USDC', 'error', 'bridge_unreachable', 15, ?)`, [now - i * 3600000]);
+    }
+    // Filler to cross 20-call threshold
+    for (let i = 0; i < 15; i++) {
+        db.run(`INSERT INTO tool_call_log (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+            VALUES ('f' || ?, 'misc', 'misc:op', 'ok', 1, ?)`, [i, now - i * 1000]);
+    }
+
+    const result = scanLogs(db, { window_days: 7, min_repetition: 3, now_ms: now });
+
+    if (result.empty) { console.error('FAIL: expected non-empty scan, got', result); fails++; }
+    else {
+        const rp = (result.repeated_patterns || []).find(p => (p.call_shape_chain && p.call_shape_chain[0] === 'shell_exec:calc'));
+        if (!rp || rp.count !== 4) { console.error('FAIL: expected repeated_patterns shell_exec:calc count=4', rp); fails++; }
+        else console.log('  ✓ scanLogs finds repeated_patterns');
+        const fs2 = (result.failed_sequences || []).find(f => f.error_kind === 'bridge_unreachable');
+        if (!fs2 || fs2.count !== 3) { console.error('FAIL: expected failed_sequences count=3', fs2); fails++; }
+        else console.log('  ✓ scanLogs finds failed_sequences');
+    }
+
+    const db2 = new SQL.Database();
+    createToolCallLogSchema(db2); createSkillTriggerLogSchema(db2);
+    const emptyRes = scanLogs(db2, { window_days: 7, min_repetition: 3, now_ms: now });
+    if (!emptyRes.empty) { console.error('FAIL: expected empty:true on empty log'); fails++; }
+    else console.log('  ✓ scanLogs returns empty:true on insufficient data');
+
+    // Exit with appropriate code
+    if (fails > 0) process.exit(1);
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => {
+    console.error('FAIL', e);
+    process.exit(1);
+});

--- a/tests/nodejs-project/school.test.js
+++ b/tests/nodejs-project/school.test.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// school.test.js — pure functions in school.js.
+// Run: node tests/nodejs-project/school.test.js
+
+const path = require('path');
+const { normalizeTitle, signatureOf } = require(
+    path.join(__dirname, '../../app/src/main/assets/nodejs-project/school.js')
+);
+
+let fails = 0;
+function assertEq(actual, expected, msg) {
+    if (actual !== expected) {
+        console.error(`FAIL ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        fails++;
+    } else console.log(`  ✓ ${msg}`);
+}
+
+// normalizeTitle — 4 variants collapse
+assertEq(normalizeTitle('Recipe Scaling'), 'recipe-scaling', 'title spaces');
+assertEq(normalizeTitle('recipe_scaling'), 'recipe-scaling', 'title underscore');
+assertEq(normalizeTitle('recipe-scaling'), 'recipe-scaling', 'title kebab');
+assertEq(normalizeTitle('RECIPE.SCALING!'), 'recipe-scaling', 'title upper+punct');
+assertEq(normalizeTitle('  --recipe scaling--  '), 'recipe-scaling', 'title trimmed');
+
+// Drift → different signature
+if (signatureOf('create', 'Recipe Scaling') === signatureOf('create', 'recipe-scaling-v2')) {
+    console.error(`FAIL signatureOf: v2 variant should differ from original`);
+    fails++;
+} else console.log('  ✓ signatureOf distinguishes v2 variant');
+
+// Same title → same sig across cases
+if (signatureOf('create', 'Recipe Scaling') !== signatureOf('create', 'RECIPE.SCALING!')) {
+    console.error(`FAIL signatureOf: same normalized title should produce same sig`);
+    fails++;
+} else console.log('  ✓ signatureOf stable across case+punctuation');
+
+if (fails > 0) process.exit(1);
+console.log('all tests passed');
+process.exit(0);

--- a/tests/nodejs-project/skill-trigger-log.test.js
+++ b/tests/nodejs-project/skill-trigger-log.test.js
@@ -44,6 +44,11 @@ async function main() {
     recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500000);
     recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500500);  // duplicate, should be ignored
 
+    // recordSkillTrigger defers the INSERT via setImmediate (off the hot path).
+    // Drain the queue before asserting so both writes have landed.
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
     const r2 = db.exec('SELECT COUNT(*) FROM skill_trigger_log WHERE message_id = ?', ['msg-42']);
     const c2 = r2[0].values[0][0];
     if (c2 !== 1) { console.error(`FAIL recordSkillTrigger dedup: expected 1, got ${c2}`); process.exit(1); }

--- a/tests/nodejs-project/skill-trigger-log.test.js
+++ b/tests/nodejs-project/skill-trigger-log.test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// skill-trigger-log.test.js — schema + UNIQUE constraint test.
+// Run: node tests/nodejs-project/skill-trigger-log.test.js
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+async function main() {
+    // database.js transitively requires config.js, which reads config.json from
+    // process.argv[2] (falls back to __dirname) and calls process.exit(1) if it's
+    // missing. Stand up a minimal fixture workdir so the require succeeds in a
+    // standalone test environment.
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seekerclaw-stl-test-'));
+    fs.writeFileSync(path.join(fixtureDir, 'config.json'), JSON.stringify({
+        channel: 'telegram',
+        botToken: 'test-bot-token',
+        ownerId: '1',
+        provider: 'claude',
+        anthropicApiKey: 'test-anthropic-key',
+        agentName: 'TestAgent',
+    }));
+    process.argv[2] = fixtureDir;
+
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    const { createSkillTriggerLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createSkillTriggerLogSchema(db);
+
+    // First insert succeeds.
+    db.run(`INSERT OR IGNORE INTO skill_trigger_log
+        (skill_name, message_id, match_type, created_at) VALUES ('weather', 'msg-1', 'keyword', 1713614400000)`);
+
+    // Duplicate (skill_name, message_id) is silently ignored.
+    db.run(`INSERT OR IGNORE INTO skill_trigger_log
+        (skill_name, message_id, match_type, created_at) VALUES ('weather', 'msg-1', 'keyword', 1713614400500)`);
+
+    const result = db.exec('SELECT COUNT(*) FROM skill_trigger_log');
+    const count = result[0].values[0][0];
+    if (count !== 1) {
+        console.error(`FAIL: expected 1 row after dedup, got ${count}`);
+        process.exit(1);
+    }
+    console.log('  ✓ skill_trigger_log dedups on (skill_name, message_id)');
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });

--- a/tests/nodejs-project/skill-trigger-log.test.js
+++ b/tests/nodejs-project/skill-trigger-log.test.js
@@ -33,6 +33,22 @@ async function main() {
         process.exit(1);
     }
     console.log('  ✓ skill_trigger_log dedups on (skill_name, message_id)');
+
+    // Verify findMatchingSkills records matches.
+    // We call a helper that simulates the match-and-log path.
+    const { recordSkillTrigger, setSkillTriggerDb } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/skills.js')
+    );
+    setSkillTriggerDb(db);
+
+    recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500000);
+    recordSkillTrigger('weather', 'msg-42', 'keyword', 1713614500500);  // duplicate, should be ignored
+
+    const r2 = db.exec('SELECT COUNT(*) FROM skill_trigger_log WHERE message_id = ?', ['msg-42']);
+    const c2 = r2[0].values[0][0];
+    if (c2 !== 1) { console.error(`FAIL recordSkillTrigger dedup: expected 1, got ${c2}`); process.exit(1); }
+    console.log('  ✓ recordSkillTrigger uses INSERT OR IGNORE (no double-count)');
+
     console.log('all tests passed');
     process.exit(0);
 }

--- a/tests/nodejs-project/skill-trigger-log.test.js
+++ b/tests/nodejs-project/skill-trigger-log.test.js
@@ -2,25 +2,11 @@
 // skill-trigger-log.test.js — schema + UNIQUE constraint test.
 // Run: node tests/nodejs-project/skill-trigger-log.test.js
 
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
+const { setupConfigFixture } = require('./_fixtures');
 
 async function main() {
-    // database.js transitively requires config.js, which reads config.json from
-    // process.argv[2] (falls back to __dirname) and calls process.exit(1) if it's
-    // missing. Stand up a minimal fixture workdir so the require succeeds in a
-    // standalone test environment.
-    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seekerclaw-stl-test-'));
-    fs.writeFileSync(path.join(fixtureDir, 'config.json'), JSON.stringify({
-        channel: 'telegram',
-        botToken: 'test-bot-token',
-        ownerId: '1',
-        provider: 'claude',
-        anthropicApiKey: 'test-anthropic-key',
-        agentName: 'TestAgent',
-    }));
-    process.argv[2] = fixtureDir;
+    setupConfigFixture('seekerclaw-stl-test-');
 
     const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
     const initSqlJs = require(SQL_PATH);

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -60,6 +60,7 @@ const LOAD_TARGETS = [
     'silent-reply.js',
     'loop-detector.js',
     'call-shape.js',
+    'tool-call-logger.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -62,6 +62,7 @@ const LOAD_TARGETS = [
     'call-shape.js',
     'tool-call-logger.js',
     'error-classifier.js',
+    'school.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which
@@ -110,6 +111,7 @@ const SKIP_REASONS = {
     'tools/system.js': 'runs shell commands',
     'tools/telegram.js': 'requires telegram.js',
     'tools/web.js': 'requires web.js caches',
+    'tools/school.js': 'lazy-requires database.js which needs config.js fixture',
     'sql-wasm.js': 'third-party bundle (sql.js)',
     'markdown-it.min.js': 'third-party bundle (markdown-it)',
 };

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -61,6 +61,7 @@ const LOAD_TARGETS = [
     'loop-detector.js',
     'call-shape.js',
     'tool-call-logger.js',
+    'error-classifier.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -59,6 +59,7 @@ const BUNDLE = path.join(REPO_ROOT, 'app', 'src', 'main', 'assets', 'nodejs-proj
 const LOAD_TARGETS = [
     'silent-reply.js',
     'loop-detector.js',
+    'call-shape.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which

--- a/tests/nodejs-project/tool-call-log-perf.test.js
+++ b/tests/nodejs-project/tool-call-log-perf.test.js
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 // tool-call-log-perf.test.js — ensure the buffered logger doesn't
 // regress p99 tool latency under a 1000-call burst.
-// Target: 1000 records + flush < 200ms wall-clock total. If this
-// fails, the buffered-insert path is slower than expected.
+//
+// Budget: 200ms wall-clock on a dev laptop; loosened to 1000ms under CI
+// (CI runners vary wildly in contention/disk). Override with env var
+// TCL_PERF_BUDGET_MS=N for custom tuning. Timing is always reported so
+// trend regressions are visible even when the assertion passes.
 
 const path = require('path');
 const { setupConfigFixture } = require('./_fixtures');
+
+const DEFAULT_BUDGET_MS = process.env.CI ? 1000 : 200;
+const BUDGET_MS = process.env.TCL_PERF_BUDGET_MS
+    ? Number(process.env.TCL_PERF_BUDGET_MS)
+    : DEFAULT_BUDGET_MS;
 
 async function main() {
     // database.js transitively requires config.js (reads config.json or exits);
@@ -44,11 +52,11 @@ async function main() {
 
     await logger.stop();
 
-    if (elapsed > 200) {
-        console.error(`FAIL: 1000-record burst took ${elapsed}ms (budget: 200ms)`);
+    if (elapsed > BUDGET_MS) {
+        console.error(`FAIL: 1000-record burst took ${elapsed}ms (budget: ${BUDGET_MS}ms)`);
         process.exit(1);
     }
-    console.log(`  ✓ 1000 records + flush = ${elapsed}ms (budget 200ms)`);
+    console.log(`  ✓ 1000 records + flush = ${elapsed}ms (budget ${BUDGET_MS}ms)`);
     console.log('all tests passed');
     process.exit(0);
 }

--- a/tests/nodejs-project/tool-call-log-perf.test.js
+++ b/tests/nodejs-project/tool-call-log-perf.test.js
@@ -11,8 +11,13 @@ const path = require('path');
 const { setupConfigFixture } = require('./_fixtures');
 
 const DEFAULT_BUDGET_MS = process.env.CI ? 1000 : 200;
-const BUDGET_MS = process.env.TCL_PERF_BUDGET_MS
-    ? Number(process.env.TCL_PERF_BUDGET_MS)
+// A non-numeric TCL_PERF_BUDGET_MS (e.g. "yes" from a copy-paste) would
+// coerce to NaN, and `elapsed > NaN` is always false — silently disabling
+// the assertion. Validate and fall back to the default in that case.
+const _rawBudget = process.env.TCL_PERF_BUDGET_MS;
+const _parsedBudget = _rawBudget === undefined ? NaN : Number(_rawBudget);
+const BUDGET_MS = Number.isFinite(_parsedBudget) && _parsedBudget > 0
+    ? _parsedBudget
     : DEFAULT_BUDGET_MS;
 
 async function main() {

--- a/tests/nodejs-project/tool-call-log-perf.test.js
+++ b/tests/nodejs-project/tool-call-log-perf.test.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// tool-call-log-perf.test.js — ensure the buffered logger doesn't
+// regress p99 tool latency under a 1000-call burst.
+// Target: 1000 records + flush < 200ms wall-clock total. If this
+// fails, the buffered-insert path is slower than expected.
+
+const path = require('path');
+const { setupConfigFixture } = require('./_fixtures');
+
+async function main() {
+    // database.js transitively requires config.js (reads config.json or exits);
+    // stand up a minimal fixture before requiring it, even though we only use
+    // createToolCallLogSchema from that module.
+    setupConfigFixture('seekerclaw-tcl-perf-');
+
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    const { createToolCallLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+
+    const { ToolCallLogger } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tool-call-logger.js')
+    );
+    const logger = new ToolCallLogger({ db, flushIntervalMs: 10000, maxBufferSize: 200 });
+
+    const start = Date.now();
+    for (let i = 0; i < 1000; i++) {
+        logger.record({
+            turn_id: 'perf', message_id: `m${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:x:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 1, created_at: start + i
+        });
+    }
+    await logger.flushNow();
+    const elapsed = Date.now() - start;
+
+    const count = db.exec('SELECT COUNT(*) FROM tool_call_log')[0].values[0][0];
+    if (count !== 1000) { console.error(`FAIL: expected 1000 rows, got ${count}`); process.exit(1); }
+
+    await logger.stop();
+
+    if (elapsed > 200) {
+        console.error(`FAIL: 1000-record burst took ${elapsed}ms (budget: 200ms)`);
+        process.exit(1);
+    }
+    console.log(`  ✓ 1000 records + flush = ${elapsed}ms (budget 200ms)`);
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -2,25 +2,11 @@
 // tool-call-log.test.js — schema + insert smoke test for tool_call_log.
 // Run: node tests/nodejs-project/tool-call-log.test.js
 
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
+const { setupConfigFixture } = require('./_fixtures');
 
 async function main() {
-    // database.js transitively requires config.js, which reads config.json from
-    // process.argv[2] (falls back to __dirname) and calls process.exit(1) if it's
-    // missing. Stand up a minimal fixture workdir so the require succeeds in a
-    // standalone test environment.
-    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seekerclaw-tcl-test-'));
-    fs.writeFileSync(path.join(fixtureDir, 'config.json'), JSON.stringify({
-        channel: 'telegram',
-        botToken: 'test-bot-token',
-        ownerId: '1',
-        provider: 'claude',
-        anthropicApiKey: 'test-anthropic-key',
-        agentName: 'TestAgent',
-    }));
-    process.argv[2] = fixtureDir;
+    setupConfigFixture('seekerclaw-tcl-test-');
 
     const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
     const initSqlJs = require(SQL_PATH);

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -120,6 +120,28 @@ async function main() {
     console.log(`  ✓ buffered logger enforces hard cap (dropped ${60 - capLogger.buffer.length} oldest rows on persistent flush failure)`);
     // No stop() needed — capDb is closed; capLogger's interval is on a different timer that will no-op on next tick
 
+    // Retention purge test
+    const { purgeOldLogs } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    const now = 1713614400000;
+    const oldMs = now - (31 * 24 * 60 * 60 * 1000);   // 31 days old
+    const recentMs = now - (5 * 24 * 60 * 60 * 1000); // 5 days old
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+        VALUES ('old', 'web_fetch', 'web_fetch:x:GET', 'ok', 1, ?)`, [oldMs]);
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, tool_name, call_shape, result_status, latency_ms, created_at)
+        VALUES ('recent', 'web_fetch', 'web_fetch:x:GET', 'ok', 1, ?)`, [recentMs]);
+
+    purgeOldLogs(db, now);
+
+    const oldCount = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE turn_id = 'old'`)[0].values[0][0];
+    const recentCount = db.exec(`SELECT COUNT(*) FROM tool_call_log WHERE turn_id = 'recent'`)[0].values[0][0];
+    if (oldCount !== 0) { console.error(`FAIL: old rows not purged, ${oldCount} remain`); process.exit(1); }
+    if (recentCount !== 1) { console.error(`FAIL: recent row purged, expected 1 got ${recentCount}`); process.exit(1); }
+    console.log('  ✓ purgeOldLogs removes rows > 30 days, keeps recent');
+
     console.log('all tests passed');
     process.exit(0);
 }

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -45,15 +45,79 @@ async function main() {
             result_status: 'ok', error_kind: null, latency_ms: 10, created_at: 1713614400000 + i
         });
     }
-    // Wait briefly for interval flush
-    await new Promise(r => setTimeout(r, 80));
+    // Explicit flush — the size-trigger setImmediate may have already fired for rows
+    // 1-5, but rows 6-7 are still buffered. Drain before asserting count.
     await logger.flushNow();
 
     const r = db.exec('SELECT COUNT(*) FROM tool_call_log WHERE turn_id = ?', ['t2']);
     const c = r[0].values[0][0];
     if (c !== 7) { console.error(`FAIL buffered logger: expected 7 rows, got ${c}`); process.exit(1); }
     console.log('  ✓ buffered logger flushes on size + interval');
-    logger.stop();
+    await logger.stop();
+
+    // Re-trigger scenario: burst records beyond 2× maxBufferSize. With the
+    // re-trigger fix, all rows should land without needing to wait for the
+    // 5s interval. We use a small flushIntervalMs so the test fails loudly
+    // if the re-trigger path is broken (would have to fall back on interval).
+    const burstLogger = new ToolCallLogger({ db, flushIntervalMs: 5000, maxBufferSize: 5 });
+    for (let i = 0; i < 20; i++) {
+        burstLogger.record({
+            turn_id: 'burst', message_id: `b${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:example.com:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 1, created_at: 1713614400000 + i
+        });
+    }
+    // Yield enough ticks for setImmediate cascades + async flushes to complete.
+    // The re-trigger in finally block should chain flushes until buffer drains.
+    await new Promise(r => setTimeout(r, 200));
+    await burstLogger.flushNow();
+    await burstLogger.stop();
+    const burstCount = db.exec('SELECT COUNT(*) FROM tool_call_log WHERE turn_id = ?', ['burst'])[0].values[0][0];
+    if (burstCount !== 20) {
+        console.error(`FAIL burst: expected 20 rows, got ${burstCount} (re-trigger path broken?)`);
+        process.exit(1);
+    }
+    console.log('  ✓ buffered logger re-triggers flush when buffer still over threshold after flush completes');
+
+    // Hard-cap scenario: simulate persistent failure by using a stopped db.
+    // Push more than 10× maxBufferSize entries. Buffer should cap, oldest dropped.
+    // We can't easily simulate real db failure without closing it (which would
+    // corrupt other tests), so we verify the cap by reaching into the buffer
+    // directly while flushing is perma-disabled via a small trick: create a
+    // logger, stop it immediately (so no background flush), and push lots.
+
+    // Actually cleaner: use a separate logger with a fresh in-memory SQL that we
+    // close mid-way to force flush failures.
+    const capSQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const capDb = new capSQL.Database();
+    createToolCallLogSchema(capDb);
+    let warnCount = 0;
+    const capLogger = new ToolCallLogger({
+        db: capDb, flushIntervalMs: 5000, maxBufferSize: 5,
+        log: (msg, level) => { if (level === 'WARN' && msg.includes('hard-cap')) warnCount++; }
+    });
+    capDb.close();  // Force all subsequent flushes to throw
+    // Push 60 rows (12× maxBufferSize, above 10× hard cap)
+    for (let i = 0; i < 60; i++) {
+        capLogger.record({
+            turn_id: 'cap', message_id: `c${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:x:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 1, created_at: i
+        });
+    }
+    // Allow any scheduled setImmediates to drain
+    await new Promise(r => setTimeout(r, 50));
+    if (warnCount === 0) {
+        console.error(`FAIL hard-cap: expected at least one WARN log for dropped rows, got 0`);
+        process.exit(1);
+    }
+    if (capLogger.buffer.length > 50) {
+        console.error(`FAIL hard-cap: buffer grew to ${capLogger.buffer.length}, expected ≤ 50 (5 × 10)`);
+        process.exit(1);
+    }
+    console.log(`  ✓ buffered logger enforces hard cap (dropped ${60 - capLogger.buffer.length} oldest rows on persistent flush failure)`);
+    // No stop() needed — capDb is closed; capLogger's interval is on a different timer that will no-op on next tick
+
     console.log('all tests passed');
     process.exit(0);
 }

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -55,10 +55,12 @@ async function main() {
     console.log('  ✓ buffered logger flushes on size + interval');
     await logger.stop();
 
-    // Re-trigger scenario: burst records beyond 2× maxBufferSize. With the
-    // re-trigger fix, all rows should land without needing to wait for the
-    // 5s interval. We use a small flushIntervalMs so the test fails loudly
-    // if the re-trigger path is broken (would have to fall back on interval).
+    // Burst test: 20 records with small maxBufferSize. With SQL.js's synchronous
+    // db operations, a single setImmediate-scheduled flush drains the whole buffer
+    // in one pass (splice grabs everything), so this test can't distinguish the
+    // re-trigger path from the happy path — but it's still a useful regression
+    // against "logger drops rows on burst load" in general. True re-trigger
+    // coverage lives in the unit-level reasoning; the code reviewer verifies it.
     const burstLogger = new ToolCallLogger({ db, flushIntervalMs: 5000, maxBufferSize: 5 });
     for (let i = 0; i < 20; i++) {
         burstLogger.record({
@@ -74,10 +76,10 @@ async function main() {
     await burstLogger.stop();
     const burstCount = db.exec('SELECT COUNT(*) FROM tool_call_log WHERE turn_id = ?', ['burst'])[0].values[0][0];
     if (burstCount !== 20) {
-        console.error(`FAIL burst: expected 20 rows, got ${burstCount} (re-trigger path broken?)`);
+        console.error(`FAIL burst: expected 20 rows, got ${burstCount}`);
         process.exit(1);
     }
-    console.log('  ✓ buffered logger re-triggers flush when buffer still over threshold after flush completes');
+    console.log('  ✓ buffered logger handles burst of 20 records with small buffer');
 
     // Hard-cap scenario: simulate persistent failure by using a stopped db.
     // Push more than 10× maxBufferSize entries. Buffer should cap, oldest dropped.

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -59,8 +59,9 @@ async function main() {
     // db operations, a single setImmediate-scheduled flush drains the whole buffer
     // in one pass (splice grabs everything), so this test can't distinguish the
     // re-trigger path from the happy path — but it's still a useful regression
-    // against "logger drops rows on burst load" in general. True re-trigger
-    // coverage lives in the unit-level reasoning; the code reviewer verifies it.
+    // against "logger drops rows on burst load". The re-trigger itself fires
+    // inside flushNow's try-after-COMMIT, NOT in finally, to avoid a CPU spin
+    // loop when COMMIT persistently fails (see commit 654e7b8).
     const burstLogger = new ToolCallLogger({ db, flushIntervalMs: 5000, maxBufferSize: 5 });
     for (let i = 0; i < 20; i++) {
         burstLogger.record({
@@ -70,7 +71,6 @@ async function main() {
         });
     }
     // Yield enough ticks for setImmediate cascades + async flushes to complete.
-    // The re-trigger in finally block should chain flushes until buffer drains.
     await new Promise(r => setTimeout(r, 200));
     await burstLogger.flushNow();
     await burstLogger.stop();

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -30,6 +30,30 @@ async function main() {
         process.exit(1);
     }
     console.log('  ✓ tool_call_log schema created + insert roundtrips');
+
+    // Buffered logger test
+    const { ToolCallLogger } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/tool-call-logger.js')
+    );
+    const logger = new ToolCallLogger({ db, flushIntervalMs: 50, maxBufferSize: 5 });
+
+    // Log 7 rows — should trigger size-based flush at 5
+    for (let i = 0; i < 7; i++) {
+        logger.record({
+            turn_id: 't2', message_id: `m${i}`, tool_name: 'web_fetch',
+            triggered_by_skill: null, call_shape: 'web_fetch:example.com:GET',
+            result_status: 'ok', error_kind: null, latency_ms: 10, created_at: 1713614400000 + i
+        });
+    }
+    // Wait briefly for interval flush
+    await new Promise(r => setTimeout(r, 80));
+    await logger.flushNow();
+
+    const r = db.exec('SELECT COUNT(*) FROM tool_call_log WHERE turn_id = ?', ['t2']);
+    const c = r[0].values[0][0];
+    if (c !== 7) { console.error(`FAIL buffered logger: expected 7 rows, got ${c}`); process.exit(1); }
+    console.log('  ✓ buffered logger flushes on size + interval');
+    logger.stop();
     console.log('all tests passed');
     process.exit(0);
 }

--- a/tests/nodejs-project/tool-call-log.test.js
+++ b/tests/nodejs-project/tool-call-log.test.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// tool-call-log.test.js — schema + insert smoke test for tool_call_log.
+// Run: node tests/nodejs-project/tool-call-log.test.js
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+async function main() {
+    // database.js transitively requires config.js, which reads config.json from
+    // process.argv[2] (falls back to __dirname) and calls process.exit(1) if it's
+    // missing. Stand up a minimal fixture workdir so the require succeeds in a
+    // standalone test environment.
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seekerclaw-tcl-test-'));
+    fs.writeFileSync(path.join(fixtureDir, 'config.json'), JSON.stringify({
+        channel: 'telegram',
+        botToken: 'test-bot-token',
+        ownerId: '1',
+        provider: 'claude',
+        anthropicApiKey: 'test-anthropic-key',
+        agentName: 'TestAgent',
+    }));
+    process.argv[2] = fixtureDir;
+
+    const SQL_PATH = path.join(__dirname, '../../app/src/main/assets/nodejs-project/sql-wasm.js');
+    const initSqlJs = require(SQL_PATH);
+    const SQL = await initSqlJs({ locateFile: f => path.join(path.dirname(SQL_PATH), f) });
+    const db = new SQL.Database();
+
+    // This will fail until the migration runs. We call the exported migration helper.
+    const { createToolCallLogSchema } = require(
+        path.join(__dirname, '../../app/src/main/assets/nodejs-project/database.js')
+    );
+    createToolCallLogSchema(db);
+
+    db.run(`INSERT INTO tool_call_log
+        (turn_id, message_id, tool_name, triggered_by_skill, call_shape, result_status, error_kind, latency_ms, created_at)
+        VALUES ('t1', 'm1', 'web_fetch', NULL, 'web_fetch:example.com:GET', 'ok', NULL, 45, 1713614400000)`);
+
+    const rows = db.exec('SELECT tool_name, call_shape FROM tool_call_log');
+    if (rows.length !== 1 || rows[0].values.length !== 1 ||
+        rows[0].values[0][0] !== 'web_fetch' || rows[0].values[0][1] !== 'web_fetch:example.com:GET') {
+        console.error('FAIL: expected single row with tool_name=web_fetch');
+        process.exit(1);
+    }
+    console.log('  ✓ tool_call_log schema created + insert roundtrips');
+    console.log('all tests passed');
+    process.exit(0);
+}
+
+main().catch(e => { console.error('FAIL', e); process.exit(1); });


### PR DESCRIPTION
## Summary

**Scope change:** this PR carries **both phases** of the Go to School feature on one branch (owner preference: one branch → one device test → one merge decision, no stacked PRs). Originally planned as PR-A (log infra, no user-visible change) + a separate PR-B; consolidated mid-flight.

**Phase A — log infrastructure (tasks A1–A9):**
- New SQL.js tables: `tool_call_log` (10 cols, 5 indexes) and `skill_trigger_log` (5 cols, `UNIQUE(skill_name, message_id)` dedup)
- **Buffered async logger** (`tool-call-logger.js`): 5s / 100-row flush, re-trigger on backlog after successful commit, 10× hard cap on persistent failure, `await stop()` drains before shutdown
- **Per-tool `call_shape`** structural classifier (`call-shape.js`, 14 tools + default). Never leaks wallet addresses, URL query strings, user text, or private filenames. Root-md allowlist (SOUL/MEMORY/IDENTITY/USER/HEARTBEAT); anything else buckets as `other:depth{N}`. 64-char cap.
- `executeTool()` wrapped with logging; exceptions converted to `{error}` per ARCHITECTURE.md contract
- Skill-trigger instrumentation in `findMatchingSkills()`
- 30-day retention + 50k-row cap, purged on service start via `setImmediate`
- Shutdown flush wired inside `gracefulShutdown` before `saveDatabase()`

**Phase B — Go to School feature (tasks B1–B14):**
- 6 new tools: `school_begin`, `school_scan`, `school_write_skill`, `school_retire_skill`, `school_end`, `school_handle_input`
- Deterministic JS state machine (`transition()` in `school.js`) with 16-transition test covering every (state, input) cell
- Pattern mining (`scanLogs()`): repeated_patterns, failed_sequences, expensive_turns, triggered_skills. Insufficient-signal threshold = 20 tool calls
- `writeSkillFile` with path sandbox (workspace/skills/ only), 64KB size cap, YAML-safe evidence injection, preserved-source patch mode
- `schoolRetireSkillHandler` moves workspace skills to `workspace/school/retired/<ts>-<name>` (reversible)
- `schoolHandleInputHandler` persists state back to SCHOOL.md after each transition (round-7 fix)
- Bundled `go-to-school` SKILL.md with 5-gate rubric (Repetition, Permanence, Gap, Utility, Actionable), dedup gate, input classification rubric, classification echo rule
- Self-Improvement block added to `buildSystemBlocks()` for agent self-awareness
- Telegram commands: `/school` (skill-matcher dispatch with 5-min / 10-per-day rate limit), `/school log` (renders last 10 sessions), `/school-reset` + `/school-reset-confirm` (two-step cleanup, 60s TTL)
- Stale-session auto-end (48h) + seamless combined-message flow on next `/school`
- DIAGNOSTICS.md troubleshooting section (8 symptoms covered)

## What's NOT in this PR

- **No version bump / CHANGELOG release entry** — deferred to release cycle per owner preference; feature branch stays at 1.9.0 / code 17 until device test passes and merge decision is made
- **No SAB audit** — deferred to release prep
- `turn_id` threading (uses `chatId` as coarse grouping; fine for call_shape-based pattern mining)

## Design

Spec: `docs/superpowers/specs/2026-04-19-go-to-school-design.md` (7 design revisions).
Plan: `docs/superpowers/plans/2026-04-19-go-to-school.md`, 24 TDD-structured tasks.

## Test plan

- [x] `node tests/nodejs-project/tool-call-log.test.js` — 5 cases (schema, buffered logger, retention purge)
- [x] `node tests/nodejs-project/tool-call-log-perf.test.js` — 1000-record burst + flush at 11-17ms (200ms budget on dev, 1000ms under CI)
- [x] `node tests/nodejs-project/skill-trigger-log.test.js` — UNIQUE dedup
- [x] `node tests/nodejs-project/call-shape.test.js` — 24 cases incl. privacy red-team
- [x] `node tests/nodejs-project/error-classifier.test.js` — 30 cases
- [x] `node tests/nodejs-project/school.test.js` — 10 cases (normalizeTitle, signatureOf, scanLogs)
- [x] `node tests/nodejs-project/school-state-machine.test.js` — 16 transitions
- [x] `node tests/nodejs-project/school-tools.test.js` — 15 cases (begin/end, write_skill, retire, handle_input persistence, no-session safety)
- [x] `node tests/nodejs-project/school-integration.test.js` — end-to-end happy path + stale-session cleanup
- [x] `node tests/nodejs-project/smoke.js` — 6/6 modules load
- [ ] **Device test on Solana Seeker (pending before merge decision)** — install debug APK, run `/school` through the full approval flow on-device, verify SCHOOL.md lifecycle + log.jsonl entries + no privacy leaks in `tool_call_log.call_shape`

🤖 Generated with [Claude Code](https://claude.com/claude-code)