### PR TITLE
feat: add GPT-5.5 to OpenAI model picker, drop GPT-5.2

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1627,6 +1627,7 @@ const MODEL_CONTEXT_LIMITS = {
     'claude-haiku-4-5':    200000,
     'gpt-5.5':             200000,
     'gpt-5.4':             200000,
+    'gpt-5.4-mini':        200000,
     'gpt-5.2':             200000, // kept for existing users with 5.2 still selected (removed from UI dropdown)
     'gpt-5.3-codex':       200000,
 };

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1625,8 +1625,9 @@ const MODEL_CONTEXT_LIMITS = {
     'claude-sonnet-4-6':   200000,
     'claude-sonnet-4-5':   200000,
     'claude-haiku-4-5':    200000,
+    'gpt-5.5':             200000,
     'gpt-5.4':             200000,
-    'gpt-5.2':             200000,
+    'gpt-5.2':             200000, // kept for existing users with 5.2 still selected (removed from UI dropdown)
     'gpt-5.3-codex':       200000,
 };
 const DEFAULT_CONTEXT_LIMIT = 128000; // conservative fallback for unknown models

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -207,7 +207,7 @@ const CUSTOM_FORMAT = (typeof config.customFormat === 'string' ? config.customFo
 const OPENROUTER_FALLBACK_MODEL = (typeof config.openrouterFallbackModel === 'string' ? config.openrouterFallbackModel : '').trim();
 const OPENROUTER_MODEL_CONTEXT = parseInt(config.openrouterModelContext, 10) || 0;
 const OPENROUTER_FALLBACK_CONTEXT = parseInt(config.openrouterFallbackContext, 10) || 0;
-const _defaultModel = PROVIDER === 'openai' ? 'gpt-5.2'
+const _defaultModel = PROVIDER === 'openai' ? 'gpt-5.4'
     : PROVIDER === 'openrouter' ? 'anthropic/claude-sonnet-4-6'
     : PROVIDER === 'custom' ? ''
     : 'claude-opus-4-7';

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -48,15 +48,21 @@ val availableProviders = listOf(
     ),
 )
 
+// Order matters — several flows use `firstOrNull()` to pick a default
+// model (fresh install via SetupScreen, provider/auth switches in
+// ProviderConfigScreen). Put 5.4 first: it's known-available across all
+// ChatGPT subscription tiers and API-key accounts. 5.5 is tier-gated
+// on some OAuth plans, so making it the list default would break
+// first-run flows for users whose plan doesn't include it yet.
 val openaiModels = listOf(
-    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.4", "GPT-5.4"),
+    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )
 
 val openaiOAuthModels = listOf(
-    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.4", "GPT-5.4"),
+    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -49,14 +49,14 @@ val availableProviders = listOf(
 )
 
 val openaiModels = listOf(
+    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.4", "GPT-5.4"),
-    ModelInfo("gpt-5.2", "GPT-5.2"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )
 
 val openaiOAuthModels = listOf(
+    ModelInfo("gpt-5.5", "GPT-5.5"),
     ModelInfo("gpt-5.4", "GPT-5.4"),
-    ModelInfo("gpt-5.2", "GPT-5.2"),
     ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -48,21 +48,20 @@ val availableProviders = listOf(
     ),
 )
 
-// Order matters — several flows use `firstOrNull()` to pick a default
-// model (fresh install via SetupScreen, provider/auth switches in
-// ProviderConfigScreen). Put 5.4 first: it's known-available across all
-// ChatGPT subscription tiers and API-key accounts. 5.5 is tier-gated
-// on some OAuth plans, so making it the list default would break
-// first-run flows for users whose plan doesn't include it yet.
+// Display order: freshest first for UX. Default selection is NOT tied
+// to list order — see defaultModelForProvider() below. Callers seeding
+// a default must use that helper, not `firstOrNull()`, so newer models
+// can appear at the top of the picker without accidentally becoming
+// the default for tier-gated users.
 val openaiModels = listOf(
-    ModelInfo("gpt-5.4", "GPT-5.4"),
     ModelInfo("gpt-5.5", "GPT-5.5"),
+    ModelInfo("gpt-5.4", "GPT-5.4"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )
 
 val openaiOAuthModels = listOf(
-    ModelInfo("gpt-5.4", "GPT-5.4"),
     ModelInfo("gpt-5.5", "GPT-5.5"),
+    ModelInfo("gpt-5.4", "GPT-5.4"),
     ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini"),
     ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
 )
@@ -91,3 +90,24 @@ fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> = 
 
 fun providerById(id: String): ProviderInfo =
     availableProviders.find { it.id == id } ?: availableProviders[0]
+
+/**
+ * Recommended default model for a given provider/authType.
+ *
+ * Decoupled from list order (intentionally) so the display list can prioritize
+ * the newest/most-exciting model at the top while the default stays on a known-
+ * safe, broadly-available choice. Rule of thumb: if a brand-new model is added
+ * that's tier-gated (e.g. only available on ChatGPT Pro), leave this alone —
+ * users on lower tiers must never hit a default that their plan can't reach.
+ *
+ * Call sites that seed an initial model (SetupScreen, provider/auth switches)
+ * should use this helper instead of `modelsForProvider(...).firstOrNull()`.
+ */
+fun defaultModelForProvider(providerId: String, authType: String?): String = when (providerId) {
+    // GPT-5.4 is available on every ChatGPT subscription tier AND via API key.
+    // GPT-5.5 is tier-gated on some plans as of 2026-04 — don't pick it as a default.
+    "openai" -> "gpt-5.4"
+    "openrouter" -> OPENROUTER_DEFAULT_MODEL
+    "custom" -> ""
+    else -> availableModels.firstOrNull()?.id ?: ""
+}

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -51,6 +51,7 @@ import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.availableModels
 import com.seekerclaw.app.config.availableProviders
 import com.seekerclaw.app.config.OPENROUTER_DEFAULT_MODEL
+import com.seekerclaw.app.config.defaultModelForProvider
 import com.seekerclaw.app.config.modelsForProvider
 import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.util.Analytics
@@ -214,7 +215,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             } else if (savedModel != null && modelsForNew.any { it.id == savedModel }) {
                 savedModel
             } else {
-                modelsForNew.firstOrNull()?.id ?: ""
+                // Use safe default, NOT list order (newer models may be tier-gated).
+                defaultModelForProvider(newProviderId, effectiveAuthType)
             }
         }
 
@@ -590,7 +592,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             mutableStateOf(
                 when {
                     current.isNotBlank() -> current
-                    else -> models.firstOrNull()?.id ?: ""
+                    // Use safe default, NOT list order (newer models may be tier-gated).
+                    else -> defaultModelForProvider(activeProvider, effectiveAuthType)
                 }
             )
         }
