### PR TITLE
[codex] Add Flipper BLE bridge tools

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Remove AD_ID permission merged from dependencies (app does not use advertising ID) -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />

--- a/app/src/main/assets/nodejs-project/tools/android.js
+++ b/app/src/main/assets/nodejs-project/tools/android.js
@@ -144,6 +144,43 @@ const tools = [
             required: ['package']
         }
     },
+    {
+        name: 'flipper_scan',
+        description: 'Scan nearby Bluetooth LE devices and return likely Flipper Zero devices. Requires BLUETOOTH_SCAN and BLUETOOTH_CONNECT permissions.',
+        input_schema: {
+            type: 'object',
+            properties: {
+                timeoutMs: { type: 'number', description: 'Scan timeout in milliseconds, 1000-30000 (default 8000)' }
+            }
+        }
+    },
+    {
+        name: 'flipper_connect',
+        description: 'Connect to the user-owned paired Flipper Zero over Bluetooth LE. Use an address from flipper_scan, or omit address to connect to the strongest detected Flipper.',
+        input_schema: {
+            type: 'object',
+            properties: {
+                address: { type: 'string', description: 'BLE MAC address from flipper_scan. Optional.' },
+                timeoutMs: { type: 'number', description: 'Connect timeout in milliseconds, 3000-45000 (default 15000)' }
+            }
+        }
+    },
+    {
+        name: 'flipper_status',
+        description: 'Return the current Flipper Zero Bluetooth connection status and discovered GATT service UUIDs.',
+        input_schema: {
+            type: 'object',
+            properties: {}
+        }
+    },
+    {
+        name: 'flipper_disconnect',
+        description: 'Disconnect the current Flipper Zero Bluetooth LE connection.',
+        input_schema: {
+            type: 'object',
+            properties: {}
+        }
+    },
 ];
 
 const handlers = {
@@ -262,6 +299,27 @@ const handlers = {
 
     async android_apps_launch(input, chatId) {
         return await androidBridgeCall('/apps/launch', { package: input.package });
+    },
+
+    async flipper_scan(input, chatId) {
+        return await androidBridgeCall('/flipper/scan', {
+            timeoutMs: input.timeoutMs || 8000
+        }, (input.timeoutMs || 8000) + 5000);
+    },
+
+    async flipper_connect(input, chatId) {
+        return await androidBridgeCall('/flipper/connect', {
+            address: input.address || '',
+            timeoutMs: input.timeoutMs || 15000
+        }, (input.timeoutMs || 15000) + 5000);
+    },
+
+    async flipper_status(input, chatId) {
+        return await androidBridgeCall('/flipper/status');
+    },
+
+    async flipper_disconnect(input, chatId) {
+        return await androidBridgeCall('/flipper/disconnect');
     },
 };
 

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -23,6 +23,9 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import com.seekerclaw.app.camera.CameraCaptureActivity
 import com.seekerclaw.app.config.ConfigManager
+import com.seekerclaw.app.flipper.FlipperBleManager
+import com.seekerclaw.app.flipper.FlipperConnectionStatus
+import com.seekerclaw.app.flipper.FlipperScanDevice
 import com.seekerclaw.app.service.SeekerClawService
 import com.seekerclaw.app.util.Analytics
 import com.seekerclaw.app.util.ServiceState
@@ -68,6 +71,8 @@ class AndroidBridge(
         "/contacts/search" to Pair(20, 60_000L),
         "/contacts/add" to Pair(10, 60_000L),
         "/location" to Pair(10, 60_000L),
+        "/flipper/scan" to Pair(10, 60_000L),
+        "/flipper/connect" to Pair(5, 60_000L),
         "/openai/oauth/save-tokens" to Pair(5, 60_000L),
         // /config/credentials loads AppConfig (Keystore decrypt +
         // agent_settings reconciliation) on every call — rate-limit so
@@ -150,6 +155,10 @@ class AndroidBridge(
                 "/location" -> handleLocation()
                 "/tts" -> handleTts(params)
                 "/camera/capture" -> handleCameraCapture(params)
+                "/flipper/scan" -> handleFlipperScan(params)
+                "/flipper/connect" -> handleFlipperConnect(params)
+                "/flipper/disconnect" -> handleFlipperDisconnect()
+                "/flipper/status" -> handleFlipperStatus()
                 "/apps/list" -> handleAppsList()
                 "/apps/launch" -> handleAppsLaunch(params)
                 "/stats/message" -> handleStatsMessage()
@@ -604,6 +613,82 @@ class AndroidBridge(
 
         return jsonResponse(408, mapOf("error" to "Camera capture timed out"))
     }
+
+    // ==================== Flipper Zero BLE ====================
+
+    private fun handleFlipperScan(params: JSONObject): Response {
+        val permissionError = requireBluetoothPermissions(scan = true, connect = true)
+        if (permissionError != null) return permissionError
+
+        val timeoutMs = params.optLong("timeoutMs", 8_000L).coerceIn(1_000L, 30_000L)
+        return try {
+            val devices = FlipperBleManager.scan(context, timeoutMs)
+            jsonResponse(
+                200,
+                mapOf(
+                    "success" to true,
+                    "devices" to devices.map { it.toJsonMap() },
+                ),
+            )
+        } catch (e: Exception) {
+            jsonResponse(400, mapOf("error" to (e.message ?: "Flipper scan failed")))
+        }
+    }
+
+    private fun handleFlipperConnect(params: JSONObject): Response {
+        val permissionError = requireBluetoothPermissions(scan = true, connect = true)
+        if (permissionError != null) return permissionError
+
+        val address = params.optString("address", "").trim().ifBlank { null }
+        val timeoutMs = params.optLong("timeoutMs", 15_000L).coerceIn(3_000L, 45_000L)
+        return try {
+            val status = FlipperBleManager.connect(context, address, timeoutMs)
+            jsonResponse(200, status.toJsonMap(success = true))
+        } catch (e: Exception) {
+            jsonResponse(400, mapOf("error" to (e.message ?: "Flipper connect failed")))
+        }
+    }
+
+    private fun handleFlipperDisconnect(): Response {
+        val permissionError = requireBluetoothPermissions(scan = false, connect = true)
+        if (permissionError != null) return permissionError
+
+        val status = FlipperBleManager.disconnect()
+        return jsonResponse(200, status.toJsonMap(success = true))
+    }
+
+    private fun handleFlipperStatus(): Response {
+        val permissionError = requireBluetoothPermissions(scan = false, connect = true)
+        if (permissionError != null) return permissionError
+
+        val status = FlipperBleManager.status(context)
+        return jsonResponse(200, status.toJsonMap(success = true))
+    }
+
+    private fun requireBluetoothPermissions(scan: Boolean, connect: Boolean): Response? {
+        if (scan && !hasPermission(Manifest.permission.BLUETOOTH_SCAN)) {
+            return jsonResponse(403, mapOf("error" to "BLUETOOTH_SCAN permission not granted"))
+        }
+        if (connect && !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)) {
+            return jsonResponse(403, mapOf("error" to "BLUETOOTH_CONNECT permission not granted"))
+        }
+        return null
+    }
+
+    private fun FlipperScanDevice.toJsonMap(): Map<String, Any?> = mapOf(
+        "name" to name,
+        "address" to address,
+        "rssi" to rssi,
+        "bonded" to bonded,
+    )
+
+    private fun FlipperConnectionStatus.toJsonMap(success: Boolean): Map<String, Any?> = mapOf(
+        "success" to success,
+        "connected" to connected,
+        "name" to name,
+        "address" to address,
+        "serviceUuids" to serviceUuids,
+    )
 
     // ==================== Apps ====================
 

--- a/app/src/main/java/com/seekerclaw/app/flipper/FlipperBleManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/flipper/FlipperBleManager.kt
@@ -1,0 +1,200 @@
+package com.seekerclaw.app.flipper
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanResult
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+data class FlipperScanDevice(
+    val name: String,
+    val address: String,
+    val rssi: Int,
+    val bonded: Boolean,
+)
+
+data class FlipperConnectionStatus(
+    val connected: Boolean,
+    val name: String?,
+    val address: String?,
+    val serviceUuids: List<String>,
+)
+
+/**
+ * Minimal BLE transport for user-paired Flipper Zero devices.
+ *
+ * This intentionally stops at scan/connect/status. Flipper RPC is protobuf-over-BLE
+ * and should be layered on top once connection behavior is verified on-device.
+ */
+object FlipperBleManager {
+    private const val DEFAULT_SCAN_TIMEOUT_MS = 8_000L
+    private const val DEFAULT_CONNECT_TIMEOUT_MS = 15_000L
+
+    private val lock = Any()
+    private var gatt: BluetoothGatt? = null
+    private var connectedDevice: BluetoothDevice? = null
+    private var discoveredServices: List<BluetoothGattService> = emptyList()
+
+    fun status(context: Context): FlipperConnectionStatus {
+        synchronized(lock) {
+            val device = connectedDevice
+            return FlipperConnectionStatus(
+                connected = gatt != null && device != null,
+                name = device?.safeName(context),
+                address = device?.address,
+                serviceUuids = discoveredServices.map { it.uuid.toString() }.sorted(),
+            )
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun scan(context: Context, timeoutMs: Long = DEFAULT_SCAN_TIMEOUT_MS): List<FlipperScanDevice> {
+        val adapter = bluetoothManager(context).adapter
+            ?: throw IllegalStateException("Bluetooth adapter unavailable")
+        if (!adapter.isEnabled) throw IllegalStateException("Bluetooth is disabled")
+        val scanner = adapter.bluetoothLeScanner
+            ?: throw IllegalStateException("BLE scanner unavailable")
+
+        val found = Collections.synchronizedMap(linkedMapOf<String, FlipperScanDevice>())
+        val callback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                record(result)
+            }
+
+            override fun onBatchScanResults(results: MutableList<ScanResult>) {
+                results.forEach { record(it) }
+            }
+
+            private fun record(result: ScanResult) {
+                val device = result.device ?: return
+                val advertisedName = result.scanRecord?.deviceName
+                val name = advertisedName ?: device.safeName(context) ?: return
+                if (!name.contains("flipper", ignoreCase = true)) return
+
+                found[device.address] = FlipperScanDevice(
+                    name = name,
+                    address = device.address,
+                    rssi = result.rssi,
+                    bonded = device.bondState == BluetoothDevice.BOND_BONDED,
+                )
+            }
+        }
+
+        scanner.startScan(callback)
+        try {
+            Thread.sleep(timeoutMs.coerceIn(1_000L, 30_000L))
+        } finally {
+            scanner.stopScan(callback)
+        }
+
+        return found.values.sortedByDescending { it.rssi }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun connect(context: Context, address: String?, timeoutMs: Long = DEFAULT_CONNECT_TIMEOUT_MS): FlipperConnectionStatus {
+        val adapter = bluetoothManager(context).adapter
+            ?: throw IllegalStateException("Bluetooth adapter unavailable")
+        if (!adapter.isEnabled) throw IllegalStateException("Bluetooth is disabled")
+
+        val targetAddress = address?.takeIf { it.isNotBlank() }
+            ?: scan(context, DEFAULT_SCAN_TIMEOUT_MS).firstOrNull()?.address
+            ?: throw IllegalStateException("No Flipper Zero BLE device found")
+
+        val device = adapter.getRemoteDevice(targetAddress)
+        val latch = CountDownLatch(1)
+        val error = AtomicReference<String?>(null)
+
+        synchronized(lock) {
+            gatt?.close()
+            gatt = null
+            connectedDevice = null
+            discoveredServices = emptyList()
+        }
+
+        val callback = object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+                if (status != BluetoothGatt.GATT_SUCCESS) {
+                    error.set("GATT connection failed with status $status")
+                    latch.countDown()
+                    return
+                }
+                if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    gatt.discoverServices()
+                } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    synchronized(lock) {
+                        if (this@FlipperBleManager.gatt == gatt) {
+                            this@FlipperBleManager.gatt = null
+                            connectedDevice = null
+                            discoveredServices = emptyList()
+                        }
+                    }
+                    latch.countDown()
+                }
+            }
+
+            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    synchronized(lock) {
+                        this@FlipperBleManager.gatt = gatt
+                        connectedDevice = gatt.device
+                        discoveredServices = gatt.services.orEmpty()
+                    }
+                } else {
+                    error.set("GATT service discovery failed with status $status")
+                }
+                latch.countDown()
+            }
+        }
+
+        val newGatt = device.connectGatt(context.applicationContext, false, callback, BluetoothDevice.TRANSPORT_LE)
+            ?: throw IllegalStateException("Failed to create BLE GATT connection")
+        synchronized(lock) { gatt = newGatt }
+
+        val completed = latch.await(timeoutMs.coerceIn(3_000L, 45_000L), TimeUnit.MILLISECONDS)
+        if (!completed) {
+            disconnect()
+            throw IllegalStateException("Timed out connecting to Flipper Zero")
+        }
+        error.get()?.let {
+            disconnect()
+            throw IllegalStateException(it)
+        }
+        return status(context)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun disconnect(): FlipperConnectionStatus {
+        synchronized(lock) {
+            gatt?.disconnect()
+            gatt?.close()
+            gatt = null
+            connectedDevice = null
+            discoveredServices = emptyList()
+        }
+        return FlipperConnectionStatus(false, null, null, emptyList())
+    }
+
+    private fun bluetoothManager(context: Context): BluetoothManager =
+        context.getSystemService(BluetoothManager::class.java)
+            ?: throw IllegalStateException("BluetoothManager unavailable")
+
+    private fun BluetoothDevice.safeName(context: Context): String? {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) !=
+            PackageManager.PERMISSION_GRANTED) {
+            return null
+        }
+        return try { name } catch (_: SecurityException) { null }
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -145,6 +145,11 @@ object SettingsHelpTexts {
         "It will always confirm the number with you before dialing. " +
         "Useful for quick calls like \"call the pizza place\"."
 
+    const val BLUETOOTH_DEVICES =
+        "Lets the agent scan for and connect to nearby Bluetooth LE devices you own, starting with Flipper Zero. " +
+        "The first version exposes scan, connect, disconnect, and status only. " +
+        "Higher-level Flipper actions will be added behind narrow tools after the connection path is proven."
+
     // ── MCP Servers ─────────────────────────────────────────────────
 
     const val MCP_SERVERS =

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -163,12 +163,23 @@ fun SettingsScreen(
     var hasCallPermission by remember {
         mutableStateOf(ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED)
     }
+    var hasBluetoothPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+        )
+    }
 
     val locationLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { hasLocationPermission = it }
     val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { hasCameraPermission = it }
     val contactsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { hasContactsPermission = it }
     val smsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { hasSmsPermission = it }
     val callLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { hasCallPermission = it }
