### PR TITLE
feat: migrate MCP server config to CrossProcessStore (BAT-514)

### DIFF
--- a/app/src/main/assets/nodejs-project/bridge.js
+++ b/app/src/main/assets/nodejs-project/bridge.js
@@ -55,10 +55,11 @@ async function androidBridgeCall(endpoint, data = {}, timeoutMs = 10000) {
     });
 }
 
-// BAT-514: fetch the per-server MCP auth token from Kotlin's encrypted
-// SharedPreferences (`mcp_token_<id>`). Mirrors the bridge's other
-// "config presence" endpoints, but returns the actual decrypted value
-// — necessary because Node has to attach the bearer header to MCP
+// BAT-514: fetch the per-server MCP auth token via the Kotlin bridge,
+// which reads it from the encrypted file at `filesDir/mcp_tokens/<id>`
+// through `McpTokenStore`. Mirrors the bridge's other "config
+// presence" endpoints, but returns the actual decrypted value —
+// necessary because Node has to attach the bearer header to MCP
 // requests itself. Returns the empty string on any failure (bridge
 // down, unauthorized, unknown id, decrypt failure) so callers don't
 // have to distinguish — the connect attempt will fail loudly if the

--- a/app/src/main/assets/nodejs-project/bridge.js
+++ b/app/src/main/assets/nodejs-project/bridge.js
@@ -55,10 +55,26 @@ async function androidBridgeCall(endpoint, data = {}, timeoutMs = 10000) {
     });
 }
 
+// BAT-514: fetch the per-server MCP auth token from Kotlin's encrypted
+// SharedPreferences (`mcp_token_<id>`). Mirrors the bridge's other
+// "config presence" endpoints, but returns the actual decrypted value
+// — necessary because Node has to attach the bearer header to MCP
+// requests itself. Returns the empty string on any failure (bridge
+// down, unauthorized, unknown id, decrypt failure) so callers don't
+// have to distinguish — the connect attempt will fail loudly if the
+// token was actually required.
+async function fetchMcpToken(id) {
+    if (typeof id !== 'string' || !id) return '';
+    const result = await androidBridgeCall('/config/mcp-token', { id }, 5000);
+    if (result && typeof result.token === 'string') return result.token;
+    return '';
+}
+
 // ============================================================================
 // EXPORTS
 // ============================================================================
 
 module.exports = {
     androidBridgeCall,
+    fetchMcpToken,
 };

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -776,32 +776,12 @@ function startDbSummaryInterval() {
     setInterval(() => { if (dbSummaryDirty) writeDbSummaryFile(); }, 30000);
 }
 
-// ============================================================================
-// INTERNAL HTTP SERVER — serves stats to Android UI via bridge proxy (BAT-31)
-// ============================================================================
-
-const STATS_PORT = 8766;
-
-function startStatsServer() {
-    const statsServer = require('http').createServer((req, res) => {
-        if (req.method === 'GET' && req.url === '/stats/db-summary') {
-            const summary = getDbSummary();
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify(summary));
-        } else {
-            res.writeHead(404, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Not found' }));
-        }
-    });
-
-    statsServer.on('error', (err) => {
-        log(`[Stats] Internal stats server error (${err.code || 'UNKNOWN'}): ${err.message}`, 'ERROR');
-    });
-
-    statsServer.listen(STATS_PORT, '127.0.0.1', () => {
-        log(`[Stats] Internal stats server listening on port ${STATS_PORT}`, 'INFO');
-    });
-}
+// BAT-514: the loopback HTTP server used to live here as
+// `startStatsServer()` (BAT-31, port 8766). It moved to
+// `internal-control-server.js` so MCP control endpoints
+// (`POST /mcp/reconcile`, `POST /healthz`) can share the same port.
+// `getDbSummary` below is the only export the new server needs from
+// this module — main.js wires the dependency.
 
 // ============================================================================
 // EXPORTS
@@ -819,5 +799,5 @@ module.exports = {
     markDbSummaryDirty,
     markDbDirty, // BAT-523 (BAT-518 phase 3A) — call after every db.run() that mutates state
     startDbSummaryInterval,
-    startStatsServer,
+    getDbSummary,
 };

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -1,0 +1,205 @@
+// SeekerClaw — internal-control-server.js
+// Loopback HTTP server bound to 127.0.0.1:8766. Single endpoint for
+// internal control & introspection traffic between the main process
+// (Kotlin) and Node.
+//
+// History:
+//   - Pre-BAT-514: this lived inline in database.js as the "stats
+//     server" — one endpoint (GET /stats/db-summary) for the Android UI
+//     stats screen. Bound to 8766.
+//   - BAT-514: extracted here. Same port (8766) — adding a new
+//     `control-server.js` on a second port would EADDRINUSE-conflict.
+//     New endpoints (POST /mcp/reconcile, POST /healthz) added with
+//     bridge-token auth + per-endpoint rate-limit.
+//
+// This module exports `start(options)` / `stop()` / `getPort()`. It
+// does NOT own the data — handlers are passed in via options:
+//   - options.bridgeToken    : per-boot string for X-Bridge-Token auth
+//   - options.getDbSummary   : () => object  (database.js hands this in)
+//   - options.requestReconcile: (id?: string) => void  (mcp-client.js
+//                              MCPManager hands this in)
+//
+// Why callbacks instead of requires: lets `main.js` wire dependencies
+// in the right order (DB init → MCP manager init → control server
+// start) without internal-control-server.js becoming a god module that
+// requires database + mcp-client (which would create circular imports
+// in the test harness).
+
+'use strict';
+
+const http = require('http');
+
+const PORT = 8766;
+const HOST = '127.0.0.1';
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_RECONCILE = 30; // 30 reconciles/min — drain coalesces, this is just intake throttle
+const RATE_LIMIT_HEALTHZ = 60;   // 1/sec average is fine for a liveness probe
+
+// Per-endpoint rate-limit state. Cleared on stop() so test harnesses
+// don't leak state between cases.
+const _buckets = new Map();
+
+function _allow(endpoint, limit) {
+    const now = Date.now();
+    const arr = _buckets.get(endpoint) || [];
+    // Drop stamps older than the window
+    while (arr.length && now - arr[0] > RATE_LIMIT_WINDOW_MS) arr.shift();
+    if (arr.length >= limit) {
+        _buckets.set(endpoint, arr);
+        return false;
+    }
+    arr.push(now);
+    _buckets.set(endpoint, arr);
+    return true;
+}
+
+function _readBody(req, maxBytes) {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        let len = 0;
+        req.on('data', (chunk) => {
+            len += Buffer.byteLength(chunk);
+            if (len > maxBytes) {
+                reject(new Error('body too large'));
+                req.destroy();
+                return;
+            }
+            data += chunk;
+        });
+        req.on('end', () => resolve(data));
+        req.on('error', reject);
+    });
+}
+
+function _json(res, status, obj, extraHeaders) {
+    const headers = Object.assign({ 'Content-Type': 'application/json' }, extraHeaders || {});
+    res.writeHead(status, headers);
+    res.end(JSON.stringify(obj));
+}
+
+let _server = null;
+let _bridgeToken = null;
+let _getDbSummary = null;
+let _requestReconcile = null;
+let _logFn = console.log;
+
+/**
+ * Start the loopback control server. Idempotent — calling twice with
+ * the same options is a no-op (returns the existing server).
+ *
+ * The handlers are stored at module scope so a future hot-reload of
+ * one of them (e.g. swapping the MCP manager during test setup)
+ * doesn't need to bring the server down.
+ */
+function start(options) {
+    if (!options || typeof options !== 'object') {
+        throw new Error('internal-control-server.start: options required');
+    }
+    _bridgeToken = typeof options.bridgeToken === 'string' ? options.bridgeToken : '';
+    _getDbSummary = typeof options.getDbSummary === 'function' ? options.getDbSummary : null;
+    _requestReconcile = typeof options.requestReconcile === 'function' ? options.requestReconcile : null;
+    _logFn = typeof options.logFn === 'function' ? options.logFn : console.log;
+
+    if (_server) return _server;
+
+    _server = http.createServer(async (req, res) => {
+        try {
+            await _route(req, res);
+        } catch (err) {
+            _logFn(`[ControlServer] handler error: ${err.message}`, 'ERROR');
+            try { _json(res, 500, { error: 'internal' }); } catch (_) {}
+        }
+    });
+
+    _server.on('error', (err) => {
+        _logFn(`[ControlServer] server error (${err.code || 'UNKNOWN'}): ${err.message}`, 'ERROR');
+    });
+
+    _server.listen(PORT, HOST, () => {
+        _logFn(`[ControlServer] Listening on ${HOST}:${PORT}`, 'INFO');
+    });
+
+    return _server;
+}
+
+async function _route(req, res) {
+    const method = (req.method || 'GET').toUpperCase();
+    const url = req.url || '/';
+
+    // GET /stats/db-summary — preserved BAT-31 behavior. No auth, no
+    // rate-limit. AndroidBridge proxies this from its own (already-
+    // authed + rate-limited) /stats/db-summary endpoint, so the inner
+    // hop doesn't need to reauthenticate. Keeping it open also matches
+    // the pre-BAT-514 contract — no UI behaviour change.
+    if (method === 'GET' && url === '/stats/db-summary') {
+        if (!_getDbSummary) return _json(res, 503, { error: 'stats unavailable' });
+        try {
+            return _json(res, 200, _getDbSummary());
+        } catch (err) {
+            _logFn(`[ControlServer] getDbSummary failed: ${err.message}`, 'ERROR');
+            return _json(res, 500, { error: 'stats failed' });
+        }
+    }
+
+    // All MCP / healthz endpoints are POST + bridge-token-authed +
+    // rate-limited.
+    if (method !== 'POST') {
+        return _json(res, 405, { error: 'method not allowed' });
+    }
+
+    // Bridge-token auth for the new endpoints (NOT /stats — see above).
+    const headerToken = req.headers['x-bridge-token'];
+    if (!_bridgeToken || headerToken !== _bridgeToken) {
+        return _json(res, 401, { error: 'unauthorized' });
+    }
+
+    if (url === '/mcp/reconcile') {
+        if (!_allow('/mcp/reconcile', RATE_LIMIT_RECONCILE)) {
+            return _json(res, 429, { error: 'rate limit exceeded' }, { 'Retry-After': '60' });
+        }
+        // Body is optional `{ id?: string }`. We accept JSON parse
+        // failures silently and treat them as full-reconcile — defensive
+        // against a buggy caller / truncated body. The id is also
+        // permitted to be a non-string (number, object) — we ignore
+        // anything that isn't a string.
+        const raw = await _readBody(req, 4096).catch(() => '');
+        let id = null;
+        if (raw) {
+            try {
+                const parsed = JSON.parse(raw);
+                if (parsed && typeof parsed.id === 'string' && parsed.id.length > 0) {
+                    id = parsed.id;
+                }
+            } catch (_) { /* full reconcile on parse failure */ }
+        }
+        if (_requestReconcile) {
+            try { _requestReconcile(id); } catch (err) {
+                _logFn(`[ControlServer] requestReconcile threw: ${err.message}`, 'ERROR');
+            }
+        }
+        return _json(res, 200, {});
+    }
+
+    if (url === '/healthz') {
+        if (!_allow('/healthz', RATE_LIMIT_HEALTHZ)) {
+            return _json(res, 429, { error: 'rate limit exceeded' }, { 'Retry-After': '60' });
+        }
+        return _json(res, 200, { ok: true });
+    }
+
+    return _json(res, 404, { error: 'not found' });
+}
+
+function stop() {
+    _buckets.clear();
+    if (_server) {
+        const s = _server;
+        _server = null;
+        return new Promise((resolve) => s.close(() => resolve()));
+    }
+    return Promise.resolve();
+}
+
+function getPort() { return PORT; }
+
+module.exports = { start, stop, getPort, PORT };

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -53,21 +53,41 @@ function _allow(endpoint, limit) {
     return true;
 }
 
+// Sentinel error code so `_route` can distinguish "body exceeded
+// limit" from a generic transport error and return 413 cleanly
+// instead of letting the connection die with ECONNRESET. (Copilot
+// R19 PR #352 finding.)
+const _BODY_TOO_LARGE = 'BODY_TOO_LARGE';
+
 function _readBody(req, maxBytes) {
     return new Promise((resolve, reject) => {
         let data = '';
         let len = 0;
+        // `done` guard so a single oversized chunk doesn't fire both
+        // reject() AND resolve() via subsequent `end`/`error` events.
+        let done = false;
         req.on('data', (chunk) => {
+            if (done) return;
             len += Buffer.byteLength(chunk);
             if (len > maxBytes) {
-                reject(new Error('body too large'));
-                req.destroy();
+                done = true;
+                const err = new Error('body too large');
+                err.code = _BODY_TOO_LARGE;
+                reject(err);
                 return;
             }
             data += chunk;
         });
-        req.on('end', () => resolve(data));
-        req.on('error', reject);
+        req.on('end', () => {
+            if (done) return;
+            done = true;
+            resolve(data);
+        });
+        req.on('error', (err) => {
+            if (done) return;
+            done = true;
+            reject(err);
+        });
     });
 }
 
