### PR TITLE
perf: per-chat idle-summary timers replace global 60s sweep (BAT-524)

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -213,6 +213,62 @@ const CHECKPOINT_MESSAGES = 50;                 // Every 50 messages → checkpo
 const CHECKPOINT_INTERVAL_MS = 30 * 60 * 1000; // 30 min active chat → checkpoint
 const MIN_MESSAGES_FOR_SUMMARY = 3;             // Don't summarize tiny sessions
 
+// ── Idle-summary per-chat timers (BAT-524, BAT-518 phase 3B) ────────────────
+// Pre-BAT-524, main.js ran a global `setInterval(60s)` that swept the
+// sessionTracking Map every minute looking for chats whose
+// `lastMessageTime` had drifted past IDLE_TIMEOUT_MS. That interval ran
+// 1,440 times/day even with no chats active. We now keep at most one
+// `setTimeout(IDLE_TIMEOUT_MS)` per chat: it's (re)armed by every new
+// message via scheduleIdleSummary, fires once if no new message arrives
+// to reset it, and is cancelled on conversation clear / sessionTracking
+// delete / shutdown. Idle agent with no chats → zero scheduled timers
+// (vs 1,440 sweep ticks/day pre-BAT-524).
+const idleSummaryTimers = new Map(); // chatId → NodeJS.Timeout
+
+/**
+ * (Re)arm the idle-summary timer for `chatId`. Cancels the previous
+ * timer (if any) and schedules a fresh one IDLE_TIMEOUT_MS out. Call
+ * from every site that updates `track.lastMessageTime = Date.now()`
+ * — the new message resets the idle window.
+ */
+function scheduleIdleSummary(chatId) {
+    cancelIdleSummary(chatId);
+    const timer = setTimeout(() => {
+        // Clear our slot first so a new message arriving DURING
+        // saveSessionSummary's async work can install a fresh timer
+        // without colliding with this stale one.
+        idleSummaryTimers.delete(chatId);
+        const conv = conversations.get(chatId);
+        if (conv && conv.length >= MIN_MESSAGES_FOR_SUMMARY) {
+            saveSessionSummary(chatId, 'idle').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
+        }
+    }, IDLE_TIMEOUT_MS);
+    idleSummaryTimers.set(chatId, timer);
+}
+
+/**
+ * Cancel any pending idle-summary timer for `chatId`. Idempotent —
+ * safe to call even when no timer exists. Use from
+ * clearConversation / sessionTracking.delete / shutdown.
+ */
+function cancelIdleSummary(chatId) {
+    const timer = idleSummaryTimers.get(chatId);
+    if (timer !== undefined) {
+        clearTimeout(timer);
+        idleSummaryTimers.delete(chatId);
+    }
+}
+
+/**
+ * Cancel ALL pending idle-summary timers. Used by SIGTERM/SIGINT
+ * handlers so dangling setTimeouts don't keep the event loop alive
+ * and delay process.exit().
+ */
+function cancelAllIdleSummaries() {
+    for (const timer of idleSummaryTimers.values()) clearTimeout(timer);
+    idleSummaryTimers.clear();
+}
+
 function getSessionTrack(chatId) {
     const today = new Date().toISOString().split('T')[0];
     if (!sessionTracking.has(chatId)) {
@@ -245,6 +301,12 @@ function addToConversation(chatId, role, content) {
 
 function clearConversation(chatId) {
     conversations.set(chatId, []);
+    // BAT-524: cancel any pending idle-summary timer — clearing the
+    // conversation invalidates the "saved this idle gap" trigger
+    // condition (length < MIN_MESSAGES_FOR_SUMMARY post-clear), and
+    // leaving a dangling timer would harmlessly fire but waste a
+    // setTimeout slot and a saveSessionSummary attempt.
+    cancelIdleSummary(chatId);
 }
 
 // Session slug generator (OpenClaw-style adj-noun, BAT-57)
@@ -1966,6 +2028,10 @@ async function chat(chatId, userMessage, options = {}) {
     const track = getSessionTrack(chatId);
     track.lastMessageTime = Date.now();
     if (!track.firstMessageTime) track.firstMessageTime = track.lastMessageTime;
+    // BAT-524: (re)arm the per-chat idle-summary timer for the new
+    // message. Replaces the global setInterval(60s) sweep that used
+    // to scan sessionTracking for stale lastMessageTime entries.
+    scheduleIdleSummary(chatId);
 
     // BAT-243: Generate unique turn ID for correlating all API calls in this turn
     const turnId = crypto.randomBytes(4).toString('hex');
@@ -2373,6 +2439,8 @@ async function chat(chatId, userMessage, options = {}) {
                 const trk = getSessionTrack(chatId);
                 trk.lastMessageTime = Date.now();
                 trk.messageCount++;
+                // BAT-524: (re)arm the per-chat idle-summary timer.
+                scheduleIdleSummary(chatId);
                 const sinceLastSummary = Date.now() - (trk.lastSummaryTime || trk.firstMessageTime || Date.now());
                 if (trk.messageCount >= CHECKPOINT_MESSAGES || sinceLastSummary > CHECKPOINT_INTERVAL_MS) {
                     saveSessionSummary(chatId, 'checkpoint').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
@@ -2461,6 +2529,8 @@ async function chat(chatId, userMessage, options = {}) {
             const trk = getSessionTrack(chatId);
             trk.lastMessageTime = Date.now();
             trk.messageCount++;
+            // BAT-524: (re)arm the per-chat idle-summary timer.
+            scheduleIdleSummary(chatId);
             const sinceLastSummary = Date.now() - (trk.lastSummaryTime || trk.firstMessageTime || Date.now());
             if (trk.messageCount >= CHECKPOINT_MESSAGES || sinceLastSummary > CHECKPOINT_INTERVAL_MS) {
                 saveSessionSummary(chatId, 'checkpoint').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
@@ -2527,6 +2597,8 @@ module.exports = {
     // Sessions
     sessionTracking, saveSessionSummary,
     MIN_MESSAGES_FOR_SUMMARY, IDLE_TIMEOUT_MS,
+    // Idle-summary per-chat timers (BAT-524, BAT-518 phase 3B)
+    scheduleIdleSummary, cancelIdleSummary, cancelAllIdleSummaries,
     // Health
     writeAgentHealthFile, writeApiUsageState,
     // Session expiry

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -243,6 +243,11 @@ function scheduleIdleSummary(chatId) {
             saveSessionSummary(chatId, 'idle').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
         }
     }, IDLE_TIMEOUT_MS);
+    // unref() so a pending idle timer can't keep the Node event loop
+    // alive past a clean exit. Same pattern cron.js uses for its long-
+    // lived timers. The defensive `if (timer.unref)` matches Node-side
+    // type variance on different Node versions.
+    if (timer.unref) timer.unref();
     idleSummaryTimers.set(chatId, timer);
 }
 

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -85,6 +85,13 @@ let _shutdownDeps = {
     conversations: null,          // Map — from main.js (will move to ai.js in BAT-203)
     saveSessionSummary: null,     // async fn — from main.js (will move to ai.js in BAT-203)
     MIN_MESSAGES_FOR_SUMMARY: 3,  // constant — from main.js (will move to ai.js in BAT-203)
+    // BAT-524: cancel all per-chat idle-summary timers from inside
+    // gracefulShutdown. main.js also registers a SIGTERM listener that
+    // calls cancelAllIdleSummaries, but gracefulShutdown can call
+    // process.exit(0) synchronously when there are no session
+    // summaries to await — bypassing main.js's listener entirely. This
+    // dep makes the cleanup happen on the gracefulShutdown path too.
+    cancelAllIdleSummaries: null, // () => void — from main.js (BAT-524)
 };
 
 /**
@@ -99,6 +106,7 @@ function setShutdownDeps(deps) {
     if (deps.conversations) _shutdownDeps.conversations = deps.conversations;
     if (typeof deps.saveSessionSummary === 'function') _shutdownDeps.saveSessionSummary = deps.saveSessionSummary;
     if (typeof deps.MIN_MESSAGES_FOR_SUMMARY === 'number') _shutdownDeps.MIN_MESSAGES_FOR_SUMMARY = deps.MIN_MESSAGES_FOR_SUMMARY;
+    if (typeof deps.cancelAllIdleSummaries === 'function') _shutdownDeps.cancelAllIdleSummaries = deps.cancelAllIdleSummaries;
 }
 
 // ============================================================================
@@ -602,6 +610,15 @@ function backfillSessionsFromFiles() {
 // Registered outside initDatabase so shutdown hooks work even if DB init fails
 async function gracefulShutdown(signal) {
     log(`[Shutdown] ${signal} received, saving session summary...`, 'INFO');
+    // BAT-524: cancel pending idle-summary timers FIRST. Without this,
+    // a timer that's about to fire could call saveSessionSummary
+    // concurrently with the per-chat summary work below, double-
+    // writing summaries for the same chat. Cancelling early also
+    // releases the unref()'d timers so the event loop can settle
+    // promptly once gracefulShutdown's own awaits complete.
+    if (typeof _shutdownDeps.cancelAllIdleSummaries === 'function') {
+        try { _shutdownDeps.cancelAllIdleSummaries(); } catch (_) {}
+    }
     try {
         const { conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY } = _shutdownDeps;
         if (conversations && saveSessionSummary) {

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -159,7 +159,8 @@ const {
     chat,
     conversations, getConversation, addToConversation, clearConversation,
     sessionTracking,
-    saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY, IDLE_TIMEOUT_MS,
+    saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY,
+    cancelIdleSummary, cancelAllIdleSummaries,
     writeAgentHealthFile,
     setChatDeps,
     getActiveTask, clearActiveTask,
@@ -731,19 +732,10 @@ telegram('getMe')
                 });
             }
 
-            // Idle session summary timer (BAT-57) — check every 60s per-chatId
-            setInterval(() => {
-                const now = Date.now();
-                sessionTracking.forEach((track, chatId) => {
-                    if (track.lastMessageTime > 0 && now - track.lastMessageTime > IDLE_TIMEOUT_MS) {
-                        track.lastMessageTime = 0; // Reset FIRST to prevent re-trigger on next tick
-                        const conv = conversations.get(chatId);
-                        if (conv && conv.length >= MIN_MESSAGES_FOR_SUMMARY) {
-                            saveSessionSummary(chatId, 'idle').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
-                        }
-                    }
-                });
-            }, 60000);
+            // BAT-524 (BAT-518 phase 3B): the prior 60s-sweep
+            // setInterval is gone. Idle session summaries now fire via
+            // per-chat setTimeout(IDLE_TIMEOUT_MS) timers (re)armed by
+            // every message — see scheduleIdleSummary in ai.js.
         } else {
             log(`ERROR: ${JSON.stringify(result)}`, 'ERROR');
             process.exit(1);
@@ -847,19 +839,10 @@ telegram('getMe')
             });
         }
 
-        // Idle session summary timer
-        setInterval(() => {
-            const now = Date.now();
-            sessionTracking.forEach((track, chatId) => {
-                if (track.lastMessageTime > 0 && now - track.lastMessageTime > IDLE_TIMEOUT_MS) {
-                    track.lastMessageTime = 0;
-                    const conv = conversations.get(chatId);
-                    if (conv && conv.length >= MIN_MESSAGES_FOR_SUMMARY) {
-                        saveSessionSummary(chatId, 'idle').catch(e => log(`[SessionSummary] ${e.message}`, 'DEBUG'));
-                    }
-                }
-            });
-        }, 60000);
+        // BAT-524 (BAT-518 phase 3B): the prior 60s-sweep setInterval
+        // is gone. Idle session summaries fire via per-chat
+        // setTimeout(IDLE_TIMEOUT_MS) timers (re)armed by every
+        // message — see scheduleIdleSummary in ai.js.
 
         log('[Discord] Discord channel fully initialized', 'INFO');
     }).catch(err => {
@@ -868,10 +851,12 @@ telegram('getMe')
     });
 }
 
-// Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram)
+// Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram).
 // Runs before database.js's gracefulShutdown which handles session summaries + DB save.
-process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} });
-process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} });
+// BAT-524: also cancel all pending idle-summary timers so dangling
+// setTimeouts don't keep the event loop alive past process.exit().
+process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} cancelAllIdleSummaries(); });
+process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} cancelAllIdleSummaries(); });
 
 // Runtime status log (uptime/memory debug, every 5 min)
 setInterval(() => {
@@ -932,6 +917,11 @@ async function runCronAgentTurn(message, jobId) {
         // the synthetic key frees all state for this cron run.
         conversations.delete(cronChatId);
         sessionTracking.delete(cronChatId);
+        // BAT-524: cancel any pending idle-summary timer for the
+        // synthetic cron chat so it doesn't fire after we've torn
+        // down conversations + sessionTracking (which would log a
+        // saveSessionSummary failure for a vanished session).
+        cancelIdleSummary(cronChatId);
         clearActiveTask(cronChatId);
     }
 }

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -851,10 +851,18 @@ telegram('getMe')
     });
 }
 
-// Graceful shutdown: stop the channel (close WebSocket for Discord, no-op for Telegram).
-// Runs before database.js's gracefulShutdown which handles session summaries + DB save.
-// BAT-524: also cancel all pending idle-summary timers so dangling
-// setTimeouts don't keep the event loop alive past process.exit().
+// Channel + timer cleanup on signal: closes the Discord WebSocket if
+// active (no-op for Telegram long-poll), and cancels all pending
+// idle-summary timers so dangling setTimeouts don't keep the event
+// loop alive past process.exit() (BAT-524).
+//
+// Ordering note: database.js registers its own SIGTERM/SIGINT handler
+// at require-time near the top of this file, so gracefulShutdown is
+// INVOKED first. Because gracefulShutdown is async (awaits session-
+// summary work), it returns a suspended promise — Node then dispatches
+// the next listener (this one), whose synchronous body completes
+// while gracefulShutdown's tail (saveDatabase + process.exit(0))
+// is still pending.
 process.on('SIGTERM', () => { try { channel.stop(); } catch (_) {} cancelAllIdleSummaries(); });
 process.on('SIGINT', () => { try { channel.stop(); } catch (_) {} cancelAllIdleSummaries(); });
 

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -629,7 +629,7 @@ telegram('getMe')
             seedHeartbeatMd();
 
             // Wire shutdown deps now that conversations + saveSessionSummary exist
-            setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY });
+            setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY, cancelAllIdleSummaries });
 
             // Wire chat deps: inject main.js state into ai.js
             setChatDeps({
@@ -758,7 +758,7 @@ telegram('getMe')
         seedHeartbeatMd();
 
         // Wire shutdown deps
-        setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY });
+        setShutdownDeps({ conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY, cancelAllIdleSummaries });
 
         // Wire chat deps: inject main.js state into ai.js
         setChatDeps({

--- a/tests/nodejs-project/idle-summary-timers.test.js
+++ b/tests/nodejs-project/idle-summary-timers.test.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+// idle-summary-timers.test.js — tests for the BAT-524 per-chat
+// idle-summary timer model in ai.js.
+//
+// Run:  node tests/nodejs-project/idle-summary-timers.test.js
+// Exit: 0 = all pass, 1 = at least one failure.
+//
+// WHY THIS FILE EXISTS
+// --------------------
+// Phase 3B of BAT-518 replaced a single global `setInterval(60s)` sweep
+// over `sessionTracking` with a per-chat `setTimeout(IDLE_TIMEOUT_MS)`
+// model. Three correctness invariants need pinning:
+//
+//   1. Each chat has at MOST one active timer at any time. A new
+//      message must cancel the prior timer before scheduling a new
+//      one — otherwise idle bursts could pile up parallel timers
+//      that fire saveSessionSummary multiple times.
+//
+//   2. New messages on chat A must NOT touch chat B's timer. The
+//      old global sweep fired one summary at a time; the new model
+//      must preserve per-chat isolation.
+//
+//   3. Cancellation paths (clearConversation, sessionTracking.delete,
+//      shutdown) must clear the timer so it never fires post-cancel.
+//
+// All three are pure timer/Map logic, but they live next to live
+// session-tracking + saveSessionSummary calls. Following the
+// active-model.test.js pattern, we mirror the schedule/cancel
+// primitives locally and grep the source at the end to fail loudly
+// on drift.
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const AI_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'ai.js');
+const MAIN_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'main.js');
+
+// --- mirrored logic (must match ai.js scheduleIdleSummary / cancelIdleSummary) ---
+function makeHarness({ idleTimeoutMs = 60_000, minMessagesForSummary = 3 } = {}) {
+    const conversations = new Map();   // chatId → array of messages
+    const idleSummaryTimers = new Map(); // chatId → NodeJS.Timeout
+    let summaryCount = 0;
+    const summaryCalls = []; // {chatId, reason, convLen}
+
+    function pretendSaveSummary(chatId, reason) {
+        summaryCount++;
+        const conv = conversations.get(chatId);
+        summaryCalls.push({ chatId, reason, convLen: conv ? conv.length : 0 });
+        return Promise.resolve();
+    }
+
+    function scheduleIdleSummary(chatId) {
+        cancelIdleSummary(chatId);
+        const timer = setTimeout(() => {
+            idleSummaryTimers.delete(chatId);
+            const conv = conversations.get(chatId);
+            if (conv && conv.length >= minMessagesForSummary) {
+                pretendSaveSummary(chatId, 'idle').catch(() => {});
+            }
+        }, idleTimeoutMs);
+        idleSummaryTimers.set(chatId, timer);
+    }
+
+    function cancelIdleSummary(chatId) {
+        const timer = idleSummaryTimers.get(chatId);
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            idleSummaryTimers.delete(chatId);
+        }
+    }
+
+    function cancelAllIdleSummaries() {
+        for (const t of idleSummaryTimers.values()) clearTimeout(t);
+        idleSummaryTimers.clear();
+    }
+
+    function setConv(chatId, msgs) { conversations.set(chatId, msgs); }
+    function clearConv(chatId) {
+        conversations.set(chatId, []);
+        cancelIdleSummary(chatId);
+    }
+
+    return {
+        scheduleIdleSummary, cancelIdleSummary, cancelAllIdleSummaries,
+        setConv, clearConv,
+        get timerCount() { return idleSummaryTimers.size; },
+        hasTimer: (chatId) => idleSummaryTimers.has(chatId),
+        get summaryCount() { return summaryCount; },
+        get summaryCalls() { return summaryCalls.slice(); },
+    };
+}
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    for (const { name, fn } of tests) {
+        try {
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+// --- behavioural tests ---
+
+test('schedule installs exactly one timer per chat', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    h.scheduleIdleSummary('chat-A');
+    assert.strictEqual(h.timerCount, 1);
+    assert.ok(h.hasTimer('chat-A'));
+    h.cancelAllIdleSummaries();
+});
+
+test('re-scheduling same chat does NOT pile up timers', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    for (let i = 0; i < 50; i++) h.scheduleIdleSummary('chat-A');
+    // A naïve impl would have 50 dangling timers in flight (event-loop
+    // memory leak + 50 saveSessionSummary fires when window expires).
+    assert.strictEqual(h.timerCount, 1, 'still exactly one pending timer');
+    h.cancelAllIdleSummaries();
+});
+
+test('different chats get independent timers', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    h.scheduleIdleSummary('chat-A');
+    h.scheduleIdleSummary('chat-B');
+    h.scheduleIdleSummary('chat-C');
+    assert.strictEqual(h.timerCount, 3);
+    assert.ok(h.hasTimer('chat-A'));
+    assert.ok(h.hasTimer('chat-B'));
+    assert.ok(h.hasTimer('chat-C'));
+    h.cancelAllIdleSummaries();
+});
+
+test('rescheduling chat A leaves chat B untouched', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    h.scheduleIdleSummary('chat-A');
+    h.scheduleIdleSummary('chat-B');
+    // Burst of activity on A — must not touch B's timer.
+    for (let i = 0; i < 10; i++) h.scheduleIdleSummary('chat-A');
+    assert.ok(h.hasTimer('chat-A'));
+    assert.ok(h.hasTimer('chat-B'));
+    assert.strictEqual(h.timerCount, 2);
+    h.cancelAllIdleSummaries();
+});
+
+test('cancelIdleSummary removes the timer and is idempotent', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    h.scheduleIdleSummary('chat-A');
+    h.cancelIdleSummary('chat-A');
+    assert.strictEqual(h.timerCount, 0);
+    // Idempotent — second cancel should not throw.
+    h.cancelIdleSummary('chat-A');
+    h.cancelIdleSummary('chat-NEVER-SCHEDULED');
+});
+
+test('cancelAllIdleSummaries clears every timer', () => {
+    const h = makeHarness({ idleTimeoutMs: 60_000 });
+    h.scheduleIdleSummary('chat-A');
+    h.scheduleIdleSummary('chat-B');
+    h.scheduleIdleSummary('chat-C');
+    h.cancelAllIdleSummaries();
+    assert.strictEqual(h.timerCount, 0);
+});
+
+test('timer fires saveSessionSummary when conversation has enough messages', async () => {
+    const h = makeHarness({ idleTimeoutMs: 30, minMessagesForSummary: 3 });
+    h.setConv('chat-A', [{}, {}, {}]);
+    h.scheduleIdleSummary('chat-A');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual(h.summaryCount, 1, 'one summary fired');
+    assert.strictEqual(h.timerCount, 0, 'timer slot cleared after firing');
+});
+
+test('timer does NOT fire saveSessionSummary when conversation is too short', async () => {
+    const h = makeHarness({ idleTimeoutMs: 30, minMessagesForSummary: 3 });
+    h.setConv('chat-A', [{}, {}]); // < MIN_MESSAGES_FOR_SUMMARY
+    h.scheduleIdleSummary('chat-A');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual(h.summaryCount, 0, 'no summary for tiny session');
+});
+
+test('rescheduling resets the idle window — timer does NOT fire if reset before deadline', async () => {
+    const h = makeHarness({ idleTimeoutMs: 50, minMessagesForSummary: 3 });
+    h.setConv('chat-A', [{}, {}, {}]);
+    h.scheduleIdleSummary('chat-A');
+    // Reset before original deadline — the new timer fires 50ms from now,
+    // so we wait less than that to confirm no fire happened.
+    await new Promise(r => setTimeout(r, 30));
+    h.scheduleIdleSummary('chat-A');
+    await new Promise(r => setTimeout(r, 30)); // total: 60ms, but reset at 30ms means new window started at 30ms
+    assert.strictEqual(h.summaryCount, 0, 'reset prevented the original timer from firing');
+    assert.ok(h.hasTimer('chat-A'), 'new timer still pending');
+    h.cancelAllIdleSummaries();
+});
+
+test('clearConv cancels the timer (so cleared sessions never re-summarize)', async () => {
+    const h = makeHarness({ idleTimeoutMs: 30, minMessagesForSummary: 3 });
+    h.setConv('chat-A', [{}, {}, {}]);
+    h.scheduleIdleSummary('chat-A');
+    h.clearConv('chat-A');
+    assert.strictEqual(h.timerCount, 0, 'timer cancelled by clearConv');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual(h.summaryCount, 0, 'no summary fired after clear');
+});
+
+test('only ONE summary fires even after a burst of (re)schedules', async () => {
+    const h = makeHarness({ idleTimeoutMs: 30, minMessagesForSummary: 3 });
+    h.setConv('chat-A', [{}, {}, {}]);
+    for (let i = 0; i < 100; i++) h.scheduleIdleSummary('chat-A');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual(h.summaryCount, 1, 'coalesced burst produced exactly one summary');
+});
+
+// --- structural drift guards ---
+
+test('drift: ai.js exports the per-chat timer helpers', () => {
+    const src = fs.readFileSync(AI_JS, 'utf8');
+    assert.ok(/scheduleIdleSummary/.test(src), 'scheduleIdleSummary must exist in ai.js');
+    assert.ok(/cancelIdleSummary/.test(src), 'cancelIdleSummary must exist in ai.js');
+    assert.ok(/cancelAllIdleSummaries/.test(src), 'cancelAllIdleSummaries must exist in ai.js');
+    // The export block must reference all three.
+    const exportMatch = src.match(/module\.exports\s*=\s*\{[\s\S]*?\};/);
+    assert.ok(exportMatch, 'module.exports block not found');
+    const exportBody = exportMatch[0];
+    assert.ok(/scheduleIdleSummary/.test(exportBody), 'export must include scheduleIdleSummary');
+    assert.ok(/cancelIdleSummary/.test(exportBody), 'export must include cancelIdleSummary');
+    assert.ok(/cancelAllIdleSummaries/.test(exportBody), 'export must include cancelAllIdleSummaries');
+});
+
+test('drift: main.js no longer has the idle-session sweep setInterval', () => {
+    const src = fs.readFileSync(MAIN_JS, 'utf8');
+    // The pre-BAT-524 sweep iterated sessionTracking.forEach inside a
+    // setInterval. Reject any reappearance.
+    assert.ok(!/setInterval[\s\S]*sessionTracking\.forEach/.test(src),
+        'main.js must not contain a setInterval that sweeps sessionTracking (BAT-524 — replaced with per-chat setTimeouts)');
+});
+
+test('drift: clearConversation in ai.js cancels the idle timer', () => {
+    const src = fs.readFileSync(AI_JS, 'utf8');
+    const fnMatch = src.match(/function\s+clearConversation\s*\(\s*chatId\s*\)\s*\{[\s\S]*?\n\}/);
+    assert.ok(fnMatch, 'clearConversation function body not found');
+    const body = fnMatch[0];
+    assert.ok(/cancelIdleSummary\s*\(\s*chatId\s*\)/.test(body),
+        'clearConversation must cancel the idle-summary timer (BAT-524 — prevents post-clear fire)');
+});
+
+test('drift: SIGTERM/SIGINT handlers in main.js cancel all idle timers', () => {
+    const src = fs.readFileSync(MAIN_JS, 'utf8');
+    // Both signal handlers must invoke cancelAllIdleSummaries so
+    // dangling setTimeouts don't keep the event loop alive past
+    // process.exit().
+    const sigtermMatch = src.match(/process\.on\(['"]SIGTERM['"][\s\S]*?\}\);/);
+    const sigintMatch = src.match(/process\.on\(['"]SIGINT['"][\s\S]*?\}\);/);
+    assert.ok(sigtermMatch, 'SIGTERM handler not found');
+    assert.ok(sigintMatch, 'SIGINT handler not found');
+    assert.ok(/cancelAllIdleSummaries/.test(sigtermMatch[0]),
+        'SIGTERM handler must call cancelAllIdleSummaries');
+    assert.ok(/cancelAllIdleSummaries/.test(sigintMatch[0]),
+        'SIGINT handler must call cancelAllIdleSummaries');
+});
+
+run();

--- a/tests/nodejs-project/idle-summary-timers.test.js
+++ b/tests/nodejs-project/idle-summary-timers.test.js
@@ -338,6 +338,36 @@ test('drift: SIGTERM/SIGINT handlers in main.js cancel all idle timers', () => {
         'SIGINT handler must call cancelAllIdleSummaries(...)');
 });
 
+test('drift: scheduleIdleSummary calls .unref() on the timer', () => {
+    // Without unref(), a pending idle timer can keep the Node event
+    // loop alive past a clean shutdown unless every exit path
+    // reliably cancels it. Pin that the live source uses the same
+    // `if (timer.unref) timer.unref()` defensive pattern as cron.js.
+    const src = readJsSource(AI_JS);
+    const fnMatch = src.match(/function\s+scheduleIdleSummary[\s\S]*?\n\}/);
+    assert.ok(fnMatch, 'scheduleIdleSummary function body not found');
+    const body = fnMatch[0];
+    assert.ok(/timer\.unref\s*\(\s*\)/.test(body),
+        'scheduleIdleSummary must call timer.unref() so a pending idle timer cannot block clean process exit');
+});
+
+test('drift: gracefulShutdown receives cancelAllIdleSummaries via setShutdownDeps', () => {
+    const dbSrc = readJsSource(path.join(__dirname, '..', '..', 'app', 'src', 'main',
+        'assets', 'nodejs-project', 'database.js'));
+    // The shutdown-deps record must declare cancelAllIdleSummaries.
+    assert.ok(/cancelAllIdleSummaries\s*:/.test(dbSrc),
+        'database.js _shutdownDeps must declare cancelAllIdleSummaries (BAT-524 — gracefulShutdown can call process.exit before main.js SIGTERM listener runs)');
+    // gracefulShutdown must invoke it.
+    const fnMatch = dbSrc.match(/async\s+function\s+gracefulShutdown[\s\S]*?\n\}/);
+    assert.ok(fnMatch, 'gracefulShutdown function body not found');
+    assert.ok(/_shutdownDeps\.cancelAllIdleSummaries\s*\(\s*\)/.test(fnMatch[0]),
+        'gracefulShutdown must call _shutdownDeps.cancelAllIdleSummaries() so timers are released even when main.js SIGTERM listener is bypassed');
+    // main.js must pass cancelAllIdleSummaries when wiring deps.
+    const mainSrc = readJsSource(MAIN_JS);
+    assert.ok(/setShutdownDeps\s*\(\s*\{[^}]*cancelAllIdleSummaries/.test(mainSrc),
+        'main.js setShutdownDeps(...) call must include cancelAllIdleSummaries');
+});
+
 test('drift: stripJsComments actually removes comments without breaking strings', () => {
     // Sanity check on the helper itself — without this the other
     // drift guards' "comment immunity" claim is unverified. If
@@ -361,7 +391,7 @@ test('drift: stripJsComments actually removes comments without breaking strings'
         'string literal SIGTERM preserved');
     assert.ok(/literal/.test(stripped),
         'template literal body preserved');
-    assert.ok(!/not a comment/.test(stripped) === false,
+    assert.ok(/not a comment/.test(stripped),
         'block-comment-looking content INSIDE a template literal is preserved');
     // Live calls preserved.
     assert.ok(/cancelIdleSummary\(99\)/.test(stripped),

--- a/tests/nodejs-project/idle-summary-timers.test.js
+++ b/tests/nodejs-project/idle-summary-timers.test.js
@@ -40,6 +40,66 @@ const AI_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
 const MAIN_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
     'assets', 'nodejs-project', 'main.js');
 
+// Strip JS comments before drift-guard matching. Without this, every
+// regex below could false-pass on a comment that happens to contain
+// the symbol it's looking for — the same trap that burned the BAT-523
+// setInterval drift guard ("Pre-BAT-523, the DB was saved every 60s
+// via setInterval(saveDatabase)" in a comment matched the regex
+// looking for the live setInterval call).
+//
+// String literals are deliberately NOT masked: real strings like
+// `process.on('SIGTERM', ...)` need the literal to match. Drift
+// guards instead use `\b<identifier>\s*\(` patterns that match a
+// function call site — a string containing an identifier never has
+// a `(` immediately after its closing quote, so the false-positive
+// surface is eliminated by anchoring on the call form rather than
+// by masking strings.
+function stripJsComments(src) {
+    let out = '';
+    let i = 0;
+    while (i < src.length) {
+        const c = src[i];
+        const next = src[i + 1];
+        if (c === '/' && next === '/') {
+            // Line comment — skip to end of line.
+            const eol = src.indexOf('\n', i);
+            i = eol === -1 ? src.length : eol;
+        } else if (c === '/' && next === '*') {
+            // Block comment — skip to */.
+            const end = src.indexOf('*/', i + 2);
+            i = end === -1 ? src.length : end + 2;
+        } else if (c === '"' || c === "'" || c === '`') {
+            // String literal — copy verbatim, skipping over its body
+            // so an inner `//` or `/*` can't be misread as a comment
+            // boundary.
+            const quote = c;
+            out += quote;
+            i++;
+            while (i < src.length && src[i] !== quote) {
+                out += src[i];
+                if (src[i] === '\\' && i + 1 < src.length) {
+                    out += src[i + 1];
+                    i += 2;
+                } else {
+                    i++;
+                }
+            }
+            if (i < src.length) {
+                out += src[i];
+                i++;
+            }
+        } else {
+            out += c;
+            i++;
+        }
+    }
+    return out;
+}
+
+function readJsSource(filePath) {
+    return stripJsComments(fs.readFileSync(filePath, 'utf8'));
+}
+
 // --- mirrored logic (must match ai.js scheduleIdleSummary / cancelIdleSummary) ---
 function makeHarness({ idleTimeoutMs = 60_000, minMessagesForSummary = 3 } = {}) {
     const conversations = new Map();   // chatId → array of messages
@@ -230,49 +290,82 @@ test('only ONE summary fires even after a burst of (re)schedules', async () => {
 // --- structural drift guards ---
 
 test('drift: ai.js exports the per-chat timer helpers', () => {
-    const src = fs.readFileSync(AI_JS, 'utf8');
-    assert.ok(/scheduleIdleSummary/.test(src), 'scheduleIdleSummary must exist in ai.js');
-    assert.ok(/cancelIdleSummary/.test(src), 'cancelIdleSummary must exist in ai.js');
-    assert.ok(/cancelAllIdleSummaries/.test(src), 'cancelAllIdleSummaries must exist in ai.js');
-    // The export block must reference all three.
+    // Use readJsSource so comments / string literals can't satisfy
+    // the regex by substring presence — pin to actual code.
+    const src = readJsSource(AI_JS);
+    // The export block must reference all three. Match each as an
+    // identifier followed by `,` or `}` so a long substring inside
+    // an unrelated context can't false-pass.
     const exportMatch = src.match(/module\.exports\s*=\s*\{[\s\S]*?\};/);
     assert.ok(exportMatch, 'module.exports block not found');
     const exportBody = exportMatch[0];
-    assert.ok(/scheduleIdleSummary/.test(exportBody), 'export must include scheduleIdleSummary');
-    assert.ok(/cancelIdleSummary/.test(exportBody), 'export must include cancelIdleSummary');
-    assert.ok(/cancelAllIdleSummaries/.test(exportBody), 'export must include cancelAllIdleSummaries');
+    for (const sym of ['scheduleIdleSummary', 'cancelIdleSummary', 'cancelAllIdleSummaries']) {
+        const re = new RegExp(`\\b${sym}\\s*[,}]`);
+        assert.ok(re.test(exportBody), `module.exports must include ${sym}`);
+    }
 });
 
 test('drift: main.js no longer has the idle-session sweep setInterval', () => {
-    const src = fs.readFileSync(MAIN_JS, 'utf8');
-    // The pre-BAT-524 sweep iterated sessionTracking.forEach inside a
-    // setInterval. Reject any reappearance.
+    // Comments now stripped — the BAT-524 explanatory comments in
+    // main.js mention the old pattern but stripped source contains
+    // only live code.
+    const src = readJsSource(MAIN_JS);
     assert.ok(!/setInterval[\s\S]*sessionTracking\.forEach/.test(src),
         'main.js must not contain a setInterval that sweeps sessionTracking (BAT-524 — replaced with per-chat setTimeouts)');
 });
 
 test('drift: clearConversation in ai.js cancels the idle timer', () => {
-    const src = fs.readFileSync(AI_JS, 'utf8');
+    const src = readJsSource(AI_JS);
     const fnMatch = src.match(/function\s+clearConversation\s*\(\s*chatId\s*\)\s*\{[\s\S]*?\n\}/);
     assert.ok(fnMatch, 'clearConversation function body not found');
     const body = fnMatch[0];
-    assert.ok(/cancelIdleSummary\s*\(\s*chatId\s*\)/.test(body),
-        'clearConversation must cancel the idle-summary timer (BAT-524 — prevents post-clear fire)');
+    assert.ok(/\bcancelIdleSummary\s*\(\s*chatId\s*\)/.test(body),
+        'clearConversation must call cancelIdleSummary(chatId) (BAT-524 — prevents post-clear fire)');
 });
 
 test('drift: SIGTERM/SIGINT handlers in main.js cancel all idle timers', () => {
-    const src = fs.readFileSync(MAIN_JS, 'utf8');
-    // Both signal handlers must invoke cancelAllIdleSummaries so
-    // dangling setTimeouts don't keep the event loop alive past
-    // process.exit().
+    const src = readJsSource(MAIN_JS);
+    // Both signal handlers must INVOKE cancelAllIdleSummaries — match
+    // the call form `cancelAllIdleSummaries(...)` not just the
+    // identifier, so a stray reference can't satisfy the guard.
     const sigtermMatch = src.match(/process\.on\(['"]SIGTERM['"][\s\S]*?\}\);/);
     const sigintMatch = src.match(/process\.on\(['"]SIGINT['"][\s\S]*?\}\);/);
     assert.ok(sigtermMatch, 'SIGTERM handler not found');
     assert.ok(sigintMatch, 'SIGINT handler not found');
-    assert.ok(/cancelAllIdleSummaries/.test(sigtermMatch[0]),
-        'SIGTERM handler must call cancelAllIdleSummaries');
-    assert.ok(/cancelAllIdleSummaries/.test(sigintMatch[0]),
-        'SIGINT handler must call cancelAllIdleSummaries');
+    assert.ok(/\bcancelAllIdleSummaries\s*\(/.test(sigtermMatch[0]),
+        'SIGTERM handler must call cancelAllIdleSummaries(...)');
+    assert.ok(/\bcancelAllIdleSummaries\s*\(/.test(sigintMatch[0]),
+        'SIGINT handler must call cancelAllIdleSummaries(...)');
+});
+
+test('drift: stripJsComments actually removes comments without breaking strings', () => {
+    // Sanity check on the helper itself — without this the other
+    // drift guards' "comment immunity" claim is unverified. If
+    // stripping breaks, the rest of the suite would still pass on
+    // raw source and silently lose the immunity.
+    const sample = `
+        // line comment with setInterval(saveDatabase, 60000)
+        const x = 1; /* block comment with cancelIdleSummary(chatId) */
+        const sig = process.on('SIGTERM', () => {});
+        const tpl = \`/* not a comment */ literal\`;
+        function liveCall() { cancelIdleSummary(99); }
+    `;
+    const stripped = stripJsComments(sample);
+    // Comments removed.
+    assert.ok(!/setInterval\(saveDatabase, 60000\)/.test(stripped),
+        'line comment content removed');
+    assert.ok(!/cancelIdleSummary\(chatId\)/.test(stripped),
+        'block comment content removed');
+    // Strings preserved (the SIGTERM drift guard depends on this).
+    assert.ok(/'SIGTERM'/.test(stripped),
+        'string literal SIGTERM preserved');
+    assert.ok(/literal/.test(stripped),
+        'template literal body preserved');
+    assert.ok(!/not a comment/.test(stripped) === false,
+        'block-comment-looking content INSIDE a template literal is preserved');
+    // Live calls preserved.
+    assert.ok(/cancelIdleSummary\(99\)/.test(stripped),
+        'live function call preserved');
 });
 
 run();


### PR DESCRIPTION
Phase 3B of [BAT-518](https://linear.app/batcave/issue/BAT-518). Closes [BAT-524](https://linear.app/batcave/issue/BAT-524).

## Summary

The prior `setInterval(() => sessionTracking.forEach(...), 60000)` ran in `main.js` — twice, once per channel (Telegram + Discord) — and swept the sessionTracking Map every minute regardless of activity. Most users have zero active chats most of the time, so that's 2,880 pointless Map iterations + Date.now() comparisons per day.

This PR replaces it with per-chat `setTimeout(IDLE_TIMEOUT_MS)` timers that arm only on actual messages and fire only if the idle window expires.

## What changed

| Before | After |
|---|---|
| Two `setInterval(60s)` sweeps in `main.js` (Telegram + Discord) | Both deleted |
| Global Map iteration every 60s | Per-chat `setTimeout` armed only on message |
| Idle agent with 0 chats → still 1,440 ticks/day | Idle agent with 0 chats → **zero** scheduled timers |
| `track.lastMessageTime = 0` reset trick to prevent re-fire | Implicit — no timer = no fire |

## Implementation shape (matches BAT-524 acceptance criteria)

- New `idleSummaryTimers: Map<chatId, NodeJS.Timeout>` in `ai.js` next to `sessionTracking`.
- `scheduleIdleSummary(chatId)` cancels any prior timer for that chat, then schedules a fresh one. Called from every site that updates `track.lastMessageTime = Date.now()` — three sites in `ai.js` (chat() entry, budget-exhausted return, success return).
- `cancelIdleSummary(chatId)` is wired into:
  - `clearConversation(chatId)` (in ai.js — covers `/reset` and `/new` via deps wiring)
  - cron-path `sessionTracking.delete(cronChatId)` in `main.js`
- `cancelAllIdleSummaries()` runs in both SIGTERM and SIGINT handlers in `main.js` so dangling setTimeouts don't keep the event loop alive past `process.exit()`.
- Both channels share the timer logic via `ai.js` — no duplication.

## Out of scope

- Watchdog 30s heartbeat (legitimately polling, BAT-518 explicitly excludes).
- agentHealth 60s heartbeat (kept as Option A per BAT-518 Codex review).
- Graceful Node shutdown on user-initiated Stop ([BAT-525](https://linear.app/batcave/issue/BAT-525), filed as separate ticket).

## Test plan

- [x] `node tests/nodejs-project/idle-summary-timers.test.js` — **15/15 green**:
  - schedule installs exactly one timer per chat
  - re-scheduling same chat does NOT pile up timers (50× burst → 1 timer)
  - different chats get independent timers
  - rescheduling chat A leaves chat B untouched
  - cancelIdleSummary is idempotent
  - cancelAllIdleSummaries clears every timer
  - timer fires saveSessionSummary when conv length ≥ MIN_MESSAGES_FOR_SUMMARY
  - timer does NOT fire when conv too short
  - rescheduling resets the idle window — original timer doesn't fire after reset
  - clearConv cancels the timer (cleared sessions never re-summarize)
  - 100× burst of (re)schedules → still exactly ONE summary fires
  - 4 drift guards: ai.js exports, no setInterval sweep, clearConversation cancels, SIGTERM/SIGINT cancel-all
- [x] All other Node suites — unchanged, still green
- [x] `scripts/pre-push-check.sh` — green
- [ ] **Device smoke on Solana Seeker (BAT-524 AC):**
  - [ ] Send Telegram message → idle 10+ min → session summary fires once (`Sessions/*.md` written)
  - [ ] Send Telegram message → send another 5 min later → only ONE summary fires (timer reset)
  - [ ] Tap /reset → no summary fires afterwards (clearConversation cancelled the timer)
  - [ ] Stop service → process exits cleanly without dangling-timer warnings in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)