@@ -797,7 +800,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             val currentModel = config?.model ?: ""
                             val allowedModels = modelsForProvider("openai", selectedAuth)
                             if (allowedModels.none { it.id == currentModel }) {
-                                val fallback = allowedModels.firstOrNull()?.id ?: "gpt-5.4"
+                                // Use safe default, NOT list order (newer models may be tier-gated).
+                                val fallback = defaultModelForProvider("openai", selectedAuth)
                                 saveField("model", fallback, needsRestart = false)
                             }
                             // If switching away from OAuth, clear any leftover OAuth UI state

--- a/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/setup/SetupScreen.kt
@@ -107,6 +107,7 @@ import com.seekerclaw.app.config.ConfigClaimImporter
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.OPENROUTER_DEFAULT_MODEL
 import com.seekerclaw.app.config.availableModels
+import com.seekerclaw.app.config.defaultModelForProvider
 import com.seekerclaw.app.config.availableProviders
 import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.config.modelsForProvider
@@ -198,11 +199,17 @@ fun SetupScreen(onSetupComplete: () -> Unit) {
         // openai when authType is null, so we must pass it through.
         val modelAuthType = if (initialProvider == "openai") initialAuthType else "api_key"
         val models = modelsForProvider(initialProvider, modelAuthType)
+        // Use defaultModelForProvider() instead of models[0] / firstOrNull() so
+        // newly-listed-but-tier-gated models (e.g. gpt-5.5 on lower ChatGPT plans)
+        // can appear at the top of the picker without silently becoming the
+        // default for fresh installs or 5.2-migration paths.
+        val safeDefault = defaultModelForProvider(initialProvider, modelAuthType)
+            .ifBlank { availableModels[0].id }
         mutableStateOf(
             existingConfig?.model?.let { model ->
                 if (models.isEmpty() || models.any { it.id == model }) model
-                else models[0].id
-            } ?: models.firstOrNull()?.id ?: availableModels[0].id
+                else safeDefault
+            } ?: safeDefault
         )
     }
     var agentName by rememberSaveable { mutableStateOf(existingConfig?.agentName ?: "SeekerClaw") }


### PR DESCRIPTION
## Summary

GPT-5.5 shipped on OpenAI's Codex (OAuth) and public API. This PR adds it as a first-class option in **Settings → OpenAI → Model** alongside the existing "Custom model" freeform path, and removes GPT-5.2 which is now several generations old.

## Changes

| File | Change |
|---|---|
| `Providers.kt` | `openaiModels` + `openaiOAuthModels` — drop 5.2, add 5.5 at the top of both lists |
| `config.js` | `_defaultModel` for `openai` bumped `5.2 → 5.4` (safe default — 5.5 still tier-gated on some OAuth plans) |
| `ai.js` | `MODEL_CONTEXT_LIMITS` adds `gpt-5.5: 200000`. Keeps `gpt-5.2` in the table (with a comment) so existing users with 5.2 saved get the correct context limit until they re-pick |

## Non-goals
- Not touching `ConfigClaimImporter.kt` OpenAI default (stays at 5.4 — QR-claim fallback, not user-facing)
- Not touching OpenRouter/Custom — both already accept freeform model IDs including `openai/gpt-5.5`

## Migration

- **Users currently on 5.2**: saved config still works. Dropdown no longer shows 5.2 as a radio, so their selection surfaces via the "Custom model" field. Context window still resolves to 200k via the kept-for-compat entry. They can pick 5.4 or 5.5 whenever.
- **Users with no explicit model set**: default bumps 5.2 → 5.4 on next config load.

## Test plan
- [x] `node --check ai.js` passes
- [x] `node --check config.js` passes
- [ ] Device: Settings → Provider → OpenAI → see `GPT-5.5` at top of dropdown, no `GPT-5.2`
- [ ] Device (OAuth users with tier access): pick `GPT-5.5` → send a message → replies normally
- [ ] Device (user previously on 5.2): open Settings → should see 5.2 in "Custom model" field, no broken state

🤖 Generated with [Claude Code](https://claude.com/claude-code)