### PR TITLE
feat: user-configurable max tool uses per turn (default 35)

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2026,20 +2026,20 @@ async function chat(chatId, userMessage, options = {}) {
     // Call Claude API with tool use loop
     let response;
     let toolUseCount = 0;
-    // Read maxToolUsesPerTurn from agent_settings.json each turn so the user's
+    // Read maxStepsPerTurn from agent_settings.json each turn so the user's
     // Settings change takes effect on the next chat() call (no service restart).
     // Mirrors getHeartbeatIntervalMs() in main.js. Clamped to [10, 100]; invalid
-    // or missing values fall back to config.maxToolUsesPerTurn, then 35.
+    // or missing values fall back to config.maxStepsPerTurn, then 35.
     const MAX_TOOL_USES = (() => {
         try {
             const settingsPath = path.join(workDir, 'agent_settings.json');
             if (fs.existsSync(settingsPath)) {
                 const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-                const n = parseInt(s.maxToolUsesPerTurn, 10);
+                const n = parseInt(s.maxStepsPerTurn, 10);
                 if (n >= 10 && n <= 100) return n;
             }
         } catch (_) {}
-        const fallback = parseInt(_config && _config.maxToolUsesPerTurn, 10);
+        const fallback = parseInt(_config && _config.maxStepsPerTurn, 10);
         return (fallback >= 10 && fallback <= 100) ? fallback : 35;
     })();
     let _ctxCache = null; // Cached system/tools char counts — reset per chat() call

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -189,13 +189,13 @@ const MAX_HISTORY = 35;
 let sessionStartedAt = Date.now();
 
 // ── Active task tracking (P2.4) ─────────────────────────────────────────────
-// Maps chatId → { taskId, startedAt, toolUseCount, reason } or null.
+// Maps chatId → { taskId, startedAt, stepCount, reason } or null.
 // In-memory only — survives budget exhaustion but NOT process restarts.
 // P2.2 will add disk-backed checkpoints; P2.4b will add auto-resume.
 const activeTasks = new Map();
 
 function setActiveTask(chatId, taskId) {
-    activeTasks.set(String(chatId), { taskId, startedAt: Date.now(), toolUseCount: 0, reason: null });
+    activeTasks.set(String(chatId), { taskId, startedAt: Date.now(), stepCount: 0, reason: null });
 }
 
 function getActiveTask(chatId) {
@@ -2025,12 +2025,12 @@ async function chat(chatId, userMessage, options = {}) {
 
     // Call Claude API with tool use loop
     let response;
-    let toolUseCount = 0;
+    let stepCount = 0;
     // Read maxStepsPerTurn from agent_settings.json each turn so the user's
     // Settings change takes effect on the next chat() call (no service restart).
     // Mirrors getHeartbeatIntervalMs() in main.js. Clamped to [10, 100]; invalid
     // or missing values fall back to config.maxStepsPerTurn, then 35.
-    const MAX_TOOL_USES = (() => {
+    const MAX_STEPS = (() => {
         try {
             const settingsPath = path.join(workDir, 'agent_settings.json');
             if (fs.existsSync(settingsPath)) {
@@ -2049,7 +2049,7 @@ async function chat(chatId, userMessage, options = {}) {
 
     try { // BAT-253: catch network errors → sanitize before user output
 
-        while (toolUseCount < MAX_TOOL_USES) {
+        while (stepCount < MAX_STEPS) {
             // BAT-259: Age old tool results to reduce payload bloat
             ageToolResults(messages, turnId);
 
@@ -2095,7 +2095,7 @@ async function chat(chatId, userMessage, options = {}) {
             const apiMessages = adapter.toApiMessages(messages);
             const body = adapter.formatRequest(MODEL, 4096, systemBlocks, apiMessages, formattedTools);
 
-            const res = await claudeApiCall(body, chatId, { turnId, iteration: toolUseCount });
+            const res = await claudeApiCall(body, chatId, { turnId, iteration: stepCount });
 
             if (res.status !== 200) {
                 log(`API error: ${res.status} - ${JSON.stringify(res.data)}`, 'ERROR');
@@ -2122,7 +2122,7 @@ async function chat(chatId, userMessage, options = {}) {
             }
 
             // Execute tools and add results
-            toolUseCount++;
+            stepCount++;
 
             // Add assistant's response to history in neutral format
             messages.push({
@@ -2286,15 +2286,15 @@ async function chat(chatId, userMessage, options = {}) {
                 chatId: String(chatId),
                 turnId,
                 startedAt: getActiveTask(chatId)?.startedAt || Date.now(),
-                toolUseCount,
-                maxToolUses: MAX_TOOL_USES,
+                stepCount,
+                maxSteps: MAX_STEPS,
                 complete: false,
                 reason: null,
                 originalGoal,
                 conversationSlice: messages.slice(-8),
             });
             if (cpDuration >= 0) {
-                log(`[Trace] ${JSON.stringify({ turnId, taskId, checkpoint: 'saved', toolUseCount, durationMs: cpDuration })}`, 'DEBUG');
+                log(`[Trace] ${JSON.stringify({ turnId, taskId, checkpoint: 'saved', stepCount, durationMs: cpDuration })}`, 'DEBUG');
             }
         }
 
@@ -2303,15 +2303,15 @@ async function chat(chatId, userMessage, options = {}) {
         let textContent = parsed.text ? { text: parsed.text } : null;
 
         // Budget exhaustion explicit handling
-        if (toolUseCount >= MAX_TOOL_USES) {
+        if (stepCount >= MAX_STEPS) {
             // P2.4: Track exhaustion reason in activeTask
             const task = getActiveTask(chatId);
             if (task) {
-                task.toolUseCount = toolUseCount;
+                task.stepCount = stepCount;
                 task.reason = 'budget_exhausted';
             }
 
-            log(`[Trace] ${JSON.stringify({ turnId, taskId, chatId: String(chatId || ''), toolUseCount, maxToolCalls: MAX_TOOL_USES, reason: 'tool_budget_exhausted', userFallbackSent: true })}`, 'WARN');
+            log(`[Trace] ${JSON.stringify({ turnId, taskId, chatId: String(chatId || ''), stepCount, maxSteps: MAX_STEPS, reason: 'tool_budget_exhausted', userFallbackSent: true })}`, 'WARN');
             const fallback = `I hit the tool-call limit for this turn (task ${taskId}). Send 'continue' or /resume to pick up where I left off.`;
 
             // Add fallback to conversation BEFORE saving checkpoint so the
@@ -2325,8 +2325,8 @@ async function chat(chatId, userMessage, options = {}) {
                 chatId: String(chatId),
                 turnId,
                 startedAt: task?.startedAt || Date.now(),
-                toolUseCount,
-                maxToolUses: MAX_TOOL_USES,
+                stepCount,
+                maxSteps: MAX_STEPS,
                 complete: false,
                 reason: 'budget_exhausted',
                 originalGoal,
@@ -2349,7 +2349,7 @@ async function chat(chatId, userMessage, options = {}) {
 
         // If no text in final response but we ran tools, make one more call so Claude
         // can summarize the tool results for the user (e.g. after solana_send)
-        if (!textContent && toolUseCount > 0) {
+        if (!textContent && stepCount > 0) {
             log('No text in final tool response, requesting summary...', 'DEBUG');
 
             // Add explicit summary prompt — without this, the model may return no text
@@ -2362,7 +2362,7 @@ async function chat(chatId, userMessage, options = {}) {
 
             const summaryRes = await claudeApiCall(
                 adapter.formatRequest(MODEL, 4096, systemBlocks, summaryApiMsgs, []),
-                chatId, { turnId, iteration: toolUseCount + 1 }
+                chatId, { turnId, iteration: stepCount + 1 }
             );
 
             if (summaryRes.status === 200) {
@@ -2390,7 +2390,7 @@ async function chat(chatId, userMessage, options = {}) {
                         }
                     }
                 }
-                const fallback = `Done — used ${toolUseCount} tool${toolUseCount !== 1 ? 's' : ''} (${toolNames.join(', ') || 'various'}).`;
+                const fallback = `Done — used ${stepCount} tool${stepCount !== 1 ? 's' : ''} (${toolNames.join(', ') || 'various'}).`;
                 clearActiveTask(chatId);
                 cleanupChatCheckpoints(chatId);
                 addToConversation(chatId, 'assistant', fallback);
@@ -2404,7 +2404,7 @@ async function chat(chatId, userMessage, options = {}) {
             clearActiveTask(chatId);
             // Only clean up checkpoints if tools were used (task progressed).
             // A text-only response (e.g. failed resume attempt) should not wipe checkpoints.
-            if (toolUseCount > 0) cleanupChatCheckpoints(chatId);
+            if (stepCount > 0) cleanupChatCheckpoints(chatId);
             addToConversation(chatId, 'assistant', '[No response generated]');
             log(`No text content in response (no tools used), returning ${SILENT_REPLY_TOKEN}`, 'DEBUG');
             return SILENT_REPLY_TOKEN;
@@ -2416,7 +2416,7 @@ async function chat(chatId, userMessage, options = {}) {
         // P2.2: Only clean up checkpoints if tools were used (task actually progressed).
         // If Claude responded with text-only (e.g. treated resume as fresh chat),
         // the checkpoint must survive for a retry.
-        if (toolUseCount > 0) cleanupChatCheckpoints(chatId);
+        if (stepCount > 0) cleanupChatCheckpoints(chatId);
 
         // Update conversation history with final response
         addToConversation(chatId, 'assistant', assistantMessage);

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2121,7 +2121,13 @@ async function chat(chatId, userMessage, options = {}) {
                 break;
             }
 
-            // Execute tools and add results
+            // Execute tools and add results.
+            // stepCount counts *tool-use rounds* (model responses that request
+            // one or more tools). A text-only final response breaks out of the
+            // loop above and does NOT increment the counter — MAX_STEPS is the
+            // ceiling on tool-use rounds, matching the UI's "Max Agent Steps Per
+            // Turn" which is documented as "a model response that requests one
+            // or more tools".
             stepCount++;
 
             // Add assistant's response to history in neutral format

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -16,6 +16,7 @@ const {
     localTimestamp, localDateStr, log,
     getOwnerId,
     USER_ENV_KEYS,
+    config: _config,
 } = require('./config');
 
 const { redactSecrets } = require('./security');
@@ -2025,7 +2026,22 @@ async function chat(chatId, userMessage, options = {}) {
     // Call Claude API with tool use loop
     let response;
     let toolUseCount = 0;
-    const MAX_TOOL_USES = 25;
+    // Read maxToolUsesPerTurn from agent_settings.json each turn so the user's
+    // Settings change takes effect on the next chat() call (no service restart).
+    // Mirrors getHeartbeatIntervalMs() in main.js. Clamped to [10, 100]; invalid
+    // or missing values fall back to config.maxToolUsesPerTurn, then 35.
+    const MAX_TOOL_USES = (() => {
+        try {
+            const settingsPath = path.join(workDir, 'agent_settings.json');
+            if (fs.existsSync(settingsPath)) {
+                const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+                const n = parseInt(s.maxToolUsesPerTurn, 10);
+                if (n >= 10 && n <= 100) return n;
+            }
+        } catch (_) {}
+        const fallback = parseInt(_config && _config.maxToolUsesPerTurn, 10);
+        return (fallback >= 10 && fallback <= 100) ? fallback : 35;
+    })();
     let _ctxCache = null; // Cached system/tools char counts — reset per chat() call
     let _loopWarned = false;  // DeerFlow P1: loop detector flags
     let _loopBroken = false;

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2312,7 +2312,7 @@ async function chat(chatId, userMessage, options = {}) {
             }
 
             log(`[Trace] ${JSON.stringify({ turnId, taskId, chatId: String(chatId || ''), stepCount, maxSteps: MAX_STEPS, reason: 'tool_budget_exhausted', userFallbackSent: true })}`, 'WARN');
-            const fallback = `I hit the tool-call limit for this turn (task ${taskId}). Send 'continue' or /resume to pick up where I left off.`;
+            const fallback = `I hit the step limit for this turn (${MAX_STEPS} steps, task ${taskId}). Send 'continue' or /resume to pick up where I left off.`;
 
             // Add fallback to conversation BEFORE saving checkpoint so the
             // checkpoint slice ends with an assistant message. This ensures
@@ -2390,7 +2390,7 @@ async function chat(chatId, userMessage, options = {}) {
                         }
                     }
                 }
-                const fallback = `Done — used ${stepCount} tool${stepCount !== 1 ? 's' : ''} (${toolNames.join(', ') || 'various'}).`;
+                const fallback = `Done — took ${stepCount} step${stepCount !== 1 ? 's' : ''} (${toolNames.join(', ') || 'various'}).`;
                 clearActiveTask(chatId);
                 cleanupChatCheckpoints(chatId);
                 addToConversation(chatId, 'assistant', fallback);

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -44,7 +44,7 @@ data class AppConfig(
     val heliusApiKey: String = "",
     val autoStartOnBoot: Boolean = true,
     val heartbeatIntervalMinutes: Int = 30,
-    val maxToolUsesPerTurn: Int = 35,
+    val maxStepsPerTurn: Int = 35,
     val provider: String = "claude", // "claude", "openai", or "openrouter"
     val openaiApiKey: String = "",
     val openrouterApiKey: String = "",
@@ -115,7 +115,7 @@ object ConfigManager {
     private const val KEY_MCP_SERVERS_ENC = "mcp_servers_enc"
     private const val KEY_ENV_VARS_ENC = "env_vars_enc"
     private const val KEY_HEARTBEAT_INTERVAL = "heartbeat_interval"
-    private const val KEY_MAX_TOOL_USES_PER_TURN = "max_tool_uses_per_turn"
+    private const val KEY_MAX_STEPS_PER_TURN = "max_steps_per_turn"
     private const val KEY_PROVIDER = "provider"
     private const val KEY_OPENAI_API_KEY_ENC = "openai_api_key_enc"
     private const val KEY_OPENROUTER_API_KEY_ENC = "openrouter_api_key_enc"
@@ -202,7 +202,7 @@ object ConfigManager {
             .putString(KEY_AUTH_TYPE, config.authType)
             .putBoolean(KEY_AUTO_START, config.autoStartOnBoot)
             .putInt(KEY_HEARTBEAT_INTERVAL, config.heartbeatIntervalMinutes)
-            .putInt(KEY_MAX_TOOL_USES_PER_TURN, config.maxToolUsesPerTurn)
+            .putInt(KEY_MAX_STEPS_PER_TURN, config.maxStepsPerTurn)
             .putBoolean(KEY_SETUP_COMPLETE, true)
 
         // Store setup token separately so switching auth type preserves both
@@ -561,7 +561,7 @@ object ConfigManager {
             heliusApiKey = heliusApiKey,
             autoStartOnBoot = p.getBoolean(KEY_AUTO_START, true),
             heartbeatIntervalMinutes = p.getInt(KEY_HEARTBEAT_INTERVAL, 30),
-            maxToolUsesPerTurn = p.getInt(KEY_MAX_TOOL_USES_PER_TURN, 35),
+            maxStepsPerTurn = p.getInt(KEY_MAX_STEPS_PER_TURN, 35),
             provider = p.getString(KEY_PROVIDER, "claude") ?: "claude",
             openaiApiKey = openaiApiKey,
             openrouterApiKey = openrouterApiKey,
@@ -682,8 +682,8 @@ object ConfigManager {
             "heartbeatIntervalMinutes" -> config.copy(
                 heartbeatIntervalMinutes = value.toIntOrNull()?.coerceIn(5, 120) ?: 30
             )
-            "maxToolUsesPerTurn" -> config.copy(
-                maxToolUsesPerTurn = value.toIntOrNull()?.coerceIn(10, 100) ?: 35
+            "maxStepsPerTurn" -> config.copy(
+                maxStepsPerTurn = value.toIntOrNull()?.coerceIn(10, 100) ?: 35
             )
             "provider" -> config.copy(provider = value)
             "openaiApiKey" -> config.copy(openaiApiKey = value)
@@ -826,7 +826,7 @@ object ConfigManager {
             put("model", config.model)
             put("agentName", config.agentName)
             put("heartbeatIntervalMinutes", config.heartbeatIntervalMinutes)
-            put("maxToolUsesPerTurn", config.maxToolUsesPerTurn)
+            put("maxStepsPerTurn", config.maxStepsPerTurn)
             put("bridgeToken", bridgeToken)
             if (config.braveApiKey.isNotBlank()) put("braveApiKey", config.braveApiKey)
             put("searchProvider", config.searchProvider)
@@ -902,7 +902,7 @@ object ConfigManager {
             }
             // Android-managed fields always overwrite
             existing.put("heartbeatIntervalMinutes", config.heartbeatIntervalMinutes)
-            existing.put("maxToolUsesPerTurn", config.maxToolUsesPerTurn)
+            existing.put("maxStepsPerTurn", config.maxStepsPerTurn)
             // Ensure apiKeys object exists (agent writes individual keys into it)
             if (!existing.has("apiKeys")) {
                 existing.put("apiKeys", JSONObject())

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -44,6 +44,7 @@ data class AppConfig(
     val heliusApiKey: String = "",
     val autoStartOnBoot: Boolean = true,
     val heartbeatIntervalMinutes: Int = 30,
+    val maxToolUsesPerTurn: Int = 35,
     val provider: String = "claude", // "claude", "openai", or "openrouter"
     val openaiApiKey: String = "",
     val openrouterApiKey: String = "",
@@ -114,6 +115,7 @@ object ConfigManager {
     private const val KEY_MCP_SERVERS_ENC = "mcp_servers_enc"
     private const val KEY_ENV_VARS_ENC = "env_vars_enc"
     private const val KEY_HEARTBEAT_INTERVAL = "heartbeat_interval"
+    private const val KEY_MAX_TOOL_USES_PER_TURN = "max_tool_uses_per_turn"
     private const val KEY_PROVIDER = "provider"
     private const val KEY_OPENAI_API_KEY_ENC = "openai_api_key_enc"
     private const val KEY_OPENROUTER_API_KEY_ENC = "openrouter_api_key_enc"
@@ -200,6 +202,7 @@ object ConfigManager {
             .putString(KEY_AUTH_TYPE, config.authType)
             .putBoolean(KEY_AUTO_START, config.autoStartOnBoot)
             .putInt(KEY_HEARTBEAT_INTERVAL, config.heartbeatIntervalMinutes)
+            .putInt(KEY_MAX_TOOL_USES_PER_TURN, config.maxToolUsesPerTurn)
             .putBoolean(KEY_SETUP_COMPLETE, true)
 
         // Store setup token separately so switching auth type preserves both
@@ -558,6 +561,7 @@ object ConfigManager {
             heliusApiKey = heliusApiKey,
             autoStartOnBoot = p.getBoolean(KEY_AUTO_START, true),
             heartbeatIntervalMinutes = p.getInt(KEY_HEARTBEAT_INTERVAL, 30),
+            maxToolUsesPerTurn = p.getInt(KEY_MAX_TOOL_USES_PER_TURN, 35),
             provider = p.getString(KEY_PROVIDER, "claude") ?: "claude",
             openaiApiKey = openaiApiKey,
             openrouterApiKey = openrouterApiKey,
@@ -677,6 +681,9 @@ object ConfigManager {
             "heliusApiKey" -> config.copy(heliusApiKey = value)
             "heartbeatIntervalMinutes" -> config.copy(
                 heartbeatIntervalMinutes = value.toIntOrNull()?.coerceIn(5, 120) ?: 30
+            )
+            "maxToolUsesPerTurn" -> config.copy(
+                maxToolUsesPerTurn = value.toIntOrNull()?.coerceIn(10, 100) ?: 35
             )
             "provider" -> config.copy(provider = value)
             "openaiApiKey" -> config.copy(openaiApiKey = value)
@@ -819,6 +826,7 @@ object ConfigManager {
             put("model", config.model)
             put("agentName", config.agentName)
             put("heartbeatIntervalMinutes", config.heartbeatIntervalMinutes)
+            put("maxToolUsesPerTurn", config.maxToolUsesPerTurn)
             put("bridgeToken", bridgeToken)
             if (config.braveApiKey.isNotBlank()) put("braveApiKey", config.braveApiKey)
             put("searchProvider", config.searchProvider)
@@ -894,6 +902,7 @@ object ConfigManager {
             }
             // Android-managed fields always overwrite
             existing.put("heartbeatIntervalMinutes", config.heartbeatIntervalMinutes)
+            existing.put("maxToolUsesPerTurn", config.maxToolUsesPerTurn)
             // Ensure apiKeys object exists (agent writes individual keys into it)
             if (!existing.has("apiKeys")) {
                 existing.put("apiKeys", JSONObject())

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -66,6 +66,11 @@ object SettingsHelpTexts {
         "How often your agent proactively checks HEARTBEAT.md for tasks. " +
         "5–120 minutes. Changes take effect automatically (usually within a minute)."
 
+    const val MAX_TOOL_USES_PER_TURN =
+        "How many tools the agent can use in a single turn before it pauses " +
+        "and asks you to continue. Lower = shorter, cheaper runs. Higher = " +
+        "agent can finish longer tasks in one turn. 10–100. Takes effect on the next turn."
+
     const val BRAVE_API_KEY =
         "Required when Brave is selected as your search provider. " +
         "Free key at brave.com/search/api."

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -67,11 +67,10 @@ object SettingsHelpTexts {
         "5–120 minutes. Changes take effect automatically (usually within a minute)."
 
     const val MAX_STEPS_PER_TURN =
-        "How many steps the agent can take in a single turn before it pauses " +
-        "and asks you to continue. Each step is one round where the agent " +
-        "thinks and may call one or more tools. Lower = shorter, cheaper runs. " +
-        "Higher = agent can finish longer tasks in one turn. 10–100. " +
-        "Takes effect on the next turn."
+        "How many tool-use steps the agent can take in a single turn before it pauses " +
+        "and asks you to continue. Each step is a model response that requests " +
+        "one or more tools. Lower = shorter, cheaper runs. Higher = agent can " +
+        "finish longer tasks in one turn. 10–100. Takes effect on the next turn."
 
     const val BRAVE_API_KEY =
         "Required when Brave is selected as your search provider. " +

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -66,10 +66,12 @@ object SettingsHelpTexts {
         "How often your agent proactively checks HEARTBEAT.md for tasks. " +
         "5–120 minutes. Changes take effect automatically (usually within a minute)."
 
-    const val MAX_TOOL_USES_PER_TURN =
-        "How many tools the agent can use in a single turn before it pauses " +
-        "and asks you to continue. Lower = shorter, cheaper runs. Higher = " +
-        "agent can finish longer tasks in one turn. 10–100. Takes effect on the next turn."
+    const val MAX_STEPS_PER_TURN =
+        "How many steps the agent can take in a single turn before it pauses " +
+        "and asks you to continue. Each step is one round where the agent " +
+        "thinks and may call one or more tools. Lower = shorter, cheaper runs. " +
+        "Higher = agent can finish longer tasks in one turn. 10–100. " +
+        "Takes effect on the next turn."
 
     const val BRAVE_API_KEY =
         "Required when Brave is selected as your search provider. " +

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -439,6 +439,16 @@ fun SettingsScreen(
                     info = SettingsHelpTexts.HEARTBEAT_INTERVAL,
                 )
                 ConfigField(
+                    label = "Max Tool Uses Per Turn",
+                    value = "${config?.maxToolUsesPerTurn ?: 35} tools",
+                    onClick = {
+                        editField = "maxToolUsesPerTurn"
+                        editLabel = "Max Tool Uses Per Turn (10–100)"
+                        editValue = (config?.maxToolUsesPerTurn ?: 35).toString()
+                    },
+                    info = SettingsHelpTexts.MAX_TOOL_USES_PER_TURN,
+                )
+                ConfigField(
                     label = "Search Provider",
                     value = searchProviderById(config?.searchProvider ?: "brave").displayName +
                         if ((config?.activeSearchApiKey ?: "").isBlank()) " (not configured)" else "",

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -361,7 +361,7 @@ fun SettingsScreen(
     // Fields whose value is re-read live from agent_settings.json on the Node
     // side (no service restart needed). Keep in sync with live-pickup readers
     // in main.js (heartbeat) and ai.js (maxStepsPerTurn).
-    val liveUpdateFields = setOf("maxStepsPerTurn")
+    val liveUpdateFields = setOf("maxStepsPerTurn", "heartbeatIntervalMinutes")
 
     fun saveField(field: String, value: String) {
         ConfigManager.updateConfigField(context, field, value)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -439,14 +439,14 @@ fun SettingsScreen(
                     info = SettingsHelpTexts.HEARTBEAT_INTERVAL,
                 )
                 ConfigField(
-                    label = "Max Tool Uses Per Turn",
-                    value = "${config?.maxToolUsesPerTurn ?: 35} tools",
+                    label = "Max Agent Steps Per Turn",
+                    value = "${config?.maxStepsPerTurn ?: 35} steps",
                     onClick = {
-                        editField = "maxToolUsesPerTurn"
-                        editLabel = "Max Tool Uses Per Turn (10–100)"
-                        editValue = (config?.maxToolUsesPerTurn ?: 35).toString()
+                        editField = "maxStepsPerTurn"
+                        editLabel = "Max Agent Steps Per Turn (10–100)"
+                        editValue = (config?.maxStepsPerTurn ?: 35).toString()
                     },
-                    info = SettingsHelpTexts.MAX_TOOL_USES_PER_TURN,
+                    info = SettingsHelpTexts.MAX_STEPS_PER_TURN,
                 )
                 ConfigField(
                     label = "Search Provider",

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -358,10 +358,17 @@ fun SettingsScreen(
         }
     }
 
+    // Fields whose value is re-read live from agent_settings.json on the Node
+    // side (no service restart needed). Keep in sync with live-pickup readers
+    // in main.js (heartbeat) and ai.js (maxStepsPerTurn).
+    val liveUpdateFields = setOf("maxStepsPerTurn")
+
     fun saveField(field: String, value: String) {
         ConfigManager.updateConfigField(context, field, value)
         config = ConfigManager.loadConfig(context)
-        showRestartDialog = true
+        if (field !in liveUpdateFields) {
+            showRestartDialog = true
+        }
     }
 
     val authTypeLabel = if (config?.authType == "setup_token") "Pro/Max Setup Token" else "API Key"

--- a/docs/internal/SETTINGS_INFO.md
+++ b/docs/internal/SETTINGS_INFO.md
@@ -18,7 +18,7 @@
 | 6 | Owner ID | `OWNER_ID` | ✅ Good | Your Telegram user ID (a number, not your @username). This is who the agent obeys. Leave blank = first person to message becomes owner. Find yours: message @userinfobot on Telegram. |
 | 7 | Agent Name | `AGENT_NAME` | ✅ Good | What should we call your agent? Shows on the dashboard and in its personality. Totally cosmetic — go wild. |
 | 8 | Brave API Key | `BRAVE_API_KEY` | ✅ Good | Optional. Gives your agent Brave Search (better results). Free key at brave.com/search/api. |
-| 8a | Max Agent Steps Per Turn | `MAX_STEPS_PER_TURN` | ✅ Good | How many steps the agent can take in a single turn before it pauses and asks you to continue. Each step is one round where the agent thinks and may call one or more tools. Lower = shorter, cheaper runs. Higher = agent can finish longer tasks in one turn. 10–100. Takes effect on the next turn. |
+| 8a | Max Agent Steps Per Turn | `MAX_STEPS_PER_TURN` | ✅ Good | How many tool-use rounds the agent can take in a single turn before it pauses and asks you to continue. A step counts when the agent uses one or more tools. Lower = shorter, cheaper runs. Higher = agent can finish longer tasks in one turn. 10–100. Takes effect on the next turn. |
 
 ## Preferences
 

--- a/docs/internal/SETTINGS_INFO.md
+++ b/docs/internal/SETTINGS_INFO.md
@@ -18,6 +18,7 @@
 | 6 | Owner ID | `OWNER_ID` | ✅ Good | Your Telegram user ID (a number, not your @username). This is who the agent obeys. Leave blank = first person to message becomes owner. Find yours: message @userinfobot on Telegram. |
 | 7 | Agent Name | `AGENT_NAME` | ✅ Good | What should we call your agent? Shows on the dashboard and in its personality. Totally cosmetic — go wild. |
 | 8 | Brave API Key | `BRAVE_API_KEY` | ✅ Good | Optional. Gives your agent Brave Search (better results). Free key at brave.com/search/api. |
+| 8a | Max Agent Steps Per Turn | `MAX_STEPS_PER_TURN` | ✅ Good | How many steps the agent can take in a single turn before it pauses and asks you to continue. Each step is one round where the agent thinks and may call one or more tools. Lower = shorter, cheaper runs. Higher = agent can finish longer tasks in one turn. 10–100. Takes effect on the next turn. |
 
 ## Preferences
 


### PR DESCRIPTION
## Summary

Exposes the previously-hardcoded `MAX_TOOL_USES = 25` in `ai.js` as a user-configurable Setting ("Max Agent Steps Per Turn"). Users can tune how many agent steps (LLM rounds) a single turn can take before pausing with *"I hit the tool-call limit for this turn. Send 'continue' or /resume to pick up where I left off."*

**Default raised from 25 → 35** (mid-range of the new 10–100 allowed span).

### Terminology note (addresses Copilot review)

The loop counter increments **once per round** (one model response, which may contain N tool_use blocks), not once per tool call. To avoid confusion, the setting and UI labels use **"step"** — matching the user's own original language ("Agent has 35 steps, afterwards it asks user to continue") and the actual behaviour.

## How it works

Follows the existing `heartbeatIntervalMinutes` plumbing:

- **Kotlin** stores `maxStepsPerTurn` in SharedPreferences
- On every Settings save, `writeAgentSettingsJson()` mirrors it to `agent_settings.json` (the live-pickup path)
- `config.json` is rewritten on service start by `OpenClawService` — it acts as a boot-time fallback, not a live channel
- **Node.js** reads `agent_settings.json` at the start of each `chat()` call — so a user's Settings change takes effect on the **next turn**, no service restart needed
- **Validation** on both sides: Kotlin clamps to `[10, 100]`; Node.js clamps on read and falls back `agent_settings.json → in-memory config → 35` if anything is corrupt

## Files

| File | Change |
|---|---|
| `ConfigManager.kt` | New field, key, getter/setter, validator, config.json + agent_settings.json writers |
| `SettingsScreen.kt` | New `ConfigField` directly below Heartbeat Interval ("Max Agent Steps Per Turn") |
| `SettingsHelpTexts.kt` | New help text explaining "each step is one round where the agent thinks and may call one or more tools" |
| `ai.js` | Replace hardcoded `const MAX_TOOL_USES = 25` with IIFE that reads `s.maxStepsPerTurn` from `agent_settings.json` with bounded fallback |

## Test plan

- [x] `node --check app/src/main/assets/nodejs-project/ai.js` passes
- [x] Behavior smoke test: 10 edge cases, all pass
  ```
  ✓ no settings, no config  → 35 (default)
  ✓ no settings, config=50  → 50
  ✓ settings=42             → 42
  ✓ settings below range    → fallback to config
  ✓ settings above range    → fallback to config
  ✓ non-numeric settings    → 35 (default)
  ✓ corrupted json          → 35 (default)
  ✓ settings missing key    → 35 (default)
  ✓ lower bound (10)        → 10
  ✓ upper bound (100)       → 100
  ```
- [ ] Manual device test: install debug APK, change setting 35 → 50 in Settings, send a long-task message, verify agent goes 50 rounds before pausing
- [ ] Verify existing `/resume` flow still works unchanged

## Out of scope (follow-ups)

Loop hardening (extract `executeToolRound()`, API-error checkpoints, per-tool timeout wrapper, etc.) from the audit is deliberately not in this PR — single focused change, separate refactor later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)