### PR TITLE
fix: flush Node state before user stop (BAT-525)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.SeekerClaw">
 

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -607,8 +607,7 @@ function backfillSessionsFromFiles() {
 // GRACEFUL SHUTDOWN (BAT-57)
 // ============================================================================
 
-// Registered outside initDatabase so shutdown hooks work even if DB init fails
-async function gracefulShutdown(signal) {
+async function flushForShutdown(signal, { summaryTimeoutMs = 5000 } = {}) {
     log(`[Shutdown] ${signal} received, saving session summary...`, 'INFO');
     // BAT-524: cancel pending idle-summary timers FIRST. Without this,
     // a timer that's about to fire could call saveSessionSummary
@@ -622,7 +621,7 @@ async function gracefulShutdown(signal) {
     try {
         const { conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY } = _shutdownDeps;
         if (conversations && saveSessionSummary) {
-            const timeout = new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 5000));
+            const timeout = new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), summaryTimeoutMs));
             const summaries = [];
             for (const [chatId, conv] of conversations) {
                 if (conv.length >= MIN_MESSAGES_FOR_SUMMARY) {
@@ -639,10 +638,16 @@ async function gracefulShutdown(signal) {
     }
     // BAT-523: force-flush any pending debounced mutations before the
     // process exits — otherwise dirty in-memory rows would be lost.
-    // scheduleRetry=false because the very next instruction is
-    // process.exit(0) — a queued retry timer would never run, and the
+    // scheduleRetry=false because shutdown callers are immediately
+    // followed by either normal Node termination or Android
+    // killProcess(); a queued retry timer would never run, and the
     // "retry in 60s" log line would be a lie.
     saveDatabase({ force: true, scheduleRetry: false });
+}
+
+// Registered outside initDatabase so shutdown hooks work even if DB init fails
+async function gracefulShutdown(signal) {
+    await flushForShutdown(signal);
     process.exit(0);
 }
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
@@ -781,7 +786,10 @@ function startDbSummaryInterval() {
 // `internal-control-server.js` so MCP control endpoints
 // (`POST /mcp/reconcile`, `POST /healthz`) can share the same port.
 // `getDbSummary` below is the only export the new server needs from
-// this module — main.js wires the dependency.
+// this module — main.js wires the dependency. BAT-525 adds
+// `flushForShutdown` to that wired-callback set so the new
+// `POST /shutdown/flush` endpoint can drive it without an import
+// cycle (database -> internal-control-server -> database).
 
 // ============================================================================
 // EXPORTS
@@ -798,6 +806,7 @@ module.exports = {
     writeDbSummaryFile,
     markDbSummaryDirty,
     markDbDirty, // BAT-523 (BAT-518 phase 3A) — call after every db.run() that mutates state
+    flushForShutdown,
     startDbSummaryInterval,
     getDbSummary,
 };

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -234,8 +234,8 @@ async function initDatabase() {
  *        lie. Init keeps the default so a failed bootstrap write
  *        retries before any mutation arrives.
  */
-// BAT-525 R5 Copilot: saveDatabase returns a tri-state result so callers
-// that need to distinguish "actually persisted to disk" from "swallowed
+// BAT-525 R5 Copilot: saveDatabase returns a Boolean so callers that
+// need to distinguish "actually persisted to disk" from "swallowed
 // I/O error" — specifically [flushForShutdown], driving the
 // `POST /shutdown/flush` endpoint that surfaces 500 vs 200/{ok:true}
 // to Kotlin — can do so. Pre-fix the function returned `undefined` and
@@ -245,9 +245,12 @@ async function initDatabase() {
 // callers (the debounced save timer + initDatabase bootstrap) can
 // continue to ignore the return value — the contract is additive.
 //
-// Return semantics:
+// Return semantics (Boolean):
 //   - true  : either persisted to disk OR no-op (db not initialized,
-//             or dirty=false && force=false — nothing to save).
+//             or dirty=false && force=false — nothing to save). The
+//             "persisted" and "no-op" cases collapse into the same
+//             return value because callers only care about
+//             "shutdown work completed without an I/O error".
 //   - false : the write attempt threw an I/O error. The error has
 //             already been logged with the same level + message it
 //             always was; the boolean is purely for flow control.

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -234,9 +234,26 @@ async function initDatabase() {
  *        lie. Init keeps the default so a failed bootstrap write
  *        retries before any mutation arrives.
  */
+// BAT-525 R5 Copilot: saveDatabase returns a tri-state result so callers
+// that need to distinguish "actually persisted to disk" from "swallowed
+// I/O error" — specifically [flushForShutdown], driving the
+// `POST /shutdown/flush` endpoint that surfaces 500 vs 200/{ok:true}
+// to Kotlin — can do so. Pre-fix the function returned `undefined` and
+// caught/logged failures internally; the shutdown endpoint therefore
+// returned 200 even when the user-Stop flush hit an I/O error and the
+// last 60s of api_request_log rows were genuinely lost. Existing
+// callers (the debounced save timer + initDatabase bootstrap) can
+// continue to ignore the return value — the contract is additive.
+//
+// Return semantics:
+//   - true  : either persisted to disk OR no-op (db not initialized,
+//             or dirty=false && force=false — nothing to save).
+//   - false : the write attempt threw an I/O error. The error has
+//             already been logged with the same level + message it
+//             always was; the boolean is purely for flow control.
 function saveDatabase({ force = false, scheduleRetry = true } = {}) {
-    if (!db) return;
-    if (!dirty && !force) return; // Idle — nothing changed since last save.
+    if (!db) return true;
+    if (!dirty && !force) return true; // Idle — nothing changed since last save.
     try {
         const data = db.export();
         const buffer = Buffer.from(data);
@@ -252,6 +269,7 @@ function saveDatabase({ force = false, scheduleRetry = true } = {}) {
             clearTimeout(saveTimer);
             saveTimer = null;
         }
+        return true;
     } catch (err) {
         // BAT-523: transient I/O failures must reschedule a retry.
         //
@@ -290,6 +308,7 @@ function saveDatabase({ force = false, scheduleRetry = true } = {}) {
                 saveDatabase({ force });
             }, SAVE_DEBOUNCE_MS);
         }
+        return false;
     }
 }
 
@@ -607,6 +626,33 @@ function backfillSessionsFromFiles() {
 // GRACEFUL SHUTDOWN (BAT-57)
 // ============================================================================
 
+/**
+ * Run shutdown-time persistence work. Cancels idle-summary timers,
+ * writes session summaries for active conversations, then force-
+ * flushes any debounced SQL.js mutations.
+ *
+ * BAT-525 R5 Copilot: returns a result object so callers can
+ * distinguish "shutdown work cleanly persisted" from "I/O errors
+ * silently swallowed". Pre-fix this function caught + logged both
+ * the summary path AND the saveDatabase path internally and
+ * returned `undefined`, so the new POST /shutdown/flush HTTP
+ * endpoint always returned 200/{ok:true} — Kotlin's "flush
+ * acknowledged" log was a lie in exactly the failure mode the
+ * endpoint exists to surface.
+ *
+ * Result shape:
+ *   {
+ *     ok: boolean,         // true iff every step persisted cleanly
+ *     summaryFailed?: string, // error message, if summary path threw
+ *     dbFailed?: boolean,  // true if saveDatabase returned false
+ *   }
+ *
+ * Both step failures are tolerated — the function ALWAYS reaches
+ * the saveDatabase call (summary timeout/error doesn't short-
+ * circuit the DB flush, since they're independent). The result
+ * just reports both outcomes so the caller (HTTP endpoint OR
+ * gracefulShutdown signal handler) can act accordingly.
+ */
 async function flushForShutdown(signal, { summaryTimeoutMs = 5000 } = {}) {
     log(`[Shutdown] ${signal} received, saving session summary...`, 'INFO');
     // BAT-524: cancel pending idle-summary timers FIRST. Without this,
@@ -618,6 +664,7 @@ async function flushForShutdown(signal, { summaryTimeoutMs = 5000 } = {}) {
     if (typeof _shutdownDeps.cancelAllIdleSummaries === 'function') {
         try { _shutdownDeps.cancelAllIdleSummaries(); } catch (_) {}
     }
+    let summaryFailed = null;
     try {
         const { conversations, saveSessionSummary, MIN_MESSAGES_FOR_SUMMARY } = _shutdownDeps;
         if (conversations && saveSessionSummary) {
@@ -635,6 +682,7 @@ async function flushForShutdown(signal, { summaryTimeoutMs = 5000 } = {}) {
         }
     } catch (err) {
         log(`[Shutdown] Summary failed: ${err.message}`, 'ERROR');
+        summaryFailed = err.message || String(err);
     }
     // BAT-523: force-flush any pending debounced mutations before the
     // process exits — otherwise dirty in-memory rows would be lost.
@@ -642,12 +690,26 @@ async function flushForShutdown(signal, { summaryTimeoutMs = 5000 } = {}) {
     // followed by either normal Node termination or Android
     // killProcess(); a queued retry timer would never run, and the
     // "retry in 60s" log line would be a lie.
-    saveDatabase({ force: true, scheduleRetry: false });
+    const dbOk = saveDatabase({ force: true, scheduleRetry: false });
+    const result = { ok: !summaryFailed && dbOk };
+    if (summaryFailed) result.summaryFailed = summaryFailed;
+    if (!dbOk) result.dbFailed = true;
+    return result;
 }
 
 // Registered outside initDatabase so shutdown hooks work even if DB init fails
 async function gracefulShutdown(signal) {
-    await flushForShutdown(signal);
+    // R5 Copilot: surface flush result in logs even on the SIGTERM/SIGINT
+    // path. The HTTP endpoint also surfaces it via 500 response, but the
+    // signal path has no caller to receive it — only the user-visible log
+    // tells the operator whether the shutdown was clean.
+    const result = await flushForShutdown(signal);
+    if (!result.ok) {
+        const parts = [];
+        if (result.summaryFailed) parts.push(`summary: ${result.summaryFailed}`);
+        if (result.dbFailed) parts.push('db: I/O error');
+        log(`[Shutdown] flush completed with errors — ${parts.join(', ')}`, 'WARN');
+    }
     process.exit(0);
 }
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -274,7 +274,17 @@ async function _route(req, res) {
         // `{ok:true}` only on clean success; 500 + `{ok:false,
         // error:...}` if `flushShutdown` rejects.
         try {
-            await _flushShutdown('USER_STOP', { summaryTimeoutMs: 1500 });
+            // R4 Copilot: summaryTimeoutMs reduced 1500 → 1200 so the
+            // Kotlin-side worst-case wall time (CONNECT 250 + READ
+            // 1500 = 1750ms) fits within SeekerClawService.onDestroy()'s
+            // outer withTimeoutOrNull(2000) budget. HttpURLConnection
+            // isn't cooperatively cancellable, so the underlying
+            // timeouts must guarantee the bound — the outer coroutine
+            // timeout can't interrupt an in-flight blocking I/O. 1200ms
+            // still covers realistic flush profiles (a real flush is
+            // <100ms; the budget exists for an unresponsive SQL.js
+            // reentry case).
+            await _flushShutdown('USER_STOP', { summaryTimeoutMs: 1200 });
             return _json(res, 200, { ok: true });
         } catch (err) {
             _logFn(`[ControlServer] /shutdown/flush failed: ${err.message}`, 'ERROR');

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -302,9 +302,16 @@ async function _route(req, res) {
                 return _json(res, 200, { ok: true });
             }
             const detail = result || {};
+            // R8 Copilot: log partial flush at WARN, not ERROR. A partial
+            // flush is best-effort degradation (one summary timed out OR
+            // saveDatabase hit transient I/O); the caller proceeds with
+            // killProcess() either way and the next service start
+            // reconciles via mcp_servers.json + AutoResume. Match the
+            // gracefulShutdown convention in database.js so operators
+            // don't treat partial results as fatal.
             _logFn(
                 `[ControlServer] /shutdown/flush partial: summary=${detail.summaryFailed || 'ok'} db=${detail.dbFailed ? 'failed' : 'ok'}`,
-                'ERROR',
+                'WARN',
             );
             return _json(res, 500, {
                 ok: false,

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -66,28 +66,34 @@ function _readBody(req, maxBytes) {
         // `done` guard so a single oversized chunk doesn't fire both
         // reject() AND resolve() via subsequent `end`/`error` events.
         let done = false;
+        const finish = (settle) => {
+            if (done) return;
+            done = true;
+            settle();
+        };
         req.on('data', (chunk) => {
             if (done) return;
             len += Buffer.byteLength(chunk);
             if (len > maxBytes) {
-                done = true;
                 const err = new Error('body too large');
                 err.code = _BODY_TOO_LARGE;
-                reject(err);
+                finish(() => reject(err));
                 return;
             }
             data += chunk;
         });
-        req.on('end', () => {
-            if (done) return;
-            done = true;
-            resolve(data);
-        });
-        req.on('error', (err) => {
-            if (done) return;
-            done = true;
-            reject(err);
-        });
+        req.on('end', () => finish(() => resolve(data)));
+        req.on('error', (err) => finish(() => reject(err)));
+        // BAT-525 R3 Copilot: if the client (typically Kotlin's
+        // SeekerClawService) times out and closes the socket before
+        // sending `end`, neither `end` nor `error` fires — the await
+        // would hang forever, leaking the request handler. Listen for
+        // `aborted` (legacy) and `close` (always emitted on socket
+        // disconnect) and reject so the route handler can return.
+        // The `done` guard makes this safe to fire alongside an
+        // already-resolved `end`/`error` (no-op if already settled).
+        req.on('aborted', () => finish(() => reject(Object.assign(new Error('client aborted'), { code: 'ECONNABORTED' }))));
+        req.on('close', () => finish(() => reject(Object.assign(new Error('client closed'), { code: 'ECONNCLOSED' }))));
     });
 }
 
@@ -101,6 +107,13 @@ let _server = null;
 let _bridgeToken = null;
 let _getDbSummary = null;
 let _requestReconcile = null;
+// BAT-525: flushShutdown is an async callback that drives Node's
+// graceful-shutdown sequence (session summaries + dirty-DB flush)
+// before Kotlin's `killProcess()`. Wired in main.js as
+// `database.flushForShutdown` so this module doesn't need a direct
+// `require('./database')` (which would create a circular import:
+// database -> ... -> internal-control-server -> database).
+let _flushShutdown = null;
 let _logFn = console.log;
 
 /**
@@ -118,6 +131,7 @@ function start(options) {
     _bridgeToken = typeof options.bridgeToken === 'string' ? options.bridgeToken : '';
     _getDbSummary = typeof options.getDbSummary === 'function' ? options.getDbSummary : null;
     _requestReconcile = typeof options.requestReconcile === 'function' ? options.requestReconcile : null;
+    _flushShutdown = typeof options.flushShutdown === 'function' ? options.flushShutdown : null;
     _logFn = typeof options.logFn === 'function' ? options.logFn : console.log;
 
     if (_server) return _server;
@@ -218,6 +232,54 @@ async function _route(req, res) {
             return _json(res, 429, { error: 'rate limit exceeded' }, { 'Retry-After': '60' });
         }
         return _json(res, 200, { ok: true });
+    }
+
+    if (url === '/shutdown/flush') {
+        // BAT-525: Android user-Stop kills :node via `killProcess()`,
+        // which bypasses Node's SIGTERM/SIGINT handlers (nodejs-mobile
+        // runs Node in-process via JNI). Kotlin calls this endpoint
+        // first and waits ≤2s, giving Node a chance to flush pending
+        // session summaries + debounced SQL.js mutations before the
+        // unavoidable kill. Without this hook, the last ~60s of
+        // `api_request_log` rows in the BAT-523 debounce window are
+        // lost on every user-Stop.
+        if (!_flushShutdown) {
+            return _json(res, 503, { error: 'flush unavailable' });
+        }
+        // R1 Copilot: drain the request body before awaiting the
+        // flush. Body is currently expected to be `{}` (≤256 bytes
+        // is generous). Leaving it unread can cause keep-alive
+        // connection issues and unnecessary buffering on the
+        // listener. The shared _readBody also handles abort/close
+        // (R3) so a Kotlin-side timeout doesn't leak this handler.
+        try {
+            await _readBody(req, 256);
+        } catch (err) {
+            // Body-too-large is unlikely (Kotlin sends `{}`) but
+            // surface as 413 for symmetry with the other endpoints.
+            // Other transport errors (abort/close) reach here too —
+            // the client is gone, but we still attempt the flush
+            // because the user-Stop intent is to persist state.
+            // Log and continue rather than abort the flush.
+            if (err && err.code === _BODY_TOO_LARGE) {
+                return _json(res, 413, { error: 'request body too large' });
+            }
+            _logFn(`[ControlServer] /shutdown/flush body read failed (${err.code || 'UNKNOWN'}): ${err.message}`, 'WARN');
+        }
+        // R2 Copilot: surface flush failures to the caller. Pre-fix
+        // returned 200 even when `flushForShutdown` threw (the
+        // original PR caught and logged but returned `{ok:true}`).
+        // Kotlin's "flush acknowledged" log would lie in exactly the
+        // failure mode this endpoint exists to handle. Now: 200 +
+        // `{ok:true}` only on clean success; 500 + `{ok:false,
+        // error:...}` if `flushShutdown` rejects.
+        try {
+            await _flushShutdown('USER_STOP', { summaryTimeoutMs: 1500 });
+            return _json(res, 200, { ok: true });
+        } catch (err) {
+            _logFn(`[ControlServer] /shutdown/flush failed: ${err.message}`, 'ERROR');
+            return _json(res, 500, { ok: false, error: err.message });
+        }
     }
 
     return _json(res, 404, { error: 'not found' });

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -284,10 +284,35 @@ async function _route(req, res) {
             // still covers realistic flush profiles (a real flush is
             // <100ms; the budget exists for an unresponsive SQL.js
             // reentry case).
-            await _flushShutdown('USER_STOP', { summaryTimeoutMs: 1200 });
-            return _json(res, 200, { ok: true });
+            //
+            // R5 Copilot: flushShutdown returns a {ok, summaryFailed?,
+            // dbFailed?} result instead of just resolving. Pre-fix it
+            // caught all errors internally and resolved unconditionally,
+            // so this endpoint always returned 200/{ok:true} even when
+            // the flush genuinely failed — Kotlin's "flush acknowledged"
+            // log was misleading in the exact failure mode this
+            // endpoint exists to surface. Now: 200 only on a clean
+            // result.ok=true; 500/{ok:false, ...details} when either
+            // the summary path threw OR saveDatabase reported an I/O
+            // error. The catch below covers the rare case where
+            // flushShutdown itself throws (shouldn't happen — all
+            // step errors are caught inside — but defense-in-depth).
+            const result = await _flushShutdown('USER_STOP', { summaryTimeoutMs: 1200 });
+            if (result && result.ok) {
+                return _json(res, 200, { ok: true });
+            }
+            const detail = result || {};
+            _logFn(
+                `[ControlServer] /shutdown/flush partial: summary=${detail.summaryFailed || 'ok'} db=${detail.dbFailed ? 'failed' : 'ok'}`,
+                'ERROR',
+            );
+            return _json(res, 500, {
+                ok: false,
+                summaryFailed: detail.summaryFailed || null,
+                dbFailed: !!detail.dbFailed,
+            });
         } catch (err) {
-            _logFn(`[ControlServer] /shutdown/flush failed: ${err.message}`, 'ERROR');
+            _logFn(`[ControlServer] /shutdown/flush threw: ${err.message}`, 'ERROR');
             return _json(res, 500, { ok: false, error: err.message });
         }
     }

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -142,6 +142,11 @@ const {
     setShutdownDeps,
     initDatabase, indexMemoryFiles, backfillSessionsFromFiles,
     startDbSummaryInterval, getDbSummary,
+    // BAT-525: wired through internalControlServer.start() so the new
+    // POST /shutdown/flush endpoint can drive the same shutdown path
+    // SIGTERM/SIGINT use, without internal-control-server having to
+    // require('./database') and create a circular import.
+    flushForShutdown,
 } = require('./database');
 
 // BAT-514: extracted from database.js. Loopback server on :8766 hosts
@@ -753,6 +758,7 @@ telegram('getMe')
                 bridgeToken: BRIDGE_TOKEN,
                 getDbSummary,
                 requestReconcile: (id) => mcpManager.requestReconcile(id),
+                flushShutdown: flushForShutdown,
                 logFn: log,
             });
             startMcpFileWatch();
@@ -893,6 +899,7 @@ telegram('getMe')
             bridgeToken: BRIDGE_TOKEN,
             getDbSummary,
             requestReconcile: (id) => mcpManager.requestReconcile(id),
+            flushShutdown: flushForShutdown,
             logFn: log,
         });
         startMcpFileWatch();

--- a/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
@@ -64,6 +64,32 @@ object NodeControlClient {
         post("/healthz", "{}")
     }
 
+    /**
+     * Drive Node's graceful-shutdown flush before
+     * [com.seekerclaw.app.service.SeekerClawService] kills the
+     * `:node` process (BAT-525). Persists pending session summaries
+     * + dirty SQL.js mutations so the last ~60s of `api_request_log`
+     * activity isn't lost on user-initiated Stop.
+     *
+     * Returns `true` on a 2xx response (Node confirmed flush
+     * complete). Returns `false` on connect-refused (service
+     * already down), 401 (bridge token rotated), 500
+     * (`flushForShutdown` rejected), or transport timeout — in
+     * every case the caller proceeds with the unconditional
+     * `killProcess()` fallback. Bridge-token auth is provided by
+     * the shared [post] helper so the endpoint's POST-auth gate
+     * doesn't 401 every Stop event.
+     *
+     * The Node side caps `summaryTimeoutMs` at 1500ms; the
+     * client's READ_TIMEOUT_MS (1500) gives the response just
+     * enough time to land. SeekerClawService wraps the suspend
+     * call in `withTimeoutOrNull(2000)` as a hard outer bound
+     * so a hung Node can't deadlock service teardown.
+     */
+    suspend fun flushShutdown(): Boolean = withContext(Dispatchers.IO) {
+        post("/shutdown/flush", "{}")
+    }
+
     private fun post(path: String, body: String): Boolean {
         val token = ServiceState.bridgeToken
         if (token.isNullOrBlank()) {

--- a/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
@@ -39,7 +39,23 @@ object NodeControlClient {
     private const val TAG = "NodeControlClient"
     private const val BASE_URL = "http://127.0.0.1:8766"
     private const val AUTH_HEADER = "X-Bridge-Token"
-    private const val CONNECT_TIMEOUT_MS = 1500
+    // BAT-525 R4 Copilot: HttpURLConnection is NOT cooperatively
+    // cancellable — a `withTimeoutOrNull` on the calling coroutine
+    // can't interrupt an in-flight blocking connect/read. The
+    // underlying timeouts MUST therefore sum to a wall-time that
+    // fits within every caller's outer budget. The strictest caller
+    // today is [flushShutdown] (BAT-525, called from
+    // SeekerClawService.onDestroy under withTimeoutOrNull(2000)).
+    //
+    // Loopback connect is essentially instant (<5ms in practice on
+    // the device); 250ms is generous defense-in-depth. Read budget
+    // remains 1500ms to cover the slow shutdown-flush path
+    // (Node-side summaryTimeoutMs = 1200ms with ~300ms buffer for
+    // Anthropic's response stream + JSON encode + socket write).
+    //
+    // Total worst-case wall time: 250 + 1500 = 1750ms — fits the
+    // 2000ms outer service-teardown budget with 250ms margin.
+    private const val CONNECT_TIMEOUT_MS = 250
     private const val READ_TIMEOUT_MS = 1500
 
     /**
@@ -80,11 +96,31 @@ object NodeControlClient {
      * the shared [post] helper so the endpoint's POST-auth gate
      * doesn't 401 every Stop event.
      *
-     * The Node side caps `summaryTimeoutMs` at 1500ms; the
-     * client's READ_TIMEOUT_MS (1500) gives the response just
-     * enough time to land. SeekerClawService wraps the suspend
-     * call in `withTimeoutOrNull(2000)` as a hard outer bound
-     * so a hung Node can't deadlock service teardown.
+     * ## Cancellation semantics (R4 Copilot — not the soft "outer
+     * timeout cancels everything" simplification it might first
+     * appear to be)
+     *
+     * `HttpURLConnection` is NOT cooperatively cancellable —
+     * `withTimeoutOrNull` on the calling coroutine fires a
+     * CancellationException at the next suspend point, but it
+     * cannot interrupt an in-flight blocking
+     * `connect()` / `responseCode` / `inputStream.readBytes()`.
+     * The hard upper bound therefore comes from the underlying
+     * connect+read timeouts, NOT the outer coroutine timeout.
+     *
+     * - [CONNECT_TIMEOUT_MS] = 250ms (loopback is near-instant; 250
+     *   is defensive padding).
+     * - [READ_TIMEOUT_MS] = 1500ms (sized 300ms above the Node-side
+     *   `summaryTimeoutMs: 1200` so a real flush response always
+     *   lands).
+     * - Worst-case wall time: 1750ms.
+     *
+     * SeekerClawService still wraps the suspend call in
+     * `withTimeoutOrNull(2000)` — that timeout primarily exists so
+     * the Kotlin-side suspension releases promptly when the underlying
+     * I/O eventually returns/throws within its bounded budget. It
+     * does NOT directly interrupt the I/O; the 1750ms worst case is
+     * the actual ceiling.
      */
     suspend fun flushShutdown(): Boolean = withContext(Dispatchers.IO) {
         post("/shutdown/flush", "{}")

--- a/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
@@ -15,6 +15,7 @@ import com.seekerclaw.app.MainActivity
 import com.seekerclaw.app.R
 import com.seekerclaw.app.SeekerClawApplication
 import com.seekerclaw.app.bridge.AndroidBridge
+import com.seekerclaw.app.bridge.NodeControlClient
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.util.LogCollector
 import com.seekerclaw.app.util.LogLevel
@@ -30,11 +31,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
 import java.util.UUID
 
 class SeekerClawService : Service() {
@@ -608,13 +606,29 @@ class SeekerClawService : Service() {
         android.os.Process.killProcess(android.os.Process.myPid())
     }
 
+    /**
+     * BAT-525: ask `:node` to flush pending session summaries + dirty
+     * SQL.js mutations BEFORE [killProcess]. Without this hook, the
+     * last ~60s of `api_request_log` rows in BAT-523's debounce
+     * window are lost on every user-initiated Stop.
+     *
+     * Bounded by [timeoutMs] (default 2s) so a hung Node can't
+     * deadlock the service teardown — the unconditional [killProcess]
+     * call below this still fires either way.
+     *
+     * R3 Copilot: delegates to [NodeControlClient.flushShutdown] so
+     * the shared `X-Bridge-Token` auth + JSON body + response-drain
+     * + connect/read-timeout logic stays in one place. Pre-fix this
+     * rolled its own [HttpURLConnection] client without setting the
+     * auth header, which would have 401'd at the bridge-token gate
+     * `/shutdown/flush` enforces — the flush would never have run
+     * in production.
+     */
     private fun flushNodeBeforeProcessKill(timeoutMs: Long = 2_000L) {
         if (!NodeBridge.isAlive()) return
         val flushed = runBlocking {
             withTimeoutOrNull(timeoutMs) {
-                withContext(Dispatchers.IO) {
-                    postNodeShutdownFlush(timeoutMs)
-                }
+                NodeControlClient.flushShutdown()
             }
         } == true
 
@@ -625,26 +639,6 @@ class SeekerClawService : Service() {
                 "[Shutdown] Node flush timed out or failed; continuing process kill",
                 LogLevel.WARN,
             )
-        }
-    }
-
-    private fun postNodeShutdownFlush(timeoutMs: Long): Boolean {
-        var conn: HttpURLConnection? = null
-        return try {
-            conn = (URL("http://127.0.0.1:8766/shutdown/flush").openConnection() as HttpURLConnection).apply {
-                requestMethod = "POST"
-                connectTimeout = 250
-                readTimeout = (timeoutMs - 250L).coerceAtLeast(250L).toInt()
-                doOutput = true
-                setRequestProperty("Content-Type", "application/json")
-            }
-            conn.outputStream.use { it.write("{}".toByteArray(Charsets.UTF_8)) }
-            conn.responseCode in 200..299
-        } catch (e: Exception) {
-            LogCollector.append("[Shutdown] Node flush request failed: ${e.message}", LogLevel.WARN)
-            false
-        } finally {
-            conn?.disconnect()
         }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
@@ -552,15 +552,21 @@ class SeekerClawService : Service() {
 
     override fun onDestroy() {
         LogCollector.append("[Service] Stopping Claw Engine...")
+        // BAT-525: flush Node BEFORE everything else. The bridge token
+        // and Node process must both still be alive for the loopback
+        // POST /shutdown/flush to land. This call is bounded
+        // (NodeControlClient timeouts ≤ 1750ms inside an outer 2000ms
+        // withTimeoutOrNull) and intentionally precedes scope cancel,
+        // observer stop, NodeBridge.stop, and clearBridgeToken below.
         flushNodeBeforeProcessKill()
-        // Cancel the service scope FIRST. This stops any in-flight
-        // forwardNewNodeDebugLines or observer reattach coroutines that
-        // would otherwise race the observer.stopWatching() below — they
-        // hold nodeDebugMutex while reading the file, and could land
-        // a stale lastPos write or trigger the now-stopped observer's
-        // unrelated event handler. cancel() is non-blocking and
-        // synchronous; in-flight launches reach a suspension point and
-        // exit.
+        // Cancel the service scope before stopping the FileObserver
+        // below. This stops any in-flight forwardNewNodeDebugLines or
+        // observer reattach coroutines that would otherwise race
+        // observer.stopWatching() — they hold nodeDebugMutex while
+        // reading the file, and could land a stale lastPos write or
+        // trigger the now-stopped observer's unrelated event handler.
+        // cancel() is non-blocking and synchronous; in-flight launches
+        // reach a suspension point and exit.
         scopeJob.cancel()
         // Stop the node-debug FileObserver (BAT-518: was nodeDebugJob coroutine).
         nodeDebugObserver?.stopWatching()

--- a/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
+++ b/app/src/main/java/com/seekerclaw/app/service/SeekerClawService.kt
@@ -27,9 +27,14 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.UUID
 
 class SeekerClawService : Service() {
@@ -549,6 +554,7 @@ class SeekerClawService : Service() {
 
     override fun onDestroy() {
         LogCollector.append("[Service] Stopping Claw Engine...")
+        flushNodeBeforeProcessKill()
         // Cancel the service scope FIRST. This stops any in-flight
         // forwardNewNodeDebugLines or observer reattach coroutines that
         // would otherwise race the observer.stopWatching() below — they
@@ -600,6 +606,46 @@ class SeekerClawService : Service() {
 
         // Service is isolated in :node process. Kill process so Node runtime cannot linger.
         android.os.Process.killProcess(android.os.Process.myPid())
+    }
+
+    private fun flushNodeBeforeProcessKill(timeoutMs: Long = 2_000L) {
+        if (!NodeBridge.isAlive()) return
+        val flushed = runBlocking {
+            withTimeoutOrNull(timeoutMs) {
+                withContext(Dispatchers.IO) {
+                    postNodeShutdownFlush(timeoutMs)
+                }
+            }
+        } == true
+
+        if (flushed) {
+            LogCollector.append("[Shutdown] Node flush acknowledged")
+        } else {
+            LogCollector.append(
+                "[Shutdown] Node flush timed out or failed; continuing process kill",
+                LogLevel.WARN,
+            )
+        }
+    }
+
+    private fun postNodeShutdownFlush(timeoutMs: Long): Boolean {
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = (URL("http://127.0.0.1:8766/shutdown/flush").openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                connectTimeout = 250
+                readTimeout = (timeoutMs - 250L).coerceAtLeast(250L).toInt()
+                doOutput = true
+                setRequestProperty("Content-Type", "application/json")
+            }
+            conn.outputStream.use { it.write("{}".toByteArray(Charsets.UTF_8)) }
+            conn.responseCode in 200..299
+        } catch (e: Exception) {
+            LogCollector.append("[Shutdown] Node flush request failed: ${e.message}", LogLevel.WARN)
+            false
+        } finally {
+            conn?.disconnect()
+        }
     }
 
     private fun createNotification(text: String): Notification {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Network security configuration.
+
+    Default policy: cleartextTrafficPermitted=false (matches Android API 28+ default).
+    All outbound HTTPS traffic (api.anthropic.com, api.openai.com, openrouter.ai,
+    api.telegram.org, the user's Custom gateway, etc.) continues to use TLS — no change.
+
+    Cleartext exception: 127.0.0.1 ONLY.
+
+    The :node process embeds a Node.js runtime via JNI (libnode.so) and runs the
+    `internal-control-server.js` HTTP listener on 127.0.0.1:8766 (BAT-514). Both
+    the Kotlin main process (NodeControlClient.reconcile / healthz / flushShutdown)
+    and the Kotlin :node process (SeekerClawService.flushNodeBeforeProcessKill —
+    BAT-525) make POST requests to this loopback. There is no TLS terminator
+    on the loopback — wrapping it in HTTPS would require an in-app cert + key
+    bundled in the APK, which has worse security properties (cert in APK vs.
+    no exposure beyond the loopback interface).
+
+    Without this exception, every HttpURLConnection to 127.0.0.1:8766 throws
+    `java.io.IOException: Cleartext HTTP traffic to 127.0.0.1 not permitted` —
+    which is what surfaced BAT-525's flush failure (and was silently failing
+    every NodeControlClient.reconcile / healthz call too — pre-existing bug
+    BAT-525 device test exposed).
+
+    Scoping the exception to `127.0.0.1` (NOT 0.0.0.0, NOT a hostname pattern)
+    ensures public network traffic still goes through the strict default
+    policy — no regression in TLS enforcement for actual remote endpoints.
+-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/tests/nodejs-project/db-dirty-debounce.test.js
+++ b/tests/nodejs-project/db-dirty-debounce.test.js
@@ -393,17 +393,17 @@ test('drift: saveDatabase catch path reschedules on failure (retry guard)', () =
         'retry condition must include `force` so init bootstrap failures retry (post-Copilot review fix)');
 });
 
-test('drift: gracefulShutdown calls saveDatabase with scheduleRetry=false', () => {
+test('drift: shutdown flush calls saveDatabase with scheduleRetry=false', () => {
     // Pin that the shutdown path opts out of retry scheduling. If a
     // future refactor drops this option, shutdown failures would
     // schedule timers that never fire (process exits immediately) and
     // the log line would falsely promise a retry.
     const src = fs.readFileSync(DATABASE_JS, 'utf8');
-    const fnMatch = src.match(/async\s+function\s+gracefulShutdown[\s\S]*?\n\}/);
-    assert.ok(fnMatch, 'gracefulShutdown function body not found');
+    const fnMatch = src.match(/async\s+function\s+flushForShutdown[\s\S]*?\n\}/);
+    assert.ok(fnMatch, 'flushForShutdown function body not found');
     const body = fnMatch[0];
     assert.ok(/saveDatabase\s*\(\s*\{[^}]*scheduleRetry\s*:\s*false/.test(body),
-        'gracefulShutdown must pass scheduleRetry=false to saveDatabase (BAT-523 — process exits immediately, retry would be dead)');
+        'shutdown flush must pass scheduleRetry=false to saveDatabase (BAT-523/BAT-525 — retry timer would be dead)');
 });
 
 test('drift: indexMemoryFiles marks dirty unconditionally', () => {

--- a/tests/nodejs-project/idle-summary-timers.test.js
+++ b/tests/nodejs-project/idle-summary-timers.test.js
@@ -351,17 +351,27 @@ test('drift: scheduleIdleSummary calls .unref() on the timer', () => {
         'scheduleIdleSummary must call timer.unref() so a pending idle timer cannot block clean process exit');
 });
 
-test('drift: gracefulShutdown receives cancelAllIdleSummaries via setShutdownDeps', () => {
+test('drift: shutdown flush helper receives cancelAllIdleSummaries via setShutdownDeps', () => {
     const dbSrc = readJsSource(path.join(__dirname, '..', '..', 'app', 'src', 'main',
         'assets', 'nodejs-project', 'database.js'));
     // The shutdown-deps record must declare cancelAllIdleSummaries.
     assert.ok(/cancelAllIdleSummaries\s*:/.test(dbSrc),
-        'database.js _shutdownDeps must declare cancelAllIdleSummaries (BAT-524 — gracefulShutdown can call process.exit before main.js SIGTERM listener runs)');
-    // gracefulShutdown must invoke it.
-    const fnMatch = dbSrc.match(/async\s+function\s+gracefulShutdown[\s\S]*?\n\}/);
-    assert.ok(fnMatch, 'gracefulShutdown function body not found');
+        'database.js _shutdownDeps must declare cancelAllIdleSummaries (BAT-524 — shutdown can call process.exit before main.js SIGTERM listener runs)');
+    // BAT-525: the cancel call moved from `gracefulShutdown` directly
+    // into the shared `flushForShutdown` helper (so the new
+    // POST /shutdown/flush HTTP endpoint also benefits, not just the
+    // signal path). The invariant — "shutdown path cancels idle
+    // timers" — is preserved; just inspect the new home.
+    const fnMatch = dbSrc.match(/async\s+function\s+flushForShutdown[\s\S]*?\n\}/);
+    assert.ok(fnMatch, 'flushForShutdown function body not found');
     assert.ok(/_shutdownDeps\.cancelAllIdleSummaries\s*\(\s*\)/.test(fnMatch[0]),
-        'gracefulShutdown must call _shutdownDeps.cancelAllIdleSummaries() so timers are released even when main.js SIGTERM listener is bypassed');
+        'flushForShutdown must call _shutdownDeps.cancelAllIdleSummaries() so timers are released on every shutdown path (signal handlers AND user-Stop HTTP flush)');
+    // gracefulShutdown must delegate to flushForShutdown so the
+    // SIGTERM/SIGINT path inherits the cancel.
+    const gsMatch = dbSrc.match(/async\s+function\s+gracefulShutdown[\s\S]*?\n\}/);
+    assert.ok(gsMatch, 'gracefulShutdown function body not found');
+    assert.ok(/await\s+flushForShutdown\s*\(/.test(gsMatch[0]),
+        'gracefulShutdown must await flushForShutdown so signal-driven shutdown also cancels idle timers');
     // main.js must pass cancelAllIdleSummaries when wiring deps.
     const mainSrc = readJsSource(MAIN_JS);
     assert.ok(/setShutdownDeps\s*\(\s*\{[^}]*cancelAllIdleSummaries/.test(mainSrc),

--- a/tests/nodejs-project/shutdown-flush.test.js
+++ b/tests/nodejs-project/shutdown-flush.test.js
@@ -39,10 +39,91 @@ test('database.js exposes a non-exiting shutdown flush helper', () => {
         'flushForShutdown must not exit before the HTTP caller receives an ack');
 });
 
+test('R5 Copilot: saveDatabase returns Boolean so flush can detect I/O failures', () => {
+    // Pre-fix saveDatabase returned undefined and caught I/O errors
+    // internally — flushForShutdown couldn't tell whether the DB
+    // actually persisted. Now saveDatabase returns true on
+    // success/no-op and false on caught error.
+    const src = fs.readFileSync(DATABASE_JS, 'utf8');
+    const fnMatch = src.match(/function saveDatabase\s*\([^)]*\)\s*\{([\s\S]*?)\n\}/);
+    assert.ok(fnMatch, 'saveDatabase function body not found');
+    const body = fnMatch[1];
+    // Three return paths: db-not-init, idle-no-op, success → all true.
+    // The catch must end with `return false`.
+    assert.ok(/if\s*\(!db\)\s*return\s+true/.test(body),
+        'saveDatabase must return true on no-op (db not initialized)');
+    assert.ok(/if\s*\(!dirty\s*&&\s*!force\)\s*return\s+true/.test(body),
+        'saveDatabase must return true on idle no-op');
+    assert.ok(/return\s+true\s*;\s*\}\s*catch/.test(body),
+        'saveDatabase must return true after a successful write');
+    assert.ok(/return\s+false\s*;\s*\}\s*\}/.test(body) || /return\s+false\s*;\s*\}\s*$/.test(body.trim()),
+        'saveDatabase must return false when the catch block runs (caught I/O error)');
+});
+
+test('R5 Copilot: flushForShutdown returns {ok, summaryFailed?, dbFailed?} result', () => {
+    // Pre-fix flushForShutdown caught both summary and saveDatabase
+    // errors and resolved unconditionally, so the HTTP endpoint
+    // always returned 200/{ok:true} even when the flush failed.
+    const src = fs.readFileSync(DATABASE_JS, 'utf8');
+    const fnMatch = src.match(/async\s+function\s+flushForShutdown\s*\([^)]*\)\s*\{([\s\S]*?)\n\}/);
+    assert.ok(fnMatch, 'flushForShutdown function body not found');
+    const body = fnMatch[1];
+    // Must capture summary error (string), then return result with ok flag.
+    assert.ok(/summaryFailed\s*=\s*err\.message/.test(body),
+        'flushForShutdown must capture the summary error message into summaryFailed');
+    assert.ok(/const\s+dbOk\s*=\s*saveDatabase\s*\(/.test(body),
+        'flushForShutdown must capture saveDatabase return value');
+    assert.ok(/result\.summaryFailed\s*=\s*summaryFailed/.test(body),
+        'flushForShutdown result must include summaryFailed when present');
+    assert.ok(/result\.dbFailed\s*=\s*true/.test(body),
+        'flushForShutdown result must set dbFailed when saveDatabase returns false');
+    assert.ok(/return\s+result\s*;?\s*$/.test(body.trim()),
+        'flushForShutdown must return the result object');
+});
+
+test('R5 Copilot: /shutdown/flush returns 500 when flushForShutdown reports failure', () => {
+    // Pre-fix the endpoint always returned 200/{ok:true} unless
+    // flushForShutdown threw — but it never throws, since it catches
+    // both summary and DB errors internally. R5 makes the endpoint
+    // inspect the returned result and surface 500 + details when
+    // ok=false.
+    const src = fs.readFileSync(CONTROL_JS, 'utf8');
+    const startIdx = src.indexOf("url === '/shutdown/flush'");
+    const tail = src.slice(startIdx);
+    const endIdx = tail.search(/(?:^|\n)\s{4}(?:if \(url ===|return _json\(res, 404)/);
+    const flushBlock = endIdx >= 0 ? tail.slice(0, endIdx) : tail;
+    // Must capture the result and gate the 200 response on result.ok.
+    assert.ok(/const\s+result\s*=\s*await\s+_flushShutdown\s*\(/.test(flushBlock),
+        '/shutdown/flush must capture the flushForShutdown result');
+    assert.ok(/result\s*&&\s*result\.ok/.test(flushBlock) || /result\.ok\s*===\s*true/.test(flushBlock),
+        '/shutdown/flush 200 response must be gated on result.ok');
+    // Failure response must surface the per-step details in the
+    // body so a user-Stop log triage can identify which path
+    // failed (summary vs db).
+    assert.ok(/summaryFailed\s*:\s*detail\.summaryFailed/.test(flushBlock),
+        '/shutdown/flush 500 body must include summaryFailed detail');
+    assert.ok(/dbFailed\s*:\s*!!detail\.dbFailed/.test(flushBlock),
+        '/shutdown/flush 500 body must include dbFailed detail');
+});
+
 test('database.js keeps signal shutdown as flush then process exit', () => {
     const src = fs.readFileSync(DATABASE_JS, 'utf8');
-    assert.ok(/async function gracefulShutdown\s*\([^)]*\)\s*\{\s*await flushForShutdown\s*\([^)]*\)\s*;\s*process\.exit\s*\(0\)/.test(src),
-        'gracefulShutdown should await the shared flush helper and then exit');
+    // Match the gracefulShutdown function body and assert it awaits
+    // flushForShutdown AND exits via process.exit(0). R5 added a
+    // result-inspection block between them to log partial failures
+    // (summary/db); the SEMANTIC ordering "await flush, then exit"
+    // is preserved — just allow text between the two anchors.
+    const fnMatch = src.match(/async\s+function\s+gracefulShutdown\s*\([^)]*\)\s*\{([\s\S]*?)\n\}/);
+    assert.ok(fnMatch, 'gracefulShutdown function body not found');
+    const body = fnMatch[1];
+    assert.ok(/await\s+flushForShutdown\s*\(/.test(body),
+        'gracefulShutdown must await the shared flushForShutdown helper');
+    assert.ok(/process\.exit\s*\(\s*0\s*\)/.test(body),
+        'gracefulShutdown must call process.exit(0)');
+    const flushIdx = body.search(/await\s+flushForShutdown/);
+    const exitIdx = body.search(/process\.exit\s*\(\s*0\s*\)/);
+    assert.ok(flushIdx < exitIdx,
+        'flushForShutdown must be awaited BEFORE process.exit so persistence completes pre-termination');
 });
 
 test('internal-control-server.js exposes POST /shutdown/flush', () => {

--- a/tests/nodejs-project/shutdown-flush.test.js
+++ b/tests/nodejs-project/shutdown-flush.test.js
@@ -125,11 +125,46 @@ test('SeekerClawService calls Node flush before stopping NodeBridge', () => {
 });
 
 test('SeekerClawService posts to Node flush endpoint with a bounded timeout', () => {
+    // R3 Copilot: SeekerClawService used to roll its own
+    // HttpURLConnection POST without setting `X-Bridge-Token`, which
+    // meant /shutdown/flush would 401 every user-Stop in production.
+    // The fix delegates to NodeControlClient.flushShutdown(), which
+    // already handles auth, JSON body, response drain, and timeouts —
+    // assert that both the bounded outer timeout AND the shared
+    // client are used.
     const src = fs.readFileSync(SERVICE_KT, 'utf8');
     assert.ok(/withTimeoutOrNull\s*\(\s*timeoutMs\s*\)/.test(src),
-        'flush wait must be bounded');
-    assert.ok(/http:\/\/127\.0\.0\.1:8766\/shutdown\/flush/.test(src),
-        'Kotlin must call the local Node shutdown flush endpoint');
+        'flush wait must be bounded by withTimeoutOrNull');
+    assert.ok(/NodeControlClient\.flushShutdown\s*\(\s*\)/.test(src),
+        'Kotlin must delegate to NodeControlClient.flushShutdown() so the bridge-token header is set (otherwise /shutdown/flush 401s in production)');
+    // Match actual usage patterns (variable type, cast, instantiation) — not
+    // KDoc prose. The pre-fix code had `var conn: HttpURLConnection?` and
+    // `URL("http://127.0.0.1:8766/shutdown/flush").openConnection()`; the
+    // post-fix code shouldn't have either form.
+    assert.ok(!/:\s*HttpURLConnection\??|as\s+HttpURLConnection|URL\s*\(\s*"http:\/\/127\.0\.0\.1:8766/.test(src),
+        'Kotlin must NOT roll its own HTTP client for the flush — the rolled-own version omitted the X-Bridge-Token header and 401\'d the endpoint');
+});
+
+test('NodeControlClient exposes flushShutdown that hits POST /shutdown/flush with auth', () => {
+    // R3.1 Copilot: pin the auth-header behavior of the shared client
+    // so a future refactor can't silently drop it. The endpoint
+    // requires X-Bridge-Token (every POST does, per BAT-514's
+    // internal-control-server contract).
+    const NCC_KT = path.join(ROOT, 'app', 'src', 'main', 'java', 'com',
+        'seekerclaw', 'app', 'bridge', 'NodeControlClient.kt');
+    const src = fs.readFileSync(NCC_KT, 'utf8');
+    assert.ok(/suspend\s+fun\s+flushShutdown\s*\(\s*\)/.test(src),
+        'NodeControlClient must expose suspend fun flushShutdown()');
+    assert.ok(/post\s*\(\s*"\/shutdown\/flush"/.test(src),
+        'flushShutdown must POST to /shutdown/flush via the shared post() helper');
+    // The shared post() helper sets the X-Bridge-Token header from
+    // ServiceState.bridgeToken — these are pre-existing invariants
+    // (since BAT-514) but pinning them here as well makes the
+    // BAT-525 contract robust against drift in either layer.
+    assert.ok(/AUTH_HEADER\s*=\s*"X-Bridge-Token"/.test(src),
+        'NodeControlClient must declare the X-Bridge-Token auth header');
+    assert.ok(/setRequestProperty\s*\(\s*AUTH_HEADER\s*,\s*token\s*\)/.test(src),
+        'NodeControlClient.post() must set the X-Bridge-Token header on every request');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/nodejs-project/shutdown-flush.test.js
+++ b/tests/nodejs-project/shutdown-flush.test.js
@@ -52,8 +52,8 @@ test('internal-control-server.js exposes POST /shutdown/flush', () => {
     const src = fs.readFileSync(CONTROL_JS, 'utf8');
     assert.ok(/url\s*===\s*'\/shutdown\/flush'/.test(src),
         'internal-control-server must expose /shutdown/flush');
-    assert.ok(/await\s+_flushShutdown\s*\(\s*'USER_STOP'\s*,\s*\{\s*summaryTimeoutMs:\s*1500\s*\}\s*\)/.test(src),
-        'POST /shutdown/flush must await the wired flushShutdown callback with summaryTimeoutMs<2000ms (Kotlin waits 2s)');
+    assert.ok(/await\s+_flushShutdown\s*\(\s*'USER_STOP'\s*,\s*\{\s*summaryTimeoutMs:\s*1200\s*\}\s*\)/.test(src),
+        'POST /shutdown/flush must await flushShutdown with summaryTimeoutMs=1200 — the R4-tightened budget that fits within Kotlin\'s 1750ms worst-case wall time (CONNECT 250 + READ 1500), which itself fits within the 2000ms outer withTimeoutOrNull. HttpURLConnection isn\'t cooperatively cancellable so the bound MUST come from the underlying timeouts, not the outer coroutine timeout.');
 });
 
 test('R1 Copilot: /shutdown/flush drains the request body', () => {
@@ -143,6 +143,38 @@ test('SeekerClawService posts to Node flush endpoint with a bounded timeout', ()
     // post-fix code shouldn't have either form.
     assert.ok(!/:\s*HttpURLConnection\??|as\s+HttpURLConnection|URL\s*\(\s*"http:\/\/127\.0\.0\.1:8766/.test(src),
         'Kotlin must NOT roll its own HTTP client for the flush — the rolled-own version omitted the X-Bridge-Token header and 401\'d the endpoint');
+});
+
+test('R4 Copilot: timeout budget chain stays within outer 2000ms (HttpURLConnection isn\'t cancellable)', () => {
+    // R4 Copilot: HttpURLConnection's blocking connect/read can't be
+    // interrupted by withTimeoutOrNull on the outer coroutine. The
+    // hard upper bound MUST therefore come from the underlying
+    // connect+read timeouts, summed against the Node-side
+    // summaryTimeoutMs. Pin both ends so a future "let's bump the
+    // read timeout to 5000" change immediately fails this guard
+    // instead of silently breaking the 2s service-teardown SLA.
+    const NCC_KT = path.join(ROOT, 'app', 'src', 'main', 'java', 'com',
+        'seekerclaw', 'app', 'bridge', 'NodeControlClient.kt');
+    const ncc = fs.readFileSync(NCC_KT, 'utf8');
+    const connect = parseInt((ncc.match(/CONNECT_TIMEOUT_MS\s*=\s*(\d+)/) || [])[1], 10);
+    const read = parseInt((ncc.match(/READ_TIMEOUT_MS\s*=\s*(\d+)/) || [])[1], 10);
+    assert.ok(Number.isFinite(connect) && Number.isFinite(read),
+        'NodeControlClient must declare numeric CONNECT_TIMEOUT_MS + READ_TIMEOUT_MS');
+    const ktWorstCase = connect + read;
+    assert.ok(ktWorstCase <= 2000,
+        `NodeControlClient timeout budget (CONNECT=${connect} + READ=${read} = ${ktWorstCase}ms) must fit within SeekerClawService.onDestroy() outer withTimeoutOrNull(2000)`);
+
+    const ctrl = fs.readFileSync(CONTROL_JS, 'utf8');
+    const summary = parseInt((ctrl.match(/summaryTimeoutMs:\s*(\d+)/) || [])[1], 10);
+    assert.ok(Number.isFinite(summary),
+        'internal-control-server.js /shutdown/flush must set summaryTimeoutMs');
+    // Node-side flush must finish AND respond before Kotlin's read
+    // timeout fires; need a small buffer for response stream + JSON
+    // encode + socket write back to Kotlin.
+    assert.ok(summary < read,
+        `Node summaryTimeoutMs (${summary}) must be less than Kotlin READ_TIMEOUT_MS (${read}) so the flush response actually lands`);
+    assert.ok(read - summary >= 200,
+        `Node summaryTimeoutMs (${summary}) needs ≥200ms buffer below Kotlin READ_TIMEOUT_MS (${read}) for response encode + socket write — current buffer is ${read - summary}ms`);
 });
 
 test('NodeControlClient exposes flushShutdown that hits POST /shutdown/flush with auth', () => {

--- a/tests/nodejs-project/shutdown-flush.test.js
+++ b/tests/nodejs-project/shutdown-flush.test.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// shutdown-flush.test.js - drift guards for BAT-525 user-Stop durability.
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DATABASE_JS = path.join(ROOT, 'app', 'src', 'main', 'assets', 'nodejs-project', 'database.js');
+const CONTROL_JS = path.join(ROOT, 'app', 'src', 'main', 'assets', 'nodejs-project', 'internal-control-server.js');
+const MAIN_JS = path.join(ROOT, 'app', 'src', 'main', 'assets', 'nodejs-project', 'main.js');
+const SERVICE_KT = path.join(ROOT, 'app', 'src', 'main', 'java', 'com', 'seekerclaw', 'app', 'service', 'SeekerClawService.kt');
+
+let pass = 0;
+let fail = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        pass++;
+        console.log(`PASS  ${name}`);
+    } catch (e) {
+        fail++;
+        console.log(`FAIL  ${name}`);
+        console.log(`  ${e.message}`);
+        if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+    }
+}
+
+test('database.js exposes a non-exiting shutdown flush helper', () => {
+    const src = fs.readFileSync(DATABASE_JS, 'utf8');
+    const helper = src.match(/async function flushForShutdown\s*\([^)]*\)\s*\{([\s\S]*?)\n\}/);
+    assert.ok(helper, 'flushForShutdown helper must exist');
+    assert.ok(/saveDatabase\s*\(\s*\{\s*force:\s*true\s*,\s*scheduleRetry:\s*false\s*\}\s*\)/.test(helper[1]),
+        'flushForShutdown must force-flush the DB without scheduling dead retries');
+    assert.ok(!/process\.exit\s*\(/.test(helper[1]),
+        'flushForShutdown must not exit before the HTTP caller receives an ack');
+});
+
+test('database.js keeps signal shutdown as flush then process exit', () => {
+    const src = fs.readFileSync(DATABASE_JS, 'utf8');
+    assert.ok(/async function gracefulShutdown\s*\([^)]*\)\s*\{\s*await flushForShutdown\s*\([^)]*\)\s*;\s*process\.exit\s*\(0\)/.test(src),
+        'gracefulShutdown should await the shared flush helper and then exit');
+});
+
+test('internal-control-server.js exposes POST /shutdown/flush', () => {
+    // BAT-525 originally lived in database.js's startStatsServer.
+    // BAT-514 moved that server to internal-control-server.js, so the
+    // BAT-525 endpoint had to follow.
+    const src = fs.readFileSync(CONTROL_JS, 'utf8');
+    assert.ok(/url\s*===\s*'\/shutdown\/flush'/.test(src),
+        'internal-control-server must expose /shutdown/flush');
+    assert.ok(/await\s+_flushShutdown\s*\(\s*'USER_STOP'\s*,\s*\{\s*summaryTimeoutMs:\s*1500\s*\}\s*\)/.test(src),
+        'POST /shutdown/flush must await the wired flushShutdown callback with summaryTimeoutMs<2000ms (Kotlin waits 2s)');
+});
+
+test('R1 Copilot: /shutdown/flush drains the request body', () => {
+    // Without draining, the keep-alive socket can't recycle and the
+    // listener buffers an unread body. Slice the file from the
+    // /shutdown/flush block start to the next route or end-of-route
+    // function so we don't accidentally match _readBody usage in
+    // other endpoints.
+    const src = fs.readFileSync(CONTROL_JS, 'utf8');
+    const startIdx = src.indexOf("url === '/shutdown/flush'");
+    assert.ok(startIdx >= 0, '/shutdown/flush block must exist');
+    // End of block: next `if (url ===` OR `return _json(res, 404` (fallthrough).
+    const tail = src.slice(startIdx);
+    const endIdx = tail.search(/(?:^|\n)\s{4}(?:if \(url ===|return _json\(res, 404)/);
+    const flushBlock = endIdx >= 0 ? tail.slice(0, endIdx) : tail;
+    assert.ok(/_readBody\s*\(\s*req\s*,/.test(flushBlock),
+        '/shutdown/flush must drain request body via _readBody');
+});
+
+test('R2 Copilot: /shutdown/flush surfaces flush failures as 500', () => {
+    // The original PR caught the throw and returned 200 + {ok:true},
+    // making Kotlin's "flush acknowledged" log lie in exactly the
+    // failure mode this endpoint exists to handle.
+    const src = fs.readFileSync(CONTROL_JS, 'utf8');
+    const startIdx = src.indexOf("url === '/shutdown/flush'");
+    const tail = src.slice(startIdx);
+    const endIdx = tail.search(/(?:^|\n)\s{4}(?:if \(url ===|return _json\(res, 404)/);
+    const flushBlock = endIdx >= 0 ? tail.slice(0, endIdx) : tail;
+    assert.ok(/_json\(res,\s*200,\s*\{\s*ok:\s*true\s*\}/.test(flushBlock),
+        '/shutdown/flush must return 200/{ok:true} on success');
+    assert.ok(/_json\(res,\s*500,\s*\{\s*ok:\s*false/.test(flushBlock),
+        '/shutdown/flush must return 500/{ok:false} on flush failure (not 200/{ok:true})');
+});
+
+test('R3 Copilot: _readBody handles aborted/close events', () => {
+    // If Kotlin times out and closes the socket before sending `end`,
+    // neither `end` nor `error` fires on the request stream — without
+    // an aborted/close listener the body-drain promise hangs forever.
+    const src = fs.readFileSync(CONTROL_JS, 'utf8');
+    assert.ok(/req\.on\s*\(\s*['"]aborted['"]/.test(src),
+        '_readBody must listen for aborted to handle client timeout');
+    assert.ok(/req\.on\s*\(\s*['"]close['"]/.test(src),
+        '_readBody must listen for close to handle abrupt disconnects');
+});
+
+test('main.js wires flushForShutdown into internal-control-server.start', () => {
+    // Without this wire-up the new endpoint's _flushShutdown stays
+    // null and the route returns 503. Both Telegram and Discord
+    // startup paths must wire the callback.
+    const src = fs.readFileSync(MAIN_JS, 'utf8');
+    const wireCount = (src.match(/flushShutdown:\s*flushForShutdown/g) || []).length;
+    assert.ok(wireCount >= 2,
+        `main.js must wire flushShutdown in BOTH start() call sites (Telegram + Discord); found ${wireCount}`);
+});
+
+test('SeekerClawService calls Node flush before stopping NodeBridge', () => {
+    const src = fs.readFileSync(SERVICE_KT, 'utf8');
+    const onDestroy = src.match(/override fun onDestroy\s*\(\)\s*\{([\s\S]*?)\n    \}/);
+    assert.ok(onDestroy, 'onDestroy body must be found');
+    const body = onDestroy[1];
+    const flushIdx = body.indexOf('flushNodeBeforeProcessKill()');
+    const stopIdx = body.indexOf('NodeBridge.stop()');
+    const killIdx = body.indexOf('killProcess');
+    assert.ok(flushIdx >= 0, 'onDestroy must call flushNodeBeforeProcessKill()');
+    assert.ok(stopIdx >= 0, 'onDestroy must still call NodeBridge.stop()');
+    assert.ok(killIdx >= 0, 'onDestroy must still kill the :node process');
+    assert.ok(flushIdx < stopIdx, 'Node flush must happen before NodeBridge.stop()');
+    assert.ok(flushIdx < killIdx, 'Node flush must happen before killProcess()');
+});
+
+test('SeekerClawService posts to Node flush endpoint with a bounded timeout', () => {
+    const src = fs.readFileSync(SERVICE_KT, 'utf8');
+    assert.ok(/withTimeoutOrNull\s*\(\s*timeoutMs\s*\)/.test(src),
+        'flush wait must be bounded');
+    assert.ok(/http:\/\/127\.0\.0\.1:8766\/shutdown\/flush/.test(src),
+        'Kotlin must call the local Node shutdown flush endpoint');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Implements BAT-525 — graceful Node shutdown on user-initiated Stop. Also fixes a pre-existing BAT-514 loopback cleartext issue surfaced during device test (see below).

When the user taps Stop Agent, Kotlin kills the `:node` process with `killProcess()`. Node runs in-process via nodejs-mobile, so its `SIGTERM`/`SIGINT` graceful shutdown handlers never run on that user-stop path. That can lose DB rows still inside BAT-523's dirty debounce window.

### Changes

- Extracts Node shutdown persistence into `flushForShutdown()` (non-exiting helper that returns `{ok, summaryFailed?, dbFailed?}`).
- Signal-driven `gracefulShutdown` now delegates to `flushForShutdown()` then `process.exit(0)`; logs partial-failure detail at WARN.
- Adds `POST /shutdown/flush` on the internal control server (`127.0.0.1:8766`, BAT-514's loopback surface), wired via `start({ flushShutdown })` callback option from both Telegram and Discord boot paths.
- Endpoint drains request body, returns `200 / {ok:true}` on success or `500 / {ok:false, summaryFailed?, dbFailed?}` on failure.
- `NodeControlClient.flushShutdown()` (peer to `reconcile`/`healthz`); reuses shared `post()` helper with `X-Bridge-Token` auth.
- `SeekerClawService.flushNodeBeforeProcessKill` calls `NodeControlClient.flushShutdown()` (replaces the rolled-own `HttpURLConnection`); `runBlocking { withTimeoutOrNull(2_000L) { ... } }`.
- Timeout budget chain: `CONNECT_TIMEOUT_MS = 250`, `READ_TIMEOUT_MS = 1500`, Node `summaryTimeoutMs = 1200` — worst-case wall time **1750ms**, fits the 2000ms outer budget. KDoc honest about `HttpURLConnection` not being cooperatively cancellable.
- Drift-guard tests pin: flushForShutdown shape, endpoint location, body draining, 500-on-failure, _readBody abort/close events, Kotlin delegation, `X-Bridge-Token` header.

### Pre-existing BAT-514 fix (commit `ee29727`)

Initial device test of the BAT-525 path showed `[Shutdown] Node flush timed out or failed` at the same timestamp as Stop. `adb logcat` revealed the real cause:

```
NodeControlClient: POST /shutdown/flush failed:
IOException: Cleartext HTTP traffic to 127.0.0.1 not permitted
```

`AndroidManifest.xml` had no `usesCleartextTraffic` and no `networkSecurityConfig`. Android API 28+ default blocks cleartext to **all** hosts including loopback. That meant every `NodeControlClient.reconcile()` / `healthz()` call had also been silently failing in production since BAT-514 — reconcile silently because it's best-effort with file-based fallback at next service-start. Flush has no fallback so it surfaced.

Fix:
- New `app/src/main/res/xml/network_security_config.xml` — cleartext exemption **scoped to `127.0.0.1` only**.
- `<application android:networkSecurityConfig="@xml/network_security_config" />` wired in manifest.
- `<domain includeSubdomains="false">127.0.0.1</domain>` — explicitly not `0.0.0.0`, not LAN ranges, not hostnames.
- TLS enforcement for all real remote endpoints (Anthropic, OpenAI, OpenRouter, Telegram, Discord, user's Custom gateway) **unchanged**.

## Test Plan

### Static / unit
- `node tests/nodejs-project/shutdown-flush.test.js` — passed (14+ assertions)
- `node tests/nodejs-project/idle-summary-timers.test.js` — passed (BAT-524 drift-guard updated)
- `node tests/nodejs-project/db-dirty-debounce.test.js` — passed
- `node --check` on all changed JS — passed
- `scripts/pre-push-check.sh` — passed (Kotlin compile via Android Studio JBR)
- `./gradlew assembleDappStoreDebug` — APK built

### Device test on Solana Seeker (`ee29727`)

**Gate 1 — flushShutdown success path:**
```
[04:33:10 PM] [Service] Stopping Claw Engine...
[04:33:10 PM] [Node] [Shutdown] USER_STOP received, saving session summary...
[04:33:10 PM] [Shutdown] Node flush acknowledged
[04:33:10 PM] [NodeBridge] Stop requested
[04:33:10 PM] [Service] Claw Engine stopped
```

**Gate 1 — invariant survives Stop+Restart:**
```
[04:35:03 PM] [AutoResume] No incomplete checkpoints found
[04:35:08 PM] [Trace] {payloadSize:84942, status:200, elapsedMs:2034}
```

**Gate 2 — `/mcp/reconcile` reaches Node** (BAT-514 path repaired):
```
[04:45:00 PM] [MCP] Context7: 2 tools discovered
[04:45:00 PM] [MCP] reconcile complete: 1 servers, 2 tools
```

**`/healthz`** — implied by parity (same `NodeControlClient.post()` helper, same loopback, same `X-Bridge-Token`, same network-security exemption as the two probed peers).

## Safety

- No app data clearing, no package/storage/schema changes.
- Cleartext config scoped to loopback only; no global `usesCleartextTraffic`; TLS enforcement unchanged for all remote endpoints.
- Bridge token auth still required on every loopback call.

## Linear

BAT-525 — Codex PM-approved at 2026-05-02T12:48Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)