### PR TITLE
perf: derive uptime locally instead of writing it every second (BAT-522)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
@@ -22,7 +22,6 @@ import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -36,7 +35,11 @@ import java.util.UUID
 class SeekerClawService : Service() {
     private var wakeLock: PowerManager.WakeLock? = null
     private var screenWakeLock: PowerManager.WakeLock? = null
-    private var uptimeJob: Job? = null
+    // BAT-522 (BAT-518 phase 2): the prior 1Hz `uptimeJob` coroutine that
+    // wrote `service_state` every second has been deleted. Uptime is now
+    // a derived quantity computed from `ServiceState.serviceStartTimeMs`,
+    // which the service writes ONCE on transition to RUNNING (and zeros
+    // on stop). UI ticks once per second for display only — no disk write.
     // BAT-518: replaced nodeDebugJob (500ms polling coroutine) with
     // FileObserver. lastPos tracks bytes already forwarded to LogCollector
     // so each event reads only new bytes. nodeDebugMutex serializes
@@ -64,7 +67,6 @@ class SeekerClawService : Service() {
     // observer.stopWatching() + null-out.
     private val scopeJob = SupervisorJob()
     private val scope = CoroutineScope(Dispatchers.IO + scopeJob)
-    private var startTimeMs = 0L
     private var androidBridge: AndroidBridge? = null
 
     /**
@@ -501,15 +503,11 @@ class SeekerClawService : Service() {
             }
         }
 
-        // Track uptime
-        startTimeMs = System.currentTimeMillis()
-        uptimeJob = scope.launch {
-            while (isActive) {
-                val elapsed = System.currentTimeMillis() - startTimeMs
-                ServiceState.updateUptime(elapsed)
-                delay(1000)
-            }
-        }
+        // BAT-522 (BAT-518 phase 2): persist a one-shot start timestamp
+        // instead of writing a recomputed uptime every second. UI derives
+        // displayed uptime as `now - serviceStartTimeMs` and ticks
+        // locally once per second for display only.
+        ServiceState.setServiceStartTimeMs(System.currentTimeMillis())
 
         LogCollector.append("[Service] Claw Engine started")
 
@@ -530,7 +528,6 @@ class SeekerClawService : Service() {
         // Stop the node-debug FileObserver (BAT-518: was nodeDebugJob coroutine).
         nodeDebugObserver?.stopWatching()
         nodeDebugObserver = null
-        uptimeJob?.cancel()
         Watchdog.stop()
         androidBridge?.shutdown()
         NodeBridge.stop()
@@ -545,7 +542,9 @@ class SeekerClawService : Service() {
         if (ServiceState.status.value != ServiceStatus.ERROR) {
             ServiceState.updateStatus(ServiceStatus.STOPPED)
         }
-        ServiceState.updateUptime(0)
+        // BAT-522: clear the persisted start timestamp so the next UI
+        // launch derives uptime=0 until the service is started again.
+        ServiceState.setServiceStartTimeMs(0L)
 
         // Clean shutdown should clear crash-loop counters. Unexpected deaths won't hit this path.
         // CRITICAL: use commit() not apply(). apply() is async — Android queues the disk
@@ -623,7 +622,9 @@ class SeekerClawService : Service() {
                 if (ServiceState.status.value != ServiceStatus.ERROR) {
                     ServiceState.updateStatus(ServiceStatus.STOPPED)
                 }
-                ServiceState.updateUptime(0)
+                // BAT-522: clear the persisted start timestamp so the next UI
+                // launch derives uptime=0 until the service is started again.
+                ServiceState.setServiceStartTimeMs(0L)
             }
             val intent = Intent(context, SeekerClawService::class.java)
             context.stopService(intent)

--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -71,6 +71,7 @@ import com.seekerclaw.app.util.LogLevel
 import com.seekerclaw.app.util.AgentHealth
 import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
+import com.seekerclaw.app.util.rememberUptime
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
@@ -96,7 +97,10 @@ fun DashboardScreen(
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     val status by ServiceState.status.collectAsState()
-    val uptime by ServiceState.uptime.collectAsState()
+    // BAT-522 (BAT-518 phase 2): uptime is derived locally from the
+    // one-shot `serviceStartTimeMs`, not subscribed from a StateFlow
+    // that used to be re-written every second by the service.
+    val uptime = rememberUptime()
     val messageCount by ServiceState.messageCount.collectAsState()
     val messagesToday by ServiceState.messagesToday.collectAsState()
     val lastActivityTime by ServiceState.lastActivityTime.collectAsState()

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -57,6 +57,7 @@ import com.seekerclaw.app.util.DbSummary
 import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
 import com.seekerclaw.app.util.fetchDbSummary
+import com.seekerclaw.app.util.rememberUptime
 import java.time.DayOfWeek
 import java.time.LocalDate
 import kotlinx.coroutines.Dispatchers
@@ -86,7 +87,9 @@ private fun heatmapColorForCount(count: Int, thresholds: List<Int>): Color {
 fun SystemScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     val status by ServiceState.status.collectAsState()
-    val uptime by ServiceState.uptime.collectAsState()
+    // BAT-522 (BAT-518 phase 2): uptime derived locally from the
+    // one-shot serviceStartTimeMs (no per-second StateFlow rewrite).
+    val uptime = rememberUptime()
     val messageCount by ServiceState.messageCount.collectAsState()
     val messagesToday by ServiceState.messagesToday.collectAsState()
     val tokensToday by ServiceState.tokensToday.collectAsState()

--- a/app/src/main/java/com/seekerclaw/app/util/ServiceState.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/ServiceState.kt
@@ -57,8 +57,13 @@ object ServiceState {
     private val _status = MutableStateFlow(ServiceStatus.STOPPED)
     val status: StateFlow<ServiceStatus> = _status
 
-    private val _uptime = MutableStateFlow(0L)
-    val uptime: StateFlow<Long> = _uptime
+    // BAT-522 (phase 2): replaces the old `_uptime` StateFlow that was
+    // re-written every 1s by SeekerClawService.uptimeJob. Now the service
+    // writes this once on transition to RUNNING and zeroes it on STOPPED.
+    // UI derives displayed uptime as `now - serviceStartTimeMs.value`,
+    // ticking once per second for display only (no disk write).
+    private val _serviceStartTimeMs = MutableStateFlow(0L)
+    val serviceStartTimeMs: StateFlow<Long> = _serviceStartTimeMs
 
     private val _messageCount = MutableStateFlow(0)
     val messageCount: StateFlow<Int> = _messageCount
@@ -214,8 +219,18 @@ object ServiceState {
         writeToFile()
     }
 
-    fun updateUptime(millis: Long) {
-        _uptime.value = millis
+    /**
+     * Persist the service start timestamp. Called once when the service
+     * transitions to RUNNING, and again with 0L on STOPPED/ERROR/shutdown.
+     *
+     * Replaces the BAT-518-era `updateUptime(millis)` writer that was
+     * called once per second from SeekerClawService.uptimeJob. The 1s
+     * write loop generated 86,400 disk writes/day even when nothing
+     * changed; deriving uptime from a one-shot start timestamp eliminates
+     * that I/O entirely (BAT-522, BAT-518 phase 2).
+     */
+    fun setServiceStartTimeMs(ms: Long) {
+        _serviceStartTimeMs.value = ms
         writeToFile()
     }
 
@@ -238,7 +253,7 @@ object ServiceState {
 
     fun reset() {
         _status.value = ServiceStatus.STOPPED
-        _uptime.value = 0L
+        _serviceStartTimeMs.value = 0L
         _messageCount.value = 0
         _messagesToday.value = 0
         _lastActivityTime.value = 0L
@@ -552,24 +567,36 @@ object ServiceState {
     /**
      * File format (one value per line):
      * 0: status name
-     * 1: uptime millis
+     * 1: (DEPRECATED, BAT-522) was uptime millis. Always written as 0
+     *    so old builds reading the new file see uptime=0 (acceptable
+     *    degradation — BAT-522 stops updating it; old build can't show
+     *    a live ticker anymore but won't misinterpret garbage).
      * 2: messageCount (all-time)
      * 3: messagesToday
      * 4: lastActivityTime
      * 5: tokensToday
      * 6: tokensTotal
+     * 7: serviceStartTimeMs (BAT-522, phase 2). New builds derive
+     *    displayed uptime as `now - serviceStartTimeMs` while RUNNING,
+     *    no live disk writes. Missing on pre-BAT-522 files → defaults
+     *    to 0L on read; the next service start populates it.
      */
     private fun writeToFile() {
         val file = stateFile ?: return
         try {
             val data = buildString {
                 appendLine(_status.value.name)
-                appendLine(_uptime.value)
+                // Line 1 is intentionally always 0L (BAT-522 — see file
+                // format docblock). Kept so old pre-BAT-522 builds
+                // running on a freshly-written file still find every
+                // line they expect at the same index.
+                appendLine(0L)
                 appendLine(_messageCount.value)
                 appendLine(_messagesToday.value)
                 appendLine(_lastActivityTime.value)
                 appendLine(_tokensToday.value)
-                append(_tokensTotal.value)
+                appendLine(_tokensTotal.value)
+                append(_serviceStartTimeMs.value)
             }
             file.writeText(data)
         } catch (_: Exception) {}
@@ -582,13 +609,13 @@ object ServiceState {
             val lines = file.readLines()
             if (lines.size >= 5) {
                 val fileStatus = try { ServiceStatus.valueOf(lines[0]) } catch (_: Exception) { return }
-                val fileUptime = lines[1].toLongOrNull() ?: return
+                // lines[1] is the deprecated uptime field — read but
+                // ignore. BAT-522 derives uptime from line 7 instead.
                 val fileMsgCount = lines[2].toIntOrNull() ?: return
                 val fileMsgToday = lines[3].toIntOrNull() ?: return
                 val fileLastActivity = lines[4].toLongOrNull() ?: return
 
                 if (_status.value != fileStatus) _status.value = fileStatus
-                if (_uptime.value != fileUptime) _uptime.value = fileUptime
                 if (_messageCount.value != fileMsgCount) _messageCount.value = fileMsgCount
                 if (_messagesToday.value != fileMsgToday) _messagesToday.value = fileMsgToday
                 if (_lastActivityTime.value != fileLastActivity) _lastActivityTime.value = fileLastActivity
@@ -600,6 +627,17 @@ object ServiceState {
                     if (_tokensToday.value != fileTokensToday) _tokensToday.value = fileTokensToday
                     if (_tokensTotal.value != fileTokensTotal) _tokensTotal.value = fileTokensTotal
                 }
+
+                // Service start time (BAT-522). Pre-BAT-522 files lack
+                // line 7 — default to 0L; the next service start writes
+                // a fresh value, after which uptime tracking resumes
+                // normally. While 0L is in effect, the UI shows
+                // "00h 00m 00s" — same as the STOPPED display, which
+                // matches user expectation for the moment of upgrade.
+                val fileStartTime = if (lines.size >= 8) {
+                    lines[7].toLongOrNull() ?: 0L
+                } else 0L
+                if (_serviceStartTimeMs.value != fileStartTime) _serviceStartTimeMs.value = fileStartTime
             }
         } catch (_: Exception) {}
     }
@@ -717,4 +755,32 @@ object ServiceState {
             if (_apiUsage.value != usage) _apiUsage.value = usage
         } catch (_: Exception) {}
     }
+
+    // ── Testing hooks ────────────────────────────────────────────────
+    // Internal-visibility hooks for unit tests. Same convention as
+    // LogCollector — kept in-class (not via androidx @VisibleForTesting)
+    // because we don't want to pull in the runtime dependency for what
+    // is fundamentally just a controlled test seam.
+
+    internal fun setStateFileForTest(file: File?) {
+        stateFile = file
+    }
+
+    internal fun resetForTest() {
+        _status.value = ServiceStatus.STOPPED
+        _serviceStartTimeMs.value = 0L
+        _messageCount.value = 0
+        _messagesToday.value = 0
+        _lastActivityTime.value = 0L
+        _tokensToday.value = 0L
+        _tokensTotal.value = 0L
+        _apiUsage.value = null
+        _agentHealth.value = AgentHealth()
+        bridgeToken = null
+        initialized = false
+    }
+
+    internal fun writeToFileForTest() = writeToFile()
+
+    internal fun readFromFileForTest() = readFromFile()
 }

--- a/app/src/main/java/com/seekerclaw/app/util/Uptime.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/Uptime.kt
@@ -1,0 +1,51 @@
+package com.seekerclaw.app.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+
+/**
+ * Composable that returns a live uptime value (millis since service
+ * started) without subscribing to any disk-backed StateFlow that ticks
+ * once per second.
+ *
+ * BAT-522 (BAT-518 phase 2) replaced the old `ServiceState.uptime`
+ * StateFlow — backed by `SeekerClawService.uptimeJob` writing to disk
+ * every 1s — with a one-shot start timestamp persisted in
+ * `service_state` line 7. The UI now derives uptime locally:
+ *
+ *   - When status is RUNNING and `serviceStartTimeMs > 0`, the value
+ *     is `now - serviceStartTimeMs`. The composable updates once per
+ *     second so the seconds counter still animates.
+ *   - Otherwise (STOPPED / ERROR / pre-BAT-522 file with no start
+ *     timestamp), the value is 0L. Rendered the same way today's
+ *     `formatUptime(0)` renders: "00h 00m 00s".
+ *
+ * The 1s tick is purely in-memory (no disk write, no StateFlow
+ * propagation across processes). When status leaves RUNNING the loop
+ * exits and the Composable settles at 0L.
+ */
+@Composable
+fun rememberUptime(): Long {
+    val startTimeMs by ServiceState.serviceStartTimeMs.collectAsState()
+    val status by ServiceState.status.collectAsState()
+    var uptime by remember { mutableLongStateOf(0L) }
+
+    LaunchedEffect(startTimeMs, status) {
+        if (status == ServiceStatus.RUNNING && startTimeMs > 0L) {
+            while (true) {
+                uptime = System.currentTimeMillis() - startTimeMs
+                delay(1000)
+            }
+        } else {
+            uptime = 0L
+        }
+    }
+
+    return uptime
+}

--- a/app/src/test/java/com/seekerclaw/app/util/ServiceStateTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/util/ServiceStateTest.kt
@@ -1,0 +1,134 @@
+package com.seekerclaw.app.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pure JVM tests for ServiceState's `service_state` file parse/write.
+ *
+ * Phase 2 of BAT-518 (BAT-522) added a new line 7 holding the
+ * `serviceStartTimeMs`, and demoted line 1 (legacy uptime) to a
+ * placeholder always written as 0L. These tests pin the upgrade
+ * compatibility:
+ *
+ *   - new build reading a pre-BAT-522 file (5 or 7 lines) does not
+ *     crash and defaults `serviceStartTimeMs` to 0L
+ *   - new build round-trips its own writes (8 lines) cleanly
+ *   - the legacy uptime line is read-tolerant: any value there is
+ *     ignored, the new build never displays it
+ */
+class ServiceStateTest {
+
+    private lateinit var tmp: File
+
+    @Before
+    fun setUp() {
+        tmp = File.createTempFile("bat522-state", ".test")
+        ServiceState.setStateFileForTest(tmp)
+        ServiceState.resetForTest()
+    }
+
+    @After
+    fun tearDown() {
+        ServiceState.setStateFileForTest(null)
+        ServiceState.resetForTest()
+        tmp.delete()
+    }
+
+    @Test
+    fun `read tolerates legacy 5-line format and defaults serviceStartTime to 0`() {
+        // Pre-tokens, pre-BAT-522 layout. lines[1] = uptime millis (ignored
+        // by new build). lines[5..] = absent.
+        tmp.writeText("RUNNING\n42000\n10\n3\n1700000000000\n")
+
+        ServiceState.readFromFileForTest()
+
+        assertEquals(ServiceStatus.RUNNING, ServiceState.status.value)
+        assertEquals(10, ServiceState.messageCount.value)
+        assertEquals(3, ServiceState.messagesToday.value)
+        assertEquals(1700000000000L, ServiceState.lastActivityTime.value)
+        assertEquals(0L, ServiceState.tokensToday.value)
+        assertEquals(0L, ServiceState.tokensTotal.value)
+        // No line 7 — defaults to 0L. UI will render uptime as 00h 00m 00s
+        // until the next service start writes a fresh start timestamp.
+        assertEquals(0L, ServiceState.serviceStartTimeMs.value)
+    }
+
+    @Test
+    fun `read tolerates legacy 7-line format with tokens and no start time`() {
+        // Pre-BAT-522 file with tokens but no line 7 yet.
+        tmp.writeText("RUNNING\n42000\n10\n3\n1700000000000\n12345\n67890\n")
+
+        ServiceState.readFromFileForTest()
+
+        assertEquals(ServiceStatus.RUNNING, ServiceState.status.value)
+        assertEquals(10, ServiceState.messageCount.value)
+        assertEquals(12345L, ServiceState.tokensToday.value)
+        assertEquals(67890L, ServiceState.tokensTotal.value)
+        assertEquals(0L, ServiceState.serviceStartTimeMs.value)
+    }
+
+    @Test
+    fun `read picks up line 7 when present`() {
+        val startTime = 1_700_000_500_000L
+        tmp.writeText("RUNNING\n0\n10\n3\n1700000000000\n12345\n67890\n$startTime")
+
+        ServiceState.readFromFileForTest()
+
+        assertEquals(startTime, ServiceState.serviceStartTimeMs.value)
+    }
+
+    @Test
+    fun `write produces an 8-line file with start time at line 7`() {
+        ServiceState.updateStatus(ServiceStatus.RUNNING)
+        ServiceState.setServiceStartTimeMs(1_700_000_500_000L)
+
+        val lines = tmp.readLines()
+        assertEquals(8, lines.size)
+        assertEquals("RUNNING", lines[0])
+        assertEquals("0", lines[1]) // legacy uptime placeholder
+        assertEquals("1700000500000", lines[7])
+    }
+
+    @Test
+    fun `write then read round-trips serviceStartTimeMs`() {
+        val startTime = 1_700_000_500_000L
+        ServiceState.updateStatus(ServiceStatus.RUNNING)
+        ServiceState.setServiceStartTimeMs(startTime)
+
+        ServiceState.resetForTest()
+        ServiceState.readFromFileForTest()
+
+        assertEquals(ServiceStatus.RUNNING, ServiceState.status.value)
+        assertEquals(startTime, ServiceState.serviceStartTimeMs.value)
+    }
+
+    @Test
+    fun `setting serviceStartTimeMs to 0 persists across read`() {
+        ServiceState.updateStatus(ServiceStatus.RUNNING)
+        ServiceState.setServiceStartTimeMs(1_700_000_500_000L)
+        ServiceState.setServiceStartTimeMs(0L)
+
+        ServiceState.resetForTest()
+        ServiceState.readFromFileForTest()
+
+        assertEquals(0L, ServiceState.serviceStartTimeMs.value)
+    }
+
+    @Test
+    fun `legacy uptime value at line 1 is ignored`() {
+        // Old build wrote an actual uptime here; new build must not
+        // surface it as serviceStartTimeMs or anywhere else.
+        tmp.writeText("RUNNING\n999999\n0\n0\n0\n0\n0\n")
+
+        ServiceState.readFromFileForTest()
+
+        // No public field maps to the legacy uptime — verify the new
+        // start-time field stayed at default since the file lacks
+        // line 7.
+        assertEquals(0L, ServiceState.serviceStartTimeMs.value)
+    }
+}


### PR DESCRIPTION
Phase 2 of [BAT-518](https://linear.app/batcave/issue/BAT-518). Closes [BAT-522](https://linear.app/batcave/issue/BAT-522).

## Summary

The prior 1Hz `uptimeJob` coroutine in `SeekerClawService` called `ServiceState.updateUptime(...)` every second, generating ~86,400 `service_state` writes/day even when nothing changed.

This PR replaces it with a one-shot start timestamp persisted on line 7 of `service_state`. The UI derives displayed uptime as `now - serviceStartTimeMs` while RUNNING and ticks once per second for display only — no disk write, no cross-process StateFlow propagation.

## What changed

| Before | After |
|---|---|
| `SeekerClawService.uptimeJob` writes `service_state` every 1s | Service writes `serviceStartTimeMs` once on RUNNING, again as `0L` on stop |
| UI subscribes to `ServiceState.uptime: StateFlow<Long>` | UI calls `rememberUptime()` Composable; ticks 1s in-memory, settles at 0L when not RUNNING |
| `service_state` line 1 = uptime millis (live) | Line 1 always written as `0L` (legacy placeholder, ignored on read); line 7 (NEW) = `serviceStartTimeMs` |

**Estimated savings**

| Polling loop | Before | After |
|---|---|---|
| `uptimeJob` writes to `service_state` | 86,400 writes/day | 2 writes per service start/stop cycle |

## Upgrade safety (per CLAUDE.md NEVER SKIP rule)

- [x] Risk category: **Low** — file format change with backwards-compat reads on both directions.
- **Old build → new file:** old build reads line 1 (uptime). New build always writes `0` there. Old build shows uptime=0 on the dashboard. Acceptable: a user mid-rollback sees a frozen counter, but no crash, no data loss, no broken status.
- **New build → old file:** old file lacks line 7. New build defaults `serviceStartTimeMs` to 0L; the UI shows `00h 00m 00s` (same as the STOPPED display) until the next service start writes a fresh value. After the user taps Deploy on the new build, normal uptime tracking resumes.
- File parsing remains tolerant of line-count mismatches: 5-line, 7-line, and 8-line layouts all parse without crash.
- Other StateFlow values (status, message counts, tokens) are untouched — no impact on cross-process state observation.

## Test plan

- [x] `scripts/pre-push-check.sh` — green (Node smoke + Kotlin compile dappStoreDebug)
- [x] `ServiceStateTest` (NEW) — 7/7 green
  - legacy 5-line read tolerance
  - legacy 7-line (with tokens) read tolerance
  - new 8-line read picks up `serviceStartTimeMs`
  - new 8-line write produces 8 lines with start time at index 7
  - write→reset→read round-trip preserves the value
  - zeroing the start time persists across read
  - legacy uptime line at index 1 is ignored on read
- [x] `LogCollectorTest` — still 16/16 green (no regression)
- [ ] **Device smoke on Solana Seeker (BAT-522 AC):**
  - [ ] Install old build → install new build (`adb install -r`) → uptime resumes correctly
  - [ ] Tap Deploy → Dashboard uptime increments visibly (00h 00m 01s, 02s, 03s...)
  - [ ] System screen Uptime row matches Dashboard (both call `rememberUptime()`)
  - [ ] Kill main UI process via Recents while service runs → reopen → uptime is correct (not reset to 0)
  - [ ] Stop Agent → uptime resets to `00h 00m 00s` immediately
  - [ ] Restart Agent → fresh count from 0

## Out of scope (deferred)

- **Phase 3A** (BAT-523): DB autosave dirty debounce
- **Phase 3B** (BAT-524): idle-session per-chat timers
- **`agentHealth` 60s heartbeat**: stays as-is per Codex Option A — it's the heartbeat the BAT-518 staleness ticker depends on. Reframing it as a redesign is a separate ticket.
- **`docs/internal/POLLING-vs-EVENTS.md`**: deferred until all three phases land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)