+    val bluetoothLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
+        hasBluetoothPermission =
+            result[Manifest.permission.BLUETOOTH_SCAN] == true &&
+            result[Manifest.permission.BLUETOOTH_CONNECT] == true
+    }
 
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
@@ -182,6 +193,9 @@ fun SettingsScreen(
                 hasContactsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED
                 hasSmsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS) == PackageManager.PERMISSION_GRANTED
                 hasCallPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
+                hasBluetoothPermission =
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED &&
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -531,7 +545,8 @@ fun SettingsScreen(
                     info = SettingsHelpTexts.SERVER_MODE,
                 )
                 val allPermissionsOff = !hasCameraPermission && !hasLocationPermission &&
-                    !hasContactsPermission && !hasSmsPermission && !hasCallPermission
+                    !hasContactsPermission && !hasSmsPermission && !hasCallPermission &&
+                    !hasBluetoothPermission
                 if (allPermissionsOff) {
                     Text(
                         text = "Enable permissions to unlock device features (camera, GPS, SMS, etc.)",
@@ -589,6 +604,20 @@ fun SettingsScreen(
                     },
                     onOpenSettings = { openAppSettings(context) },
                     info = SettingsHelpTexts.PHONE_CALLS,
+                )
+                PermissionRow(
+                    label = "Bluetooth devices",
+                    granted = hasBluetoothPermission,
+                    onRequest = {
+                        bluetoothLauncher.launch(
+                            arrayOf(
+                                Manifest.permission.BLUETOOTH_SCAN,
+                                Manifest.permission.BLUETOOTH_CONNECT,
+                            )
+                        )
+                    },
+                    onOpenSettings = { openAppSettings(context) },
+                    info = SettingsHelpTexts.BLUETOOTH_DEVICES,
                 )
             }
         }