@@ -157,12 +177,25 @@ async function _route(req, res) {
         if (!_allow('/mcp/reconcile', RATE_LIMIT_RECONCILE)) {
             return _json(res, 429, { error: 'rate limit exceeded' }, { 'Retry-After': '60' });
         }
-        // Body is optional `{ id?: string }`. We accept JSON parse
-        // failures silently and treat them as full-reconcile — defensive
-        // against a buggy caller / truncated body. The id is also
-        // permitted to be a non-string (number, object) — we ignore
-        // anything that isn't a string.
-        const raw = await _readBody(req, 4096).catch(() => '');
+        // Body is optional `{ id?: string }` (typically <50 bytes).
+        // JSON parse failures are accepted silently and treated as
+        // full-reconcile — defensive against a buggy caller /
+        // truncated body. Body-size overflow is a different class of
+        // failure (oversized request implies a misbehaving or
+        // hostile caller); return 413 cleanly and skip the reconcile
+        // so we don't do work for an already-rejected request.
+        // (Copilot R19 PR #352 finding.)
+        let raw
+        try {
+            raw = await _readBody(req, 4096)
+        } catch (err) {
+            if (err && err.code === _BODY_TOO_LARGE) {
+                return _json(res, 413, { error: 'request body too large' })
+            }
+            // Other transport errors: fall back to full-reconcile
+            // (matches the prior tolerant behavior).
+            raw = ''
+        }
         let id = null;
         if (raw) {
             try {

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -15,6 +15,7 @@ const {
     getOwnerId, setOwnerId,
     workDir, config, debugLog,
     USER_ENV_KEYS,
+    BRIDGE_TOKEN, // BAT-514: passed to internal-control-server for X-Bridge-Token auth
 } = require('./config');
 
 process.on('uncaughtException', (err) => log('UNCAUGHT: ' + (err.stack || err), 'ERROR'));
@@ -28,6 +29,7 @@ const {
     redactSecrets,
     wrapExternalContent,
     registerRedactedSecrets,
+    registerRedactedSecret, // BAT-514: per-fetch MCP token redaction (mcp-client.js)
 } = require('./security');
 
 // Wire redactSecrets into config.js log() so early log lines before this point
@@ -46,13 +48,65 @@ registerRedactedSecrets(
 // BRIDGE (extracted to bridge.js — BAT-195)
 // ============================================================================
 
-const { androidBridgeCall } = require('./bridge');
+const { androidBridgeCall, fetchMcpToken } = require('./bridge');
 const { stripSilentReply, containsSilentReply } = require('./silent-reply');
 const { telegramCommandMenu, telegramFallbackMenu } = require('./telegram-commands');
 
-// ── MCP (Model Context Protocol) — Remote tool servers (BAT-168) ───
+// ── MCP (Model Context Protocol) — Remote tool servers (BAT-168, BAT-514) ───
 const { MCPManager } = require('./mcp-client');
-const mcpManager = new MCPManager(log, wrapExternalContent);
+const _mcpServersStore = require('./mcp-servers').open(workDir);
+// MCP_SERVERS resolution order (BAT-514):
+//   1. mcp_servers.json (Kotlin McpServersStore — live source of truth)
+//   2. config.json's mcpServers field (cold-start fallback for upgrades
+//      and legacy installs that haven't migrated yet)
+// Tokens are NOT in #1 — `tokenFetcher` resolves them via the bridge
+// at connect time. #2 entries may still carry inline `authToken` for
+// downgrade compatibility; MCPClient prefers the fetcher when set.
+function _resolveMcpConfigs() {
+    const fromFile = _mcpServersStore.read();
+    if (fromFile.length > 0) return fromFile;
+    return MCP_SERVERS;
+}
+const mcpManager = new MCPManager(log, wrapExternalContent, {
+    tokenFetcher: fetchMcpToken,
+    registerSecret: registerRedactedSecret,
+    configsProvider: _resolveMcpConfigs,
+});
+
+/**
+ * fs.watch the MCP servers file. On change, request a full reconcile —
+ * the manager's drain coalesces bursts (FileObserver-equivalent storms
+ * during atomic-move-based writes) into a single MCPManager.reconcile()
+ * pass. The bridge `POST /mcp/reconcile` endpoint is the deterministic
+ * catch-up; this is the fast path.
+ *
+ * Handles two transient cases:
+ *  - File doesn't exist yet on first launch: skip the watch and rely
+ *    on the bridge endpoint exclusively. The first Settings save will
+ *    create the file, and the next service start will pick up the
+ *    watch.
+ *  - Watch handle drops (rename across atomic-move can detach the
+ *    watcher on some kernels): re-attach lazily on next change via
+ *    the underlying inotify; if that fails, the bridge endpoint still
+ *    works as the safety net.
+ */
+function startMcpFileWatch() {
+    const filePath = _mcpServersStore.filePath;
+    if (!fs.existsSync(filePath)) {
+        log(`[MCP] mcp_servers.json absent at watch start (${filePath}) — relying on bridge reconcile endpoint`, 'DEBUG');
+        return;
+    }
+    try {
+        fs.watch(filePath, { persistent: false }, (eventType) => {
+            if (eventType === 'change' || eventType === 'rename') {
+                mcpManager.requestReconcile(null);
+            }
+        });
+        log(`[MCP] watching ${filePath} for live config updates`, 'DEBUG');
+    } catch (err) {
+        log(`[MCP] fs.watch on ${filePath} failed: ${err.message} — bridge endpoint still works`, 'WARN');
+    }
+}
 
 
 // ============================================================================
@@ -79,8 +133,14 @@ const {
 const {
     setShutdownDeps,
     initDatabase, indexMemoryFiles, backfillSessionsFromFiles,
-    startDbSummaryInterval, startStatsServer,
+    startDbSummaryInterval, getDbSummary,
 } = require('./database');
+
+// BAT-514: extracted from database.js. Loopback server on :8766 hosts
+// the existing GET /stats/db-summary AND the new POST /mcp/reconcile +
+// POST /healthz endpoints. Started below after MCP manager init order
+// settles.
+const internalControlServer = require('./internal-control-server');
 
 // ============================================================================
 // SOLANA (extracted to solana.js — BAT-201)
@@ -620,7 +680,7 @@ telegram('getMe')
             // Condensed startup banner (Phase 4 — single INFO line replaces 10+ verbose startup lines)
             const _skillCount = loadSkills().length;
             const _cronCount = cronService.store?.jobs?.length || 0;
-            log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | @${result.result.username} | ${_skillCount} skills | ${MCP_SERVERS.length} MCP | ${_cronCount} cron`, 'INFO');
+            log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | @${result.result.username} | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
 
             // Initialize SQL.js database before polling (non-fatal if WASM fails)
             await initDatabase();
@@ -673,7 +733,17 @@ telegram('getMe')
             setFullToolRegistry(() => [...TOOLS, ...mcpManager.getAllTools()]);
 
             startDbSummaryInterval();
-            startStatsServer();
+            // BAT-514: single internal HTTP server hosts both stats and
+            // MCP control endpoints. Started after MCP manager so its
+            // requestReconcile callback is wired before the listener
+            // accepts connections.
+            internalControlServer.start({
+                bridgeToken: BRIDGE_TOKEN,
+                getDbSummary,
+                requestReconcile: (id) => mcpManager.requestReconcile(id),
+                logFn: log,
+            });
+            startMcpFileWatch();
 
             // Agent health heartbeat: write immediately on startup (prevents false "stale"
             // when Kotlin reads the old file before the first interval tick), then every 60s.
@@ -721,15 +791,20 @@ telegram('getMe')
             setTimeout(() => autoResumeOnStartup(), 3000);
 
             // Initialize MCP servers in background (non-blocking, won't delay Telegram)
-            if (MCP_SERVERS.length > 0) {
-                mcpManager.initializeAll(MCP_SERVERS).then((mcpResults) => {
-                    const ok = mcpResults.filter(r => r.status === 'connected');
-                    const fail = mcpResults.filter(r => r.status === 'failed');
-                    if (ok.length > 0) log(`[MCP] ${ok.length} server(s) connected, ${ok.reduce((s, r) => s + r.tools, 0)} tools available`, 'INFO');
-                    if (fail.length > 0) log(`[MCP] ${fail.length} server(s) failed to connect`, 'WARN');
-                }).catch((e) => {
-                    log(`[MCP] Initialization error: ${e.message}`, 'ERROR');
-                });
+            // BAT-514: resolve from `mcp_servers.json` first, falling
+            // back to `config.json`'s `mcpServers` for cold-start.
+            {
+                const _mcpInitial = _resolveMcpConfigs();
+                if (_mcpInitial.length > 0) {
+                    mcpManager.initializeAll(_mcpInitial).then((mcpResults) => {
+                        const ok = mcpResults.filter(r => r.status === 'connected');
+                        const fail = mcpResults.filter(r => r.status === 'failed');
+                        if (ok.length > 0) log(`[MCP] ${ok.length} server(s) connected, ${ok.reduce((s, r) => s + r.tools, 0)} tools available`, 'INFO');
+                        if (fail.length > 0) log(`[MCP] ${fail.length} server(s) failed to connect`, 'WARN');
+                    }).catch((e) => {
+                        log(`[MCP] Initialization error: ${e.message}`, 'ERROR');
+                    });
+                }
             }
 
             // BAT-524 (BAT-518 phase 3B): the prior 60s-sweep
@@ -749,7 +824,7 @@ telegram('getMe')
     // Condensed startup banner
     const _skillCount = loadSkills().length;
     const _cronCount = cronService.store?.jobs?.length || 0;
-    log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | Discord | ${_skillCount} skills | ${MCP_SERVERS.length} MCP | ${_cronCount} cron`, 'INFO');
+    log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | Discord | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
 
     // Initialize SQL.js database (non-fatal if WASM fails)
     initDatabase().then(() => {
@@ -800,7 +875,14 @@ telegram('getMe')
         setFullToolRegistry(() => [...TOOLS, ...mcpManager.getAllTools()]);
 
         startDbSummaryInterval();
-        startStatsServer();
+        // BAT-514: see Telegram path comment above.
+        internalControlServer.start({
+            bridgeToken: BRIDGE_TOKEN,
+            getDbSummary,
+            requestReconcile: (id) => mcpManager.requestReconcile(id),
+            logFn: log,
+        });
+        startMcpFileWatch();
 
         // Agent health heartbeat
         writeAgentHealthFile();
@@ -827,16 +909,19 @@ telegram('getMe')
         // Auto-resume checkpoints after 3s
         setTimeout(() => autoResumeOnStartup(), 3000);
 
-        // Initialize MCP servers in background
-        if (MCP_SERVERS.length > 0) {
-            mcpManager.initializeAll(MCP_SERVERS).then((mcpResults) => {
-                const ok = mcpResults.filter(r => r.status === 'connected');
-                const fail = mcpResults.filter(r => r.status === 'failed');
-                if (ok.length > 0) log(`[MCP] ${ok.length} server(s) connected, ${ok.reduce((s, r) => s + r.tools, 0)} tools available`, 'INFO');
-                if (fail.length > 0) log(`[MCP] ${fail.length} server(s) failed to connect`, 'WARN');
-            }).catch((e) => {
-                log(`[MCP] Initialization error: ${e.message}`, 'ERROR');
-            });
+        // Initialize MCP servers in background (BAT-514: file first, config.json fallback)
+        {
+            const _mcpInitial = _resolveMcpConfigs();
+            if (_mcpInitial.length > 0) {
+                mcpManager.initializeAll(_mcpInitial).then((mcpResults) => {
+                    const ok = mcpResults.filter(r => r.status === 'connected');
+                    const fail = mcpResults.filter(r => r.status === 'failed');
+                    if (ok.length > 0) log(`[MCP] ${ok.length} server(s) connected, ${ok.reduce((s, r) => s + r.tools, 0)} tools available`, 'INFO');
+                    if (fail.length > 0) log(`[MCP] ${fail.length} server(s) failed to connect`, 'WARN');
+                }).catch((e) => {
+                    log(`[MCP] Initialization error: ${e.message}`, 'ERROR');
+                });
+            }
         }
 
         // BAT-524 (BAT-518 phase 3B): the prior 60s-sweep setInterval

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -92,9 +92,11 @@ const mcpManager = new MCPManager(log, wrapExternalContent, {
  *    create the file, and the next service start will pick up the
  *    watch.
  *  - Watch handle drops (rename across atomic-move can detach the
- *    watcher on some kernels): re-attach lazily on next change via
- *    the underlying inotify; if that fails, the bridge endpoint still
- *    works as the safety net.
+ *    watcher on some kernels): live updates may stop until the
+ *    service is restarted, but the bridge endpoint still works as
+ *    the safety net for explicit reconcile requests from main. (No
+ *    automatic re-attach is implemented — Copilot R11 noted the
+ *    earlier comment promised behavior the code didn't have.)
  */
 function startMcpFileWatch() {
     const filePath = _mcpServersStore.filePath;

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -56,15 +56,21 @@ const { telegramCommandMenu, telegramFallbackMenu } = require('./telegram-comman
 const { MCPManager } = require('./mcp-client');
 const _mcpServersStore = require('./mcp-servers').open(workDir);
 // MCP_SERVERS resolution order (BAT-514):
-//   1. mcp_servers.json (Kotlin McpServersStore — live source of truth)
-//   2. config.json's mcpServers field (cold-start fallback for upgrades
-//      and legacy installs that haven't migrated yet)
-// Tokens are NOT in #1 — `tokenFetcher` resolves them via the bridge
-// at connect time. #2 entries may still carry inline `authToken` for
-// downgrade compatibility; MCPClient prefers the fetcher when set.
+//   1. mcp_servers.json (Kotlin McpServersStore — live source of truth).
+//      If the file exists we ALWAYS use its content, even when empty —
+//      an empty `servers: []` is a valid "user deleted everything"
+//      state, and falling back to legacy config.json there would
+//      resurrect stale entries (Copilot R3 PR #352 finding).
+//   2. config.json's mcpServers field — cold-start fallback used ONLY
+//      when the file is absent (pre-migration first launch, or a
+//      fresh install where the user hasn't opened Settings -> MCP
+//      Servers yet). Tokens for #2 entries may still be inline as
+//      authToken for downgrade compatibility; MCPClient prefers the
+//      bridge fetcher when set.
 function _resolveMcpConfigs() {
-    const fromFile = _mcpServersStore.read();
-    if (fromFile.length > 0) return fromFile;
+    if (fs.existsSync(_mcpServersStore.filePath)) {
+        return _mcpServersStore.read();
+    }
     return MCP_SERVERS;
 }
 const mcpManager = new MCPManager(log, wrapExternalContent, {

--- a/app/src/main/assets/nodejs-project/mcp-client.js
+++ b/app/src/main/assets/nodejs-project/mcp-client.js
@@ -190,7 +190,8 @@ class MCPClient {
         this.url = serverConfig.url;
         // BAT-514: tokens are no longer inline on `serverConfig` for
         // file-sourced (`mcp_servers.json`) entries — they come from
-        // `tokenFetcher`, which fetches per-id encrypted prefs via the
+        // `tokenFetcher`, which fetches per-id encrypted token files
+        // (`filesDir/mcp_tokens/<id>`) via the
         // AndroidBridge. The legacy inline `authToken` field still
         // works when `tokenFetcher` isn't provided (cold-start fallback
         // through `config.json`'s `mcpServers`).

--- a/app/src/main/assets/nodejs-project/mcp-client.js
+++ b/app/src/main/assets/nodejs-project/mcp-client.js
@@ -165,13 +165,27 @@ function httpRequest(url, options, body, timeoutMs) {
     });
 }
 
+// ── safeId normalization ───────────────────────────────────────────
+// Single source of truth for the id->safeId fold used by both
+// MCPClient (constructor: `this.safeId`) and MCPManager (reconcile +
+// reconcileServer key normalization). Pinned to the same regex on the
+// Kotlin side via McpServersStore.normalizeId — drift here would
+// silently disconnect/reconnect-loop servers whose ids differ between
+// raw and folded forms.
+function _safeId(id) {
+    return (id || '').replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
 // ── MCP Client ─────────────────────────────────────────────────────
 
 class MCPClient {
     constructor(serverConfig, logFn, options = {}) {
         this.id = serverConfig.id || serverConfig.name;
-        // Sanitized ID used in tool name prefixes and as map key
-        this.safeId = (this.id || '').replace(/[^a-zA-Z0-9_-]/g, '_');
+        // Sanitized ID used in tool name prefixes and as map key.
+        // Routes through the module-level helper so MCPManager's
+        // reconcile path (which keys `desiredById` and looks up
+        // `this.servers` by the same fold) cannot drift.
+        this.safeId = _safeId(this.id);
         this.name = serverConfig.name;
         this.url = serverConfig.url;
         // BAT-514: tokens are no longer inline on `serverConfig` for
@@ -656,10 +670,19 @@ class MCPManager {
             this.log(`[MCP] configsProvider threw during reconcile: ${err.message}`, 'ERROR');
             return;
         }
-        const desiredById = new Map();
+        // `this.servers` is keyed by `safeId` (set in _connectServer
+        // via `client.safeId`), but configs carry RAW user-facing
+        // ids. For canonical BAT-514 ids these are identical (the
+        // regex's allowed alphabet survives `safeId` unchanged), but
+        // legacy config.json entries with shell-meta chars (".",
+        // ";", spaces, etc.) get folded by safeId. Keying
+        // `desiredById` by raw id then would mismatch the servers
+        // map and produce a disconnect/reconnect churn loop. Key by
+        // safeId here to align both sides. (Copilot R4 PR #352 finding.)
+        const desiredById = new Map(); // safeId -> raw config object
         for (const c of (configs || [])) {
             if (c && typeof c.id === 'string' && c.enabled !== false) {
-                desiredById.set(c.id, c);
+                desiredById.set(_safeId(c.id), c);
             }
         }
         // Disconnect gone-or-now-disabled OR url-changed servers.
@@ -676,8 +699,8 @@ class MCPManager {
             }
         }
         // Connect everything in desired that isn't currently connected.
-        for (const [id, cfg] of desiredById) {
-            if (!this.servers.has(id)) {
+        for (const [safeId, cfg] of desiredById) {
+            if (!this.servers.has(safeId)) {
                 await this._connectServer(cfg);
             }
         }
@@ -701,8 +724,14 @@ class MCPManager {
             this.log(`[MCP] configsProvider threw during reconcileServer(${id}): ${err.message}`, 'ERROR');
             return;
         }
+        // Caller (control-server / fs.watch) hands us a RAW id.
+        // The configs list also carries raw ids — so the find-by-id
+        // below is a raw match. The disconnect, on the other hand,
+        // looks up `this.servers` which is keyed by safeId — so
+        // normalize the input before disconnecting (Copilot R4 PR
+        // #352 same-bug-class sweep).
         const desired = (configs || []).find((c) => c && c.id === id);
-        this._disconnectAndRemove(id);
+        this._disconnectAndRemove(_safeId(id));
         if (desired && desired.enabled !== false) {
             await this._connectServer(desired);
         }

--- a/app/src/main/assets/nodejs-project/mcp-client.js
+++ b/app/src/main/assets/nodejs-project/mcp-client.js
@@ -168,13 +168,24 @@ function httpRequest(url, options, body, timeoutMs) {
 // ── MCP Client ─────────────────────────────────────────────────────
 
 class MCPClient {
-    constructor(serverConfig, logFn) {
+    constructor(serverConfig, logFn, options = {}) {
         this.id = serverConfig.id || serverConfig.name;
         // Sanitized ID used in tool name prefixes and as map key
         this.safeId = (this.id || '').replace(/[^a-zA-Z0-9_-]/g, '_');
         this.name = serverConfig.name;
         this.url = serverConfig.url;
-        this.authToken = serverConfig.authToken || '';
+        // BAT-514: tokens are no longer inline on `serverConfig` for
+        // file-sourced (`mcp_servers.json`) entries — they come from
+        // `tokenFetcher`, which fetches per-id encrypted prefs via the
+        // AndroidBridge. The legacy inline `authToken` field still
+        // works when `tokenFetcher` isn't provided (cold-start fallback
+        // through `config.json`'s `mcpServers`).
+        this._initialAuthToken = serverConfig.authToken || '';
+        this.tokenFetcher = typeof options.tokenFetcher === 'function' ? options.tokenFetcher : null;
+        this.registerSecret = typeof options.registerSecret === 'function' ? options.registerSecret : null;
+        // Set in connect() after token resolution; bearer header lookup
+        // in `_headers()` reads this.
+        this.authToken = '';
         this.rateLimit = new RateLimiter(serverConfig.rateLimit || DEFAULT_RATE_LIMIT);
         this.log = logFn || console.log;
         this.sessionId = null;
@@ -182,15 +193,44 @@ class MCPClient {
         this.toolHashes = new Map(); // originalName → SHA-256 hash
         this.connected = false;
         this.requestId = 0;
+        // URL safety check (refuse bearer-token over plain non-loopback
+        // HTTP) is deferred to connect() — see `_checkUrlSafety`. We
+        // can't run it here because the token isn't known yet when
+        // tokenFetcher is in play.
+    }
 
-        // Security: refuse to send auth tokens over plain HTTP (credential disclosure)
-        const urlObj = new URL(this.url);
-        if (this.authToken && urlObj.protocol !== 'https:') {
-            const h = urlObj.hostname; // URL() strips brackets from IPv6
-            const isLocalhost = h === 'localhost' || h === '127.0.0.1' || h === '::1';
-            if (!isLocalhost) {
-                throw new Error(`Refusing to send auth token over plain HTTP to ${this.url}. Use HTTPS or localhost.`);
+    /**
+     * Resolve the auth token for this server. Prefers `tokenFetcher`
+     * (BAT-514 path: encrypted prefs via AndroidBridge); falls back
+     * to inline `serverConfig.authToken` for cold-start config.json
+     * entries.
+     */
+    async _resolveAuthToken() {
+        if (this.tokenFetcher) {
+            try {
+                const t = await this.tokenFetcher(this.id);
+                if (typeof t === 'string') return t;
+            } catch (err) {
+                this.log(`[MCP] tokenFetcher(${this.id}) failed: ${err.message}`, 'WARN');
             }
+        }
+        return this._initialAuthToken;
+    }
+
+    /**
+     * Refuse to send auth tokens over plain (non-loopback) HTTP. Run
+     * after token resolution, before any request that would attach the
+     * bearer header. Throws `Error` (caller — connect — surfaces as a
+     * failed connect; rest of the agent keeps running).
+     */
+    _checkUrlSafety(token) {
+        if (!token) return;
+        const urlObj = new URL(this.url);
+        if (urlObj.protocol === 'https:') return;
+        const h = urlObj.hostname; // URL() strips brackets from IPv6
+        const isLocalhost = h === 'localhost' || h === '127.0.0.1' || h === '::1';
+        if (!isLocalhost) {
+            throw new Error(`Refusing to send auth token over plain HTTP to ${this.url}. Use HTTPS or localhost.`);
         }
     }
 
@@ -287,6 +327,18 @@ class MCPClient {
 
     /** Three-step handshake: initialize → receive result → send initialized notification. */
     async connect() {
+        // BAT-514: resolve auth token + register redaction BEFORE any
+        // logging that could include the bearer header. The
+        // registerSecret callback (security.registerRedactedSecret)
+        // skips values shorter than its min-len threshold so empty
+        // tokens are silently a no-op.
+        const token = await this._resolveAuthToken();
+        if (token && this.registerSecret) {
+            try { this.registerSecret(token); } catch (_) { /* best-effort */ }
+        }
+        this._checkUrlSafety(token);
+        this.authToken = token;
+
         this.log(`[MCP] Connecting to ${this.name} at ${this.url}`, 'DEBUG');
 
         // Step 1: Initialize
@@ -440,12 +492,31 @@ class MCPClient {
 // ── MCP Manager ────────────────────────────────────────────────────
 
 class MCPManager {
-    constructor(logFn, wrapExternalContentFn) {
+    constructor(logFn, wrapExternalContentFn, options = {}) {
         this.servers = new Map(); // safeId → MCPClient
         this.toolMap = new Map(); // prefixedName → { client, originalName }
         this.log = logFn || console.log;
         this.wrapExternalContent = wrapExternalContentFn;
         this.globalRateLimit = new RateLimiter(GLOBAL_RATE_LIMIT);
+        // BAT-514: per-server bearer-token resolution + log-redaction
+        // registration. Both come from main.js — tokenFetcher hits
+        // `POST /config/mcp-token` on the AndroidBridge; registerSecret
+        // calls security.registerRedactedSecret. Either may be null
+        // (cold-start fallback path), in which case MCPClient falls
+        // back to its inline `serverConfig.authToken`.
+        this.tokenFetcher = typeof options.tokenFetcher === 'function' ? options.tokenFetcher : null;
+        this.registerSecret = typeof options.registerSecret === 'function' ? options.registerSecret : null;
+        // BAT-514 reconcile path: when we get a /mcp/reconcile signal
+        // from Kotlin, we re-read the latest config snapshot via this
+        // provider. Without it, requestReconcile() is a no-op (the
+        // pre-BAT-514 cold-start path doesn't need it).
+        this.configsProvider = typeof options.configsProvider === 'function' ? options.configsProvider : null;
+        // Coalesce reconcile requests so a burst (Settings save + token
+        // edit + fs.watch all firing within 50ms) collapses to a
+        // single drain pass. `pendingFull` always wins over individual
+        // ids — full reconcile already covers everything.
+        this._reconcileQueue = { pendingFull: false, pendingIds: new Set() };
+        this._reconcileRunning = false;
     }
 
     /** Connect to all enabled servers. Non-fatal: logs errors and continues. */
@@ -463,7 +534,7 @@ class MCPManager {
             }
 
             try {
-                const client = new MCPClient(cfg, this.log);
+                const client = this._buildClient(cfg);
                 if (!client.safeId) {
                     this.log(`[MCP] Skipping server with missing id: ${cfg.name || '<unnamed>'}`, 'WARN');
                     results.push({ id: null, name: cfg.name, tools: 0, status: 'failed', error: 'Missing server id' });
@@ -491,6 +562,179 @@ class MCPManager {
         const total = this.getAllTools().length;
         this.log(`[MCP] Initialization complete: ${this.servers.size} servers, ${total} tools`, 'INFO');
         return results;
+    }
+
+    /**
+     * Construct an MCPClient with the manager's tokenFetcher /
+     * registerSecret options threaded through. Centralized so
+     * initializeAll, reconcile, and reconcileServer share one
+     * construction path (changes to options shape stay here).
+     */
+    _buildClient(cfg) {
+        return new MCPClient(cfg, this.log, {
+            tokenFetcher: this.tokenFetcher,
+            registerSecret: this.registerSecret,
+        });
+    }
+
+    /**
+     * Public coalesced reconcile entry point. Called from:
+     *   - control-server's `POST /mcp/reconcile` handler
+     *   - fs.watch on `mcp_servers.json` (full reconcile)
+     *
+     * `id === null` (or omitted) requests a full reconcile against
+     * the configsProvider. `id` as a string requests a force-reconnect
+     * of just that server (used after a token edit, when the file
+     * didn't change). The drain runs serially — bursts collapse.
+     */
+    requestReconcile(id) {
+        if (id === null || id === undefined) {
+            this._reconcileQueue.pendingFull = true;
+            this._reconcileQueue.pendingIds.clear();
+        } else if (typeof id === 'string' && id.length > 0) {
+            // If a full reconcile is already pending, the per-id
+            // request is moot — it'll be covered by the full pass.
+            if (!this._reconcileQueue.pendingFull) this._reconcileQueue.pendingIds.add(id);
+        } else {
+            return;
+        }
+        this._drainReconcile();
+    }
+
+    /**
+     * Serial drain. Returns immediately if a drain is already running
+     * — that drain's loop will pick up newly-pending work before
+     * exiting. The `_reconcileRunning` flag is set/cleared inside this
+     * function only, so there's no race.
+     */
+    async _drainReconcile() {
+        if (this._reconcileRunning) return;
+        this._reconcileRunning = true;
+        try {
+            while (this._reconcileQueue.pendingFull || this._reconcileQueue.pendingIds.size > 0) {
+                if (this._reconcileQueue.pendingFull) {
+                    this._reconcileQueue.pendingFull = false;
+                    this._reconcileQueue.pendingIds.clear();
+                    await this.reconcile();
+                } else {
+                    // Snapshot + clear so concurrent requestReconcile
+                    // calls during this iteration land in the next loop.
+                    const ids = Array.from(this._reconcileQueue.pendingIds);
+                    this._reconcileQueue.pendingIds.clear();
+                    for (const id of ids) {
+                        await this.reconcileServer(id);
+                    }
+                }
+            }
+        } catch (err) {
+            this.log(`[MCP] reconcile drain error: ${err.message}`, 'ERROR');
+        } finally {
+            this._reconcileRunning = false;
+        }
+    }
+
+    /**
+     * Diff current connected servers against the latest configs and
+     * reconcile: connect new, disconnect removed/disabled, reconnect
+     * URL-changed. Token-only edits aren't covered here (file didn't
+     * change → URLs equal → no reconnect); reconcileServer handles
+     * those.
+     */
+    async reconcile() {
+        if (!this.configsProvider) {
+            this.log('[MCP] reconcile() skipped: no configsProvider', 'DEBUG');
+            return;
+        }
+        let configs;
+        try {
+            configs = await Promise.resolve(this.configsProvider());
+        } catch (err) {
+            this.log(`[MCP] configsProvider threw during reconcile: ${err.message}`, 'ERROR');
+            return;
+        }
+        const desiredById = new Map();
+        for (const c of (configs || [])) {
+            if (c && typeof c.id === 'string' && c.enabled !== false) {
+                desiredById.set(c.id, c);
+            }
+        }
+        // Disconnect gone-or-now-disabled OR url-changed servers.
+        const currentIds = Array.from(this.servers.keys());
+        for (const id of currentIds) {
+            const client = this.servers.get(id);
+            const desired = desiredById.get(id);
+            if (!desired) {
+                this._disconnectAndRemove(id);
+                continue;
+            }
+            if (desired.url !== client.url) {
+                this._disconnectAndRemove(id);
+            }
+        }
+        // Connect everything in desired that isn't currently connected.
+        for (const [id, cfg] of desiredById) {
+            if (!this.servers.has(id)) {
+                await this._connectServer(cfg);
+            }
+        }
+        const total = this.getAllTools().length;
+        this.log(`[MCP] reconcile complete: ${this.servers.size} servers, ${total} tools`, 'INFO');
+    }
+
+    /**
+     * Force-reconnect a single server. Used after a token edit (file
+     * unchanged but bearer differs). Disconnects first so the next
+     * connect's `_resolveAuthToken` fetches fresh from the bridge.
+     * Silent no-op if the id isn't in the current configs (e.g. a
+     * stale signal arrived after the server was deleted).
+     */
+    async reconcileServer(id) {
+        if (!this.configsProvider) return;
+        let configs;
+        try {
+            configs = await Promise.resolve(this.configsProvider());
+        } catch (err) {
+            this.log(`[MCP] configsProvider threw during reconcileServer(${id}): ${err.message}`, 'ERROR');
+            return;
+        }
+        const desired = (configs || []).find((c) => c && c.id === id);
+        this._disconnectAndRemove(id);
+        if (desired && desired.enabled !== false) {
+            await this._connectServer(desired);
+        }
+        const total = this.getAllTools().length;
+        this.log(`[MCP] reconcileServer(${id}) complete: ${this.servers.size} servers, ${total} tools`, 'INFO');
+    }
+
+    _disconnectAndRemove(id) {
+        const client = this.servers.get(id);
+        if (!client) return;
+        try { client.disconnect(); } catch (_) { /* fire-and-forget */ }
+        for (const [key, val] of this.toolMap) {
+            if (val.client === client) this.toolMap.delete(key);
+        }
+        this.servers.delete(id);
+    }
+
+    async _connectServer(cfg) {
+        try {
+            const client = this._buildClient(cfg);
+            if (!client.safeId) {
+                this.log(`[MCP] Skipping server with missing id: ${cfg.name || '<unnamed>'}`, 'WARN');
+                return;
+            }
+            if (this.servers.has(client.safeId)) {
+                this.log(`[MCP] Duplicate server id "${client.safeId}" from ${cfg.name} — skipping`, 'WARN');
+                return;
+            }
+            await client.connect();
+            this.servers.set(client.safeId, client);
+            for (const tool of client.tools) {
+                this.toolMap.set(tool.name, { client, originalName: tool.originalName });
+            }
+        } catch (err) {
+            this.log(`[MCP] Failed to (re)connect ${cfg.name}: ${err.message}`, 'ERROR');
+        }
     }
 
     /** Get all tools from all connected servers (Claude API format). */

--- a/app/src/main/assets/nodejs-project/mcp-client.js
+++ b/app/src/main/assets/nodejs-project/mcp-client.js
@@ -713,8 +713,13 @@ class MCPManager {
      * Force-reconnect a single server. Used after a token edit (file
      * unchanged but bearer differs). Disconnects first so the next
      * connect's `_resolveAuthToken` fetches fresh from the bridge.
-     * Silent no-op if the id isn't in the current configs (e.g. a
-     * stale signal arrived after the server was deleted).
+     *
+     * Behaviour for IDs not in current configs (e.g. a stale signal
+     * arrived after the server was deleted): the disconnect runs
+     * unconditionally — it's a no-op against `this.servers` if the
+     * id was never connected, and a clean teardown if the server was
+     * just removed by an earlier full reconcile. The reconnect step
+     * is gated on `desired && desired.enabled !== false`.
      */
     async reconcileServer(id) {
         if (!this.configsProvider) return;

--- a/app/src/main/assets/nodejs-project/mcp-client.js
+++ b/app/src/main/assets/nodejs-project/mcp-client.js
@@ -203,13 +203,17 @@ class MCPClient {
      * Resolve the auth token for this server. Prefers `tokenFetcher`
      * (BAT-514 path: encrypted prefs via AndroidBridge); falls back
      * to inline `serverConfig.authToken` for cold-start config.json
-     * entries.
+     * entries OR when the bridge fetch returns empty (bridge down,
+     * unknown id, decryption failed — `fetchMcpToken` collapses all
+     * those to `""`). Treating `""` as authoritative would silently
+     * drop the inline token during a config.json-fed cold start
+     * (Copilot R3 PR #352 finding).
      */
     async _resolveAuthToken() {
         if (this.tokenFetcher) {
             try {
                 const t = await this.tokenFetcher(this.id);
-                if (typeof t === 'string') return t;
+                if (typeof t === 'string' && t.length > 0) return t;
             } catch (err) {
                 this.log(`[MCP] tokenFetcher(${this.id}) failed: ${err.message}`, 'WARN');
             }

--- a/app/src/main/assets/nodejs-project/mcp-servers.js
+++ b/app/src/main/assets/nodejs-project/mcp-servers.js
@@ -14,9 +14,10 @@
 //   { servers: [ { id, name, url, enabled, rateLimit } ] }
 //
 // `authToken` is intentionally NOT in the file. Tokens live in
-// per-id encrypted SharedPreferences on the Kotlin side keyed by
-// `mcp_token_<id>` and are fetched on every connect via the
-// AndroidBridge `POST /config/mcp-token` endpoint.
+// per-id encrypted files on the Kotlin side under
+// `filesDir/mcp_tokens/<id>` and are fetched on every connect via
+// the AndroidBridge `POST /config/mcp-token` endpoint through
+// `McpTokenStore`.
 //
 // Read drops invalid entries (defensive — manual edits / future-build
 // values shouldn't break the agent for valid entries). Write throws

--- a/app/src/main/assets/nodejs-project/mcp-servers.js
+++ b/app/src/main/assets/nodejs-project/mcp-servers.js
@@ -1,0 +1,143 @@
+// SeekerClaw — mcp-servers.js
+// Cross-process file-IPC for MCP server config (BAT-514).
+//
+// Sibling of runtime-state.js — same shape, same conventions:
+//
+//   const { open } = require('./mcp-servers');
+//   const store = open(workDir);
+//   store.read();          // → array of validated server configs
+//   store.write({...});    // throws on caller-bug invalid input
+//   store.filePath;        // → absolute path of mcp_servers.json
+//   store.validateShape(s);// per-server validity check
+//
+// The schema:
+//   { servers: [ { id, name, url, enabled, rateLimit } ] }
+//
+// `authToken` is intentionally NOT in the file. Tokens live in
+// per-id encrypted SharedPreferences on the Kotlin side keyed by
+// `mcp_token_<id>` and are fetched on every connect via the
+// AndroidBridge `POST /config/mcp-token` endpoint.
+//
+// Read drops invalid entries (defensive — manual edits / future-build
+// values shouldn't break the agent for valid entries). Write throws
+// on invalid (caller bug — Settings UI should reject before writing).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FILE_NAME = 'mcp_servers.json';
+
+// Mirror of the Kotlin McpServersStore.ID_REGEX. The Kotlin write
+// boundary already rejects anything outside this set, so by the time
+// data lands in the file it should already match. We re-validate
+// here as defense-in-depth.
+const ID_REGEX = /^[A-Za-z0-9_-]+$/;
+
+function _isObj(x) { return x != null && typeof x === 'object' && !Array.isArray(x); }
+
+/**
+ * Per-server validity. Returns null if valid, else a short reason
+ * string suitable for logging. Mirrors McpServersStore.isValid /
+ * reasonFor on the Kotlin side.
+ */
+function validateShape(s) {
+    if (!_isObj(s)) return 'not an object';
+    if (typeof s.id !== 'string' || !ID_REGEX.test(s.id)) return `id ${JSON.stringify(s.id)} fails ${ID_REGEX}`;
+    if (typeof s.name !== 'string' || !s.name.trim()) return 'name blank or non-string';
+    if (typeof s.url !== 'string' || !s.url) return 'url blank or non-string';
+    let u;
+    try { u = new URL(s.url); } catch (_) { return `url ${JSON.stringify(s.url)} unparseable`; }
+    const scheme = (u.protocol || '').toLowerCase();
+    if (scheme !== 'http:' && scheme !== 'https:') return `url scheme ${scheme} not http(s)`;
+    if (!u.hostname) return 'url missing host';
+    if (typeof s.rateLimit !== 'number' || !isFinite(s.rateLimit) || s.rateLimit <= 0) {
+        return `rateLimit ${JSON.stringify(s.rateLimit)} <= 0`;
+    }
+    if (s.enabled !== undefined && typeof s.enabled !== 'boolean') {
+        return `enabled ${JSON.stringify(s.enabled)} not boolean`;
+    }
+    return null;
+}
+
+function open(workDir) {
+    const filePath = path.join(workDir, FILE_NAME);
+
+    /**
+     * Read + validate. Returns an array (possibly empty) of valid
+     * server objects. Invalid entries are dropped with a warning sent
+     * to stderr (Node's main log goes through `log()` from config.js,
+     * but this helper deliberately doesn't require config.js — caller
+     * can re-log if needed via `validateShape`). Missing file →
+     * empty array. Malformed JSON → empty array (logged via
+     * console.warn so a corrupt file is still diagnosable).
+     */
+    function read() {
+        if (!fs.existsSync(filePath)) return [];
+        let parsed;
+        try {
+            parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        } catch (err) {
+            console.warn(`[mcp-servers] ${FILE_NAME} JSON parse failed: ${err.message}`);
+            return [];
+        }
+        if (!_isObj(parsed) || !Array.isArray(parsed.servers)) return [];
+        const seenIds = new Set();
+        const cleaned = [];
+        for (const s of parsed.servers) {
+            const reason = validateShape(s);
+            if (reason !== null) {
+                console.warn(`[mcp-servers] dropping invalid entry id=${s && s.id} reason=${reason}`);
+                continue;
+            }
+            // Drop duplicates by raw id (Kotlin's normalized-id check
+            // is stricter; Node's safeId in mcp-client.js handles
+            // collisions further downstream)
+            if (seenIds.has(s.id)) {
+                console.warn(`[mcp-servers] dropping duplicate id=${s.id}`);
+                continue;
+            }
+            seenIds.add(s.id);
+            cleaned.push({
+                id: s.id,
+                name: s.name.trim(),
+                url: s.url.trim(),
+                enabled: s.enabled !== false,
+                rateLimit: s.rateLimit,
+            });
+        }
+        return cleaned;
+    }
+
+    /**
+     * Write + validate. Throws TypeError on invalid input (caller
+     * bug — UI should reject before invoking this). On valid input,
+     * persists the file atomically (tmp + rename) so a reader
+     * never sees a half-written file.
+     */
+    function write(value) {
+        const file = _isObj(value) ? value : null;
+        if (!file || !Array.isArray(file.servers)) {
+            throw new TypeError('mcp-servers.write: expected { servers: [...] }');
+        }
+        for (const s of file.servers) {
+            const reason = validateShape(s);
+            if (reason !== null) {
+                throw new TypeError(`mcp-servers.write: invalid entry id=${s && s.id} reason=${reason}`);
+            }
+        }
+        const tmp = filePath + '.tmp';
+        fs.writeFileSync(tmp, JSON.stringify(file, null, 2));
+        fs.renameSync(tmp, filePath);
+    }
+
+    return {
+        read,
+        write,
+        filePath,
+        validateShape,
+    };
+}
+
+module.exports = { open, validateShape, ID_REGEX, FILE_NAME };

--- a/app/src/main/assets/nodejs-project/mcp-servers.js
+++ b/app/src/main/assets/nodejs-project/mcp-servers.js
@@ -53,8 +53,14 @@ function validateShape(s) {
     const scheme = (u.protocol || '').toLowerCase();
     if (scheme !== 'http:' && scheme !== 'https:') return `url scheme ${scheme} not http(s)`;
     if (!u.hostname) return 'url missing host';
-    if (typeof s.rateLimit !== 'number' || !isFinite(s.rateLimit) || s.rateLimit <= 0) {
-        return `rateLimit ${JSON.stringify(s.rateLimit)} <= 0`;
+    // Cross-language schema parity: Kotlin's McpServer.rateLimit is
+    // Int, so a fractional value (e.g. 1.5) here would fail
+    // kotlinx-serialization decode of the whole file and CrossProcessStore.read
+    // would fall back to its `initial` (effectively dropping every
+    // server until the next valid write). Require an integer to keep
+    // both sides of the contract aligned. (Copilot R19 PR #352 finding.)
+    if (typeof s.rateLimit !== 'number' || !Number.isInteger(s.rateLimit) || s.rateLimit <= 0) {
+        return `rateLimit ${JSON.stringify(s.rateLimit)} not a positive integer`;
     }
     if (s.enabled !== undefined && typeof s.enabled !== 'boolean') {
         return `enabled ${JSON.stringify(s.enabled)} not boolean`;

--- a/app/src/main/assets/nodejs-project/mcp-servers.js
+++ b/app/src/main/assets/nodejs-project/mcp-servers.js
@@ -10,6 +10,20 @@
 //   store.filePath;        // → absolute path of mcp_servers.json
 //   store.validateShape(s);// per-server validity check
 //
+// File layout (NOT under workDir — mirrors BAT-513 runtime-state.js):
+//   /data/data/com.seekerclaw.app/files/mcp_servers.json
+//
+// Why not under workDir? `CrossProcessStore.kt` rejects path separators
+// in its `fileName` parameter (basename-only validation), so the file
+// MUST sit directly under `filesDir`. SeekerClawService starts Node
+// with `workDir = filesDir/workspace`, so the matching path is
+// `path.dirname(workDir) + /mcp_servers.json`. Without this dirname
+// climb, Node would watch `workspace/mcp_servers.json` (which never
+// exists) while Kotlin writes to `filesDir/mcp_servers.json` — the
+// two sides would never converge. (Caught at device test on the first
+// MCP-add — the Kotlin write succeeded and persisted, but Node's
+// fs.watch + read pointed at the wrong directory.)
+//
 // The schema:
 //   { servers: [ { id, name, url, enabled, rateLimit } ] }
 //
@@ -69,7 +83,14 @@ function validateShape(s) {
 }
 
 function open(workDir) {
-    const filePath = path.join(workDir, FILE_NAME);
+    if (typeof workDir !== 'string' || !workDir) {
+        throw new TypeError('mcp-servers: workDir must be a non-empty string');
+    }
+    // Resolve to filesDir/mcp_servers.json — see file-layout comment
+    // at the top of this module. `path.dirname(workDir)` climbs out of
+    // `workspace/` so we end up with `filesDir/<FILE_NAME>` which
+    // matches Kotlin's CrossProcessStore writes.
+    const filePath = path.join(path.dirname(workDir), FILE_NAME);
 
     /**
      * Read + validate. Returns an array (possibly empty) of valid

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -75,11 +75,11 @@ function rebuildRedactPatterns() {
     }
     // BAT-514: MCP server auth tokens are no longer iterated at
     // startup — tokens aren't in `MCP_SERVERS` post-migration (they
-    // live in per-id encrypted SharedPreferences and are fetched on
-    // demand by `MCPClient.connect`). Each fetched token registers
-    // itself via `registerRedactedSecret(...)` BEFORE the bearer
-    // header is attached or any connect log fires; see
-    // `mcp-client.js` connect().
+    // live in encrypted per-id files under `filesDir/mcp_tokens/<id>`
+    // and are fetched on demand by `MCPClient.connect`). Each fetched
+    // token registers itself via `registerRedactedSecret(...)`
+    // BEFORE the bearer header is attached or any connect log fires;
+    // see `mcp-client.js` connect().
     _dynamicPatterns = patterns;
 }
 

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -4,7 +4,7 @@
 
 const path = require('path');
 
-const { BRIDGE_TOKEN, config, MCP_SERVERS, log, workDir } = require('./config');
+const { BRIDGE_TOKEN, config, log, workDir } = require('./config');
 
 // ============================================================================
 // SECRET REDACTION
@@ -73,12 +73,13 @@ function rebuildRedactPatterns() {
             patterns.push({ rx: new RegExp(_escRx(config[key]), 'g'), replacement: `[REDACTED:${key}]` });
         }
     }
-    // MCP server auth tokens (literal match per server)
-    for (const server of MCP_SERVERS) {
-        if (server.authToken && server.authToken.length >= 8) {
-            patterns.push({ rx: new RegExp(_escRx(server.authToken), 'g'), replacement: '[REDACTED:mcp-token]' });
-        }
-    }
+    // BAT-514: MCP server auth tokens are no longer iterated at
+    // startup — tokens aren't in `MCP_SERVERS` post-migration (they
+    // live in per-id encrypted SharedPreferences and are fetched on
+    // demand by `MCPClient.connect`). Each fetched token registers
+    // itself via `registerRedactedSecret(...)` BEFORE the bearer
+    // header is attached or any connect log fires; see
+    // `mcp-client.js` connect().
     _dynamicPatterns = patterns;
 }
 

--- a/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
+++ b/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
@@ -70,7 +70,7 @@ class SeekerClawApplication : Application() {
             // before any UI screen reads it. Mirrors RuntimeStateStore.init
             // — main process only (`:node` reads the same file directly
             // via mcp-servers.js). On first launch, splits legacy
-            // `KEY_MCP_SERVERS_ENC` tokens into per-id encrypted prefs
+            // `KEY_MCP_SERVERS_ENC` tokens into per-id encrypted files
             // and seeds the file. Sweeps orphan tokens after.
             McpServersStore.init(this)
             registerConfigChangedReceiver()

--- a/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
+++ b/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.content.ContextCompat
 import com.seekerclaw.app.config.ConfigManager
+import com.seekerclaw.app.state.McpServersStore
 import com.seekerclaw.app.state.RuntimeStateStore
 import com.seekerclaw.app.util.Analytics
 import com.seekerclaw.app.util.LogCollector
@@ -65,6 +66,13 @@ class SeekerClawApplication : Application() {
             // process and reads the same file directly via
             // runtime-state.js.
             RuntimeStateStore.init(this)
+            // BAT-514: own the MCP server config (`mcp_servers.json`)
+            // before any UI screen reads it. Mirrors RuntimeStateStore.init
+            // — main process only (`:node` reads the same file directly
+            // via mcp-servers.js). On first launch, splits legacy
+            // `KEY_MCP_SERVERS_ENC` tokens into per-id encrypted prefs
+            // and seeds the file. Sweeps orphan tokens after.
+            McpServersStore.init(this)
             registerConfigChangedReceiver()
         }
     }

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -229,8 +229,9 @@ class AndroidBridge(
 
     /**
      * Returns the decrypted bearer token for the requested MCP server
-     * id, sourced from per-id encrypted SharedPreferences
-     * (`mcp_token_<id>`). Called by `MCPClient.connect` in `:node` once
+     * id, sourced from per-id encrypted file storage
+     * (`filesDir/mcp_tokens/<id>`, AES-GCM via `KeystoreHelper`).
+     * Called by `MCPClient.connect` in `:node` once
      * per connect attempt — the token never persists in `MCP_SERVERS`
      * post-BAT-514, so the bridge fetch is the only path.
      *

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -47,6 +47,11 @@ class AndroidBridge(
     companion object {
         private const val TAG = "AndroidBridge"
         private const val AUTH_HEADER = "X-Bridge-Token"
+        // BAT-514: MCP server id format mirrors McpServersStore.ID_REGEX.
+        // Validated at the bridge boundary so a malformed id can't slip
+        // into McpTokenStore.read() (which is otherwise process-agnostic
+        // and trusts its caller).
+        private val MCP_TOKEN_ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
         // Delay between returning HTTP 200 and stopping the service — gives the
         // Node caller (and its Telegram reply) time to flush.
         private const val RESTART_DELAY_MS = 500L
@@ -74,6 +79,10 @@ class AndroidBridge(
         // a misbehaving Node caller can't spin it. 10/min is ample for
         // normal /provider interactive use.
         "/config/credentials" to Pair(10, 60_000L),
+        // BAT-514: /config/mcp-token can fire once per MCP server per
+        // connect; 30/min covers a 10-server install with reconcile
+        // bursts during Settings edits without throttling normal use.
+        "/config/mcp-token" to Pair(30, 60_000L),
         "/service/restart" to Pair(3, 60_000L),
     )
 
@@ -162,6 +171,7 @@ class AndroidBridge(
                 "/config/save-owner" -> handleConfigSaveOwner(params)
                 "/openai/oauth/save-tokens" -> handleOpenAIOAuthSaveTokens(params)
                 "/config/credentials" -> handleConfigCredentials()
+                "/config/mcp-token" -> handleConfigMcpToken(params)
                 "/service/restart" -> handleServiceRestart()
                 "/stats/db-summary" -> proxyToNodeStats()
                 "/ping" -> jsonResponse(200, mapOf("status" to "ok", "bridge" to "AndroidBridge"))
@@ -213,6 +223,41 @@ class AndroidBridge(
             "customBaseUrl" to if (config.customBaseUrl.isNotBlank()) placeholder else "",
         )
         return jsonResponse(200, mapOf("ok" to true, "credentials" to creds))
+    }
+
+    // ==================== MCP token fetch (BAT-514) ====================
+
+    /**
+     * Returns the decrypted bearer token for the requested MCP server
+     * id, sourced from per-id encrypted SharedPreferences
+     * (`mcp_token_<id>`). Called by `MCPClient.connect` in `:node` once
+     * per connect attempt — the token never persists in `MCP_SERVERS`
+     * post-BAT-514, so the bridge fetch is the only path.
+     *
+     * Security:
+     *  - Bridge-token auth on the outer hop (already enforced by
+     *    [serve]).
+     *  - Body validates `id` as `^[A-Za-z0-9_-]+$` so a hostile caller
+     *    can't probe arbitrary prefs keys via this endpoint.
+     *  - Returns `{ token: "" }` for unknown ids and decryption
+     *    failures — the caller can't distinguish "no token" from
+     *    "decrypt failed", which is the same defensive behavior as
+     *    `McpTokenStore.read`.
+     */
+    private fun handleConfigMcpToken(params: JSONObject): Response {
+        val id = params.optString("id", "").trim()
+        if (id.isEmpty() || !MCP_TOKEN_ID_REGEX.matches(id)) {
+            return jsonResponse(400, mapOf("error" to "invalid id"))
+        }
+        return try {
+            val token = com.seekerclaw.app.state.McpTokenStore.read(context, id)
+            jsonResponse(200, mapOf("token" to token))
+        } catch (e: Exception) {
+            // Don't leak the failure mode to the caller — same shape
+            // as the token-not-found response.
+            Log.w(TAG, "[Bridge] /config/mcp-token failed for id=$id: ${e.message}")
+            jsonResponse(200, mapOf("token" to ""))
+        }
     }
 
     // ==================== Service restart ====================

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -239,7 +239,9 @@ class AndroidBridge(
      *  - Bridge-token auth on the outer hop (already enforced by
      *    [serve]).
      *  - Body validates `id` as `^[A-Za-z0-9_-]+$` so a hostile caller
-     *    can't probe arbitrary prefs keys via this endpoint.
+     *    can't use path traversal or crafted names to probe arbitrary
+     *    files via this endpoint; access is constrained to the
+     *    intended per-id token files under `filesDir/mcp_tokens/`.
      *  - Returns `{ token: "" }` for unknown ids and decryption
      *    failures — the caller can't distinguish "no token" from
      *    "decrypt failed", which is the same defensive behavior as

--- a/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/AndroidBridge.kt
@@ -48,9 +48,12 @@ class AndroidBridge(
         private const val TAG = "AndroidBridge"
         private const val AUTH_HEADER = "X-Bridge-Token"
         // BAT-514: MCP server id format mirrors McpServersStore.ID_REGEX.
-        // Validated at the bridge boundary so a malformed id can't slip
-        // into McpTokenStore.read() (which is otherwise process-agnostic
-        // and trusts its caller).
+        // Validated at the bridge boundary as defense-in-depth /
+        // early reject — McpTokenStore.read() also runs its own
+        // ID_REGEX check before constructing the file path, so the
+        // bridge check is the outer rail (rejects malformed JSON-RPC
+        // input with HTTP 400 + a clean log) rather than a unique
+        // safety boundary.
         private val MCP_TOKEN_ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
         // Delay between returning HTTP 200 and stopping the service — gives the
         // Node caller (and its Telegram reply) time to flush.

--- a/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/NodeControlClient.kt
@@ -1,0 +1,104 @@
+package com.seekerclaw.app.bridge
+
+import android.util.Log
+import com.seekerclaw.app.util.ServiceState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Main-process HTTP client for the Node-side internal control server
+ * (`internal-control-server.js`, port 8766) introduced in BAT-514.
+ *
+ * The reverse direction of [com.seekerclaw.app.bridge.AndroidBridge]:
+ * AndroidBridge runs in `:node` and accepts requests from JS callers;
+ * this client lives in main and POSTs to `:node` after Settings writes
+ * land. Both ends use the same per-boot `BRIDGE_TOKEN` (read from the
+ * `bridge_token` file via [ServiceState]) for auth.
+ *
+ * ## Bridge-down behaviour
+ *
+ * If the service isn't running (port not bound, connect-refused,
+ * timeout), [reconcile] / [healthz] return `false` — they NEVER throw.
+ * The caller (typically [com.seekerclaw.app.state.McpServersStore])
+ * already persisted the file write, so a missed reconcile signal is
+ * NOT a failure mode the user should see: the next service start reads
+ * `mcp_servers.json` fresh and reconciles.
+ *
+ * ## Auth token resolution
+ *
+ * [ServiceState.bridgeToken] is hydrated by the BAT-518 file-observer
+ * pattern. If it's null at call time (service has never started this
+ * boot), this client returns `false` immediately without making a
+ * request — there's no auth token to send and the server isn't
+ * listening anyway.
+ */
+object NodeControlClient {
+    private const val TAG = "NodeControlClient"
+    private const val BASE_URL = "http://127.0.0.1:8766"
+    private const val AUTH_HEADER = "X-Bridge-Token"
+    private const val CONNECT_TIMEOUT_MS = 1500
+    private const val READ_TIMEOUT_MS = 1500
+
+    /**
+     * Tell the `:node` MCP manager to reconcile the active server set.
+     * Pass [id] = `null` for a full-list reconcile (after bulk add /
+     * remove / enable-toggle), or a specific server id when the change
+     * is scoped to one entry (e.g. token edit).
+     *
+     * Returns `true` on a 2xx response. Returns `false` on any
+     * transport / auth / status failure — caller treats that as
+     * best-effort, not fatal.
+     */
+    suspend fun reconcile(id: String? = null): Boolean = withContext(Dispatchers.IO) {
+        val body = JSONObject().apply {
+            if (id != null) put("id", id)
+        }.toString()
+        post("/mcp/reconcile", body)
+    }
+
+    /** Best-effort liveness probe (`POST /healthz`). Mirrors [reconcile]'s failure shape. */
+    suspend fun healthz(): Boolean = withContext(Dispatchers.IO) {
+        post("/healthz", "{}")
+    }
+
+    private fun post(path: String, body: String): Boolean {
+        val token = ServiceState.bridgeToken
+        if (token.isNullOrBlank()) {
+            // No bridge token = service has never started this boot,
+            // so the control server isn't listening either. Skip the
+            // round-trip and the noisy connect-refused log.
+            return false
+        }
+        var conn: HttpURLConnection? = null
+        return try {
+            val url = URL(BASE_URL + path)
+            conn = (url.openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                doOutput = true
+                setRequestProperty("Content-Type", "application/json")
+                setRequestProperty(AUTH_HEADER, token)
+            }
+            conn.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+            val code = conn.responseCode
+            // Drain the response stream so the underlying socket can
+            // be returned to the keep-alive pool cleanly.
+            (if (code in 200..299) conn.inputStream else conn.errorStream)
+                ?.use { it.readBytes() }
+            code in 200..299
+        } catch (e: Exception) {
+            // Bridge-down, connect-refused, timeout — all the same as
+            // far as caller is concerned. Log at DEBUG via Android
+            // Log.d so it doesn't pollute LogCollector when the user
+            // edits a server while the service is stopped.
+            Log.d(TAG, "POST $path failed: ${e.javaClass.simpleName}: ${e.message}")
+            false
+        } finally {
+            conn?.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -1665,25 +1665,14 @@ object ConfigManager {
 
     // ==================== MCP Servers ====================
 
-    fun saveMcpServers(context: Context, servers: List<McpServerConfig>) {
-        val json = JSONArray().apply {
-            for (s in servers) {
-                put(JSONObject().apply {
-                    put("id", s.id)
-                    put("name", s.name)
-                    put("url", s.url)
-                    put("authToken", s.authToken)
-                    put("enabled", s.enabled)
-                    put("rateLimit", s.rateLimit)
-                })
-            }
-        }.toString()
-        val enc = KeystoreHelper.encrypt(json)
-        prefs(context).edit()
-            .putString(KEY_MCP_SERVERS_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
-            .apply()
-        bumpConfigVersionOnMain()
-    }
+    // BAT-514: `saveMcpServers` was deleted. Settings UI writes go
+    // through [com.seekerclaw.app.state.McpServersStore.write] /
+    // [com.seekerclaw.app.state.McpServersStore.setAuthToken] now.
+    // Rollback-shadow writes (`KEY_MCP_SERVERS_ENC` with tokens
+    // inline) are owned by McpServersStore — see its
+    // `rebuildRollbackShadow`. `loadMcpServers` below is kept because
+    // it's still the read path for cold-start fallback (config.json
+    // regeneration, SettingsScreen count, McpServersStore migration).
 
     fun loadMcpServers(context: Context): List<McpServerConfig> {
         return try {

--- a/app/src/main/java/com/seekerclaw/app/state/McpServer.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServer.kt
@@ -6,13 +6,13 @@ import kotlinx.serialization.Serializable
  * Single MCP (Model Context Protocol) server config entry persisted in
  * `mcp_servers.json` (BAT-514).
  *
- * `authToken` is intentionally NOT a field on this type — tokens live in
- * per-id encrypted SharedPreferences keyed by `mcp_token_<id>` and are
- * fetched on connect by the Node side via the AndroidBridge
- * `/config/mcp-token` endpoint. Splitting credentials from the file-IPC
- * payload keeps `mcp_servers.json` plaintext-safe (the legacy
- * `KEY_MCP_SERVERS_ENC` rollback shadow stays the home for tokens
- * during downgrade — see [McpServersStore]).
+ * `authToken` is intentionally NOT a field on this type — tokens live
+ * in per-id encrypted files at `filesDir/mcp_tokens/<id>` (AES-GCM via
+ * KeystoreHelper) and are fetched on connect by the Node side via the
+ * AndroidBridge `/config/mcp-token` endpoint. Splitting credentials
+ * from the file-IPC payload keeps `mcp_servers.json` plaintext-safe
+ * (the legacy `KEY_MCP_SERVERS_ENC` rollback shadow stays the home
+ * for tokens during downgrade — see [McpServersStore]).
  */
 @Serializable
 data class McpServer(

--- a/app/src/main/java/com/seekerclaw/app/state/McpServer.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServer.kt
@@ -1,0 +1,35 @@
+package com.seekerclaw.app.state
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Single MCP (Model Context Protocol) server config entry persisted in
+ * `mcp_servers.json` (BAT-514).
+ *
+ * `authToken` is intentionally NOT a field on this type — tokens live in
+ * per-id encrypted SharedPreferences keyed by `mcp_token_<id>` and are
+ * fetched on connect by the Node side via the AndroidBridge
+ * `/config/mcp-token` endpoint. Splitting credentials from the file-IPC
+ * payload keeps `mcp_servers.json` plaintext-safe (the legacy
+ * `KEY_MCP_SERVERS_ENC` rollback shadow stays the home for tokens
+ * during downgrade — see [McpServersStore]).
+ */
+@Serializable
+data class McpServer(
+    val id: String,
+    val name: String,
+    val url: String,
+    val enabled: Boolean = true,
+    val rateLimit: Int = 10,
+)
+
+/**
+ * Top-level shape persisted in `mcp_servers.json`. Wrapping the list in
+ * an object (rather than serializing a bare `List<McpServer>`) gives
+ * us a place to add file-level fields later without breaking parse
+ * compatibility.
+ */
+@Serializable
+data class McpServersFile(
+    val servers: List<McpServer> = emptyList(),
+)

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -78,11 +78,13 @@ object McpServersStore {
 
     /**
      * MCP server `id` must match this regex AND be unique after
-     * `safeId` normalization (the Node side replaces `[^A-Za-z0-9_]`
-     * with `_`, so `server-1` and `server_1` would collide). The
-     * regex itself doesn't allow `-` to be replaced — it allows `-`
-     * intentionally — but `safeId` normalization is a stricter check
-     * that catches collisions if the regex is ever loosened.
+     * `safeId` normalization (the Node side replaces
+     * `[^A-Za-z0-9_-]` with `_`, so `-` is preserved). Because the
+     * regex's allowed alphabet is exactly the set Node's `safeId`
+     * leaves untouched, the post-normalization uniqueness check is
+     * identity for any in-spec id — kept as defense-in-depth in case
+     * the regex is ever loosened to allow characters Node would fold
+     * (e.g. `.`, which `safeId` would map to `_`).
      */
     private val ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
 
@@ -152,22 +154,50 @@ object McpServersStore {
             // Step 2: migration write (one-shot if file is absent).
             val file = File(app.filesDir, FILE_NAME)
             if (!file.exists()) {
-                // Encrypt every legacy token into per-id prefs FIRST,
-                // so a crash after the file write but before this
-                // loop doesn't lose tokens.
+                // Encrypt every legacy token into per-id prefs FIRST.
+                // If ANY token write fails (Keystore error, prefs
+                // commit failure), abort migration: don't seed the
+                // file, don't rebuild the rollback shadow. Reasoning:
+                //   - The legacy KEY_MCP_SERVERS_ENC blob is still
+                //     intact and contains the tokens. Pre-BAT-514
+                //     code (and this build's `loadMcpServers`) can
+                //     still read it.
+                //   - If we proceeded, `rebuildRollbackShadow` would
+                //     read `""` for the failed entry from
+                //     `McpTokenStore.read` and overwrite
+                //     `KEY_MCP_SERVERS_ENC` with a tokenless copy —
+                //     silently losing the token on downgrade AND
+                //     breaking next-launch's Node-side connect.
+                //   - Aborting leaves `mcp_servers.json` absent, so
+                //     next launch retries the whole migration.
+                var allTokensOk = true
                 for (s in legacy) {
                     if (s.authToken.isNotBlank()) {
-                        McpTokenStore.write(app, s.id, s.authToken)
+                        if (!McpTokenStore.write(app, s.id, s.authToken)) {
+                            allTokensOk = false
+                            Log.w(
+                                TAG,
+                                "Migration token write failed for id=${s.id}; " +
+                                    "aborting migration to keep KEY_MCP_SERVERS_ENC intact",
+                            )
+                        }
                     }
                 }
-                if (!cps.write(McpServersFile(servers = seeded))) {
-                    Log.w(
-                        TAG,
-                        "first-launch migration write to $FILE_NAME failed — " +
-                            "in-memory state retained; next save retries the file write",
-                    )
+                if (allTokensOk) {
+                    if (cps.write(McpServersFile(servers = seeded))) {
+                        rebuildRollbackShadow(app, seeded)
+                    } else {
+                        Log.w(
+                            TAG,
+                            "first-launch migration write to $FILE_NAME failed — " +
+                                "in-memory state retained; next save retries the file write",
+                        )
+                    }
                 }
-                rebuildRollbackShadow(app, seeded)
+                // If allTokensOk is false: file is NOT seeded, shadow
+                // is NOT rebuilt. KEY_MCP_SERVERS_ENC stays as the
+                // legacy source, _state has the in-memory view, and
+                // the next launch retries the whole migration.
             }
 
             // Step 3: orphan token sweep.
@@ -333,7 +363,18 @@ object McpServersStore {
      */
     fun setAuthToken(context: Context, id: String, token: String): Boolean {
         if (!isInitialized) return false
-        val server = _state.value.firstOrNull { it.id == id }
+        val s = store ?: return false
+        // Read from disk, not `_state.value`. The collector observes
+        // file changes asynchronously, so `_state.value` may still
+        // reflect the prior list for a few coroutine ticks after a
+        // just-successful `write()`. The McpConfigScreen Save flow
+        // does write() then setAuthToken() back-to-back for new
+        // servers — validating against the lagging `_state.value`
+        // would make that flow flake with "unknown server id".
+        // `s.read()` parses the on-disk file synchronously
+        // (CrossProcessStore.write uses atomic move, so the read is
+        // never half-written). (Copilot R2 PR #352 finding.)
+        val server = s.read().servers.firstOrNull { it.id == id }
         if (server == null) {
             Log.w(TAG, "setAuthToken rejected: unknown server id=$id")
             return false

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
@@ -133,11 +134,19 @@ object McpServersStore {
         appContext = app
 
         // Step 1: seed _state from prefs (last-valid pre-BAT-514 view).
+        // Run the raw legacy list through `onObserved` so it gets the
+        // SAME treatment file-observed content does: invalid entries
+        // dropped, name/url trimmed, duplicates collapsed by id.
+        // Without this pass, a corrupt legacy KEY_MCP_SERVERS_ENC
+        // (e.g. duplicate ids from a buggy old write path, or
+        // whitespace-padded URLs from a manual edit) would briefly
+        // publish to `_state` AND get persisted into the migrated
+        // file. The collector eventually re-cleans on its first
+        // emission — but only AFTER the migration write already
+        // landed on disk. Copilot R6/R7 PR #352 finding.
         val legacy = ConfigManager.loadMcpServers(app)
-        val seeded = legacy
-            .map { it.toMcpServer() }
-            .filter { isValid(it) }
-        _state.value = seeded
+        val rawSeed = legacy.map { it.toMcpServer() }
+        val seeded = onObserved(McpServersFile(servers = rawSeed))
 
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         ownedScope = scope
@@ -443,9 +452,17 @@ object McpServersStore {
     }
 
     private fun isValidUrl(raw: String): Boolean {
-        if (raw.isBlank()) return false
+        // Trim before parse so whitespace-padded URLs from observed
+        // file content (manual edit, or a Node-side pre-trim quirk)
+        // don't get rejected here while Node's mcp-servers.js read()
+        // accepts and normalizes them. `onObserved` separately trims
+        // the stored value into _state so the cross-language behavior
+        // is symmetric: both sides accept whitespace AND both sides
+        // strip it before storage. Copilot R6/R7 PR #352 finding.
+        val trimmed = raw.trim()
+        if (trimmed.isBlank()) return false
         return try {
-            val u = URL(raw)
+            val u = URL(trimmed)
             val scheme = u.protocol?.lowercase()
             val host = u.host?.lowercase()
             (scheme == "http" || scheme == "https") && !host.isNullOrBlank()
@@ -521,15 +538,23 @@ object McpServersStore {
     }
 
     /**
-     * Pure helper: drop invalid entries with a WARN log, drop
-     * duplicates after `safeId` normalization (keep first), publish
-     * the cleaned list to [_state]. Returns the cleaned list so
-     * callers can decide whether to fire side effects.
+     * Pure helper: trim name + url, drop invalid entries with a WARN
+     * log, drop duplicates after `safeId` normalization (keep first),
+     * publish the cleaned list to [_state]. Returns the cleaned list
+     * so callers can decide whether to fire side effects.
+     *
+     * Trimming mirrors Node's `mcp-servers.js read()` so the two
+     * sides agree on the canonical stored shape; otherwise a
+     * whitespace-padded value (manual file edit, copy-paste with a
+     * trailing space) would be accepted by Node's tolerant parse but
+     * stored verbatim by Kotlin and produce cross-language drift on
+     * downstream comparisons.
      */
     internal fun onObserved(observed: McpServersFile): List<McpServer> {
         val cleaned = mutableListOf<McpServer>()
         val seen = mutableSetOf<String>()
-        for (s in observed.servers) {
+        for (raw in observed.servers) {
+            val s = raw.copy(name = raw.name.trim(), url = raw.url.trim())
             if (!isValid(s)) {
                 Log.w(TAG, "dropped corrupt entry id=${s.id} reason=${reasonFor(s)}")
                 continue

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -385,11 +385,23 @@ object McpServersStore {
         // Side effects after successful persist (kept out of the
         // CrossProcessStore lock per BAT-513 round-18 pattern).
         // `preIds` was captured inside the transform under the lock,
-        // so the diff is accurate even if another writer landed
-        // between transform-entry and now.
+        // so the diff against `nextIds` is accurate at the moment
+        // the persist landed. Re-read fresh before the actual
+        // clear() to defend against a concurrent update that
+        // re-added the same id between our lock release and now —
+        // very rare in practice (BAT-514 ids are UUIDs that don't
+        // collide with deleted ones), but the contract claim is
+        // atomic RMW and the defensive check is cheap. (Copilot
+        // R18 PR #352 finding.)
         val nextIds = list.map { it.id }.toSet()
-        for (id in preIds - nextIds) {
-            McpTokenStore.clear(app, id)
+        val removedIds = preIds - nextIds
+        if (removedIds.isNotEmpty()) {
+            val latestIds = s.read().servers.map { it.id }.toSet()
+            for (id in removedIds) {
+                if (id !in latestIds) {
+                    McpTokenStore.clear(app, id)
+                }
+            }
         }
         rebuildRollbackShadow(app, list)
         ownedScope?.launch { NodeControlClient.reconcile(null) }
@@ -455,10 +467,20 @@ object McpServersStore {
         // Side effects (post-write, outside the lock — same pattern
         // as [write]). preIds + next are both captured inside the
         // transform, so the diff is consistent with what we just
-        // persisted.
+        // persisted. The `latestIds` re-read (mirrors the [write]
+        // path's defense) skips a clear if a concurrent update
+        // re-added the same id between our lock release and now —
+        // see [write]'s rationale comment. (Copilot R18 PR #352
+        // finding.)
         val nextIds = next.map { it.id }.toSet()
-        for (id in preIds - nextIds) {
-            McpTokenStore.clear(app, id)
+        val removedIds = preIds - nextIds
+        if (removedIds.isNotEmpty()) {
+            val latestIds = s.read().servers.map { it.id }.toSet()
+            for (id in removedIds) {
+                if (id !in latestIds) {
+                    McpTokenStore.clear(app, id)
+                }
+            }
         }
         rebuildRollbackShadow(app, next)
         ownedScope?.launch { NodeControlClient.reconcile(null) }

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -167,7 +167,8 @@ object McpServersStore {
             // Step 2: migration write (one-shot if file is absent).
             val file = File(app.filesDir, FILE_NAME)
             if (!file.exists()) {
-                // Encrypt every legacy token into per-id prefs FIRST.
+                // Encrypt every legacy token into per-id token files
+                // (`filesDir/mcp_tokens/<id>`) FIRST.
                 // If ANY token write fails (Keystore error, prefs
                 // commit failure), abort migration: don't seed the
                 // file, don't rebuild the rollback shadow. Reasoning:
@@ -336,6 +337,24 @@ object McpServersStore {
         // mirrors the disk write to `_state` runs on its own coroutine
         // and may not have observed the new value yet (Copilot R1
         // PR #352 finding).
+        // Pre-validate the insecure-token combination OUTSIDE the
+        // CrossProcessStore.update writeLock. `hasInsecureToken` does
+        // file I/O + Keystore decrypt (via McpTokenStore.read), which
+        // would block other writers/observers if held inside the
+        // synchronized block (Copilot R11 PR #352 finding). Race
+        // window: if a concurrent setAuthToken changes a server's
+        // token between this check and the lock acquisition, the
+        // resulting state could violate the http+token gate — but
+        // MCPClient.connect's `_checkUrlSafety` is the actual
+        // security boundary (it refuses to send tokens over plain
+        // non-loopback HTTP at request time), so the store-level
+        // check is defense-in-depth, not a hard guarantee.
+        val initialNext = transform(s.read().servers).toList()
+        if (initialNext.any { hasInsecureToken(app, it) }) {
+            Log.w(TAG, "update rejected: server has token over insecure HTTP")
+            return false
+        }
+
         var pre: List<McpServer> = emptyList()
         var next: List<McpServer> = emptyList()
         // CrossProcessStore.update does NOT catch transform exceptions
@@ -353,16 +372,15 @@ object McpServersStore {
                 }
                 // Duplicate-id check inside the transform so the lock
                 // covers it too (a concurrent write that produced the
-                // duplicate can't slip through).
+                // duplicate can't slip through). Cheap and pure
+                // (no I/O), as required by CrossProcessStore.update's
+                // "transforms must be cheap and pure" rule.
                 val seen = mutableSetOf<String>()
                 for (entry in computed) {
                     val n = normalizeId(entry.id)
                     require(seen.add(n)) {
                         "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
                     }
-                }
-                require(computed.none { hasInsecureToken(app, it) }) {
-                    "Server has token over insecure HTTP"
                 }
                 next = computed
                 McpServersFile(servers = computed)
@@ -647,10 +665,19 @@ object McpServersStore {
             // the synchronous wait is benign. Mirrors McpTokenStore
             // which uses commit() for the same reason. (Copilot R8
             // PR #352 finding.)
-            context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            // Surface a commit() failure: the rollback shadow is
+            // explicitly part of the downgrade-durability contract,
+            // so a silent failure here would defeat that guarantee
+            // for the user without any diagnostic trail. (Copilot
+            // R11 PR #352 finding.)
+            val committed = context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 .edit()
                 .putString(KEY_MCP_SERVERS_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
                 .commit()
+            if (!committed) {
+                Log.w(TAG, "rebuildRollbackShadow commit failed; downgrade shadow not durably persisted")
+            }
         } catch (e: Exception) {
             Log.w(TAG, "rebuildRollbackShadow failed: ${e.message}")
         }

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -32,14 +32,18 @@ import java.util.concurrent.atomic.AtomicBoolean
  * UI-safe StateFlow, AND token I/O wrappers that delegate to the
  * stateless [McpTokenStore].
  *
- * ## Field split (file vs. encrypted prefs)
+ * ## Field split (file vs. encrypted-token files)
  *
  *  - **File:** id, name, url, enabled, rateLimit. Plaintext JSON, safe
  *    for cross-process file IPC.
- *  - **Encrypted prefs:** authToken per server, keyed by `mcp_token_<id>`.
- *    Lives in `seekerclaw_prefs` via [KeystoreHelper] AES-GCM. Read on
- *    every connect by the Node side via AndroidBridge
- *    `POST /config/mcp-token`.
+ *  - **Encrypted token files:** authToken per server in
+ *    `filesDir/mcp_tokens/<id>`. Encrypted via [KeystoreHelper]
+ *    AES-GCM. Read on every connect by the Node side via
+ *    AndroidBridge `POST /config/mcp-token`. Backing storage is
+ *    file-per-token so cross-process token edits propagate live —
+ *    SharedPreferences would have a per-process cache that
+ *    invalidates the BAT-514 live-edit contract (see
+ *    [McpTokenStore]'s class doc).
  *
  * Tokens DO get reattached when reconstructing the legacy
  * `KEY_MCP_SERVERS_ENC` rollback shadow (BAT-514 v2 §2): pre-BAT-514
@@ -121,11 +125,11 @@ object McpServersStore {
      *     tokens; on fresh install, it's empty.
      *  2. If `mcp_servers.json` is missing AND prefs has servers:
      *     migrate. Split each entry → encrypt token to
-     *     `mcp_token_<id>`, drop authToken from in-memory list,
+     *     `mcp_tokens/<id>` (encrypted file), drop authToken from in-memory list,
      *     write cleaned list to file. Rebuild rollback shadow with
      *     tokens reattached.
-     *  3. Sweep orphan tokens: any `mcp_token_*` key whose id isn't
-     *     in the current server list is cleared.
+     *  3. Sweep orphan tokens: any `mcp_tokens/<id>` file whose id
+     *     isn't in the current server list is cleared.
      *  4. Start the observe-and-mirror collector.
      */
     fun init(context: Context) {
@@ -215,7 +219,7 @@ object McpServersStore {
             // diverge from `mcp_servers.json` until the collector's
             // first emission lands. If it did diverge (e.g. a `:node`
             // write modified the file under us), sweeping by the
-            // prefs view would clear `mcp_token_<id>` entries for
+            // prefs view would clear `mcp_tokens/<id>` files for
             // servers that ARE in the file. Copilot R3 PR #352
             // finding.
             sweepOrphanTokens(app, cps.read().servers)
@@ -334,28 +338,38 @@ object McpServersStore {
         // PR #352 finding).
         var pre: List<McpServer> = emptyList()
         var next: List<McpServer> = emptyList()
-        val applied = s.update { current ->
-            pre = current.servers
-            val computed = transform(current.servers).toList()
-            require(computed.all { isValid(it) }) {
-                val bad = computed.firstOrNull { !isValid(it) }
-                "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
-            }
-            // Duplicate-id check inside the transform so the lock
-            // covers it too (a concurrent write that produced the
-            // duplicate can't slip through).
-            val seen = mutableSetOf<String>()
-            for (entry in computed) {
-                val n = normalizeId(entry.id)
-                require(seen.add(n)) {
-                    "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
+        // CrossProcessStore.update does NOT catch transform exceptions
+        // — a `require(...)` that fails inside the transform throws out
+        // of `s.update` and would crash the calling coroutine. Wrap
+        // the call so validation failures surface as the documented
+        // `false` return instead. (Copilot R10 PR #352 finding.)
+        val applied = try {
+            s.update { current ->
+                pre = current.servers
+                val computed = transform(current.servers).toList()
+                require(computed.all { isValid(it) }) {
+                    val bad = computed.firstOrNull { !isValid(it) }
+                    "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
                 }
+                // Duplicate-id check inside the transform so the lock
+                // covers it too (a concurrent write that produced the
+                // duplicate can't slip through).
+                val seen = mutableSetOf<String>()
+                for (entry in computed) {
+                    val n = normalizeId(entry.id)
+                    require(seen.add(n)) {
+                        "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
+                    }
+                }
+                require(computed.none { hasInsecureToken(app, it) }) {
+                    "Server has token over insecure HTTP"
+                }
+                next = computed
+                McpServersFile(servers = computed)
             }
-            require(computed.none { hasInsecureToken(app, it) }) {
-                "Server has token over insecure HTTP"
-            }
-            next = computed
-            McpServersFile(servers = computed)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "update rejected: ${e.message}")
+            false
         }
         if (applied) {
             val nextIds = next.map { it.id }.toSet()
@@ -369,7 +383,8 @@ object McpServersStore {
     }
 
     /**
-     * Persist [token] for [id] (encrypted prefs) and trigger reconcile.
+     * Persist [token] for [id] (encrypted file at `mcp_tokens/<id>`)
+     * and trigger reconcile.
      *
      * Returns `false` if [init] wasn't called, [id] doesn't match a
      * server in the list (token-without-server is meaningless), the
@@ -481,12 +496,21 @@ object McpServersStore {
      * AND connect time.
      */
     private fun isUrlSafeForToken(raw: String): Boolean {
-        if (!isValidUrl(raw)) return false
-        val u = URL(raw)
-        val scheme = u.protocol.lowercase()
-        if (scheme == "https") return true
-        val host = u.host.lowercase()
-        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+        // `isValidUrl` trims internally before parse, so a
+        // whitespace-padded URL can pass it but `URL(raw)` here would
+        // throw on the same input. Trim + try/catch defensively to
+        // keep this predicate from killing callers on what is
+        // logically a valid URL. (Copilot R10 PR #352 finding.)
+        val trimmed = raw.trim()
+        return try {
+            val u = URL(trimmed)
+            val scheme = u.protocol.lowercase()
+            if (scheme == "https") return true
+            val host = u.host.lowercase()
+            host == "localhost" || host == "127.0.0.1" || host == "::1"
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun hasInsecureToken(context: Context, server: McpServer): Boolean {
@@ -633,7 +657,7 @@ object McpServersStore {
     }
 
     /**
-     * Clear `mcp_token_<id>` entries for ids not present in [current].
+     * Clear `mcp_tokens/<id>` files for ids not present in [current].
      * Catches the case where a previous build deleted a server but the
      * pre-BAT-514 path didn't have a per-id token to clear (it just
      * rewrote the whole encrypted list).
@@ -643,7 +667,7 @@ object McpServersStore {
         val tokenIds = McpTokenStore.listAllIds(context)
         for (id in tokenIds) {
             if (id !in knownIds) {
-                Log.i(TAG, "clearing orphan token mcp_token_$id (no matching server)")
+                Log.i(TAG, "clearing orphan token mcp_tokens/$id (no matching server)")
                 McpTokenStore.clear(context, id)
             }
         }

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -217,17 +217,35 @@ object McpServersStore {
                 //     the existing Toast — the user gets a clear
                 //     "save failed" signal and the workflow is to
                 //     restart.
+                // Only migrate tokens for legacy entries that pass
+                // `isValid` — invalid ids would have McpTokenStore.write
+                // return false (the file path validation rejects them),
+                // which would flip allTokensOk and abort the entire
+                // migration permanently. A SINGLE corrupt legacy id
+                // would brick first-launch migration for all the
+                // user's other servers. (Copilot R17 PR #352 finding.)
+                // Invalid entries are dropped from `seeded` by
+                // onObserved, so their tokens are unreachable
+                // post-migration anyway — losing them here doesn't
+                // change the user-visible state.
                 var allTokensOk = true
                 for (s in legacy) {
-                    if (s.authToken.isNotBlank()) {
-                        if (!McpTokenStore.write(app, s.id, s.authToken)) {
-                            allTokensOk = false
-                            Log.w(
-                                TAG,
-                                "Migration token write failed for id=${s.id}; " +
-                                    "aborting migration to keep KEY_MCP_SERVERS_ENC intact",
-                            )
-                        }
+                    if (s.authToken.isBlank()) continue
+                    if (!isValid(s.toMcpServer())) {
+                        Log.w(
+                            TAG,
+                            "Migration skipping token for invalid legacy id=${s.id} " +
+                                "(server entry will be dropped from migrated file)",
+                        )
+                        continue
+                    }
+                    if (!McpTokenStore.write(app, s.id, s.authToken)) {
+                        allTokensOk = false
+                        Log.w(
+                            TAG,
+                            "Migration token write failed for id=${s.id}; " +
+                                "aborting migration to keep KEY_MCP_SERVERS_ENC intact",
+                        )
                     }
                 }
                 if (!allTokensOk) {
@@ -506,9 +524,26 @@ object McpServersStore {
      * Read the decrypted token for [id]. `""` if absent or decryption
      * failed (matches [McpTokenStore.read]). Process-agnostic — works
      * in `:node` without [init] having run.
+     *
+     * Note: `""` doesn't distinguish "no token" from
+     * "present-but-corrupt token". Use [hasAuthToken] when callers
+     * need to know whether a token file exists on disk regardless of
+     * decrypt success (e.g. the Edit dialog's corrupt-token self-heal
+     * path — Copilot R17 PR #352 finding).
      */
     fun getAuthToken(context: Context, id: String): String =
         McpTokenStore.read(context, id)
+
+    /**
+     * Cheap presence check: is a token file on disk for [id]? No
+     * decrypt. Wraps [McpTokenStore.hasToken] for callers that need
+     * to distinguish "token never set" from "token set but
+     * unreadable" — the http+token validity gate uses this internally,
+     * and the Edit dialog uses it to detect a corrupt-token state and
+     * force a clear on Save.
+     */
+    fun hasAuthToken(context: Context, id: String): Boolean =
+        McpTokenStore.hasToken(context, id)
 
     /**
      * Remove the stored token for [id]. Same return semantics as
@@ -665,8 +700,14 @@ object McpServersStore {
             }
             cleaned.add(s)
         }
-        _state.value = cleaned
-        return cleaned
+        // Publish an immutable snapshot — the mutable builder must
+        // not leak into StateFlow observers or `_previousMirrored`,
+        // since either could end up cast to MutableList by a careless
+        // caller and silently mutate the published value (Copilot
+        // R17 PR #352 finding).
+        val snapshot = cleaned.toList()
+        _state.value = snapshot
+        return snapshot
     }
 
     // Track last-mirrored to dedupe collector emissions (BAT-513

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -613,10 +613,20 @@ object McpServersStore {
         }
         try {
             val enc = KeystoreHelper.encrypt(arr.toString())
+            // commit() not apply(): the rollback shadow is the
+            // pre-BAT-514 build's source of truth on downgrade. The
+            // PR's known-limitation note specifically scopes the
+            // race to "the millisecond window during commit()" —
+            // apply() is async and would widen that window to
+            // include arbitrary deferred-write delay (Android batches
+            // apply() flushes). All callers run on Dispatchers.IO so
+            // the synchronous wait is benign. Mirrors McpTokenStore
+            // which uses commit() for the same reason. (Copilot R8
+            // PR #352 finding.)
             context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 .edit()
                 .putString(KEY_MCP_SERVERS_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
-                .apply()
+                .commit()
         } catch (e: Exception) {
             Log.w(TAG, "rebuildRollbackShadow failed: ${e.message}")
         }

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -118,55 +118,74 @@ object McpServersStore {
     /**
      * Idempotent. Call once from `SeekerClawApplication.onCreate`.
      *
-     * Ordering:
+     * The body of this function does NO disk I/O — it only allocates
+     * the owned IO scope and constructs the [CrossProcessStore]
+     * (which itself defers its first read to that scope). All work
+     * that touches disk or Keystore runs inside the launched
+     * coroutine below, so this call is safe to invoke from
+     * `Application.onCreate` on the main thread.
      *
-     *  1. Read legacy [KEY_MCP_SERVERS_ENC] prefs (the pre-BAT-514
-     *     source of truth). On upgrade, this contains servers WITH
-     *     tokens; on fresh install, it's empty.
-     *  2. If `mcp_servers.json` is missing AND prefs has servers:
-     *     migrate. Split each entry → encrypt token to
-     *     `mcp_tokens/<id>` (encrypted file), drop authToken from in-memory list,
-     *     write cleaned list to file. Rebuild rollback shadow with
-     *     tokens reattached.
-     *  3. Sweep orphan tokens: any `mcp_tokens/<id>` file whose id
+     * Ordering inside the IO coroutine:
+     *
+     *  1. If `mcp_servers.json` is missing: read legacy
+     *     [KEY_MCP_SERVERS_ENC] prefs (Keystore decrypt + JSON
+     *     parse), then migrate. Split each entry → encrypt token to
+     *     `mcp_tokens/<id>` (encrypted file), drop authToken from
+     *     in-memory list, write cleaned list to file. Rebuild
+     *     rollback shadow with tokens reattached. Steady-state
+     *     launches (file exists) skip this entirely — the
+     *     CrossProcessStore catch-up reload populates `_state` from
+     *     the file via the collector below.
+     *  2. Sweep orphan tokens: any `mcp_tokens/<id>` file whose id
      *     isn't in the current server list is cleared.
-     *  4. Start the observe-and-mirror collector.
+     *  3. Start the observe-and-mirror collector.
      */
     fun init(context: Context) {
         if (!initialized.compareAndSet(false, true)) return
         val app = context.applicationContext
         appContext = app
 
-        // Step 1: seed _state from prefs (last-valid pre-BAT-514 view).
-        // Run the raw legacy list through `onObserved` so it gets the
-        // SAME treatment file-observed content does: invalid entries
-        // dropped, name/url trimmed, duplicates collapsed by id.
-        // Without this pass, a corrupt legacy KEY_MCP_SERVERS_ENC
-        // (e.g. duplicate ids from a buggy old write path, or
-        // whitespace-padded URLs from a manual edit) would briefly
-        // publish to `_state` AND get persisted into the migrated
-        // file. The collector eventually re-cleans on its first
-        // emission — but only AFTER the migration write already
-        // landed on disk. Copilot R6/R7 PR #352 finding.
-        val legacy = ConfigManager.loadMcpServers(app)
-        val rawSeed = legacy.map { it.toMcpServer() }
-        val seeded = onObserved(McpServersFile(servers = rawSeed))
-
+        // Caller is `SeekerClawApplication.onCreate` (main thread).
+        // The legacy `ConfigManager.loadMcpServers` does Keystore
+        // decrypt + JSON parse — slow enough to trip StrictMode and
+        // add startup jank. Defer it (and everything else that
+        // touches disk) to the owned IO scope below. UI binds to
+        // `state` which is empty until either:
+        //   (a) CrossProcessStore's catch-up reload publishes the
+        //       file content (steady state — most launches), OR
+        //   (b) the migration scope.launch publishes the legacy
+        //       view (upgrade path on first BAT-514 launch).
+        // (Copilot R12 PR #352 finding.)
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         ownedScope = scope
         val cps = CrossProcessStore(
             context = app,
             fileName = FILE_NAME,
             serializer = McpServersFile.serializer(),
-            initial = McpServersFile(servers = seeded),
+            initial = McpServersFile(emptyList()),
             parentScope = scope,
         )
         store = cps
 
         scope.launch {
-            // Step 2: migration write (one-shot if file is absent).
+            // Step 1: migration check + legacy load — only when the
+            // file is missing. Steady-state launches (file exists)
+            // skip the Keystore decrypt entirely; CrossProcessStore's
+            // own catch-up reload populates `cps._state` from the
+            // file, and the collector below mirrors that into our
+            // `_state`. Run the raw legacy list through `onObserved`
+            // so it gets the SAME treatment file-observed content
+            // does: invalid entries dropped, name/url trimmed,
+            // duplicates collapsed by id. Without this pass, a
+            // corrupt legacy KEY_MCP_SERVERS_ENC (e.g. duplicate ids
+            // from a buggy old write path, or whitespace-padded URLs
+            // from a manual edit) would briefly publish to `_state`
+            // AND get persisted into the migrated file (Copilot R6/R7).
             val file = File(app.filesDir, FILE_NAME)
             if (!file.exists()) {
+                val legacy = ConfigManager.loadMcpServers(app)
+                val rawSeed = legacy.map { it.toMcpServer() }
+                val seeded = onObserved(McpServersFile(servers = rawSeed))
                 // Encrypt every legacy token into per-id token files
                 // (`filesDir/mcp_tokens/<id>`) FIRST.
                 // If ANY token write fails (Keystore error, prefs
@@ -214,18 +233,17 @@ object McpServersStore {
                 // the next launch retries the whole migration.
             }
 
-            // Step 3: orphan token sweep against the on-disk file —
-            // NOT `_state.value`. _state is seeded from the legacy
-            // KEY_MCP_SERVERS_ENC prefs blob and may temporarily
-            // diverge from `mcp_servers.json` until the collector's
-            // first emission lands. If it did diverge (e.g. a `:node`
-            // write modified the file under us), sweeping by the
-            // prefs view would clear `mcp_tokens/<id>` files for
-            // servers that ARE in the file. Copilot R3 PR #352
-            // finding.
+            // Step 2: orphan token sweep against the on-disk file —
+            // NOT `_state.value`. `_state` may not have observed the
+            // CrossProcessStore catch-up reload yet at this point,
+            // and on the upgrade path it briefly held the legacy
+            // view from the migration block above. Sweeping by an
+            // out-of-sync view would clear `mcp_tokens/<id>` files
+            // for servers that ARE in the file. (Copilot R3 PR #352
+            // finding.)
             sweepOrphanTokens(app, cps.read().servers)
 
-            // Step 4: observe-and-mirror collector.
+            // Step 3: observe-and-mirror collector.
             cps.state.collect { observed ->
                 observeFromCollector(observed)
             }

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -297,7 +297,9 @@ object McpServersStore {
     fun read(): List<McpServer> = _state.value
 
     /**
-     * Persist [servers] atomically.
+     * Persist [servers] atomically. Suspending so the caller-side
+     * write+side-effects compose under a single
+     * [CrossProcessStore.update] transaction.
      *
      * Returns `false` (without persisting) on:
      *  - [init] not yet called (main-process gate)
@@ -305,65 +307,68 @@ object McpServersStore {
      *  - duplicate id after `safeId` normalization
      *  - any entry has `http://non-loopback` URL with a non-empty
      *    auth token in [McpTokenStore] (insecure bearer-over-HTTP)
-     *  - underlying [CrossProcessStore.write] failure
+     *  - underlying [CrossProcessStore.update] failure
      *
-     * On success: rebuilds the rollback shadow (with tokens reattached)
-     * AND fires a best-effort `reconcile(null)` to `:node`.
+     * On success: clears orphan tokens for removed servers, rebuilds
+     * the rollback shadow (with tokens reattached) AND fires a
+     * best-effort `reconcile(null)` to `:node`.
+     *
+     * Atomicity (Copilot R15): the read+transform+write all happen
+     * under [CrossProcessStore.writeLock], so two concurrent
+     * `write()` calls from the same process serialize and the second
+     * sees the first's result as `current`. Without this, the
+     * orphan-token diff (`preIds - nextIds`) could be computed from
+     * a stale baseline and clear tokens that a concurrent writer
+     * just added. The bearer-over-insecure-HTTP check and other
+     * cheap validations also run inside the transform — the slow
+     * Keystore decrypt that R11 moved out is replaced by
+     * [McpTokenStore.hasToken] which is just a `File.exists` check.
      */
-    fun write(servers: List<McpServer>): Boolean {
+    suspend fun write(servers: List<McpServer>): Boolean {
         val app = appContext ?: return false
         val s = store ?: return false
         // Defensive copy so caller-side mutation can't poison the
         // validation/persist pipeline.
         val list = servers.toList()
-        val invalid = list.firstOrNull { !isValid(it) }
-        if (invalid != null) {
-            Log.w(TAG, "rejected write: invalid server id=${invalid.id} reason=${reasonFor(invalid)}")
-            return false
-        }
-        val normalizedSeen = mutableSetOf<String>()
-        for (entry in list) {
-            val normalized = normalizeId(entry.id)
-            if (!normalizedSeen.add(normalized)) {
-                Log.w(
-                    TAG,
-                    "rejected write: duplicate id after normalization: ${entry.id} (normalizes to $normalized)",
-                )
-                return false
+
+        var preIds: Set<String> = emptySet()
+        val applied = try {
+            s.update { current ->
+                preIds = current.servers.map { it.id }.toSet()
+                val invalid = list.firstOrNull { !isValid(it) }
+                require(invalid == null) {
+                    "rejected write: invalid server id=${invalid?.id} reason=${invalid?.let { reasonFor(it) }}"
+                }
+                val normalizedSeen = mutableSetOf<String>()
+                for (entry in list) {
+                    val normalized = normalizeId(entry.id)
+                    require(normalizedSeen.add(normalized)) {
+                        "rejected write: duplicate id after normalization: ${entry.id} (normalizes to $normalized)"
+                    }
+                }
+                // Bearer-over-insecure-HTTP gate (v2.1 §5b). Mirrors
+                // mcp-client.js's URL-vs-token check so the same rule
+                // fails fast at write time rather than only when Node
+                // tries to connect.
+                require(list.none { hasInsecureToken(app, it) }) {
+                    "rejected write: server has token over insecure HTTP (use HTTPS or loopback)"
+                }
+                McpServersFile(servers = list)
             }
+        } catch (e: IllegalArgumentException) {
+            // CrossProcessStore.update doesn't catch transform
+            // exceptions — convert require() failures to false here
+            // so the documented Boolean return holds.
+            Log.w(TAG, e.message ?: "write rejected")
+            false
         }
-        // Bearer-over-insecure-HTTP gate (v2.1 §5b). Mirrors
-        // mcp-client.js's URL-vs-token check so the same rule fails
-        // fast at write-time rather than only when Node tries to
-        // connect.
-        for (entry in list) {
-            if (hasInsecureToken(app, entry)) {
-                Log.w(
-                    TAG,
-                    "rejected write: ${entry.id} has token over insecure HTTP (use HTTPS or loopback)",
-                )
-                return false
-            }
-        }
-        // Snapshot the disk's current servers BEFORE persisting, so
-        // the orphan-token cleanup diff is accurate even when our
-        // collector hasn't caught up to a recent prior write.
-        // Reading `_state.value` here would observe collector lag —
-        // by contrast, `s.read()` parses the JSON file synchronously
-        // (CrossProcessStore.write uses atomic move, so the read is
-        // never half-written). Best-effort against TOCTOU: another
-        // process writing between this read and the write below
-        // would race, but the orphan sweep at next `init()` catches
-        // any drift, and main-process writes from here serialize via
-        // CrossProcessStore.writeLock anyway.
-        val preIds = s.read().servers.map { it.id }.toSet()
-        if (!s.write(McpServersFile(servers = list))) return false
+        if (!applied) return false
 
         // Side effects after successful persist (kept out of the
         // CrossProcessStore lock per BAT-513 round-18 pattern).
-        // Clear orphan tokens for removed servers BEFORE rebuilding
-        // the rollback shadow — otherwise the shadow would still see
-        // the orphan via McpTokenStore.read and reattach it.
+        // `preIds` was captured inside the transform under the lock,
+        // so the diff is accurate even if another writer landed
+        // between transform-entry and now.
         val nextIds = list.map { it.id }.toSet()
         for (id in preIds - nextIds) {
             McpTokenStore.clear(app, id)
@@ -374,75 +379,70 @@ object McpServersStore {
     }
 
     /**
-     * Read current state, run [transform] EXACTLY once on it, validate
-     * the result, then atomically write. Same last-writer-wins
-     * semantics as [write] — a concurrent writer between the read and
-     * the write supersedes (acceptable for BAT-514: the only writer
-     * is the UI process; `:node` only reads `mcp_servers.json`).
+     * Read-modify-write under [CrossProcessStore.writeLock]. The
+     * transform sees the current on-disk state, the resulting list
+     * is validated and persisted atomically — concurrent same-process
+     * `update`/`write` calls serialize through the lock so the second
+     * caller's transform sees the first's result, not a stale
+     * baseline (Copilot R15).
      *
-     * Returns `false` on init-not-called, validation failure, or
-     * persist failure. Validation runs OUTSIDE the
-     * [CrossProcessStore] writeLock so the slow Keystore decrypt for
-     * the http+token check doesn't block other writers/observers
-     * (Copilot R11). Calling [transform] only once avoids the
-     * non-deterministic foot-gun of running caller-supplied code
-     * twice with different inputs (Copilot R13).
+     * Validation (cheap predicates only) runs INSIDE the transform.
+     * The slow path R11 flagged — `hasInsecureToken` doing Keystore
+     * decrypt — is gone: [hasInsecureToken] now uses
+     * [McpTokenStore.hasToken] (a `File.exists` check, not a
+     * decrypt), so it's safe under the lock.
      *
-     * Use this for delta-style edits where the transform composes a
-     * new list from the current one (`current.map { ... }`,
+     * `transform` is invoked exactly once (Copilot R13). Validation
+     * failures are raised as `require(...)` and converted to `false`
+     * by the outer try/catch — `CrossProcessStore.update` does NOT
+     * catch transform exceptions on its own (Copilot R10).
+     *
+     * Use this for delta-style edits where the next list is composed
+     * from the current one (`current.map { ... }`,
      * `current.filter { ... }`); use [write] for direct
-     * replace-the-whole-list flows.
+     * replace-the-whole-list flows. Both are now suspend.
      */
     suspend fun update(transform: (List<McpServer>) -> List<McpServer>): Boolean {
         val app = appContext ?: return false
         val s = store ?: return false
-        // Snapshot the current disk state, run the transform exactly
-        // once, validate the result, then write. The snapshot is also
-        // used downstream for the orphan-token diff so it stays
-        // consistent with what we're about to persist.
-        val current = s.read().servers
-        val computed = transform(current).toList()
-
-        // Validation — all checks run outside the lock. `isValid`,
-        // dedup, normalization are cheap; `hasInsecureToken` does
-        // file I/O + Keystore decrypt and would unacceptably hold the
-        // writeLock if run inside the transform per
-        // CrossProcessStore.update's "cheap and pure" contract.
-        val invalid = computed.firstOrNull { !isValid(it) }
-        if (invalid != null) {
-            Log.w(TAG, "update rejected: invalid entry id=${invalid.id} reason=${reasonFor(invalid)}")
-            return false
-        }
-        val seen = mutableSetOf<String>()
-        for (entry in computed) {
-            val n = normalizeId(entry.id)
-            if (!seen.add(n)) {
-                Log.w(
-                    TAG,
-                    "update rejected: duplicate id after normalization: ${entry.id} (normalizes to $n)",
-                )
-                return false
+        var preIds: Set<String> = emptySet()
+        var next: List<McpServer> = emptyList()
+        val applied = try {
+            s.update { current ->
+                preIds = current.servers.map { it.id }.toSet()
+                val computed = transform(current.servers).toList()
+                require(computed.all { isValid(it) }) {
+                    val bad = computed.firstOrNull { !isValid(it) }
+                    "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
+                }
+                val seen = mutableSetOf<String>()
+                for (entry in computed) {
+                    val n = normalizeId(entry.id)
+                    require(seen.add(n)) {
+                        "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
+                    }
+                }
+                require(computed.none { hasInsecureToken(app, it) }) {
+                    "Server has token over insecure HTTP"
+                }
+                next = computed
+                McpServersFile(servers = computed)
             }
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "update rejected: ${e.message}")
+            false
         }
-        if (computed.any { hasInsecureToken(app, it) }) {
-            // MCPClient.connect's `_checkUrlSafety` is the actual
-            // security boundary at request time; this store-level
-            // check is defense-in-depth.
-            Log.w(TAG, "update rejected: server has token over insecure HTTP")
-            return false
-        }
-
-        if (!s.write(McpServersFile(servers = computed))) return false
+        if (!applied) return false
 
         // Side effects (post-write, outside the lock — same pattern
-        // as [write]). The pre/next diff uses the snapshots captured
-        // above, NOT `_state.value`, so a lagging collector can't
-        // make us miss orphan tokens.
-        val nextIds = computed.map { it.id }.toSet()
-        for (id in current.map { it.id }.toSet() - nextIds) {
+        // as [write]). preIds + next are both captured inside the
+        // transform, so the diff is consistent with what we just
+        // persisted.
+        val nextIds = next.map { it.id }.toSet()
+        for (id in preIds - nextIds) {
             McpTokenStore.clear(app, id)
         }
-        rebuildRollbackShadow(app, computed)
+        rebuildRollbackShadow(app, next)
         ownedScope?.launch { NodeControlClient.reconcile(null) }
         return true
     }
@@ -582,8 +582,12 @@ object McpServersStore {
     }
 
     private fun hasInsecureToken(context: Context, server: McpServer): Boolean {
-        val token = McpTokenStore.read(context, server.id)
-        if (token.isBlank()) return false
+        // Cheap presence check (no Keystore decrypt) — token VALUE
+        // doesn't matter for the http+token gate, only token EXISTENCE.
+        // This keeps the predicate cheap enough to run inside
+        // CrossProcessStore.update's transform without violating the
+        // "transforms must be cheap and pure" contract.
+        if (!McpTokenStore.hasToken(context, server.id)) return false
         return !isUrlSafeForToken(server.url)
     }
 

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -119,26 +119,32 @@ object McpServersStore {
      * Idempotent. Call once from `SeekerClawApplication.onCreate`.
      *
      * The body of this function does NO disk I/O — it only allocates
-     * the owned IO scope and constructs the [CrossProcessStore]
-     * (which itself defers its first read to that scope). All work
-     * that touches disk or Keystore runs inside the launched
-     * coroutine below, so this call is safe to invoke from
-     * `Application.onCreate` on the main thread.
+     * the owned IO scope. CrossProcessStore creation itself is
+     * deferred to the IO scope so the legacy load can complete first
+     * and seed the store's `initial` value (preserving the legacy
+     * view if migration aborts). All work that touches disk or
+     * Keystore runs inside the launched coroutine below, so this
+     * call is safe to invoke from `Application.onCreate` on the
+     * main thread.
      *
      * Ordering inside the IO coroutine:
      *
      *  1. If `mcp_servers.json` is missing: read legacy
      *     [KEY_MCP_SERVERS_ENC] prefs (Keystore decrypt + JSON
-     *     parse), then migrate. Split each entry → encrypt token to
-     *     `mcp_tokens/<id>` (encrypted file), drop authToken from
-     *     in-memory list, write cleaned list to file. Rebuild
-     *     rollback shadow with tokens reattached. Steady-state
-     *     launches (file exists) skip this entirely — the
-     *     CrossProcessStore catch-up reload populates `_state` from
-     *     the file via the collector below.
-     *  2. Sweep orphan tokens: any `mcp_tokens/<id>` file whose id
+     *     parse), then encrypt each token to `mcp_tokens/<id>`. If
+     *     ANY token write fails, abort: leave `KEY_MCP_SERVERS_ENC`
+     *     intact, leave `_state` showing the legacy view, and
+     *     return without creating [store] (UI writes return false
+     *     until the user restarts). Steady-state launches (file
+     *     exists) skip step 1 entirely.
+     *  2. Construct [CrossProcessStore] with `initial = seeded` so
+     *     `cps.read()` returns the legacy view if the file write
+     *     below fails.
+     *  3. Migration write of cleaned list + rollback shadow (only
+     *     when the file was missing).
+     *  4. Sweep orphan tokens: any `mcp_tokens/<id>` file whose id
      *     isn't in the current server list is cleared.
-     *  3. Start the observe-and-mirror collector.
+     *  5. Start the observe-and-mirror collector.
      */
     fun init(context: Context) {
         if (!initialized.compareAndSet(false, true)) return
@@ -148,24 +154,21 @@ object McpServersStore {
         // Caller is `SeekerClawApplication.onCreate` (main thread).
         // The legacy `ConfigManager.loadMcpServers` does Keystore
         // decrypt + JSON parse — slow enough to trip StrictMode and
-        // add startup jank. Defer it (and everything else that
-        // touches disk) to the owned IO scope below. UI binds to
-        // `state` which is empty until either:
-        //   (a) CrossProcessStore's catch-up reload publishes the
-        //       file content (steady state — most launches), OR
-        //   (b) the migration scope.launch publishes the legacy
-        //       view (upgrade path on first BAT-514 launch).
-        // (Copilot R12 PR #352 finding.)
+        // add startup jank. Defer EVERYTHING that touches disk or
+        // Keystore to the owned IO scope below. UI binds to `state`
+        // which starts empty for a few ms while the catch-up reload
+        // runs (steady state) or while the legacy load + migration
+        // runs (upgrade path). (Copilot R12 PR #352 finding.)
+        //
+        // CrossProcessStore creation is also deferred — we want to
+        // pass the legacy-seeded list as `initial` so a migration
+        // abort (token write failure or file write failure) leaves
+        // `cps.read()` returning the legacy view instead of an empty
+        // list (Copilot R13 finding 1+2: an empty `initial` would
+        // both clobber `_state` via the collector AND make the
+        // orphan sweep clear all newly-written token files).
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         ownedScope = scope
-        val cps = CrossProcessStore(
-            context = app,
-            fileName = FILE_NAME,
-            serializer = McpServersFile.serializer(),
-            initial = McpServersFile(emptyList()),
-            parentScope = scope,
-        )
-        store = cps
 
         scope.launch {
             // Step 1: migration check + legacy load — only when the
@@ -182,15 +185,21 @@ object McpServersStore {
             // from a manual edit) would briefly publish to `_state`
             // AND get persisted into the migrated file (Copilot R6/R7).
             val file = File(app.filesDir, FILE_NAME)
-            if (!file.exists()) {
+            val needsMigration = !file.exists()
+            var seeded: List<McpServer> = emptyList()
+            if (needsMigration) {
                 val legacy = ConfigManager.loadMcpServers(app)
                 val rawSeed = legacy.map { it.toMcpServer() }
-                val seeded = onObserved(McpServersFile(servers = rawSeed))
+                // onObserved cleans + sets `_state.value` so the UI's
+                // collectAsState binding sees the legacy view
+                // immediately while migration finishes.
+                seeded = onObserved(McpServersFile(servers = rawSeed))
                 // Encrypt every legacy token into per-id token files
                 // (`filesDir/mcp_tokens/<id>`) FIRST.
                 // If ANY token write fails (Keystore error, prefs
                 // commit failure), abort migration: don't seed the
-                // file, don't rebuild the rollback shadow. Reasoning:
+                // file, don't rebuild the rollback shadow, and don't
+                // even create the CrossProcessStore. Reasoning:
                 //   - The legacy KEY_MCP_SERVERS_ENC blob is still
                 //     intact and contains the tokens. Pre-BAT-514
                 //     code (and this build's `loadMcpServers`) can
@@ -202,7 +211,12 @@ object McpServersStore {
                 //     silently losing the token on downgrade AND
                 //     breaking next-launch's Node-side connect.
                 //   - Aborting leaves `mcp_servers.json` absent, so
-                //     next launch retries the whole migration.
+                //     next launch retries the whole migration. UI
+                //     writes via `McpServersStore.write` return false
+                //     in the meantime (store is null) and surface
+                //     the existing Toast — the user gets a clear
+                //     "save failed" signal and the workflow is to
+                //     restart.
                 var allTokensOk = true
                 for (s in legacy) {
                     if (s.authToken.isNotBlank()) {
@@ -216,24 +230,51 @@ object McpServersStore {
                         }
                     }
                 }
-                if (allTokensOk) {
-                    if (cps.write(McpServersFile(servers = seeded))) {
-                        rebuildRollbackShadow(app, seeded)
-                    } else {
-                        Log.w(
-                            TAG,
-                            "first-launch migration write to $FILE_NAME failed — " +
-                                "in-memory state retained; next save retries the file write",
-                        )
-                    }
+                if (!allTokensOk) {
+                    // Don't create the store. Don't start the
+                    // collector. Don't run the orphan sweep —
+                    // `cps.read()` would be `[]` and would clear
+                    // every token file we just successfully wrote
+                    // (Copilot R13 finding 2). _state retains the
+                    // legacy view from `onObserved` above so the UI
+                    // remains usable until the user restarts.
+                    return@launch
                 }
-                // If allTokensOk is false: file is NOT seeded, shadow
-                // is NOT rebuilt. KEY_MCP_SERVERS_ENC stays as the
-                // legacy source, _state has the in-memory view, and
-                // the next launch retries the whole migration.
             }
 
-            // Step 2: orphan token sweep against the on-disk file —
+            // Step 2: construct the CrossProcessStore. `initial` is
+            // the seeded legacy view (when migration just ran) or
+            // `emptyList()` (when file already existed). On a
+            // file-missing read, cps.read() returns `cloneSafe(initial)`,
+            // so post-migration the legacy view is still visible
+            // even if the file write below fails.
+            val cps = CrossProcessStore(
+                context = app,
+                fileName = FILE_NAME,
+                serializer = McpServersFile.serializer(),
+                initial = McpServersFile(servers = seeded),
+                parentScope = scope,
+            )
+            store = cps
+
+            // Step 3: migration write (if needed). Token files are
+            // already on disk from step 1, so a file-write failure
+            // here doesn't lose tokens — next launch sees the file
+            // still missing and retries the file seed (token writes
+            // are idempotent: McpTokenStore.write overwrites).
+            if (needsMigration) {
+                if (cps.write(McpServersFile(servers = seeded))) {
+                    rebuildRollbackShadow(app, seeded)
+                } else {
+                    Log.w(
+                        TAG,
+                        "first-launch migration write to $FILE_NAME failed — " +
+                            "tokens already persisted; next save retries the file write",
+                    )
+                }
+            }
+
+            // Step 4: orphan token sweep against the on-disk file —
             // NOT `_state.value`. `_state` may not have observed the
             // CrossProcessStore catch-up reload yet at this point,
             // and on the upgrade path it briefly held the legacy
@@ -243,7 +284,7 @@ object McpServersStore {
             // finding.)
             sweepOrphanTokens(app, cps.read().servers)
 
-            // Step 3: observe-and-mirror collector.
+            // Step 5: observe-and-mirror collector.
             cps.state.collect { observed ->
                 observeFromCollector(observed)
             }
@@ -333,89 +374,77 @@ object McpServersStore {
     }
 
     /**
-     * Read-modify-write under [CrossProcessStore]'s lock so
-     * concurrent writes can't drop updates. The transformed list goes
-     * through the same validity gate as [write] — an invalid result
-     * throws [IllegalArgumentException] (caller tests / debug
-     * builds) rather than silently persisting corrupt state.
+     * Read current state, run [transform] EXACTLY once on it, validate
+     * the result, then atomically write. Same last-writer-wins
+     * semantics as [write] — a concurrent writer between the read and
+     * the write supersedes (acceptable for BAT-514: the only writer
+     * is the UI process; `:node` only reads `mcp_servers.json`).
      *
-     * Returns `false` on init-not-called, lock acquisition failure,
-     * or persist failure. The caller is expected to use [write] for
-     * the simple replace-all path; this is for atomic delta cases
-     * (toggle one server's `enabled`, edit one server's URL) where
-     * read-then-write would race against `:node` writes.
+     * Returns `false` on init-not-called, validation failure, or
+     * persist failure. Validation runs OUTSIDE the
+     * [CrossProcessStore] writeLock so the slow Keystore decrypt for
+     * the http+token check doesn't block other writers/observers
+     * (Copilot R11). Calling [transform] only once avoids the
+     * non-deterministic foot-gun of running caller-supplied code
+     * twice with different inputs (Copilot R13).
+     *
+     * Use this for delta-style edits where the transform composes a
+     * new list from the current one (`current.map { ... }`,
+     * `current.filter { ... }`); use [write] for direct
+     * replace-the-whole-list flows.
      */
     suspend fun update(transform: (List<McpServer>) -> List<McpServer>): Boolean {
         val app = appContext ?: return false
         val s = store ?: return false
-        // Capture pre-transform AND next snapshots inside the
-        // CrossProcessStore.update lock so the post-update side
-        // effects don't race the collector. Reading `_state.value`
-        // after `s.update` returns is unreliable — the collector that
-        // mirrors the disk write to `_state` runs on its own coroutine
-        // and may not have observed the new value yet (Copilot R1
-        // PR #352 finding).
-        // Pre-validate the insecure-token combination OUTSIDE the
-        // CrossProcessStore.update writeLock. `hasInsecureToken` does
-        // file I/O + Keystore decrypt (via McpTokenStore.read), which
-        // would block other writers/observers if held inside the
-        // synchronized block (Copilot R11 PR #352 finding). Race
-        // window: if a concurrent setAuthToken changes a server's
-        // token between this check and the lock acquisition, the
-        // resulting state could violate the http+token gate — but
-        // MCPClient.connect's `_checkUrlSafety` is the actual
-        // security boundary (it refuses to send tokens over plain
-        // non-loopback HTTP at request time), so the store-level
-        // check is defense-in-depth, not a hard guarantee.
-        val initialNext = transform(s.read().servers).toList()
-        if (initialNext.any { hasInsecureToken(app, it) }) {
+        // Snapshot the current disk state, run the transform exactly
+        // once, validate the result, then write. The snapshot is also
+        // used downstream for the orphan-token diff so it stays
+        // consistent with what we're about to persist.
+        val current = s.read().servers
+        val computed = transform(current).toList()
+
+        // Validation — all checks run outside the lock. `isValid`,
+        // dedup, normalization are cheap; `hasInsecureToken` does
+        // file I/O + Keystore decrypt and would unacceptably hold the
+        // writeLock if run inside the transform per
+        // CrossProcessStore.update's "cheap and pure" contract.
+        val invalid = computed.firstOrNull { !isValid(it) }
+        if (invalid != null) {
+            Log.w(TAG, "update rejected: invalid entry id=${invalid.id} reason=${reasonFor(invalid)}")
+            return false
+        }
+        val seen = mutableSetOf<String>()
+        for (entry in computed) {
+            val n = normalizeId(entry.id)
+            if (!seen.add(n)) {
+                Log.w(
+                    TAG,
+                    "update rejected: duplicate id after normalization: ${entry.id} (normalizes to $n)",
+                )
+                return false
+            }
+        }
+        if (computed.any { hasInsecureToken(app, it) }) {
+            // MCPClient.connect's `_checkUrlSafety` is the actual
+            // security boundary at request time; this store-level
+            // check is defense-in-depth.
             Log.w(TAG, "update rejected: server has token over insecure HTTP")
             return false
         }
 
-        var pre: List<McpServer> = emptyList()
-        var next: List<McpServer> = emptyList()
-        // CrossProcessStore.update does NOT catch transform exceptions
-        // — a `require(...)` that fails inside the transform throws out
-        // of `s.update` and would crash the calling coroutine. Wrap
-        // the call so validation failures surface as the documented
-        // `false` return instead. (Copilot R10 PR #352 finding.)
-        val applied = try {
-            s.update { current ->
-                pre = current.servers
-                val computed = transform(current.servers).toList()
-                require(computed.all { isValid(it) }) {
-                    val bad = computed.firstOrNull { !isValid(it) }
-                    "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
-                }
-                // Duplicate-id check inside the transform so the lock
-                // covers it too (a concurrent write that produced the
-                // duplicate can't slip through). Cheap and pure
-                // (no I/O), as required by CrossProcessStore.update's
-                // "transforms must be cheap and pure" rule.
-                val seen = mutableSetOf<String>()
-                for (entry in computed) {
-                    val n = normalizeId(entry.id)
-                    require(seen.add(n)) {
-                        "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
-                    }
-                }
-                next = computed
-                McpServersFile(servers = computed)
-            }
-        } catch (e: IllegalArgumentException) {
-            Log.w(TAG, "update rejected: ${e.message}")
-            false
+        if (!s.write(McpServersFile(servers = computed))) return false
+
+        // Side effects (post-write, outside the lock — same pattern
+        // as [write]). The pre/next diff uses the snapshots captured
+        // above, NOT `_state.value`, so a lagging collector can't
+        // make us miss orphan tokens.
+        val nextIds = computed.map { it.id }.toSet()
+        for (id in current.map { it.id }.toSet() - nextIds) {
+            McpTokenStore.clear(app, id)
         }
-        if (applied) {
-            val nextIds = next.map { it.id }.toSet()
-            for (id in pre.map { it.id }.toSet() - nextIds) {
-                McpTokenStore.clear(app, id)
-            }
-            rebuildRollbackShadow(app, next)
-            ownedScope?.launch { NodeControlClient.reconcile(null) }
-        }
-        return applied
+        rebuildRollbackShadow(app, computed)
+        ownedScope?.launch { NodeControlClient.reconcile(null) }
+        return true
     }
 
     /**

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -1,0 +1,569 @@
+package com.seekerclaw.app.state
+
+import android.content.Context
+import android.util.Base64
+import android.util.Log
+import com.seekerclaw.app.bridge.NodeControlClient
+import com.seekerclaw.app.config.ConfigManager
+import com.seekerclaw.app.config.KeystoreHelper
+import com.seekerclaw.app.config.McpServerConfig
+import com.seekerclaw.app.util.CrossProcessStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.net.URL
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Cross-process MCP server config store (BAT-514).
+ *
+ * Mirrors [RuntimeStateStore]'s shape — a [CrossProcessStore]-backed
+ * file (`mcp_servers.json`) wrapped with a validity gate, a rollback
+ * shadow mirror to legacy [android.content.SharedPreferences], a
+ * UI-safe StateFlow, AND token I/O wrappers that delegate to the
+ * stateless [McpTokenStore].
+ *
+ * ## Field split (file vs. encrypted prefs)
+ *
+ *  - **File:** id, name, url, enabled, rateLimit. Plaintext JSON, safe
+ *    for cross-process file IPC.
+ *  - **Encrypted prefs:** authToken per server, keyed by `mcp_token_<id>`.
+ *    Lives in `seekerclaw_prefs` via [KeystoreHelper] AES-GCM. Read on
+ *    every connect by the Node side via AndroidBridge
+ *    `POST /config/mcp-token`.
+ *
+ * Tokens DO get reattached when reconstructing the legacy
+ * `KEY_MCP_SERVERS_ENC` rollback shadow (BAT-514 v2 §2): pre-BAT-514
+ * builds expect the token in each server entry, so a downgrade after
+ * a token edit shouldn't lose it.
+ *
+ * ## Validity gate (UI-write fail-fast vs. observed-file drop-defensively)
+ *
+ * v2.1 §5 differentiates:
+ *
+ *  - [write] / [update] (the UI write boundary) returns `false` on the
+ *    first invalid entry. The UI sees this and rebinds to last-valid
+ *    via [state] (Toast + revert). NOT silent drop — a server the user
+ *    just typed should never disappear without explanation.
+ *  - The collector [observeFromCollector] running against the underlying
+ *    [CrossProcessStore] DROPS individual invalid entries with a WARN
+ *    log. A corrupt file from a manual edit / partial write loses only
+ *    the bad entries; the rest stay usable.
+ *
+ * Both paths share [isValid] / [reasonFor] for predicate parity.
+ *
+ * ## Reconcile dispatch (Kotlin → Node)
+ *
+ * Every successful mutation (file write OR token write OR token clear)
+ * fires `NodeControlClient.reconcile(id?)` best-effort. The Node side
+ * runs an internal HTTP server on `127.0.0.1:8766` (the existing stats
+ * server, extended to host `/mcp/reconcile` and `/healthz` in BAT-514).
+ * If the service is stopped (port not bound), the reconcile call
+ * returns false — that's fine, the next service start reads the file
+ * fresh. See [NodeControlClient].
+ */
+object McpServersStore {
+    private const val TAG = "McpServersStore"
+    private const val FILE_NAME = "mcp_servers.json"
+    private const val PREFS_NAME = "seekerclaw_prefs"
+    private const val KEY_MCP_SERVERS_ENC = "mcp_servers_enc"
+
+    /**
+     * MCP server `id` must match this regex AND be unique after
+     * `safeId` normalization (the Node side replaces `[^A-Za-z0-9_]`
+     * with `_`, so `server-1` and `server_1` would collide). The
+     * regex itself doesn't allow `-` to be replaced — it allows `-`
+     * intentionally — but `safeId` normalization is a stricter check
+     * that catches collisions if the regex is ever loosened.
+     */
+    private val ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
+
+    private val initialized = AtomicBoolean(false)
+    private val _state = MutableStateFlow<List<McpServer>>(emptyList())
+    private var appContext: Context? = null
+
+    /**
+     * Last valid server list observed. UI binds here; invalid file
+     * content (corrupt entry, manual edit) is filtered out so the UI
+     * never displays a bad server.
+     */
+    val state: StateFlow<List<McpServer>> = _state.asStateFlow()
+
+    /**
+     * `true` once [init] has wired up the cross-process store. Mirrors
+     * [RuntimeStateStore.isInitialized] — gates main-process-only
+     * mutation paths so a `:node`-side caller (which never calls
+     * [init]) can't trip an NPE on [store].
+     */
+    val isInitialized: Boolean get() = store != null
+
+    private var ownedScope: CoroutineScope? = null
+    private var store: CrossProcessStore<McpServersFile>? = null
+
+    /**
+     * Idempotent. Call once from `SeekerClawApplication.onCreate`.
+     *
+     * Ordering:
+     *
+     *  1. Read legacy [KEY_MCP_SERVERS_ENC] prefs (the pre-BAT-514
+     *     source of truth). On upgrade, this contains servers WITH
+     *     tokens; on fresh install, it's empty.
+     *  2. If `mcp_servers.json` is missing AND prefs has servers:
+     *     migrate. Split each entry → encrypt token to
+     *     `mcp_token_<id>`, drop authToken from in-memory list,
+     *     write cleaned list to file. Rebuild rollback shadow with
+     *     tokens reattached.
+     *  3. Sweep orphan tokens: any `mcp_token_*` key whose id isn't
+     *     in the current server list is cleared.
+     *  4. Start the observe-and-mirror collector.
+     */
+    fun init(context: Context) {
+        if (!initialized.compareAndSet(false, true)) return
+        val app = context.applicationContext
+        appContext = app
+
+        // Step 1: seed _state from prefs (last-valid pre-BAT-514 view).
+        val legacy = ConfigManager.loadMcpServers(app)
+        val seeded = legacy
+            .map { it.toMcpServer() }
+            .filter { isValid(it) }
+        _state.value = seeded
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        ownedScope = scope
+        val cps = CrossProcessStore(
+            context = app,
+            fileName = FILE_NAME,
+            serializer = McpServersFile.serializer(),
+            initial = McpServersFile(servers = seeded),
+            parentScope = scope,
+        )
+        store = cps
+
+        scope.launch {
+            // Step 2: migration write (one-shot if file is absent).
+            val file = File(app.filesDir, FILE_NAME)
+            if (!file.exists()) {
+                // Encrypt every legacy token into per-id prefs FIRST,
+                // so a crash after the file write but before this
+                // loop doesn't lose tokens.
+                for (s in legacy) {
+                    if (s.authToken.isNotBlank()) {
+                        McpTokenStore.write(app, s.id, s.authToken)
+                    }
+                }
+                if (!cps.write(McpServersFile(servers = seeded))) {
+                    Log.w(
+                        TAG,
+                        "first-launch migration write to $FILE_NAME failed — " +
+                            "in-memory state retained; next save retries the file write",
+                    )
+                }
+                rebuildRollbackShadow(app, seeded)
+            }
+
+            // Step 3: orphan token sweep.
+            sweepOrphanTokens(app, _state.value)
+
+            // Step 4: observe-and-mirror collector.
+            cps.state.collect { observed ->
+                observeFromCollector(observed)
+            }
+        }
+    }
+
+    /**
+     * Returns the last valid server list (the same value [state] exposes).
+     */
+    fun read(): List<McpServer> = _state.value
+
+    /**
+     * Persist [servers] atomically.
+     *
+     * Returns `false` (without persisting) on:
+     *  - [init] not yet called (main-process gate)
+     *  - any entry fails [isValid]
+     *  - duplicate id after `safeId` normalization
+     *  - any entry has `http://non-loopback` URL with a non-empty
+     *    auth token in [McpTokenStore] (insecure bearer-over-HTTP)
+     *  - underlying [CrossProcessStore.write] failure
+     *
+     * On success: rebuilds the rollback shadow (with tokens reattached)
+     * AND fires a best-effort `reconcile(null)` to `:node`.
+     */
+    fun write(servers: List<McpServer>): Boolean {
+        val app = appContext ?: return false
+        val s = store ?: return false
+        // Defensive copy so caller-side mutation can't poison the
+        // validation/persist pipeline.
+        val list = servers.toList()
+        val invalid = list.firstOrNull { !isValid(it) }
+        if (invalid != null) {
+            Log.w(TAG, "rejected write: invalid server id=${invalid.id} reason=${reasonFor(invalid)}")
+            return false
+        }
+        val normalizedSeen = mutableSetOf<String>()
+        for (entry in list) {
+            val normalized = normalizeId(entry.id)
+            if (!normalizedSeen.add(normalized)) {
+                Log.w(
+                    TAG,
+                    "rejected write: duplicate id after normalization: ${entry.id} (normalizes to $normalized)",
+                )
+                return false
+            }
+        }
+        // Bearer-over-insecure-HTTP gate (v2.1 §5b). Mirrors
+        // mcp-client.js's URL-vs-token check so the same rule fails
+        // fast at write-time rather than only when Node tries to
+        // connect.
+        for (entry in list) {
+            if (hasInsecureToken(app, entry)) {
+                Log.w(
+                    TAG,
+                    "rejected write: ${entry.id} has token over insecure HTTP (use HTTPS or loopback)",
+                )
+                return false
+            }
+        }
+        // Snapshot removed-ids BEFORE persisting so the post-write
+        // orphan token cleanup is correct even if the StateFlow
+        // emission lands first (the collector observer would otherwise
+        // see the new list and the diff would be empty).
+        val removedIds = _state.value.map { it.id }.toSet() - list.map { it.id }.toSet()
+        if (!s.write(McpServersFile(servers = list))) return false
+
+        // Side effects after successful persist (kept out of the
+        // CrossProcessStore lock per BAT-513 round-18 pattern).
+        // Clear orphan tokens for removed servers BEFORE rebuilding
+        // the rollback shadow — otherwise the shadow would still see
+        // the orphan via McpTokenStore.read and reattach it.
+        for (id in removedIds) {
+            McpTokenStore.clear(app, id)
+        }
+        rebuildRollbackShadow(app, list)
+        ownedScope?.launch { NodeControlClient.reconcile(null) }
+        return true
+    }
+
+    /**
+     * Read-modify-write under [CrossProcessStore]'s lock so
+     * concurrent writes can't drop updates. The transformed list goes
+     * through the same validity gate as [write] — an invalid result
+     * throws [IllegalArgumentException] (caller tests / debug
+     * builds) rather than silently persisting corrupt state.
+     *
+     * Returns `false` on init-not-called, lock acquisition failure,
+     * or persist failure. The caller is expected to use [write] for
+     * the simple replace-all path; this is for atomic delta cases
+     * (toggle one server's `enabled`, edit one server's URL) where
+     * read-then-write would race against `:node` writes.
+     */
+    suspend fun update(transform: (List<McpServer>) -> List<McpServer>): Boolean {
+        val app = appContext ?: return false
+        val s = store ?: return false
+        // Capture pre-transform ids so the post-update orphan sweep
+        // sees an accurate diff. We can't compute this inside the
+        // transform lambda — `_state` may not have observed the new
+        // value yet, which is the whole point of doing it here.
+        val preIds = _state.value.map { it.id }.toSet()
+        val applied = s.update { current ->
+            val next = transform(current.servers).toList()
+            require(next.all { isValid(it) }) {
+                val bad = next.firstOrNull { !isValid(it) }
+                "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
+            }
+            // Duplicate-id check inside the transform so the lock
+            // covers it too (a concurrent write that produced the
+            // duplicate can't slip through).
+            val seen = mutableSetOf<String>()
+            for (entry in next) {
+                val n = normalizeId(entry.id)
+                require(seen.add(n)) {
+                    "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
+                }
+            }
+            require(next.none { hasInsecureToken(app, it) }) {
+                "Server has token over insecure HTTP"
+            }
+            McpServersFile(servers = next)
+        }
+        if (applied) {
+            val postIds = _state.value.map { it.id }.toSet()
+            for (id in preIds - postIds) {
+                McpTokenStore.clear(app, id)
+            }
+            rebuildRollbackShadow(app, _state.value)
+            ownedScope?.launch { NodeControlClient.reconcile(null) }
+        }
+        return applied
+    }
+
+    /**
+     * Persist [token] for [id] (encrypted prefs) and trigger reconcile.
+     *
+     * Returns `false` if [init] wasn't called, [id] doesn't match a
+     * server in the list (token-without-server is meaningless), the
+     * server's URL is `http://non-loopback` (insecure bearer reject),
+     * or encryption / commit fails. Returns `true` once the token
+     * lands in prefs — the reconcile dispatch is best-effort and its
+     * outcome doesn't change this return.
+     */
+    fun setAuthToken(context: Context, id: String, token: String): Boolean {
+        if (!isInitialized) return false
+        val server = _state.value.firstOrNull { it.id == id }
+        if (server == null) {
+            Log.w(TAG, "setAuthToken rejected: unknown server id=$id")
+            return false
+        }
+        if (token.isNotBlank() && !isUrlSafeForToken(server.url)) {
+            Log.w(TAG, "setAuthToken rejected: ${id} url is http://non-loopback (use HTTPS)")
+            return false
+        }
+        val ok = if (token.isBlank()) {
+            McpTokenStore.clear(context, id)
+        } else {
+            McpTokenStore.write(context, id, token)
+        }
+        if (ok) {
+            rebuildRollbackShadow(context, _state.value)
+            ownedScope?.launch { NodeControlClient.reconcile(id) }
+        }
+        return ok
+    }
+
+    /**
+     * Read the decrypted token for [id]. `""` if absent or decryption
+     * failed (matches [McpTokenStore.read]). Process-agnostic — works
+     * in `:node` without [init] having run.
+     */
+    fun getAuthToken(context: Context, id: String): String =
+        McpTokenStore.read(context, id)
+
+    /**
+     * Remove the stored token for [id]. Same return semantics as
+     * [setAuthToken] with an empty token.
+     */
+    fun clearAuthToken(context: Context, id: String): Boolean = setAuthToken(context, id, "")
+
+    // ---- Validation predicates (visible for testing) -------------------
+
+    internal fun isValid(s: McpServer): Boolean {
+        if (!ID_REGEX.matches(s.id)) return false
+        if (s.name.isBlank()) return false
+        if (!isValidUrl(s.url)) return false
+        if (s.rateLimit <= 0) return false
+        return true
+    }
+
+    internal fun reasonFor(s: McpServer): String {
+        if (!ID_REGEX.matches(s.id)) return "id '${s.id}' fails $ID_REGEX"
+        if (s.name.isBlank()) return "name blank"
+        if (!isValidUrl(s.url)) return "url '${s.url}' invalid (must be http(s) with non-empty host)"
+        if (s.rateLimit <= 0) return "rateLimit ${s.rateLimit} <= 0"
+        return "ok"
+    }
+
+    private fun isValidUrl(raw: String): Boolean {
+        if (raw.isBlank()) return false
+        return try {
+            val u = URL(raw)
+            val scheme = u.protocol?.lowercase()
+            val host = u.host?.lowercase()
+            (scheme == "http" || scheme == "https") && !host.isNullOrBlank()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * `false` iff the URL is `http://` AND the host is NOT a loopback.
+     * Plain HTTPS — secure. Plain HTTP to localhost — secure (no wire).
+     * Plain HTTP elsewhere — insecure for bearer tokens.
+     *
+     * Mirrors `mcp-client.js`'s constructor check (lines 186-194 of
+     * the pre-BAT-514 file) so the same rule applies at write time
+     * AND connect time.
+     */
+    private fun isUrlSafeForToken(raw: String): Boolean {
+        if (!isValidUrl(raw)) return false
+        val u = URL(raw)
+        val scheme = u.protocol.lowercase()
+        if (scheme == "https") return true
+        val host = u.host.lowercase()
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+
+    private fun hasInsecureToken(context: Context, server: McpServer): Boolean {
+        val token = McpTokenStore.read(context, server.id)
+        if (token.isBlank()) return false
+        return !isUrlSafeForToken(server.url)
+    }
+
+    /**
+     * Mirror Node's `safeId` normalization (mcp-client.js line 174):
+     * `replace(/[^a-zA-Z0-9_-]/g, '_')`. We also disallow the bare `-`
+     * collision via [ID_REGEX] up front, but use this for the
+     * post-normalization uniqueness check so a future regex-loosen
+     * doesn't open a duplicate-id hole.
+     */
+    private fun normalizeId(id: String): String =
+        id.replace(Regex("[^A-Za-z0-9_]"), "_")
+
+    // ---- Collector path -------------------------------------------------
+
+    /**
+     * Production-side wrapper around [onObserved]: drops invalid
+     * entries from the file (NOT a UI write — the file came from
+     * elsewhere, possibly a partial write or a manual edit) and
+     * publishes the cleaned list to [_state]. Also rebuilds the
+     * rollback shadow + notifies UI when the cleaned list differs
+     * from current state.
+     */
+    private fun observeFromCollector(observed: McpServersFile) {
+        val cleaned = onObserved(observed)
+        val app = appContext ?: return
+        // Rebuild the legacy shadow only when the cleaned list
+        // actually differs from the prior _state — otherwise the
+        // cross-process broadcast amplifies on every redundant
+        // FileObserver tick.
+        if (cleaned != _previousMirrored) {
+            rebuildRollbackShadow(app, cleaned)
+            _previousMirrored = cleaned
+            // Compose UI screens that read the legacy shadow via
+            // ConfigManager.loadMcpServers need a configVersion bump
+            // to recompose. Mirrors the BAT-513 RuntimeStateStore
+            // collector path.
+            ConfigManager.signalConfigChanged(app)
+        }
+    }
+
+    /**
+     * Pure helper: drop invalid entries with a WARN log, drop
+     * duplicates after `safeId` normalization (keep first), publish
+     * the cleaned list to [_state]. Returns the cleaned list so
+     * callers can decide whether to fire side effects.
+     */
+    internal fun onObserved(observed: McpServersFile): List<McpServer> {
+        val cleaned = mutableListOf<McpServer>()
+        val seen = mutableSetOf<String>()
+        for (s in observed.servers) {
+            if (!isValid(s)) {
+                Log.w(TAG, "dropped corrupt entry id=${s.id} reason=${reasonFor(s)}")
+                continue
+            }
+            val normalized = normalizeId(s.id)
+            if (!seen.add(normalized)) {
+                Log.w(
+                    TAG,
+                    "dropped duplicate entry id=${s.id} (normalizes to $normalized)",
+                )
+                continue
+            }
+            cleaned.add(s)
+        }
+        _state.value = cleaned
+        return cleaned
+    }
+
+    // Track last-mirrored to dedupe collector emissions (BAT-513
+    // pattern). Nullable + sentinel-checked: the first emission after
+    // init() always mirrors regardless of equality, since the legacy
+    // shadow may be stale relative to a Node-side write that landed
+    // before the collector started.
+    @Volatile
+    private var _previousMirrored: List<McpServer>? = null
+
+    // ---- Rollback shadow + orphan sweep --------------------------------
+
+    /**
+     * Reconstruct legacy `KEY_MCP_SERVERS_ENC` from [servers] PLUS the
+     * encrypted-prefs tokens. A pre-BAT-514 build downgraded onto the
+     * current state expects each server entry to carry its `authToken`
+     * — without re-attaching here, downgrade would silently break
+     * authenticated MCP servers.
+     *
+     * Writes the same JSON shape the pre-BAT-514 `loadMcpServers`
+     * path expects (servers with `authToken` inline), encrypted via
+     * [KeystoreHelper] and Base64'd into `KEY_MCP_SERVERS_ENC`. The
+     * legacy writer (`ConfigManager.saveMcpServers`) was deleted in
+     * BAT-514 — this method is now the only writer of that prefs
+     * key, and the only reader is [ConfigManager.loadMcpServers]
+     * (cold-start config.json regeneration + SettingsScreen count).
+     */
+    private fun rebuildRollbackShadow(context: Context, servers: List<McpServer>) {
+        val arr = JSONArray()
+        for (s in servers) {
+            val token = McpTokenStore.read(context, s.id)
+            arr.put(JSONObject().apply {
+                put("id", s.id)
+                put("name", s.name)
+                put("url", s.url)
+                put("authToken", token)
+                put("enabled", s.enabled)
+                put("rateLimit", s.rateLimit)
+            })
+        }
+        try {
+            val enc = KeystoreHelper.encrypt(arr.toString())
+            context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_MCP_SERVERS_ENC, Base64.encodeToString(enc, Base64.NO_WRAP))
+                .apply()
+        } catch (e: Exception) {
+            Log.w(TAG, "rebuildRollbackShadow failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Clear `mcp_token_<id>` entries for ids not present in [current].
+     * Catches the case where a previous build deleted a server but the
+     * pre-BAT-514 path didn't have a per-id token to clear (it just
+     * rewrote the whole encrypted list).
+     */
+    private fun sweepOrphanTokens(context: Context, current: List<McpServer>) {
+        val knownIds = current.map { it.id }.toSet()
+        val tokenIds = McpTokenStore.listAllIds(context)
+        for (id in tokenIds) {
+            if (id !in knownIds) {
+                Log.i(TAG, "clearing orphan token mcp_token_$id (no matching server)")
+                McpTokenStore.clear(context, id)
+            }
+        }
+    }
+
+    // ---- Test seams ----------------------------------------------------
+
+    @androidx.annotation.VisibleForTesting
+    internal fun resetForTest() {
+        ownedScope?.cancel()
+        ownedScope = null
+        store?.close()
+        store = null
+        appContext = null
+        _state.value = emptyList()
+        _previousMirrored = null
+        initialized.set(false)
+    }
+}
+
+/**
+ * Convert the legacy [McpServerConfig] (which carries authToken inline)
+ * to the BAT-514 [McpServer] (no authToken). The migration path uses
+ * this to seed `_state` from the pre-BAT-514 prefs blob.
+ */
+private fun McpServerConfig.toMcpServer(): McpServer = McpServer(
+    id = id,
+    name = name,
+    url = url,
+    enabled = enabled,
+    rateLimit = rateLimit,
+)

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -200,8 +200,16 @@ object McpServersStore {
                 // the next launch retries the whole migration.
             }
 
-            // Step 3: orphan token sweep.
-            sweepOrphanTokens(app, _state.value)
+            // Step 3: orphan token sweep against the on-disk file —
+            // NOT `_state.value`. _state is seeded from the legacy
+            // KEY_MCP_SERVERS_ENC prefs blob and may temporarily
+            // diverge from `mcp_servers.json` until the collector's
+            // first emission lands. If it did diverge (e.g. a `:node`
+            // write modified the file under us), sweeping by the
+            // prefs view would clear `mcp_token_<id>` entries for
+            // servers that ARE in the file. Copilot R3 PR #352
+            // finding.
+            sweepOrphanTokens(app, cps.read().servers)
 
             // Step 4: observe-and-mirror collector.
             cps.state.collect { observed ->
@@ -389,7 +397,14 @@ object McpServersStore {
             McpTokenStore.write(context, id, token)
         }
         if (ok) {
-            rebuildRollbackShadow(context, _state.value)
+            // Use the same disk snapshot used for the existence
+            // check above, NOT `_state.value` — the collector lag
+            // means `_state` may be missing the server we just
+            // validated against, and the rebuilt shadow would be
+            // a stale list (potentially missing the just-added
+            // server during the create-server -> write -> setAuthToken
+            // flow). Copilot R3 PR #352 finding.
+            rebuildRollbackShadow(context, s.read().servers)
             ownedScope?.launch { NodeControlClient.reconcile(id) }
         }
         return ok

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -234,11 +234,18 @@ object McpServersStore {
                 return false
             }
         }
-        // Snapshot removed-ids BEFORE persisting so the post-write
-        // orphan token cleanup is correct even if the StateFlow
-        // emission lands first (the collector observer would otherwise
-        // see the new list and the diff would be empty).
-        val removedIds = _state.value.map { it.id }.toSet() - list.map { it.id }.toSet()
+        // Snapshot the disk's current servers BEFORE persisting, so
+        // the orphan-token cleanup diff is accurate even when our
+        // collector hasn't caught up to a recent prior write.
+        // Reading `_state.value` here would observe collector lag —
+        // by contrast, `s.read()` parses the JSON file synchronously
+        // (CrossProcessStore.write uses atomic move, so the read is
+        // never half-written). Best-effort against TOCTOU: another
+        // process writing between this read and the write below
+        // would race, but the orphan sweep at next `init()` catches
+        // any drift, and main-process writes from here serialize via
+        // CrossProcessStore.writeLock anyway.
+        val preIds = s.read().servers.map { it.id }.toSet()
         if (!s.write(McpServersFile(servers = list))) return false
 
         // Side effects after successful persist (kept out of the
@@ -246,7 +253,8 @@ object McpServersStore {
         // Clear orphan tokens for removed servers BEFORE rebuilding
         // the rollback shadow — otherwise the shadow would still see
         // the orphan via McpTokenStore.read and reattach it.
-        for (id in removedIds) {
+        val nextIds = list.map { it.id }.toSet()
+        for (id in preIds - nextIds) {
             McpTokenStore.clear(app, id)
         }
         rebuildRollbackShadow(app, list)
@@ -270,38 +278,44 @@ object McpServersStore {
     suspend fun update(transform: (List<McpServer>) -> List<McpServer>): Boolean {
         val app = appContext ?: return false
         val s = store ?: return false
-        // Capture pre-transform ids so the post-update orphan sweep
-        // sees an accurate diff. We can't compute this inside the
-        // transform lambda — `_state` may not have observed the new
-        // value yet, which is the whole point of doing it here.
-        val preIds = _state.value.map { it.id }.toSet()
+        // Capture pre-transform AND next snapshots inside the
+        // CrossProcessStore.update lock so the post-update side
+        // effects don't race the collector. Reading `_state.value`
+        // after `s.update` returns is unreliable — the collector that
+        // mirrors the disk write to `_state` runs on its own coroutine
+        // and may not have observed the new value yet (Copilot R1
+        // PR #352 finding).
+        var pre: List<McpServer> = emptyList()
+        var next: List<McpServer> = emptyList()
         val applied = s.update { current ->
-            val next = transform(current.servers).toList()
-            require(next.all { isValid(it) }) {
-                val bad = next.firstOrNull { !isValid(it) }
+            pre = current.servers
+            val computed = transform(current.servers).toList()
+            require(computed.all { isValid(it) }) {
+                val bad = computed.firstOrNull { !isValid(it) }
                 "Invalid entry after transform: id=${bad?.id} reason=${bad?.let { reasonFor(it) }}"
             }
             // Duplicate-id check inside the transform so the lock
             // covers it too (a concurrent write that produced the
             // duplicate can't slip through).
             val seen = mutableSetOf<String>()
-            for (entry in next) {
+            for (entry in computed) {
                 val n = normalizeId(entry.id)
                 require(seen.add(n)) {
                     "Duplicate id after normalization: ${entry.id} (normalizes to $n)"
                 }
             }
-            require(next.none { hasInsecureToken(app, it) }) {
+            require(computed.none { hasInsecureToken(app, it) }) {
                 "Server has token over insecure HTTP"
             }
-            McpServersFile(servers = next)
+            next = computed
+            McpServersFile(servers = computed)
         }
         if (applied) {
-            val postIds = _state.value.map { it.id }.toSet()
-            for (id in preIds - postIds) {
+            val nextIds = next.map { it.id }.toSet()
+            for (id in pre.map { it.id }.toSet() - nextIds) {
                 McpTokenStore.clear(app, id)
             }
-            rebuildRollbackShadow(app, _state.value)
+            rebuildRollbackShadow(app, next)
             ownedScope?.launch { NodeControlClient.reconcile(null) }
         }
         return applied
@@ -410,13 +424,17 @@ object McpServersStore {
 
     /**
      * Mirror Node's `safeId` normalization (mcp-client.js line 174):
-     * `replace(/[^a-zA-Z0-9_-]/g, '_')`. We also disallow the bare `-`
-     * collision via [ID_REGEX] up front, but use this for the
-     * post-normalization uniqueness check so a future regex-loosen
-     * doesn't open a duplicate-id hole.
+     * `replace(/[^a-zA-Z0-9_-]/g, '_')` — note the dash IS preserved
+     * on both sides so `server-1` is NOT folded to `server_1`. The
+     * post-normalization uniqueness check below is identity for any
+     * id that already passes [ID_REGEX] (since the regex's allowed
+     * set matches safeId's preserved set), but it remains as defense-
+     * in-depth: if [ID_REGEX] is ever loosened to allow e.g. `.`,
+     * Node would fold that to `_` via safeId, and this check would
+     * catch the resulting collision before either side sees it.
      */
     private fun normalizeId(id: String): String =
-        id.replace(Regex("[^A-Za-z0-9_]"), "_")
+        id.replace(Regex("[^A-Za-z0-9_-]"), "_")
 
     // ---- Collector path -------------------------------------------------
 

--- a/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpServersStore.kt
@@ -454,9 +454,12 @@ object McpServersStore {
      * Returns `false` if [init] wasn't called, [id] doesn't match a
      * server in the list (token-without-server is meaningless), the
      * server's URL is `http://non-loopback` (insecure bearer reject),
-     * or encryption / commit fails. Returns `true` once the token
-     * lands in prefs — the reconcile dispatch is best-effort and its
-     * outcome doesn't change this return.
+     * or [McpTokenStore.write] / [McpTokenStore.clear] fails (Keystore
+     * encrypt error, atomic move failure, or `File.delete` failure
+     * for an existing entry). Returns `true` once the token change
+     * has been written via [McpTokenStore]; any rollback shadow
+     * update and the reconcile dispatch are best-effort, and their
+     * outcomes don't change this return value.
      */
     fun setAuthToken(context: Context, id: String, token: String): Boolean {
         if (!isInitialized) return false
@@ -674,10 +677,11 @@ object McpServersStore {
 
     /**
      * Reconstruct legacy `KEY_MCP_SERVERS_ENC` from [servers] PLUS the
-     * encrypted-prefs tokens. A pre-BAT-514 build downgraded onto the
-     * current state expects each server entry to carry its `authToken`
-     * — without re-attaching here, downgrade would silently break
-     * authenticated MCP servers.
+     * per-id tokens read fresh from [McpTokenStore]'s encrypted token
+     * files (`filesDir/mcp_tokens/<id>`). A pre-BAT-514 build
+     * downgraded onto the current state expects each server entry to
+     * carry its `authToken` inline — without re-attaching here,
+     * downgrade would silently break authenticated MCP servers.
      *
      * Writes the same JSON shape the pre-BAT-514 `loadMcpServers`
      * path expects (servers with `authToken` inline), encrypted via
@@ -709,9 +713,9 @@ object McpServersStore {
             // apply() is async and would widen that window to
             // include arbitrary deferred-write delay (Android batches
             // apply() flushes). All callers run on Dispatchers.IO so
-            // the synchronous wait is benign. Mirrors McpTokenStore
-            // which uses commit() for the same reason. (Copilot R8
-            // PR #352 finding.)
+            // the synchronous wait is benign, and synchronous
+            // persistence here preserves the intended downgrade-
+            // durability contract. (Copilot R8 PR #352 finding.)
             // Surface a commit() failure: the rollback shadow is
             // explicitly part of the downgrade-durability contract,
             // so a silent failure here would defeat that guarantee

--- a/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
@@ -180,6 +180,20 @@ object McpTokenStore {
     }
 
     /**
+     * Cheap presence check: does a token file exist for [id]? No
+     * decrypt, just `File.exists()`. Used by the http+token validity
+     * gate in [McpServersStore], where we only need to know whether
+     * a token IS set (to reject `http://non-loopback` with token), not
+     * what its value is — letting that gate run inside the
+     * [com.seekerclaw.app.util.CrossProcessStore] writeLock without
+     * the Keystore decrypt cost.
+     */
+    fun hasToken(context: Context, id: String): Boolean {
+        val file = fileFor(context, id) ?: return false
+        return file.exists()
+    }
+
+    /**
      * Return the set of server ids that currently have a token file.
      * Used by [McpServersStore.init] to detect orphan tokens (tokens
      * whose server was deleted while a previous build was running and

--- a/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
@@ -111,37 +111,62 @@ object McpTokenStore {
      * UX). Empty / blank [token] writes nothing and returns `false` —
      * use [clear] to remove a token explicitly.
      *
-     * Atomic via tmp-file + `renameTo` — readers either see the prior
-     * file (or no file, if first write) or the new one, never a
-     * truncated mid-write.
+     * Atomic via tmp-file + `Files.move(REPLACE_EXISTING, ATOMIC_MOVE)`
+     * — same guarantee CrossProcessStore relies on for its JSON
+     * file. `File.renameTo` is unreliable on Android when the
+     * destination already exists (token rotations would silently
+     * fail and leak `<id>.tmp` files); the NIO move handles overwrite
+     * properly and falls back to non-atomic REPLACE_EXISTING on the
+     * narrow case where ATOMIC_MOVE isn't supported (cross-device
+     * — doesn't happen here since src + dst are in the same
+     * directory). Tmp is removed on any failure path so stale
+     * `<id>.tmp` entries don't accumulate. (Copilot R11 PR #352
+     * finding.)
      */
     fun write(context: Context, id: String, token: String): Boolean {
         if (token.isBlank()) return false
         val file = fileFor(context, id) ?: return false
+        val tmp = File(file.parentFile, "$id.tmp")
         return try {
             val enc = KeystoreHelper.encrypt(token)
-            val tmp = File(file.parentFile, "$id.tmp")
             tmp.writeBytes(enc)
-            // renameTo on the same filesystem is atomic on the
-            // Android-supported filesystems (ext4, F2FS) — same
-            // guarantee CrossProcessStore relies on for its tmp+move
-            // pattern. If the rename ever fails, fall through to
-            // false so the caller knows the write didn't land.
-            if (tmp.renameTo(file)) {
-                true
-            } else {
-                Log.w(TAG, "renameTo failed for mcp_tokens/$id; tmp file left in place")
-                false
+            try {
+                java.nio.file.Files.move(
+                    tmp.toPath(),
+                    file.toPath(),
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                    java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                )
+            } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+                // Same-directory move that the kernel decided isn't
+                // atomically replaceable (rare on ext4/F2FS). Fall
+                // back to REPLACE_EXISTING — still single-syscall.
+                java.nio.file.Files.move(
+                    tmp.toPath(),
+                    file.toPath(),
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                )
             }
+            true
         } catch (e: Exception) {
             Log.w(TAG, "Failed to write mcp_tokens/$id: ${e.message}")
+            // Clean up the tmp file we may have created so a future
+            // call doesn't trip over a stale partial write.
+            try { if (tmp.exists()) tmp.delete() } catch (_: Exception) {}
             false
         }
     }
 
     /**
-     * Remove the token entry for [id]. Returns `true` if the file is
-     * gone after the call (whether or not it existed before).
+     * Remove the token entry for [id].
+     *
+     * Returns:
+     *  - `true` when the file is gone after the call (whether it
+     *    existed before or not — clearing a non-existent token is a
+     *    no-op success)
+     *  - `false` when [id] fails [ID_REGEX] validation (caller bug —
+     *    valid server ids never trip this), or when [File.delete]
+     *    fails on an existing file (rare permission / FS error)
      */
     fun clear(context: Context, id: String): Boolean {
         val file = fileFor(context, id) ?: return false

--- a/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
@@ -1,22 +1,38 @@
 package com.seekerclaw.app.state
 
 import android.content.Context
-import android.content.SharedPreferences
-import android.util.Base64
 import android.util.Log
 import com.seekerclaw.app.config.KeystoreHelper
+import java.io.File
 
 /**
- * Process-agnostic encrypted-prefs helper for MCP server auth tokens
+ * Process-agnostic encrypted-file helper for MCP server auth tokens
  * (BAT-514).
  *
  * Each token is encrypted via [KeystoreHelper] (Keystore-backed AES-GCM,
- * same as the rest of the app's per-secret prefs entries), base64'd, and
- * stored in `seekerclaw_prefs` under the key `mcp_token_<id>`.
+ * same primitive used elsewhere for at-rest secrets) and persisted as
+ * its own file under `filesDir/mcp_tokens/<id>`. Atomic-rename writes
+ * keep readers from observing partial files.
  *
- * ## Why this is split out from [McpServersStore]
+ * ## Why files instead of SharedPreferences
  *
- * Token I/O has to work in BOTH processes:
+ * Earlier BAT-514 drafts stored tokens as encrypted blobs in
+ * `seekerclaw_prefs` keyed by `mcp_token_<id>`. The
+ * [com.seekerclaw.app.util.CrossProcessStore] class doc explicitly
+ * calls SharedPreferences "BROKEN cross-process — every field that's
+ * read on BOTH UI and `:node` sides has the same staleness bug": each
+ * process has its own in-memory `SharedPreferencesImpl` cache that
+ * doesn't reload after another process writes. For the BAT-514
+ * live-token-edit contract this would mean the FIRST token read in
+ * `:node` (cache miss → fresh disk load) sees the right value, but
+ * every subsequent edit returns the cached pre-edit value. Token
+ * rotation would silently fail until the service restarts.
+ *
+ * Switching to files-on-disk fixes this: every [read] does a fresh
+ * `File.readBytes()`, so `:node`'s view always matches whatever the
+ * main process most-recently wrote. (Copilot R10 PR #352 finding.)
+ *
+ * ## Token I/O works in BOTH processes
  *
  *  - **Main process:** Settings UI writes / clears via [McpServersStore]
  *    wrapper methods, which delegate to this object.
@@ -28,10 +44,9 @@ import com.seekerclaw.app.config.KeystoreHelper
  * Putting reads in [McpServersStore] would gate them on
  * `McpServersStore.init()` (main-process-only, per the BAT-513 pattern).
  * Splitting reads here means the bridge endpoint works regardless of
- * which process invoked it; `init()` isn't a precondition. Shared prefs
- * are file-backed and accessible cross-process for read, and the
- * Keystore key itself is per-app (not per-process), so the same
- * encrypted blob decrypts identically in either process.
+ * which process invoked it; `init()` isn't a precondition. The
+ * Keystore key is per-app (not per-process), so the same encrypted
+ * file decrypts identically in either process.
  *
  * ## What this does NOT do
  *
@@ -45,13 +60,25 @@ import com.seekerclaw.app.config.KeystoreHelper
  */
 object McpTokenStore {
     private const val TAG = "McpTokenStore"
-    private const val PREFS_NAME = "seekerclaw_prefs"
-    private const val KEY_PREFIX = "mcp_token_"
+    private const val DIR_NAME = "mcp_tokens"
 
-    private fun prefs(context: Context): SharedPreferences =
-        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    /**
+     * Same alphabet [McpServersStore.ID_REGEX] enforces. Validating at
+     * the file boundary prevents path traversal (`../`, `/`) and any
+     * caller bug from materializing a file outside `mcp_tokens/`.
+     */
+    private val ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
 
-    private fun keyFor(id: String): String = KEY_PREFIX + id
+    private fun dir(context: Context): File {
+        val d = File(context.applicationContext.filesDir, DIR_NAME)
+        if (!d.exists()) d.mkdirs()
+        return d
+    }
+
+    private fun fileFor(context: Context, id: String): File? {
+        if (!ID_REGEX.matches(id)) return null
+        return File(dir(context), id)
+    }
 
     /**
      * Read the decrypted token for [id]. Returns `""` (empty) when no
@@ -59,63 +86,87 @@ object McpTokenStore {
      * which is intentional: a corrupt entry should behave the same as
      * "no token" (the connect path handles missing tokens by attempting
      * unauthenticated, and a `WARN` log here is enough for diagnostics).
+     *
+     * Always reads fresh from disk — no caching layer that could go
+     * stale after a write from another process.
      */
     fun read(context: Context, id: String): String {
-        val raw = prefs(context).getString(keyFor(id), null) ?: return ""
+        val file = fileFor(context, id) ?: return ""
+        if (!file.exists()) return ""
         return try {
-            KeystoreHelper.decrypt(Base64.decode(raw, Base64.NO_WRAP))
+            KeystoreHelper.decrypt(file.readBytes())
         } catch (e: Exception) {
-            // Corrupt entry — treat as missing rather than crash the
-            // bridge endpoint. The user can re-enter the token in
-            // Settings if the connect attempt fails.
-            Log.w(TAG, "Failed to decrypt mcp_token_$id: ${e.message}")
+            // Corrupt or partially-written entry — treat as missing
+            // rather than crash the bridge endpoint. The user can
+            // re-enter the token in Settings if the connect attempt
+            // fails.
+            Log.w(TAG, "Failed to decrypt mcp_tokens/$id: ${e.message}")
             ""
         }
     }
 
     /**
      * Encrypt + persist [token] under [id]. Returns `true` on success,
-     * `false` on encryption / commit failure (caller surfaces via UX).
-     * Empty / blank [token] writes nothing and returns `false` — use
-     * [clear] to remove a token explicitly.
+     * `false` on encryption or filesystem failure (caller surfaces via
+     * UX). Empty / blank [token] writes nothing and returns `false` —
+     * use [clear] to remove a token explicitly.
+     *
+     * Atomic via tmp-file + `renameTo` — readers either see the prior
+     * file (or no file, if first write) or the new one, never a
+     * truncated mid-write.
      */
     fun write(context: Context, id: String, token: String): Boolean {
         if (token.isBlank()) return false
+        val file = fileFor(context, id) ?: return false
         return try {
             val enc = KeystoreHelper.encrypt(token)
-            prefs(context).edit()
-                .putString(keyFor(id), Base64.encodeToString(enc, Base64.NO_WRAP))
-                .commit()
+            val tmp = File(file.parentFile, "$id.tmp")
+            tmp.writeBytes(enc)
+            // renameTo on the same filesystem is atomic on the
+            // Android-supported filesystems (ext4, F2FS) — same
+            // guarantee CrossProcessStore relies on for its tmp+move
+            // pattern. If the rename ever fails, fall through to
+            // false so the caller knows the write didn't land.
+            if (tmp.renameTo(file)) {
+                true
+            } else {
+                Log.w(TAG, "renameTo failed for mcp_tokens/$id; tmp file left in place")
+                false
+            }
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to write mcp_token_$id: ${e.message}")
+            Log.w(TAG, "Failed to write mcp_tokens/$id: ${e.message}")
             false
         }
     }
 
     /**
-     * Remove the token entry for [id]. Returns `true` if the commit
-     * succeeded (whether or not a key was present beforehand).
+     * Remove the token entry for [id]. Returns `true` if the file is
+     * gone after the call (whether or not it existed before).
      */
     fun clear(context: Context, id: String): Boolean {
+        val file = fileFor(context, id) ?: return false
         return try {
-            prefs(context).edit().remove(keyFor(id)).commit()
+            if (!file.exists()) return true
+            file.delete()
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to clear mcp_token_$id: ${e.message}")
+            Log.w(TAG, "Failed to clear mcp_tokens/$id: ${e.message}")
             false
         }
     }
 
     /**
-     * Return the set of server ids that currently have a token entry.
+     * Return the set of server ids that currently have a token file.
      * Used by [McpServersStore.init] to detect orphan tokens (tokens
      * whose server was deleted while a previous build was running and
-     * the legacy `saveMcpServers` path didn't clean them up).
+     * the legacy `saveMcpServers` path didn't clean them up). Skips
+     * stale `<id>.tmp` files left by a crashed write.
      */
     fun listAllIds(context: Context): List<String> {
-        return prefs(context).all.keys
-            .asSequence()
-            .filter { it.startsWith(KEY_PREFIX) }
-            .map { it.removePrefix(KEY_PREFIX) }
-            .toList()
+        return dir(context).listFiles()
+            ?.asSequence()
+            ?.filter { it.isFile && ID_REGEX.matches(it.name) }
+            ?.map { it.name }
+            ?.toList()
+            ?: emptyList()
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/McpTokenStore.kt
@@ -1,0 +1,121 @@
+package com.seekerclaw.app.state
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import android.util.Log
+import com.seekerclaw.app.config.KeystoreHelper
+
+/**
+ * Process-agnostic encrypted-prefs helper for MCP server auth tokens
+ * (BAT-514).
+ *
+ * Each token is encrypted via [KeystoreHelper] (Keystore-backed AES-GCM,
+ * same as the rest of the app's per-secret prefs entries), base64'd, and
+ * stored in `seekerclaw_prefs` under the key `mcp_token_<id>`.
+ *
+ * ## Why this is split out from [McpServersStore]
+ *
+ * Token I/O has to work in BOTH processes:
+ *
+ *  - **Main process:** Settings UI writes / clears via [McpServersStore]
+ *    wrapper methods, which delegate to this object.
+ *  - **`:node` process:** AndroidBridge's `POST /config/mcp-token`
+ *    handler reads the token to give it to the Node MCP client. That
+ *    handler runs in `:node` (where `AndroidBridge` lives — see
+ *    `AndroidManifest.xml:55 android:process=":node"`).
+ *
+ * Putting reads in [McpServersStore] would gate them on
+ * `McpServersStore.init()` (main-process-only, per the BAT-513 pattern).
+ * Splitting reads here means the bridge endpoint works regardless of
+ * which process invoked it; `init()` isn't a precondition. Shared prefs
+ * are file-backed and accessible cross-process for read, and the
+ * Keystore key itself is per-app (not per-process), so the same
+ * encrypted blob decrypts identically in either process.
+ *
+ * ## What this does NOT do
+ *
+ *  - Does NOT manage the server list (id/name/url/enabled/rateLimit) —
+ *    that's [McpServersStore]'s domain.
+ *  - Does NOT register secrets for log redaction — Node owns that
+ *    after fetching the token in `MCPClient.connect`. See
+ *    `mcp-client.js`.
+ *  - Does NOT trigger reconnect on token change — [McpServersStore]
+ *    wrappers call `NodeControlClient.reconcile(id)` for that.
+ */
+object McpTokenStore {
+    private const val TAG = "McpTokenStore"
+    private const val PREFS_NAME = "seekerclaw_prefs"
+    private const val KEY_PREFIX = "mcp_token_"
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun keyFor(id: String): String = KEY_PREFIX + id
+
+    /**
+     * Read the decrypted token for [id]. Returns `""` (empty) when no
+     * token is stored OR decryption fails — callers can't distinguish,
+     * which is intentional: a corrupt entry should behave the same as
+     * "no token" (the connect path handles missing tokens by attempting
+     * unauthenticated, and a `WARN` log here is enough for diagnostics).
+     */
+    fun read(context: Context, id: String): String {
+        val raw = prefs(context).getString(keyFor(id), null) ?: return ""
+        return try {
+            KeystoreHelper.decrypt(Base64.decode(raw, Base64.NO_WRAP))
+        } catch (e: Exception) {
+            // Corrupt entry — treat as missing rather than crash the
+            // bridge endpoint. The user can re-enter the token in
+            // Settings if the connect attempt fails.
+            Log.w(TAG, "Failed to decrypt mcp_token_$id: ${e.message}")
+            ""
+        }
+    }
+
+    /**
+     * Encrypt + persist [token] under [id]. Returns `true` on success,
+     * `false` on encryption / commit failure (caller surfaces via UX).
+     * Empty / blank [token] writes nothing and returns `false` — use
+     * [clear] to remove a token explicitly.
+     */
+    fun write(context: Context, id: String, token: String): Boolean {
+        if (token.isBlank()) return false
+        return try {
+            val enc = KeystoreHelper.encrypt(token)
+            prefs(context).edit()
+                .putString(keyFor(id), Base64.encodeToString(enc, Base64.NO_WRAP))
+                .commit()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to write mcp_token_$id: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Remove the token entry for [id]. Returns `true` if the commit
+     * succeeded (whether or not a key was present beforehand).
+     */
+    fun clear(context: Context, id: String): Boolean {
+        return try {
+            prefs(context).edit().remove(keyFor(id)).commit()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to clear mcp_token_$id: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Return the set of server ids that currently have a token entry.
+     * Used by [McpServersStore.init] to detect orphan tokens (tokens
+     * whose server was deleted while a previous build was running and
+     * the legacy `saveMcpServers` path didn't clean them up).
+     */
+    fun listAllIds(context: Context): List<String> {
+        return prefs(context).all.keys
+            .asSequence()
+            .filter { it.startsWith(KEY_PREFIX) }
+            .map { it.removePrefix(KEY_PREFIX) }
+            .toList()
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -147,12 +147,25 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                 SeekerClawSwitch(
                                     checked = server.enabled,
                                     onCheckedChange = { enabled ->
-                                        val updated = mcpServers.map {
-                                            if (it.id == server.id) it.copy(enabled = enabled) else it
-                                        }
+                                        val targetId = server.id
+                                        // BAT-514 R9: route through
+                                        // update() for atomic RMW
+                                        // against the latest disk
+                                        // snapshot. write(mcpServers.map{}
+                                        // would compute from the UI's
+                                        // collected StateFlow value,
+                                        // which lags behind disk by a
+                                        // collector tick — two rapid
+                                        // toggles (or a toggle racing
+                                        // a /provider write from :node)
+                                        // could overwrite each other.
                                         scope.launch {
                                             val ok = withContext(Dispatchers.IO) {
-                                                McpServersStore.write(updated)
+                                                McpServersStore.update { current ->
+                                                    current.map {
+                                                        if (it.id == targetId) it.copy(enabled = enabled) else it
+                                                    }
+                                                }
                                             }
                                             // Success path is silent —
                                             // StateFlow refreshes the list
@@ -344,21 +357,29 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                 enabled = editingMcpServer?.enabled ?: true,
                                 rateLimit = editingMcpServer?.rateLimit ?: 10,
                             )
-                            val updated = if (editingMcpServer != null) {
-                                mcpServers.map { if (it.id == serverId) server else it }
-                            } else {
-                                mcpServers + server
-                            }
                             val tokenValue = mcpToken.trim()
                             val wasEditing = editingMcpServer != null
-                            // BAT-514 R2: persist + token write run on
-                            // Dispatchers.IO. write() does atomic file
-                            // move + KeystoreHelper.encrypt for the
-                            // shadow rebuild; setAuthToken does
-                            // KeystoreHelper.encrypt + commit.
+                            // BAT-514 R9: route through update() for
+                            // atomic RMW (same rationale as toggle /
+                            // delete). The transform composes the new
+                            // list against the latest on-disk state,
+                            // so concurrent edits from another screen
+                            // or the :node side can't be silently
+                            // overwritten by the UI's lagging
+                            // StateFlow snapshot. Validation throws
+                            // inside update()'s transform are caught
+                            // by CrossProcessStore.update and surface
+                            // as `false` here, which the existing
+                            // Toast path handles.
                             scope.launch {
                                 val writeOk = withContext(Dispatchers.IO) {
-                                    McpServersStore.write(updated)
+                                    McpServersStore.update { current ->
+                                        if (wasEditing) {
+                                            current.map { if (it.id == serverId) server else it }
+                                        } else {
+                                            current + server
+                                        }
+                                    }
                                 }
                                 if (!writeOk) {
                                     Toast.makeText(
@@ -434,13 +455,16 @@ fun McpConfigScreen(onBack: () -> Unit) {
             confirmButton = {
                 TextButton(onClick = {
                     val targetId = deletingMcpServer?.id
-                    val updated = mcpServers.filter { it.id != targetId }
-                    // BAT-514 R2: write off the UI thread (atomic move
-                    // + shadow rebuild + orphan token clear all do
-                    // disk + Keystore work).
+                    // BAT-514 R9: route through update() for atomic
+                    // RMW. Same rationale as the toggle handler —
+                    // the UI's `mcpServers` snapshot lags behind disk
+                    // by a collector tick, so a delete computed from
+                    // a stale list could miss a concurrent edit.
                     scope.launch {
                         val ok = withContext(Dispatchers.IO) {
-                            McpServersStore.write(updated)
+                            McpServersStore.update { current ->
+                                current.filter { it.id != targetId }
+                            }
                         }
                         if (ok) {
                             showDeleteMcpDialog = false

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -242,13 +242,35 @@ fun McpConfigScreen(onBack: () -> Unit) {
         // PasswordVisualTransformation hides the placeholder anyway,
         // so the user doesn't see flicker).
         var mcpToken by remember(editingMcpServer) { mutableStateOf("") }
+        // BAT-514 R16: track whether the user has typed in the token
+        // field. Used for two related bugs the prior implementation
+        // had:
+        //   (a) The async hydration could clobber what the user typed
+        //       between dialog open and getAuthToken returning
+        //       (Copilot R16 t1).
+        //   (b) The Save flow inferred "did this server have a stored
+        //       token?" via `getAuthToken(...).isNotEmpty()`, which
+        //       returns "" both for "no token" AND for
+        //       "present-but-corrupt token" — the user couldn't clear
+        //       a corrupted entry (Copilot R16 t2).
+        // Tracking explicit user edits lets us:
+        //   - skip auto-fill if the user has touched the field, AND
+        //   - only call setAuthToken when the user explicitly typed
+        //     (set or cleared) — never overwriting stored state via
+        //     a stale empty mcpToken from a slow async hydrate.
+        var tokenEdited by remember(editingMcpServer) { mutableStateOf(false) }
         LaunchedEffect(editingMcpServer) {
             val target = editingMcpServer
-            mcpToken = if (target == null) {
-                ""
+            if (target == null) {
+                mcpToken = ""
             } else {
-                withContext(Dispatchers.IO) {
+                val storedToken = withContext(Dispatchers.IO) {
                     McpServersStore.getAuthToken(context, target.id)
+                }
+                // Only auto-fill if the user hasn't started typing
+                // yet — otherwise we'd overwrite their input.
+                if (!tokenEdited) {
+                    mcpToken = storedToken
                 }
             }
         }
@@ -302,7 +324,7 @@ fun McpConfigScreen(onBack: () -> Unit) {
                     Spacer(modifier = Modifier.height(8.dp))
                     OutlinedTextField(
                         value = mcpToken,
-                        onValueChange = { mcpToken = it },
+                        onValueChange = { mcpToken = it; tokenEdited = true },
                         label = { Text("Auth Token (optional)", fontFamily = RethinkSans) },
                         visualTransformation = PasswordVisualTransformation(),
                         singleLine = true,
@@ -388,14 +410,20 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                     ).show()
                                     return@launch
                                 }
-                                // Token is optional — only call
-                                // setAuthToken when the user entered
-                                // or changed one, OR when an existing
-                                // entry's token needs to be cleared.
-                                val hadExistingToken = wasEditing && withContext(Dispatchers.IO) {
-                                    McpServersStore.getAuthToken(context, serverId).isNotEmpty()
-                                }
-                                if (tokenValue.isNotEmpty() || hadExistingToken) {
+                                // Token is optional. Only route through
+                                // setAuthToken when the user explicitly
+                                // typed in the token field — `tokenEdited`
+                                // tracks that. This is more robust than
+                                // the previous `getAuthToken(...).isNotEmpty()`
+                                // check, which couldn't distinguish "no
+                                // token" from "present-but-corrupt token"
+                                // (both return "" by design) and would
+                                // either silently skip a corrupt-clear OR
+                                // overwrite a stored token with a stale
+                                // empty `mcpToken` if the user clicked
+                                // Save before the async hydrate completed.
+                                // (Copilot R16 PR #352 finding.)
+                                if (tokenEdited) {
                                     val tokenOk = withContext(Dispatchers.IO) {
                                         McpServersStore.setAuthToken(context, serverId, tokenValue)
                                     }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -26,10 +26,15 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -67,8 +72,13 @@ fun McpConfigScreen(onBack: () -> Unit) {
     var deletingMcpServer by remember { mutableStateOf<McpServer?>(null) }
     var showRestartDialog by remember { mutableStateOf(false) }
 
-    // No prefs-load LaunchedEffect: the StateFlow above replaces it.
-    // Auth tokens are fetched lazily on edit (see Edit dialog).
+    // BAT-514 R2: McpServersStore.write / setAuthToken do disk I/O
+    // (JSON encode + atomic move + KeystoreHelper encrypt for the
+    // rollback-shadow rebuild) and need to run off the UI thread to
+    // avoid jank / StrictMode / ANR. All click handlers below dispatch
+    // through this scope onto Dispatchers.IO; UI state updates land
+    // back on Main via withContext.
+    val scope = rememberCoroutineScope()
 
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
@@ -134,19 +144,21 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                         val updated = mcpServers.map {
                                             if (it.id == server.id) it.copy(enabled = enabled) else it
                                         }
-                                        if (McpServersStore.write(updated)) {
-                                            showRestartDialog = true
-                                        } else {
-                                            // Revert via the StateFlow — UI will
-                                            // re-read the last-valid list. Not
-                                            // expected on a simple toggle, but
-                                            // covers the rare case of a concurrent
-                                            // FS failure.
-                                            Toast.makeText(
-                                                context,
-                                                "Couldn't update server",
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
+                                        scope.launch {
+                                            val ok = withContext(Dispatchers.IO) {
+                                                McpServersStore.write(updated)
+                                            }
+                                            if (ok) {
+                                                showRestartDialog = true
+                                            } else {
+                                                // Revert via the StateFlow —
+                                                // UI re-reads last valid list.
+                                                Toast.makeText(
+                                                    context,
+                                                    "Couldn't update server",
+                                                    Toast.LENGTH_SHORT,
+                                                ).show()
+                                            }
                                         }
                                     },
                                 )
@@ -201,11 +213,23 @@ fun McpConfigScreen(onBack: () -> Unit) {
     if (showMcpDialog) {
         var mcpName by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.name ?: "") }
         var mcpUrl by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.url ?: "") }
-        // BAT-514: tokens live in encrypted prefs (`mcp_token_<id>`),
-        // not on the McpServer object. Hydrate the field on dialog open
-        // so an edit shows the existing token; an add starts empty.
-        var mcpToken by remember(editingMcpServer) {
-            mutableStateOf(editingMcpServer?.let { McpServersStore.getAuthToken(context, it.id) } ?: "")
+        // BAT-514: tokens live in encrypted prefs (`mcp_token_<id>`).
+        // Hydrate the field via LaunchedEffect on Dispatchers.IO —
+        // KeystoreHelper.decrypt is blocking and was running on the
+        // composition thread inside `remember { }` before the R2 fix.
+        // While the decrypt is in flight the field stays "" (the
+        // PasswordVisualTransformation hides the placeholder anyway,
+        // so the user doesn't see flicker).
+        var mcpToken by remember(editingMcpServer) { mutableStateOf("") }
+        LaunchedEffect(editingMcpServer) {
+            val target = editingMcpServer
+            mcpToken = if (target == null) {
+                ""
+            } else {
+                withContext(Dispatchers.IO) {
+                    McpServersStore.getAuthToken(context, target.id)
+                }
+            }
         }
 
         AlertDialog(
@@ -317,40 +341,47 @@ fun McpConfigScreen(onBack: () -> Unit) {
                             } else {
                                 mcpServers + server
                             }
-                            // BAT-514: persist server first, token
-                            // second. If write fails, the token write
-                            // is skipped — we only want a token
-                            // attached to a persisted server. Token
-                            // value of "" clears the entry (handled by
-                            // setAuthToken).
                             val tokenValue = mcpToken.trim()
-                            val ok = McpServersStore.write(updated)
-                            if (!ok) {
-                                Toast.makeText(
-                                    context,
-                                    "Couldn't save server (check URL / token over insecure HTTP)",
-                                    Toast.LENGTH_LONG,
-                                ).show()
-                                return@TextButton
-                            }
-                            // Token is optional — only call setAuthToken
-                            // when the user actually entered/changed
-                            // one OR when explicitly clearing. The
-                            // store's setAuthToken handles both.
-                            if (tokenValue.isNotEmpty() ||
-                                (editingMcpServer != null &&
-                                    McpServersStore.getAuthToken(context, serverId).isNotEmpty())
-                            ) {
-                                if (!McpServersStore.setAuthToken(context, serverId, tokenValue)) {
+                            val wasEditing = editingMcpServer != null
+                            // BAT-514 R2: persist + token write run on
+                            // Dispatchers.IO. write() does atomic file
+                            // move + KeystoreHelper.encrypt for the
+                            // shadow rebuild; setAuthToken does
+                            // KeystoreHelper.encrypt + commit.
+                            scope.launch {
+                                val writeOk = withContext(Dispatchers.IO) {
+                                    McpServersStore.write(updated)
+                                }
+                                if (!writeOk) {
                                     Toast.makeText(
                                         context,
-                                        "Server saved, but token couldn't be stored",
+                                        "Couldn't save server (check URL / token over insecure HTTP)",
                                         Toast.LENGTH_LONG,
                                     ).show()
+                                    return@launch
                                 }
+                                // Token is optional — only call
+                                // setAuthToken when the user entered
+                                // or changed one, OR when an existing
+                                // entry's token needs to be cleared.
+                                val hadExistingToken = wasEditing && withContext(Dispatchers.IO) {
+                                    McpServersStore.getAuthToken(context, serverId).isNotEmpty()
+                                }
+                                if (tokenValue.isNotEmpty() || hadExistingToken) {
+                                    val tokenOk = withContext(Dispatchers.IO) {
+                                        McpServersStore.setAuthToken(context, serverId, tokenValue)
+                                    }
+                                    if (!tokenOk) {
+                                        Toast.makeText(
+                                            context,
+                                            "Server saved, but token couldn't be stored",
+                                            Toast.LENGTH_LONG,
+                                        ).show()
+                                    }
+                                }
+                                showMcpDialog = false
+                                showRestartDialog = true
                             }
-                            showMcpDialog = false
-                            showRestartDialog = true
                         }
                     },
                     enabled = mcpName.trim().isNotBlank() && mcpUrl.trim().isNotBlank(),
@@ -397,19 +428,24 @@ fun McpConfigScreen(onBack: () -> Unit) {
                 TextButton(onClick = {
                     val targetId = deletingMcpServer?.id
                     val updated = mcpServers.filter { it.id != targetId }
-                    if (McpServersStore.write(updated)) {
-                        // McpServersStore.write also runs the
-                        // delete-server cleanup (orphan token clear +
-                        // rollback shadow rebuild + reconcile).
-                        showDeleteMcpDialog = false
-                        deletingMcpServer = null
-                        showRestartDialog = true
-                    } else {
-                        Toast.makeText(
-                            context,
-                            "Couldn't remove server",
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    // BAT-514 R2: write off the UI thread (atomic move
+                    // + shadow rebuild + orphan token clear all do
+                    // disk + Keystore work).
+                    scope.launch {
+                        val ok = withContext(Dispatchers.IO) {
+                            McpServersStore.write(updated)
+                        }
+                        if (ok) {
+                            showDeleteMcpDialog = false
+                            deletingMcpServer = null
+                            showRestartDialog = true
+                        } else {
+                            Toast.makeText(
+                                context,
+                                "Couldn't remove server",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
                     }
                 }) {
                     Text(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -70,7 +70,13 @@ fun McpConfigScreen(onBack: () -> Unit) {
     var editingMcpServer by remember { mutableStateOf<McpServer?>(null) }
     var showDeleteMcpDialog by remember { mutableStateOf(false) }
     var deletingMcpServer by remember { mutableStateOf<McpServer?>(null) }
-    var showRestartDialog by remember { mutableStateOf(false) }
+    // BAT-514: no restart prompt for MCP edits. The Node side picks
+    // up file changes via fs.watch + the bridge `/mcp/reconcile`
+    // endpoint within ~1-2s, so the agent never needs to be
+    // restarted for an MCP server add/edit/disable/delete/token
+    // change. The StateFlow-driven list above provides the visual
+    // confirmation (Copilot R5 PR #352 finding — the prior restart
+    // prompt contradicted the BAT-514 design).
 
     // BAT-514 R2: McpServersStore.write / setAuthToken do disk I/O
     // (JSON encode + atomic move + KeystoreHelper encrypt for the
@@ -148,11 +154,13 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                             val ok = withContext(Dispatchers.IO) {
                                                 McpServersStore.write(updated)
                                             }
-                                            if (ok) {
-                                                showRestartDialog = true
-                                            } else {
-                                                // Revert via the StateFlow —
-                                                // UI re-reads last valid list.
+                                            // Success path is silent —
+                                            // StateFlow refreshes the list
+                                            // and Node reconciles within
+                                            // ~1-2s. Failure surfaces a
+                                            // Toast and reverts via the
+                                            // StateFlow re-read.
+                                            if (!ok) {
                                                 Toast.makeText(
                                                     context,
                                                     "Couldn't update server",
@@ -380,7 +388,6 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                     }
                                 }
                                 showMcpDialog = false
-                                showRestartDialog = true
                             }
                         }
                     },
@@ -438,7 +445,6 @@ fun McpConfigScreen(onBack: () -> Unit) {
                         if (ok) {
                             showDeleteMcpDialog = false
                             deletingMcpServer = null
-                            showRestartDialog = true
                         } else {
                             Toast.makeText(
                                 context,
@@ -466,11 +472,5 @@ fun McpConfigScreen(onBack: () -> Unit) {
         )
     }
 
-    // ==================== Restart Prompt ====================
-    if (showRestartDialog) {
-        RestartDialog(
-            context = context,
-            onDismiss = { showRestartDialog = false },
-        )
-    }
+    // No restart prompt — see comment at the top of this composable.
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -234,7 +234,7 @@ fun McpConfigScreen(onBack: () -> Unit) {
     if (showMcpDialog) {
         var mcpName by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.name ?: "") }
         var mcpUrl by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.url ?: "") }
-        // BAT-514: tokens live in encrypted prefs (`mcp_token_<id>`).
+        // BAT-514: tokens live in encrypted files (`mcp_tokens/<id>`).
         // Hydrate the field via LaunchedEffect on Dispatchers.IO —
         // KeystoreHelper.decrypt is blocking and was running on the
         // composition thread inside `remember { }` before the R2 fix.

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -359,18 +359,17 @@ fun McpConfigScreen(onBack: () -> Unit) {
                             )
                             val tokenValue = mcpToken.trim()
                             val wasEditing = editingMcpServer != null
-                            // BAT-514 R9: route through update() for
-                            // atomic RMW (same rationale as toggle /
-                            // delete). The transform composes the new
-                            // list against the latest on-disk state,
-                            // so concurrent edits from another screen
-                            // or the :node side can't be silently
-                            // overwritten by the UI's lagging
-                            // StateFlow snapshot. Validation throws
-                            // inside update()'s transform are caught
-                            // by CrossProcessStore.update and surface
-                            // as `false` here, which the existing
-                            // Toast path handles.
+                            // BAT-514 R9/R13: route through update() for
+                            // a fresh-disk-read + transform + atomic
+                            // write. Picks up edits from another
+                            // screen or the :node side that the UI's
+                            // collected `mcpServers` snapshot might
+                            // not have observed yet. Validation
+                            // failures (invalid id, dup id, http +
+                            // token) surface as `false` directly —
+                            // McpServersStore.update returns false
+                            // without throwing, so the Toast path
+                            // handles them naturally.
                             scope.launch {
                                 val writeOk = withContext(Dispatchers.IO) {
                                     McpServersStore.update { current ->

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -267,9 +267,26 @@ fun McpConfigScreen(onBack: () -> Unit) {
                 val storedToken = withContext(Dispatchers.IO) {
                     McpServersStore.getAuthToken(context, target.id)
                 }
-                // Only auto-fill if the user hasn't started typing
-                // yet — otherwise we'd overwrite their input.
-                if (!tokenEdited) {
+                if (storedToken.isEmpty()) {
+                    // `""` from getAuthToken means EITHER no token is
+                    // stored OR the token file exists but couldn't be
+                    // decrypted (Keystore failure, file corruption).
+                    // Self-heal the corrupt-file case: force tokenEdited
+                    // so the user's next Save calls setAuthToken("")
+                    // and clears the stale file. Without this, the
+                    // file lingers and the http+token gate keeps
+                    // blocking edits via `hasToken` even though the
+                    // UI shows an empty field. (Copilot R17 PR #352
+                    // finding.)
+                    val corruptFilePresent = withContext(Dispatchers.IO) {
+                        McpServersStore.hasAuthToken(context, target.id)
+                    }
+                    if (corruptFilePresent) {
+                        tokenEdited = true
+                    }
+                } else if (!tokenEdited) {
+                    // Only auto-fill if the user hasn't started typing
+                    // yet — otherwise we'd overwrite their input.
                     mcpToken = storedToken
                 }
             }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -26,9 +26,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,8 +41,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.seekerclaw.app.config.ConfigManager
-import com.seekerclaw.app.config.McpServerConfig
+import androidx.compose.runtime.collectAsState
+import com.seekerclaw.app.state.McpServer
+import com.seekerclaw.app.state.McpServersStore
 import com.seekerclaw.app.ui.components.CardSurface
 import com.seekerclaw.app.ui.components.SectionLabel
 import com.seekerclaw.app.ui.components.SeekerClawScaffold
@@ -57,20 +55,20 @@ import com.seekerclaw.app.ui.theme.SeekerClawColors
 fun McpConfigScreen(onBack: () -> Unit) {
     val context = LocalContext.current
 
-    var mcpServers by remember { mutableStateOf(emptyList<McpServerConfig>()) }
+    // BAT-514: observe `McpServersStore.state` directly. Reads come
+    // from `mcp_servers.json` (the cross-process source of truth),
+    // not the legacy KEY_MCP_SERVERS_ENC prefs blob — so a Telegram
+    // /mcp edit (when that lands) or any other-process write reflects
+    // here within ~1-2s of the file change.
+    val mcpServers by McpServersStore.state.collectAsState()
     var showMcpDialog by remember { mutableStateOf(false) }
-    var editingMcpServer by remember { mutableStateOf<McpServerConfig?>(null) }
+    var editingMcpServer by remember { mutableStateOf<McpServer?>(null) }
     var showDeleteMcpDialog by remember { mutableStateOf(false) }
-    var deletingMcpServer by remember { mutableStateOf<McpServerConfig?>(null) }
+    var deletingMcpServer by remember { mutableStateOf<McpServer?>(null) }
     var showRestartDialog by remember { mutableStateOf(false) }
 
-    // Load MCP servers off main thread (Keystore decrypt + JSON parse)
-    val configVer by ConfigManager.configVersion
-    LaunchedEffect(configVer) {
-        mcpServers = withContext(Dispatchers.IO) {
-            ConfigManager.loadMcpServers(context)
-        }
-    }
+    // No prefs-load LaunchedEffect: the StateFlow above replaces it.
+    // Auth tokens are fetched lazily on edit (see Edit dialog).
 
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
@@ -133,11 +131,23 @@ fun McpConfigScreen(onBack: () -> Unit) {
                                 SeekerClawSwitch(
                                     checked = server.enabled,
                                     onCheckedChange = { enabled ->
-                                        mcpServers = mcpServers.map {
+                                        val updated = mcpServers.map {
                                             if (it.id == server.id) it.copy(enabled = enabled) else it
                                         }
-                                        ConfigManager.saveMcpServers(context, mcpServers)
-                                        showRestartDialog = true
+                                        if (McpServersStore.write(updated)) {
+                                            showRestartDialog = true
+                                        } else {
+                                            // Revert via the StateFlow — UI will
+                                            // re-read the last-valid list. Not
+                                            // expected on a simple toggle, but
+                                            // covers the rare case of a concurrent
+                                            // FS failure.
+                                            Toast.makeText(
+                                                context,
+                                                "Couldn't update server",
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                        }
                                     },
                                 )
                                 IconButton(onClick = {
@@ -191,7 +201,12 @@ fun McpConfigScreen(onBack: () -> Unit) {
     if (showMcpDialog) {
         var mcpName by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.name ?: "") }
         var mcpUrl by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.url ?: "") }
-        var mcpToken by remember(editingMcpServer) { mutableStateOf(editingMcpServer?.authToken ?: "") }
+        // BAT-514: tokens live in encrypted prefs (`mcp_token_<id>`),
+        // not on the McpServer object. Hydrate the field on dialog open
+        // so an edit shows the existing token; an add starts empty.
+        var mcpToken by remember(editingMcpServer) {
+            mutableStateOf(editingMcpServer?.let { McpServersStore.getAuthToken(context, it.id) } ?: "")
+        }
 
         AlertDialog(
             onDismissRequest = { showMcpDialog = false },
@@ -285,28 +300,55 @@ fun McpConfigScreen(onBack: () -> Unit) {
                             }
                         }
                         if (trimName.isNotBlank() && trimUrl.isNotBlank()) {
+                            // UUID generated for new entries — UUID
+                            // characters (hex + "-") all match
+                            // McpServersStore.ID_REGEX.
                             val serverId = editingMcpServer?.id
                                 ?: java.util.UUID.randomUUID().toString()
-                            val server = if (editingMcpServer != null) {
-                                editingMcpServer!!.copy(
-                                    name = trimName,
-                                    url = trimUrl,
-                                    authToken = mcpToken.trim(),
-                                )
-                            } else {
-                                McpServerConfig(
-                                    id = serverId,
-                                    name = trimName,
-                                    url = trimUrl,
-                                    authToken = mcpToken.trim(),
-                                )
-                            }
-                            mcpServers = if (editingMcpServer != null) {
+                            val server = McpServer(
+                                id = serverId,
+                                name = trimName,
+                                url = trimUrl,
+                                enabled = editingMcpServer?.enabled ?: true,
+                                rateLimit = editingMcpServer?.rateLimit ?: 10,
+                            )
+                            val updated = if (editingMcpServer != null) {
                                 mcpServers.map { if (it.id == serverId) server else it }
                             } else {
                                 mcpServers + server
                             }
-                            ConfigManager.saveMcpServers(context, mcpServers)
+                            // BAT-514: persist server first, token
+                            // second. If write fails, the token write
+                            // is skipped — we only want a token
+                            // attached to a persisted server. Token
+                            // value of "" clears the entry (handled by
+                            // setAuthToken).
+                            val tokenValue = mcpToken.trim()
+                            val ok = McpServersStore.write(updated)
+                            if (!ok) {
+                                Toast.makeText(
+                                    context,
+                                    "Couldn't save server (check URL / token over insecure HTTP)",
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                                return@TextButton
+                            }
+                            // Token is optional — only call setAuthToken
+                            // when the user actually entered/changed
+                            // one OR when explicitly clearing. The
+                            // store's setAuthToken handles both.
+                            if (tokenValue.isNotEmpty() ||
+                                (editingMcpServer != null &&
+                                    McpServersStore.getAuthToken(context, serverId).isNotEmpty())
+                            ) {
+                                if (!McpServersStore.setAuthToken(context, serverId, tokenValue)) {
+                                    Toast.makeText(
+                                        context,
+                                        "Server saved, but token couldn't be stored",
+                                        Toast.LENGTH_LONG,
+                                    ).show()
+                                }
+                            }
                             showMcpDialog = false
                             showRestartDialog = true
                         }
@@ -353,11 +395,22 @@ fun McpConfigScreen(onBack: () -> Unit) {
             },
             confirmButton = {
                 TextButton(onClick = {
-                    mcpServers = mcpServers.filter { it.id != deletingMcpServer?.id }
-                    ConfigManager.saveMcpServers(context, mcpServers)
-                    showDeleteMcpDialog = false
-                    deletingMcpServer = null
-                    showRestartDialog = true
+                    val targetId = deletingMcpServer?.id
+                    val updated = mcpServers.filter { it.id != targetId }
+                    if (McpServersStore.write(updated)) {
+                        // McpServersStore.write also runs the
+                        // delete-server cleanup (orphan token clear +
+                        // rollback shadow rebuild + reconcile).
+                        showDeleteMcpDialog = false
+                        deletingMcpServer = null
+                        showRestartDialog = true
+                    } else {
+                        Toast.makeText(
+                            context,
+                            "Couldn't remove server",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
                 }) {
                     Text(
                         "Remove",

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsHelpTexts.kt
@@ -149,9 +149,9 @@ object SettingsHelpTexts {
 
     const val MCP_SERVERS =
         "MCP (Model Context Protocol) servers give your agent extra tools from external services. " +
-        "Add a server URL, optionally an auth token, and your agent discovers its tools on startup. " +
-        "Remote only — your phone just makes HTTP calls. " +
-        "Restart the agent after adding or changing servers."
+        "Add a server URL, optionally an auth token, and your agent discovers its tools live — " +
+        "edits apply within a couple seconds without restarting the agent. " +
+        "Remote only — your phone just makes HTTP calls."
 
     // ── Discord ────────────────────────────────────────────────────
 

--- a/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
@@ -115,11 +115,15 @@ class McpServersStoreTest {
     }
 
     @Test
-    fun `onObserved drops duplicate normalized ids keeping the first`() {
-        // "server-1" and "server_1" both normalize to "server_1" via
-        // mcp-client.js's safeId. Only the first survives.
-        val first = McpServer(id = "server-1", name = "First", url = "https://a", rateLimit = 1)
-        val collide = McpServer(id = "server_1", name = "Collide", url = "https://b", rateLimit = 1)
+    fun `onObserved drops duplicate ids keeping the first`() {
+        // Both Kotlin's normalizeId and Node's safeId preserve the
+        // ID_REGEX-allowed alphabet (alpha + digit + `_` + `-`)
+        // unchanged, so any two entries that normalize to the same
+        // bucket must already share an exact id. The collision check
+        // is identity for in-spec ids, but kept as defense-in-depth
+        // for a future ID_REGEX loosening.
+        val first = McpServer(id = "ctx", name = "First", url = "https://a", rateLimit = 1)
+        val collide = McpServer(id = "ctx", name = "Collide", url = "https://b", rateLimit = 1)
         val third = McpServer(id = "different", name = "Third", url = "https://c", rateLimit = 1)
         val cleaned = McpServersStore.onObserved(
             McpServersFile(servers = listOf(first, collide, third)),

--- a/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
@@ -1,0 +1,185 @@
+package com.seekerclaw.app.state
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pure JVM tests for McpServersStore's validity gate, normalization,
+ * and collector path (BAT-514).
+ *
+ * Same convention as RuntimeStateStoreTest / CrossProcessStoreTest: the
+ * Android-specific surfaces (FileObserver, BroadcastReceiver,
+ * Keystore-backed token I/O, NodeControlClient HTTP) are validated by
+ * device test or by separate integration tests, not here.
+ *
+ * The collector path is exercised via the internal
+ * [McpServersStore.onObserved] entry point — driving the singleton
+ * directly without spinning up a real CrossProcessStore.
+ */
+class McpServersStoreTest {
+
+    @Before
+    fun setUp() {
+        McpServersStore.resetForTest()
+    }
+
+    @After
+    fun tearDown() {
+        McpServersStore.resetForTest()
+    }
+
+    // ---------- isValid predicate ----------
+
+    @Test
+    fun `isValid accepts canonical id name url rateLimit`() {
+        val s = McpServer(id = "context7", name = "Context7", url = "https://api.example.com/mcp", rateLimit = 10)
+        assertTrue(McpServersStore.isValid(s))
+    }
+
+    @Test
+    fun `isValid rejects empty id`() {
+        val s = McpServer(id = "", name = "x", url = "https://x", rateLimit = 1)
+        assertFalse(McpServersStore.isValid(s))
+    }
+
+    @Test
+    fun `isValid rejects id with whitespace`() {
+        val s = McpServer(id = "context 7", name = "x", url = "https://x", rateLimit = 1)
+        assertFalse(McpServersStore.isValid(s))
+    }
+
+    @Test
+    fun `isValid rejects id with shell-meta chars`() {
+        // The Node side normalizes these to "_" via safeId, but the
+        // Kotlin write boundary rejects them outright so the file
+        // never carries an id that needs normalization on read.
+        for (bad in listOf("a/b", "a;b", "a b", "a\$b", "a.b", "🦄", "a/../b")) {
+            val s = McpServer(id = bad, name = "x", url = "https://x", rateLimit = 1)
+            assertFalse("expected reject: id='$bad'", McpServersStore.isValid(s))
+        }
+    }
+
+    @Test
+    fun `isValid rejects blank name`() {
+        val s = McpServer(id = "ctx", name = "  ", url = "https://x", rateLimit = 1)
+        assertFalse(McpServersStore.isValid(s))
+    }
+
+    @Test
+    fun `isValid rejects rateLimit zero or negative`() {
+        val zero = McpServer(id = "ctx", name = "n", url = "https://x", rateLimit = 0)
+        val neg = McpServer(id = "ctx", name = "n", url = "https://x", rateLimit = -1)
+        assertFalse(McpServersStore.isValid(zero))
+        assertFalse(McpServersStore.isValid(neg))
+    }
+
+    @Test
+    fun `isValid rejects bad URL schemes`() {
+        for (bad in listOf("ftp://x", "file:///etc/passwd", "javascript:alert(1)", "data:text/plain,foo", "")) {
+            val s = McpServer(id = "ctx", name = "n", url = bad, rateLimit = 1)
+            assertFalse("expected reject: url='$bad'", McpServersStore.isValid(s))
+        }
+    }
+
+    @Test
+    fun `isValid accepts http and https`() {
+        // http alone is valid at the matrix level — the bearer-over-
+        // insecure-HTTP rule is enforced separately at write boundary
+        // (when a token is also present).
+        val httpsS = McpServer(id = "ctx", name = "n", url = "https://example.com/mcp", rateLimit = 1)
+        val httpS = McpServer(id = "ctx", name = "n", url = "http://localhost:8080/mcp", rateLimit = 1)
+        assertTrue(McpServersStore.isValid(httpsS))
+        assertTrue(McpServersStore.isValid(httpS))
+    }
+
+    @Test
+    fun `isValid rejects URL without host`() {
+        val s = McpServer(id = "ctx", name = "n", url = "https:///path", rateLimit = 1)
+        assertFalse(McpServersStore.isValid(s))
+    }
+
+    // ---------- collector path (onObserved) ----------
+
+    @Test
+    fun `onObserved drops corrupt entries and keeps the rest`() {
+        val good = McpServer(id = "ok1", name = "OK1", url = "https://a", rateLimit = 5)
+        val bad = McpServer(id = "bad id", name = "x", url = "https://b", rateLimit = 1)
+        val good2 = McpServer(id = "ok2", name = "OK2", url = "https://c", rateLimit = 3)
+        val cleaned = McpServersStore.onObserved(McpServersFile(servers = listOf(good, bad, good2)))
+        assertEquals(listOf(good, good2), cleaned)
+        assertEquals(listOf(good, good2), McpServersStore.state.value)
+    }
+
+    @Test
+    fun `onObserved drops duplicate normalized ids keeping the first`() {
+        // "server-1" and "server_1" both normalize to "server_1" via
+        // mcp-client.js's safeId. Only the first survives.
+        val first = McpServer(id = "server-1", name = "First", url = "https://a", rateLimit = 1)
+        val collide = McpServer(id = "server_1", name = "Collide", url = "https://b", rateLimit = 1)
+        val third = McpServer(id = "different", name = "Third", url = "https://c", rateLimit = 1)
+        val cleaned = McpServersStore.onObserved(
+            McpServersFile(servers = listOf(first, collide, third)),
+        )
+        assertEquals(listOf(first, third), cleaned)
+    }
+
+    @Test
+    fun `onObserved on empty file publishes empty list`() {
+        val cleaned = McpServersStore.onObserved(McpServersFile(servers = emptyList()))
+        assertTrue(cleaned.isEmpty())
+        assertTrue(McpServersStore.state.value.isEmpty())
+    }
+
+    @Test
+    fun `onObserved with all-corrupt input publishes empty list`() {
+        val corrupt = listOf(
+            McpServer(id = "", name = "x", url = "https://a", rateLimit = 1),
+            McpServer(id = "ok", name = "x", url = "ftp://b", rateLimit = 1),
+            McpServer(id = "ok2", name = "", url = "https://c", rateLimit = 1),
+        )
+        val cleaned = McpServersStore.onObserved(McpServersFile(servers = corrupt))
+        assertTrue("all entries corrupt → cleaned is empty", cleaned.isEmpty())
+    }
+
+    // ---------- drift guards ----------
+
+    @Test
+    fun `ID_REGEX is exactly the documented set`() {
+        // Drift guard: the contract pins this to ^[A-Za-z0-9_-]+$.
+        // Node's safeId normalization replaces [^A-Za-z0-9_] with "_"
+        // — narrower than this regex (no "-"). The Kotlin write
+        // boundary intentionally allows "-" (canonical mcp ids like
+        // "server-1") AND adds the post-normalization uniqueness
+        // check so "-" / "_" can't collide silently.
+        val good = listOf("a", "A", "0", "_", "-", "abc", "a-b_c", "Z9_-")
+        val bad = listOf("", " ", "a b", "a/b", "a.b", "a;b", "🦄", "a/../b")
+        for (g in good) {
+            assertTrue("'$g' should match", McpServersStore.isValid(
+                McpServer(id = g, name = "n", url = "https://x", rateLimit = 1),
+            ))
+        }
+        for (b in bad) {
+            assertFalse("'$b' should not match", McpServersStore.isValid(
+                McpServer(id = b, name = "n", url = "https://x", rateLimit = 1),
+            ))
+        }
+    }
+
+    @Test
+    fun `reasonFor distinguishes failure modes`() {
+        val badId = McpServer(id = "x y", name = "n", url = "https://h", rateLimit = 1)
+        val badName = McpServer(id = "x", name = "  ", url = "https://h", rateLimit = 1)
+        val badUrl = McpServer(id = "x", name = "n", url = "ftp://h", rateLimit = 1)
+        val badRate = McpServer(id = "x", name = "n", url = "https://h", rateLimit = 0)
+        val ok = McpServer(id = "x", name = "n", url = "https://h", rateLimit = 1)
+        assertTrue(McpServersStore.reasonFor(badId).contains("id"))
+        assertTrue(McpServersStore.reasonFor(badName).contains("name"))
+        assertTrue(McpServersStore.reasonFor(badUrl).contains("url"))
+        assertTrue(McpServersStore.reasonFor(badRate).contains("rateLimit"))
+        assertEquals("ok", McpServersStore.reasonFor(ok))
+    }
+}

--- a/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/McpServersStoreTest.kt
@@ -154,11 +154,14 @@ class McpServersStoreTest {
     @Test
     fun `ID_REGEX is exactly the documented set`() {
         // Drift guard: the contract pins this to ^[A-Za-z0-9_-]+$.
-        // Node's safeId normalization replaces [^A-Za-z0-9_] with "_"
-        // — narrower than this regex (no "-"). The Kotlin write
-        // boundary intentionally allows "-" (canonical mcp ids like
-        // "server-1") AND adds the post-normalization uniqueness
-        // check so "-" / "_" can't collide silently.
+        // Node's safeId normalization in mcp-client.js uses
+        // `replace(/[^a-zA-Z0-9_-]/g, '_')` and PRESERVES "-" — the
+        // alphabet here matches that exactly so canonical mcp ids
+        // like "server-1" pass through both sides unchanged. The
+        // post-normalization uniqueness check is identity for any
+        // in-spec id; kept as defense-in-depth in case the regex
+        // is ever loosened to allow characters Node would fold
+        // (e.g. "." -> "_" via safeId).
         val good = listOf("a", "A", "0", "_", "-", "abc", "a-b_c", "Z9_-")
         val bad = listOf("", " ", "a b", "a/b", "a.b", "a;b", "🦄", "a/../b")
         for (g in good) {

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -131,11 +131,12 @@ test('GET /stats/db-summary works without auth (BAT-31 contract preserved)', asy
     assert.deepStrictEqual(r.body, _dbSummary);
 });
 
-test('GET /stats/db-summary on unrelated paths returns 404', async () => {
+test('GET on non-stats path falls through to 405 (method check before 404)', async () => {
+    // _route's first check is "GET + path === /stats/db-summary"; any
+    // other GET hits the "method !== POST" gate before the 404 fallback.
+    // 405 (not 404) is the documented behavior for unknown GET paths.
     const r = await _get('/stats/something-else');
-    assert.strictEqual(r.status, 405); // GET on /stats/something-else is method not allowed before reaching 404 path? actually GET on non-/stats falls through to method check
-    // _route runs path-match for GET /stats/db-summary first; otherwise falls
-    // through to "method !== POST → 405". This documents that behavior.
+    assert.strictEqual(r.status, 405);
 });
 
 // ---------- /mcp/reconcile auth ----------

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+// internal-control-server.test.js — tests for BAT-514's loopback HTTP
+// server on 127.0.0.1:8766 hosting both /stats/db-summary AND the new
+// /mcp/reconcile + /healthz endpoints.
+//
+// Run:  node tests/nodejs-project/internal-control-server.test.js
+// Exit: 0 = all pass, 1 = at least one failure.
+//
+// Pins:
+//   - port 8766 (must match AndroidBridge.kt's proxy URL)
+//   - GET /stats/db-summary works without auth (preserves BAT-31 contract)
+//   - POST /mcp/reconcile requires bridge-token auth
+//   - POST /mcp/reconcile coalesces enqueue (single drain pass per burst)
+//   - POST /healthz round-trip
+//   - 404 / 405 / 401 / 429 status codes
+//   - id validation: non-string/empty becomes full reconcile
+
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+
+const SERVER_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'internal-control-server.js');
+const server = require(SERVER_JS);
+
+const HOST = '127.0.0.1';
+const PORT = server.PORT;
+const BRIDGE_TOKEN = 'test-bridge-token-1234567890';
+
+// Aggregate state for assertions
+let _reconcileCalls = [];
+let _dbSummary = { messages: 1, tools: 2 };
+
+function _post(path, body, headers) {
+    return new Promise((resolve, reject) => {
+        const data = body == null ? '' : JSON.stringify(body);
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path,
+            method: 'POST',
+            headers: Object.assign({
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(data),
+            }, headers || {}),
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, headers: res.headers, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+function _get(path, headers) {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path,
+            method: 'GET',
+            headers: headers || {},
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, headers: res.headers, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+        req.end();
+    });
+}
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    server.start({
+        bridgeToken: BRIDGE_TOKEN,
+        getDbSummary: () => _dbSummary,
+        requestReconcile: (id) => { _reconcileCalls.push(id); },
+        logFn: () => {}, // suppress
+    });
+    // small delay so listen() callback fires
+    await new Promise((r) => setTimeout(r, 30));
+    for (const { name, fn } of tests) {
+        try {
+            _reconcileCalls = [];
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    await server.stop();
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+// ---------- port + drift ----------
+
+test('drift: PORT is exactly 8766 (must match AndroidBridge proxy URL)', () => {
+    assert.strictEqual(PORT, 8766);
+});
+
+// ---------- /stats/db-summary ----------
+
+test('GET /stats/db-summary works without auth (BAT-31 contract preserved)', async () => {
+    const r = await _get('/stats/db-summary');
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(r.body, _dbSummary);
+});
+
+test('GET /stats/db-summary on unrelated paths returns 404', async () => {
+    const r = await _get('/stats/something-else');
+    assert.strictEqual(r.status, 405); // GET on /stats/something-else is method not allowed before reaching 404 path? actually GET on non-/stats falls through to method check
+    // _route runs path-match for GET /stats/db-summary first; otherwise falls
+    // through to "method !== POST → 405". This documents that behavior.
+});
+
+// ---------- /mcp/reconcile auth ----------
+
+test('POST /mcp/reconcile without X-Bridge-Token returns 401', async () => {
+    const r = await _post('/mcp/reconcile', {});
+    assert.strictEqual(r.status, 401);
+    assert.deepStrictEqual(_reconcileCalls, []);
+});
+
+test('POST /mcp/reconcile with wrong token returns 401', async () => {
+    const r = await _post('/mcp/reconcile', {}, { 'X-Bridge-Token': 'wrong' });
+    assert.strictEqual(r.status, 401);
+    assert.deepStrictEqual(_reconcileCalls, []);
+});
+
+test('POST /mcp/reconcile with correct token returns 200 and enqueues full reconcile', async () => {
+    const r = await _post('/mcp/reconcile', {}, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(_reconcileCalls, [null]);
+});
+
+test('POST /mcp/reconcile with id enqueues per-server reconcile', async () => {
+    const r = await _post('/mcp/reconcile', { id: 'ctx7' }, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(_reconcileCalls, ['ctx7']);
+});
+
+test('POST /mcp/reconcile with empty body enqueues full reconcile', async () => {
+    const r = await _post('/mcp/reconcile', null, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(_reconcileCalls, [null]);
+});
+
+test('POST /mcp/reconcile with non-string id falls back to full reconcile', async () => {
+    const r = await _post('/mcp/reconcile', { id: 123 }, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(_reconcileCalls, [null]);
+});
+
+test('POST /mcp/reconcile with malformed JSON falls back to full reconcile', async () => {
+    // Send a body the server's body-reader will see as non-JSON
+    const data = 'not json';
+    const r = await new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path: '/mcp/reconcile',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(data),
+                'X-Bridge-Token': BRIDGE_TOKEN,
+            },
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => resolve({ status: res.statusCode, body: raw }));
+        });
+        req.on('error', reject);
+        req.write(data);
+        req.end();
+    });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(_reconcileCalls, [null]);
+});
+
+// ---------- /healthz ----------
+
+test('POST /healthz with valid token returns 200 ok:true', async () => {
+    const r = await _post('/healthz', {}, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(r.body, { ok: true });
+});
+
+test('POST /healthz without token returns 401', async () => {
+    const r = await _post('/healthz', {});
+    assert.strictEqual(r.status, 401);
+});
+
+// ---------- method / path errors ----------
+
+test('GET /mcp/reconcile returns 405', async () => {
+    const r = await _get('/mcp/reconcile', { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 405);
+});
+
+test('POST /unknown returns 404', async () => {
+    const r = await _post('/unknown', {}, { 'X-Bridge-Token': BRIDGE_TOKEN });
+    assert.strictEqual(r.status, 404);
+});
+
+run();

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -10,10 +10,15 @@
 //   - port 8766 (must match AndroidBridge.kt's proxy URL)
 //   - GET /stats/db-summary works without auth (preserves BAT-31 contract)
 //   - POST /mcp/reconcile requires bridge-token auth
-//   - POST /mcp/reconcile coalesces enqueue (single drain pass per burst)
+//   - POST /mcp/reconcile enqueues to MCPManager.requestReconcile
 //   - POST /healthz round-trip
-//   - 404 / 405 / 401 / 429 status codes
+//   - 401 / 404 / 405 status codes
 //   - id validation: non-string/empty becomes full reconcile
+//
+// Rate-limit (429) behavior is documented in internal-control-server.js
+// (RATE_LIMIT_RECONCILE = 30/min; RATE_LIMIT_HEALTHZ = 60/min) but
+// not exercised here — firing 31+ requests would pollute the
+// shared per-process bucket state for later tests in the run.
 
 'use strict';
 

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -181,6 +181,40 @@ test('POST /mcp/reconcile with empty body enqueues full reconcile', async () => 
     assert.deepStrictEqual(_reconcileCalls, [null]);
 });
 
+test('POST /mcp/reconcile with oversized body returns 413 and skips reconcile', async () => {
+    // BAT-514 R19: oversized requests should produce a clean 413
+    // response and not trigger reconcile work. Build a JSON-shaped
+    // payload >4 KB.
+    const oversized = JSON.stringify({ id: 'a'.repeat(8192) });
+    const r = await new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path: '/mcp/reconcile',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(oversized),
+                'X-Bridge-Token': BRIDGE_TOKEN,
+            },
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.write(oversized);
+        req.end();
+    });
+    assert.strictEqual(r.status, 413);
+    assert.deepStrictEqual(_reconcileCalls, []);
+});
+
 test('POST /mcp/reconcile with non-string id falls back to full reconcile', async () => {
     const r = await _post('/mcp/reconcile', { id: 123 }, { 'X-Bridge-Token': BRIDGE_TOKEN });
     assert.strictEqual(r.status, 200);

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -96,14 +96,19 @@ const tests = [];
 let pass = 0, fail = 0;
 function test(name, fn) { tests.push({ name, fn }); }
 async function run() {
-    server.start({
+    const httpServer = server.start({
         bridgeToken: BRIDGE_TOKEN,
         getDbSummary: () => _dbSummary,
         requestReconcile: (id) => { _reconcileCalls.push(id); },
         logFn: () => {}, // suppress
     });
-    // small delay so listen() callback fires
-    await new Promise((r) => setTimeout(r, 30));
+    // Wait deterministically for the listening event (Copilot R9 PR
+    // #352 finding — the prior fixed 30ms sleep could race CI loaded
+    // runners and produce ECONNREFUSED on the first request).
+    await new Promise((resolve) => {
+        if (httpServer.listening) resolve();
+        else httpServer.once('listening', resolve);
+    });
     for (const { name, fn } of tests) {
         try {
             _reconcileCalls = [];

--- a/tests/nodejs-project/mcp-servers.test.js
+++ b/tests/nodejs-project/mcp-servers.test.js
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// mcp-servers.test.js — tests for the BAT-514 Node helper that
+// reads/writes mcp_servers.json shared with the Kotlin
+// McpServersStore.
+//
+// Run:  node tests/nodejs-project/mcp-servers.test.js
+// Exit: 0 = all pass, 1 = at least one failure.
+//
+// Pins the parity contract between Kotlin McpServersStore and Node
+// mcp-servers.js:
+//   - schema: { servers: [ { id, name, url, enabled, rateLimit } ] }
+//   - id matches ^[A-Za-z0-9_-]+$
+//   - url is http/https with non-empty host
+//   - rateLimit > 0
+//   - read drops invalid entries with WARN, write throws on invalid
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const STORE_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'mcp-servers.js');
+const { open, validateShape, ID_REGEX, FILE_NAME } = require(STORE_JS);
+
+// Suppress test-time console.warn so a "drops invalid" assertion's
+// expected warning doesn't litter the run output.
+const _origWarn = console.warn;
+console.warn = () => {};
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    for (const { name, fn } of tests) {
+        try {
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    cleanupTmp();
+    console.warn = _origWarn;
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+const _scratch = [];
+function tmpDir() {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-servers-test-'));
+    _scratch.push(d);
+    return d;
+}
+function cleanupTmp() {
+    for (const d of _scratch) {
+        try { fs.rmSync(d, { recursive: true, force: true }); } catch (_) {}
+    }
+}
+
+// ---------- validateShape ----------
+
+test('validateShape accepts canonical entry', () => {
+    assert.strictEqual(validateShape({
+        id: 'context7',
+        name: 'Context7',
+        url: 'https://api.example.com/mcp',
+        rateLimit: 10,
+    }), null);
+});
+
+test('validateShape rejects bad id (regex mismatch)', () => {
+    for (const bad of ['', 'a b', 'a/b', 'a.b', 'a;b', '🦄', 'a/../b']) {
+        const reason = validateShape({ id: bad, name: 'n', url: 'https://x', rateLimit: 1 });
+        assert.notStrictEqual(reason, null, `expected reject id='${bad}'`);
+        assert.match(reason, /^id /, `reason should mention id, got "${reason}"`);
+    }
+});
+
+test('validateShape rejects blank name', () => {
+    const r = validateShape({ id: 'x', name: '   ', url: 'https://x', rateLimit: 1 });
+    assert.match(r || '', /name/);
+});
+
+test('validateShape rejects bad URL schemes', () => {
+    for (const bad of ['ftp://x', 'file:///etc/passwd', 'javascript:alert(1)', '']) {
+        const r = validateShape({ id: 'x', name: 'n', url: bad, rateLimit: 1 });
+        assert.notStrictEqual(r, null, `expected reject url='${bad}'`);
+    }
+});
+
+test('validateShape accepts http and https', () => {
+    assert.strictEqual(
+        validateShape({ id: 'x', name: 'n', url: 'http://localhost:8080/mcp', rateLimit: 1 }),
+        null,
+    );
+    assert.strictEqual(
+        validateShape({ id: 'x', name: 'n', url: 'https://example.com/mcp', rateLimit: 1 }),
+        null,
+    );
+});
+
+test('validateShape rejects rateLimit <= 0', () => {
+    for (const bad of [0, -1, 'ten', NaN, Infinity, null, undefined]) {
+        const r = validateShape({ id: 'x', name: 'n', url: 'https://x', rateLimit: bad });
+        assert.notStrictEqual(r, null, `expected reject rateLimit=${bad}`);
+    }
+});
+
+test('validateShape rejects non-boolean enabled', () => {
+    const r = validateShape({ id: 'x', name: 'n', url: 'https://x', rateLimit: 1, enabled: 'yes' });
+    assert.match(r || '', /enabled/);
+});
+
+// ---------- read ----------
+
+test('read returns empty array when file is absent', () => {
+    const dir = tmpDir();
+    const store = open(dir);
+    assert.deepStrictEqual(store.read(), []);
+});
+
+test('read returns empty array on malformed JSON', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, FILE_NAME), 'not valid json{{{');
+    const store = open(dir);
+    assert.deepStrictEqual(store.read(), []);
+});
+
+test('read drops invalid entries and keeps the rest', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+        servers: [
+            { id: 'ok1', name: 'OK1', url: 'https://a', rateLimit: 5 },
+            { id: 'bad id', name: 'X', url: 'https://b', rateLimit: 1 },     // bad id
+            { id: 'ok2', name: 'OK2', url: 'https://c', rateLimit: 3 },
+            { id: 'ok3', name: '', url: 'https://d', rateLimit: 1 },         // blank name
+            { id: 'ok4', name: 'OK4', url: 'ftp://e', rateLimit: 1 },        // bad scheme
+        ],
+    }));
+    const cleaned = open(dir).read();
+    assert.deepStrictEqual(cleaned.map((s) => s.id), ['ok1', 'ok2']);
+});
+
+test('read drops duplicate ids (first wins)', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+        servers: [
+            { id: 'ctx', name: 'First', url: 'https://a', rateLimit: 1 },
+            { id: 'ctx', name: 'Dupe', url: 'https://b', rateLimit: 2 },
+        ],
+    }));
+    const cleaned = open(dir).read();
+    assert.strictEqual(cleaned.length, 1);
+    assert.strictEqual(cleaned[0].name, 'First');
+});
+
+test('read defaults enabled to true and trims name/url', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+        servers: [
+            { id: 'ctx', name: '  Context7  ', url: '  https://api.example.com/mcp  ', rateLimit: 5 },
+        ],
+    }));
+    const [s] = open(dir).read();
+    assert.strictEqual(s.enabled, true);
+    assert.strictEqual(s.name, 'Context7');
+    assert.strictEqual(s.url, 'https://api.example.com/mcp');
+});
+
+// ---------- write ----------
+
+test('write throws on invalid entry', () => {
+    const dir = tmpDir();
+    const store = open(dir);
+    assert.throws(() => store.write({
+        servers: [{ id: 'bad id', name: 'n', url: 'https://x', rateLimit: 1 }],
+    }), /TypeError/);
+});
+
+test('write throws on missing servers array', () => {
+    const dir = tmpDir();
+    const store = open(dir);
+    assert.throws(() => store.write({ foo: 'bar' }), /TypeError/);
+    assert.throws(() => store.write(null), /TypeError/);
+    assert.throws(() => store.write([]), /TypeError/);
+});
+
+test('write persists valid input atomically and read round-trips', () => {
+    const dir = tmpDir();
+    const store = open(dir);
+    const value = {
+        servers: [
+            { id: 'ctx', name: 'Context7', url: 'https://api.example.com/mcp', rateLimit: 10, enabled: true },
+            { id: 'time', name: 'Time', url: 'https://time.example.com/mcp', rateLimit: 5, enabled: false },
+        ],
+    };
+    store.write(value);
+    // No leftover .tmp
+    assert.strictEqual(fs.existsSync(path.join(dir, FILE_NAME + '.tmp')), false);
+    const back = store.read();
+    assert.strictEqual(back.length, 2);
+    assert.strictEqual(back[0].id, 'ctx');
+    assert.strictEqual(back[1].enabled, false);
+});
+
+// ---------- drift guards ----------
+
+test('drift: file basename is exactly mcp_servers.json', () => {
+    assert.strictEqual(FILE_NAME, 'mcp_servers.json',
+        'Kotlin McpServersStore.FILE_NAME pins this name; do not change without updating both sides');
+});
+
+test('drift: ID_REGEX matches the documented pattern', () => {
+    assert.strictEqual(ID_REGEX.source, '^[A-Za-z0-9_-]+$',
+        'Must match McpServersStore.ID_REGEX exactly so Kotlin and Node agree');
+});
+
+run();

--- a/tests/nodejs-project/mcp-servers.test.js
+++ b/tests/nodejs-project/mcp-servers.test.js
@@ -107,8 +107,12 @@ test('validateShape accepts http and https', () => {
     );
 });
 
-test('validateShape rejects rateLimit <= 0', () => {
-    for (const bad of [0, -1, 'ten', NaN, Infinity, null, undefined]) {
+test('validateShape rejects rateLimit not a positive integer', () => {
+    // Cross-language schema parity check (BAT-514 R19): Kotlin
+    // McpServer.rateLimit is Int, so non-integer values would fail
+    // kotlinx-serialization decode. Floats and non-numbers must
+    // both reject.
+    for (const bad of [0, -1, 1.5, -0.5, 'ten', NaN, Infinity, null, undefined]) {
         const r = validateShape({ id: 'x', name: 'n', url: 'https://x', rateLimit: bad });
         assert.notStrictEqual(r, null, `expected reject rateLimit=${bad}`);
     }

--- a/tests/nodejs-project/mcp-servers.test.js
+++ b/tests/nodejs-project/mcp-servers.test.js
@@ -54,10 +54,27 @@ async function run() {
 }
 
 const _scratch = [];
+// Returns a `workspace` subdirectory inside a fresh tmpdir, mirroring
+// the production layout where Node's workDir is `filesDir/workspace`
+// and the mcp_servers.json file lives at `filesDir/mcp_servers.json`
+// (one level up). `mcp-servers.js open(workDir)` resolves the file
+// via `path.dirname(workDir)`, so passing the workspace path here
+// makes tests exercise the real path-resolution logic — the bug
+// caught at device test on the first MCP-add was specifically that
+// pre-fix tests used `tmpDir → file in same dir`, which masked the
+// production mismatch between workspace/ and filesDir/.
 function tmpDir() {
-    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-servers-test-'));
-    _scratch.push(d);
-    return d;
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-servers-test-'));
+    _scratch.push(parent);
+    const workspace = path.join(parent, 'workspace');
+    fs.mkdirSync(workspace);
+    return workspace;
+}
+// Resolve the actual mcp_servers.json file path the way the module
+// will. Used by tests that pre-seed file content before calling
+// open(workDir).read().
+function fileFor(workDir) {
+    return path.join(path.dirname(workDir), FILE_NAME);
 }
 function cleanupTmp() {
     for (const d of _scratch) {
@@ -133,14 +150,14 @@ test('read returns empty array when file is absent', () => {
 
 test('read returns empty array on malformed JSON', () => {
     const dir = tmpDir();
-    fs.writeFileSync(path.join(dir, FILE_NAME), 'not valid json{{{');
+    fs.writeFileSync(fileFor(dir), 'not valid json{{{');
     const store = open(dir);
     assert.deepStrictEqual(store.read(), []);
 });
 
 test('read drops invalid entries and keeps the rest', () => {
     const dir = tmpDir();
-    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+    fs.writeFileSync(fileFor(dir), JSON.stringify({
         servers: [
             { id: 'ok1', name: 'OK1', url: 'https://a', rateLimit: 5 },
             { id: 'bad id', name: 'X', url: 'https://b', rateLimit: 1 },     // bad id
@@ -155,7 +172,7 @@ test('read drops invalid entries and keeps the rest', () => {
 
 test('read drops duplicate ids (first wins)', () => {
     const dir = tmpDir();
-    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+    fs.writeFileSync(fileFor(dir), JSON.stringify({
         servers: [
             { id: 'ctx', name: 'First', url: 'https://a', rateLimit: 1 },
             { id: 'ctx', name: 'Dupe', url: 'https://b', rateLimit: 2 },
@@ -168,7 +185,7 @@ test('read drops duplicate ids (first wins)', () => {
 
 test('read defaults enabled to true and trims name/url', () => {
     const dir = tmpDir();
-    fs.writeFileSync(path.join(dir, FILE_NAME), JSON.stringify({
+    fs.writeFileSync(fileFor(dir), JSON.stringify({
         servers: [
             { id: 'ctx', name: '  Context7  ', url: '  https://api.example.com/mcp  ', rateLimit: 5 },
         ],
@@ -208,7 +225,7 @@ test('write persists valid input atomically and read round-trips', () => {
     };
     store.write(value);
     // No leftover .tmp
-    assert.strictEqual(fs.existsSync(path.join(dir, FILE_NAME + '.tmp')), false);
+    assert.strictEqual(fs.existsSync(fileFor(dir) + '.tmp'), false);
     const back = store.read();
     assert.strictEqual(back.length, 2);
     assert.strictEqual(back[0].id, 'ctx');
@@ -220,6 +237,28 @@ test('write persists valid input atomically and read round-trips', () => {
 test('drift: file basename is exactly mcp_servers.json', () => {
     assert.strictEqual(FILE_NAME, 'mcp_servers.json',
         'Kotlin McpServersStore.FILE_NAME pins this name; do not change without updating both sides');
+});
+
+test('drift: open(workDir).filePath resolves to dirname(workDir)/mcp_servers.json', () => {
+    // Pin the production path-resolution rule. Kotlin's CrossProcessStore
+    // writes to `filesDir/mcp_servers.json` (no path separators allowed
+    // in CrossProcessStore.fileName), but Node receives `workDir =
+    // filesDir/workspace`. Without the dirname climb, Node's fs.watch
+    // + read would target workspace/ and never see Kotlin's writes —
+    // exactly the device-test failure mode the BAT-514 R20-fix patches.
+    const workDir = '/data/data/com.seekerclaw.app/files/workspace';
+    const expected = '/data/data/com.seekerclaw.app/files/mcp_servers.json';
+    // path.posix.normalize for cross-platform comparison (test runs on
+    // Windows in dev but the production target is Android/Linux).
+    const actual = open(workDir).filePath.replace(/\\/g, '/');
+    assert.strictEqual(actual, expected);
+});
+
+test('open() rejects empty/non-string workDir', () => {
+    assert.throws(() => open(''), TypeError);
+    assert.throws(() => open(undefined), TypeError);
+    assert.throws(() => open(null), TypeError);
+    assert.throws(() => open(123), TypeError);
 });
 
 test('drift: ID_REGEX matches the documented pattern', () => {

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -61,6 +61,12 @@ const LOAD_TARGETS = [
     'loop-detector.js',
     'model-catalog.js',
     'telegram-commands.js',
+    // BAT-514: both modules are pure (functions only, no top-level
+    // side effects). internal-control-server.js's HTTP listener is
+    // gated behind `start()`; mcp-servers.js's filesystem read is
+    // gated behind `open(workDir).read()`.
+    'mcp-servers.js',
+    'internal-control-server.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which


### PR DESCRIPTION
## Summary

Migrates MCP server config from per-process `SharedPreferences`
(`KEY_MCP_SERVERS_ENC`) to a `CrossProcessStore`-backed file
(`mcp_servers.json`), with auth tokens split out into per-id encrypted
files (`mcp_tokens/<id>`). Settings UI in main process and the MCP
client in `:node` now agree on a single source of truth, with live
updates (~1-2s) without service restart.

Sibling of BAT-513's runtime-state migration; reuses the same
patterns. Contract iterated through v1 -> v2.2 with Codex review on
[BAT-514](https://linear.app/batcave/issue/BAT-514).

## Implementation contract

- **Storage split:** plaintext `mcp_servers.json` for id/name/url/
  enabled/rateLimit; tokens in `mcp_tokens/<id>` encrypted files
  (AES-GCM via `KeystoreHelper`). File-per-token (not SharedPreferences)
  so cross-process token edits propagate live — SharedPreferences has
  a per-process cache that would invalidate the BAT-514 live-edit
  contract (Copilot R10 finding; BAT-516 will revisit if file-IPC
  payload encryption becomes available).
- **Live updates:** Kotlin -> JS via main process POSTing to
  `127.0.0.1:8766/mcp/reconcile` (the existing `:8766` stats server,
  extracted to `internal-control-server.js` to host both endpoints).
  `fs.watch(mcp_servers.json)` is the fast path; the bridge endpoint
  is the deterministic catch-up.
- **Token resolution:** `MCPClient.connect` fetches tokens via
  AndroidBridge `POST /config/mcp-token`, then immediately calls
  `registerRedactedSecret` BEFORE attaching the bearer header.
  `security.js`'s startup `MCP_SERVERS[*].authToken` redaction loop
  removed.
- **Validation:** ID regex `^[A-Za-z0-9_-]+$`, post-normalization
  uniqueness (matching Node's `safeId` fold), http://non-loopback +
  token rejection, URL trim parity with Node's `mcp-servers.js`
  `read()`. UI write boundary fails fast (Toast); collector
  observed-file path drops invalid entries with WARN.
- **Migration:** `McpServersStore.init` reads legacy
  `KEY_MCP_SERVERS_ENC`, splits tokens into per-id encrypted files,
  seeds the file. Aborts (skips file seed + shadow rebuild) if any
  token write fails so `KEY_MCP_SERVERS_ENC` stays intact for retry.
  Sweeps orphan tokens at init AND after every write/update/delete.
- **Rollback shadow:** `KEY_MCP_SERVERS_ENC` retained, rebuilt with
  tokens reattached on every successful mutation via `commit()` (not
  `apply()`) so downgrade durability matches the documented contract.

## Test plan

- [x] `node tests/nodejs-project/mcp-servers.test.js` — 17 passed
- [x] `node tests/nodejs-project/internal-control-server.test.js` — 14 passed
- [x] `node tests/nodejs-project/smoke.js` — 6/6 modules load
- [x] `./gradlew :app:compileDappStoreDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDappStoreDebugUnitTest` — 119/119 passed
- [x] `bash scripts/pre-push-check.sh` — ALL CHECKS PASSED
- [ ] Device acceptance — pending merge + install:
  - Add MCP server in Settings -> connects within ~1-2s, no restart
  - Edit URL -> reconnects to new URL within ~1-2s
  - Disable -> disconnects within ~1-2s
  - Edit auth token -> reconnects with new bearer within ~1-2s
    (validates the file-per-token cross-process correctness fix)
  - Delete -> disconnects + tools removed + orphan token cleared
  - Install pre-BAT-514 build with MCP server + token -> install
    BAT-514 -> server preserved, token preserved
  - Downgrade to pre-BAT-514 -> server still there with token
    (rollback shadow)
  - http://non-loopback + token -> Toast "Auth token requires HTTPS"

## Known limitations

- Token field in `mcp_servers.json` is intentionally not encrypted
  (file-IPC payload encryption is BAT-516's scope). Tokens DO live
  encrypted in `mcp_tokens/<id>` files via the same KeystoreHelper
  AES-GCM primitive used elsewhere.
- Pre-BAT-514 downgrade preserves servers + tokens, but if the user
  edits a token under BAT-514 and immediately downgrades before the
  rollback-shadow rebuild's `commit()` returns (millisecond window),
  the downgrade sees the previous token. Acceptable for human-
  timescale operations.
- `signalConfigChanged` is fired via the collector mirror (file
  changes), not from `setAuthToken` — token-only edits don't bump
  configVersion. UI binds to `McpServersStore.state` directly so it
  doesn't need the bump; legacy callers that read via
  `loadMcpServers` (SettingsScreen count) only see token changes
  via the rollback shadow rebuild + the eventual broadcast that the
  collector emits when other fields change. Intentional — the
  count doesn't depend on tokens.

## Self-Awareness Checklist

- [x] N/A — internal infrastructure migration (file-IPC, control-server
      extraction). No new user-visible AI capability, no new bridge
      endpoints exposed to the agent, no `buildSystemBlocks()` change,
      no new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)