--- a/docs/internal/SETTINGS_INFO.md
+++ b/docs/internal/SETTINGS_INFO.md
@@ -38,6 +38,7 @@
 | 14 | Contacts | `CONTACTS` | ✅ Good | Lets the agent read your contacts list. This allows it to look up names and phone numbers when you ask, for example "text Mom" or "call John". Your contacts are never sent to the cloud — only used on-device to resolve names. |
 | 15 | SMS | `SMS` | ✅ Good | Lets the agent send text messages on your behalf. The agent will always tell you who it's texting and what it's sending before it acts. Standard carrier SMS rates may apply. |
 | 16 | Phone Calls | `PHONE_CALLS` | ✅ Good | Lets the agent make phone calls for you. It will always confirm the number with you before dialing. Useful for quick calls like "call the pizza place". |
+| 17 | Bluetooth devices | `BLUETOOTH_DEVICES` | ✅ Good | Lets the agent scan for and connect to nearby Bluetooth LE devices you own, starting with Flipper Zero. The first version exposes scan, connect, disconnect, and status only. Higher-level Flipper actions will be added behind narrow tools after the connection path is proven. |
 
 ## Solana Wallet
 


### PR DESCRIPTION
## Summary
- add Android Bluetooth LE permissions and a settings permission row for Bluetooth devices
- add a Kotlin `FlipperBleManager` for scanning, connecting, disconnecting, and reporting discovered GATT services for likely Flipper Zero devices
- expose narrow AndroidBridge endpoints and Node tools: `flipper_scan`, `flipper_connect`, `flipper_status`, and `flipper_disconnect`

## Notes
This is intentionally a transport-first draft. It does not expose raw Flipper RPC or security-sensitive Flipper actions. Higher-level Flipper commands should be layered on top after validating scan/connect behavior with a real paired Flipper Zero.

## Validation
- `node --check app/src/main/assets/nodejs-project/tools/android.js`
- `ANDROID_HOME=C:\Users\User\AppData\Local\Android\Sdk ./gradlew.bat :app:testGooglePlayDebugUnitTest --no-daemon --console=plain`
