### PR TITLE
feat: single shared model-registry.json (BAT-517)

### DIFF
--- a/app/src/main/assets/nodejs-project/model-catalog.js
+++ b/app/src/main/assets/nodejs-project/model-catalog.js
@@ -89,7 +89,12 @@ function modelsForProvider(providerId, authType) {
     if (!provider) return [];
     if (provider.freeform) return [];
     if (provider.id === 'openai') {
-        if (authType === 'oauth') return provider.modelsByAuth.oauth || provider.models;
+        // BAT-517 R2 Copilot: guard `modelsByAuth` — schema marks it
+        // optional (Kotlin defaults to emptyMap()), so the
+        // `modelsByAuth.oauth` direct access could TypeError if a future
+        // registry omits the field. Symmetric with the
+        // OPENAI_OAUTH_MODELS constant derivation above.
+        if (authType === 'oauth') return (provider.modelsByAuth && provider.modelsByAuth.oauth) || provider.models;
         if (authType === 'api_key') return provider.models;
         return [];
     }

--- a/app/src/main/assets/nodejs-project/model-catalog.js
+++ b/app/src/main/assets/nodejs-project/model-catalog.js
@@ -24,16 +24,50 @@ const EXPECTED_VERSION = 1;
 // Load + validate at require-time. Failure throws — matches Kotlin's
 // "fail loud at boot" behaviour and makes a malformed bundled asset
 // (a build-time bug) impossible to ship undetected.
-function _loadRegistry() {
-    const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
-    const parsed = JSON.parse(raw);
+// IDs whose presence the constant derivations below depend on. Kept
+// in sync with the dereferences `_byId.claude / _byId.openai /
+// _byId.openrouter` further down — `custom` is intentionally NOT
+// required at this layer (no top-level constant references it).
+const REQUIRED_PROVIDER_IDS = ['openai', 'claude', 'openrouter'];
+
+/**
+ * Validate a parsed registry object. Pure function (no I/O) so tests
+ * can exercise the failure paths without touching the bundled asset.
+ * Throws Error with a clear message on any contract violation.
+ *
+ * BAT-517 R4 Copilot: duplicate-id and required-id checks added —
+ * Object.fromEntries silently overwrites duplicates, and the
+ * constant derivations below directly deref _byId.{claude,openai,
+ * openrouter}, so without this guard those failures would surface as
+ * unhelpful "Cannot read properties of undefined" TypeErrors at
+ * require-time. Symmetric with Kotlin's `loadAndValidate` +
+ * `requireProviderById`.
+ */
+function _validateRegistry(parsed) {
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Error('model-registry.json is not a JSON object');
+    }
     if (parsed.version !== EXPECTED_VERSION) {
         throw new Error(`model-registry.json version=${parsed.version}, expected=${EXPECTED_VERSION}`);
     }
     if (!Array.isArray(parsed.providers) || parsed.providers.length === 0) {
         throw new Error('model-registry.json has no providers');
     }
+    const ids = parsed.providers.map((p) => p && p.id);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    if (dupes.length > 0) {
+        throw new Error(`model-registry.json has duplicate provider ids: ${[...new Set(dupes)].join(', ')}`);
+    }
+    const missing = REQUIRED_PROVIDER_IDS.filter((id) => !ids.includes(id));
+    if (missing.length > 0) {
+        throw new Error(`model-registry.json is missing required provider(s): ${missing.join(', ')}`);
+    }
     return parsed;
+}
+
+function _loadRegistry() {
+    const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
+    return _validateRegistry(JSON.parse(raw));
 }
 
 const _REGISTRY = _loadRegistry();
@@ -231,4 +265,9 @@ module.exports = {
     hasCredentialsFor,
     validateModelForProvider,
     displayNameForProvider,
+    // Test seam — exposes the loader's pure validation so unit tests
+    // can exercise failure paths (duplicate ids, missing required ids,
+    // bad version) without writing temp asset files. Not used by
+    // production code paths.
+    _validateRegistry,
 };

--- a/app/src/main/assets/nodejs-project/model-catalog.js
+++ b/app/src/main/assets/nodejs-project/model-catalog.js
@@ -47,7 +47,13 @@ const _byId = Object.fromEntries(_REGISTRY.providers.map((p) => [p.id, p]));
 
 const CLAUDE_MODELS         = _byId.claude.models;
 const OPENAI_API_KEY_MODELS = _byId.openai.models;
-const OPENAI_OAUTH_MODELS   = _byId.openai.modelsByAuth.oauth;
+// BAT-517 R1 Copilot: `modelsByAuth` is optional in the schema (Kotlin
+// defaults it to emptyMap()), so we must not assume the override exists.
+// If a future registry omits it, fall back to the base `models` list —
+// same behaviour as `modelsForProvider('openai','oauth')` and Kotlin's
+// `modelsByAuth["oauth"] ?: models`.
+const OPENAI_OAUTH_MODELS   = (_byId.openai.modelsByAuth && _byId.openai.modelsByAuth.oauth)
+    || _byId.openai.models;
 
 const CLAUDE_DEFAULT_MODEL     = _byId.claude.defaultModel;
 const OPENAI_DEFAULT_MODEL     = _byId.openai.defaultModel;

--- a/app/src/main/assets/nodejs-project/model-catalog.js
+++ b/app/src/main/assets/nodejs-project/model-catalog.js
@@ -1,54 +1,73 @@
 // ============================================================================
-// Model & provider catalog — mirrors Kotlin Providers.kt / Models.kt.
+// Model & provider catalog — derived from the shared model-registry.json (BAT-517).
 //
 // Used by the `/model` and `/provider` Telegram slash commands to validate
-// user input. Kept deliberately simple (pure data + pure functions) so it's
-// easy to unit-test and easy to spot drift vs the Kotlin source.
+// user input. After BAT-517, the catalog data lives in ONE place:
+//   app/src/main/assets/nodejs-project/model-registry.json
+// Both this module AND Kotlin's ModelRegistry load the same file. Adding
+// a model means editing the JSON; both runtimes pick it up at next start.
 //
-// KEEP IN SYNC with:
-//   app/src/main/java/com/seekerclaw/app/config/Providers.kt
-//   app/src/main/java/com/seekerclaw/app/config/Models.kt
+// Export shape preserved from pre-BAT-517 (CLAUDE_MODELS, OPENAI_*_MODELS,
+// *_DEFAULT_MODEL, KNOWN_PROVIDERS, PROVIDER_DISPLAY_NAMES, the
+// validate/resolve helpers) so existing callers in message-handler.js and
+// the test suite keep working without churn.
 // ============================================================================
 
 'use strict';
 
-// Ordered for display: freshest first. Default selection is explicit (see
-// defaultModelForProvider) and NOT tied to list position — so newly-added
-// tier-gated models can appear at the top of pickers without silently
-// becoming the default.
-const CLAUDE_MODELS = [
-    { id: 'claude-opus-4-7',   displayName: 'Opus 4.7' },
-    { id: 'claude-opus-4-6',   displayName: 'Opus 4.6' },
-    { id: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6' },
-    { id: 'claude-haiku-4-5',  displayName: 'Haiku 4.5' },
-];
+const fs = require('fs');
+const path = require('path');
 
-const OPENAI_API_KEY_MODELS = [
-    { id: 'gpt-5.5',       displayName: 'GPT-5.5' },
-    { id: 'gpt-5.4',       displayName: 'GPT-5.4' },
-    { id: 'gpt-5.3-codex', displayName: 'GPT-5.3 Codex' },
-];
+const REGISTRY_PATH = path.join(__dirname, 'model-registry.json');
+const EXPECTED_VERSION = 1;
 
-const OPENAI_OAUTH_MODELS = [
-    { id: 'gpt-5.5',       displayName: 'GPT-5.5' },
-    { id: 'gpt-5.4',       displayName: 'GPT-5.4' },
-    { id: 'gpt-5.4-mini',  displayName: 'GPT-5.4 Mini' },
-    { id: 'gpt-5.3-codex', displayName: 'GPT-5.3 Codex' },
-];
+// Load + validate at require-time. Failure throws — matches Kotlin's
+// "fail loud at boot" behaviour and makes a malformed bundled asset
+// (a build-time bug) impossible to ship undetected.
+function _loadRegistry() {
+    const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== EXPECTED_VERSION) {
+        throw new Error(`model-registry.json version=${parsed.version}, expected=${EXPECTED_VERSION}`);
+    }
+    if (!Array.isArray(parsed.providers) || parsed.providers.length === 0) {
+        throw new Error('model-registry.json has no providers');
+    }
+    return parsed;
+}
 
-const OPENROUTER_DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';
+const _REGISTRY = _loadRegistry();
+const _byId = Object.fromEntries(_REGISTRY.providers.map((p) => [p.id, p]));
 
-// Explicit safe defaults per provider. Do NOT derive these from list order —
-// a new model inserted at the top of a display list shouldn't silently change
-// the default. Tier-gated models (eg. gpt-5.5 on some ChatGPT plans) must
-// never be listed here, or fresh installs / provider-switch fallbacks would
-// land users on a model their plan can't reach.
-const CLAUDE_DEFAULT_MODEL = 'claude-opus-4-7';
-const OPENAI_DEFAULT_MODEL = 'gpt-5.4'; // available on every ChatGPT tier + api key
+// ─── Backward-compat exports derived from the registry ──────────────────────
+//
+// Pre-BAT-517 callers import these names directly. Computed once at module
+// load — the registry is read-only at runtime, so freezing the references
+// here matches the previous semantics (top-level `const`s).
+
+const CLAUDE_MODELS         = _byId.claude.models;
+const OPENAI_API_KEY_MODELS = _byId.openai.models;
+const OPENAI_OAUTH_MODELS   = _byId.openai.modelsByAuth.oauth;
+
+const CLAUDE_DEFAULT_MODEL     = _byId.claude.defaultModel;
+const OPENAI_DEFAULT_MODEL     = _byId.openai.defaultModel;
+const OPENROUTER_DEFAULT_MODEL = _byId.openrouter.defaultModel;
+
+const KNOWN_PROVIDERS = _REGISTRY.providers.map((p) => p.id);
+
+// Canonical display names for user-facing messaging (Telegram replies,
+// TG command descriptions, etc). Mirrors Kotlin's Settings UI convention
+// — `claude` maps to "Anthropic" (the company making Claude). NOT used
+// for identity/routing — that's always `providerId`.
+const PROVIDER_DISPLAY_NAMES = Object.fromEntries(
+    _REGISTRY.providers.map((p) => [p.id, p.displayName]),
+);
+
+// ─── Resolution helpers ─────────────────────────────────────────────────────
 
 /**
  * Resolve the model list for a given provider + auth.
- * Returns [] for freeform providers (openrouter, custom).
+ * Returns [] for freeform providers (openrouter, custom) and unknown providers.
  *
  * For OpenAI, `authType` MUST be explicitly 'api_key' or 'oauth'.
  * Passing null/undefined/anything else returns [] so callers
@@ -56,22 +75,22 @@ const OPENAI_DEFAULT_MODEL = 'gpt-5.4'; // available on every ChatGPT tier + api
  * rather than silently validating against the API-key allowlist.
  * Mirrors Kotlin's modelsForProvider which throws on the same
  * ambiguity — we return empty instead of throwing because a thrown
- * error from inside a Node tool would crash the chat turn.
+ * error from inside a Node tool would crash the chat turn (BAT-517
+ * preserves this asymmetry).
  */
 function modelsForProvider(providerId, authType) {
-    switch (providerId) {
-        case 'claude':
-            return CLAUDE_MODELS;
-        case 'openai':
-            if (authType === 'oauth') return OPENAI_OAUTH_MODELS;
-            if (authType === 'api_key') return OPENAI_API_KEY_MODELS;
-            return [];
-        case 'openrouter':
-        case 'custom':
-            return [];
-        default:
-            return [];
+    const provider = _byId[providerId];
+    if (!provider) return [];
+    if (provider.freeform) return [];
+    if (provider.id === 'openai') {
+        if (authType === 'oauth') return provider.modelsByAuth.oauth || provider.models;
+        if (authType === 'api_key') return provider.models;
+        return [];
     }
+    if (authType && provider.modelsByAuth && provider.modelsByAuth[authType]) {
+        return provider.modelsByAuth[authType];
+    }
+    return provider.models;
 }
 
 /**
@@ -79,41 +98,18 @@ function modelsForProvider(providerId, authType) {
  * Deliberately decoupled from list order — don't put tier-gated models here.
  * Mirrors Kotlin defaultModelForProvider(...).
  */
+// eslint-disable-next-line no-unused-vars
 function defaultModelForProvider(providerId, authType) {
-    switch (providerId) {
-        case 'claude':     return CLAUDE_DEFAULT_MODEL;
-        case 'openai':     return OPENAI_DEFAULT_MODEL;
-        case 'openrouter': return OPENROUTER_DEFAULT_MODEL;
-        case 'custom':     return '';
-        default:           return '';
-    }
+    const provider = _byId[providerId];
+    if (!provider) return '';
+    return provider.defaultModel;
 }
-
-const KNOWN_PROVIDERS = ['claude', 'openai', 'openrouter', 'custom'];
-
-// Canonical display names for user-facing messaging (Telegram replies,
-// TG command descriptions, etc). Mirrors Kotlin's Providers.kt
-// `availableProviders[].displayName` so Settings UI and Telegram
-// replies never disagree on branding. NOT used for identity/routing
-// — that's always `providerId`.
-//
-// Note: `claude` maps to "Anthropic" (the company making Claude) to
-// match Kotlin's Settings UI convention. Settings shows "Anthropic"
-// with the sk-ant-api03-… key hint, so the Telegram reply saying
-// "Switching to Anthropic" is consistent with where the user
-// configured credentials.
-const PROVIDER_DISPLAY_NAMES = {
-    claude: 'Anthropic',
-    openai: 'OpenAI',
-    openrouter: 'OpenRouter',
-    custom: 'Custom',
-};
 
 /**
  * Render a provider ID as a canonical brand name ("OpenAI", not
  * "Openai"). Falls back to the raw ID (capitalized) for anything
  * not in the registry so future providers don't crash the display
- * path if someone forgets to update PROVIDER_DISPLAY_NAMES.
+ * path if the JSON forgets to register one.
  */
 function displayNameForProvider(providerId) {
     if (PROVIDER_DISPLAY_NAMES[providerId]) return PROVIDER_DISPLAY_NAMES[providerId];
@@ -122,14 +118,13 @@ function displayNameForProvider(providerId) {
 }
 
 /**
- * Valid auth types per provider. OpenAI is the only one with multiple.
+ * Valid auth types per provider. Falls back to ['api_key'] for unknown
+ * providers (defensive — matches the pre-BAT-517 default branch).
  */
 function authTypesForProvider(providerId) {
-    switch (providerId) {
-        case 'openai': return ['api_key', 'oauth'];
-        case 'claude': return ['api_key', 'setup_token'];
-        default: return ['api_key'];
-    }
+    const provider = _byId[providerId];
+    if (provider) return provider.authTypes;
+    return ['api_key'];
 }
 
 /**
@@ -137,6 +132,11 @@ function authTypesForProvider(providerId) {
  * Reads from the startup `config` object loaded by config.js. Returns:
  *   { ok: true }                          — credentials present
  *   { ok: false, reason: <human string> } — missing / not configured
+ *
+ * NOT registry data — the runtime-config-key mapping (which `config.X`
+ * field corresponds to each provider/auth) is loader-side behaviour
+ * that stays per-language. Could move into the schema later if both
+ * runtimes need it; out of scope for BAT-517.
  */
 function hasCredentialsFor(config, providerId, authType) {
     const nonBlank = (v) => typeof v === 'string' && v.trim().length > 0;
@@ -184,7 +184,13 @@ function hasCredentialsFor(config, providerId, authType) {
 function validateModelForProvider(providerId, authType, modelId) {
     const trimmed = typeof modelId === 'string' ? modelId.trim() : '';
     if (!trimmed) return { ok: false, reason: 'Model ID must not be empty.' };
+    const provider = _byId[providerId];
+    if (provider && provider.freeform) {
+        return { ok: true, model: trimmed };
+    }
     if (providerId === 'openrouter' || providerId === 'custom') {
+        // Defensive: keep freeform behaviour at this call site even if
+        // someone removes the freeform flag from the registry entries.
         return { ok: true, model: trimmed };
     }
     const list = modelsForProvider(providerId, authType);

--- a/app/src/main/assets/nodejs-project/model-registry.json
+++ b/app/src/main/assets/nodejs-project/model-registry.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "openai",
+      "displayName": "OpenAI",
+      "authTypes": ["api_key", "oauth"],
+      "keyHint": "sk-proj-…",
+      "consoleUrl": "https://platform.openai.com",
+      "keysUrl": "https://platform.openai.com/api-keys",
+      "freeform": false,
+      "defaultModel": "gpt-5.4",
+      "models": [
+        { "id": "gpt-5.5",       "displayName": "GPT-5.5" },
+        { "id": "gpt-5.4",       "displayName": "GPT-5.4" },
+        { "id": "gpt-5.3-codex", "displayName": "GPT-5.3 Codex" }
+      ],
+      "modelsByAuth": {
+        "oauth": [
+          { "id": "gpt-5.5",       "displayName": "GPT-5.5" },
+          { "id": "gpt-5.4",       "displayName": "GPT-5.4" },
+          { "id": "gpt-5.4-mini",  "displayName": "GPT-5.4 Mini" },
+          { "id": "gpt-5.3-codex", "displayName": "GPT-5.3 Codex" }
+        ]
+      }
+    },
+    {
+      "id": "claude",
+      "displayName": "Anthropic",
+      "authTypes": ["api_key", "setup_token"],
+      "keyHint": "sk-ant-api03-…",
+      "consoleUrl": "https://console.anthropic.com",
+      "keysUrl": "https://console.anthropic.com/settings/keys",
+      "freeform": false,
+      "defaultModel": "claude-opus-4-7",
+      "models": [
+        { "id": "claude-opus-4-7",   "displayName": "Opus 4.7" },
+        { "id": "claude-opus-4-6",   "displayName": "Opus 4.6" },
+        { "id": "claude-sonnet-4-6", "displayName": "Sonnet 4.6" },
+        { "id": "claude-haiku-4-5",  "displayName": "Haiku 4.5" }
+      ]
+    },
+    {
+      "id": "openrouter",
+      "displayName": "OpenRouter",
+      "authTypes": ["api_key"],
+      "keyHint": "sk-or-v1-…",
+      "consoleUrl": "https://openrouter.ai",
+      "keysUrl": "https://openrouter.ai/keys",
+      "freeform": true,
+      "defaultModel": "anthropic/claude-sonnet-4-6",
+      "models": []
+    },
+    {
+      "id": "custom",
+      "displayName": "Custom",
+      "authTypes": ["api_key"],
+      "keyHint": "your-api-key",
+      "consoleUrl": "https://seekerclaw.xyz/docs/custom-provider",
+      "keysUrl": "https://seekerclaw.xyz/docs/custom-provider",
+      "freeform": true,
+      "defaultModel": "",
+      "models": []
+    }
+  ]
+}

--- a/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
+++ b/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
@@ -21,6 +21,17 @@ class SeekerClawApplication : Application() {
         super.onCreate()
         createNotificationChannel()
 
+        // BAT-517: load the shared provider+model registry FIRST,
+        // before anything else that might touch ConfigManager /
+        // provider helpers. Runs in EVERY Android process (NOT
+        // gated on isMainProcess) — the `:node` service process
+        // also calls ConfigManager paths that depend on the
+        // registry. `init` is idempotent so a second call from
+        // a future code path (or a test) is a no-op. Failed parse
+        // throws and leaves the registry uninitialized so a retry
+        // can re-attempt the load.
+        com.seekerclaw.app.config.ModelRegistry.init(this)
+
         // Firebase Analytics
         Analytics.init(this)
         ConfigManager.loadConfig(this)?.let { config ->

--- a/app/src/main/java/com/seekerclaw/app/config/Models.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Models.kt
@@ -17,9 +17,15 @@ data class ModelInfo(
  *
  * Property getter (NOT eager top-level val) so each access reads
  * AFTER `ModelRegistry.init()` has run — Codex v2.1 finding.
+ *
+ * Uses the strict [ModelRegistry.requireProviderById] lookup (NOT the
+ * fall-back-tolerant `providerById`) — the alias is by name "the
+ * Claude model list", so a malformed registry that drops or renames
+ * `claude` must fail fast instead of silently returning OpenAI's
+ * models (BAT-517 R3 Copilot finding).
  */
 val availableModels: List<ModelInfo>
-    get() = ModelRegistry.providerById("claude").models
+    get() = ModelRegistry.requireProviderById("claude").models
 
 /**
  * Render a model id as its display label.

--- a/app/src/main/java/com/seekerclaw/app/config/Models.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Models.kt
@@ -1,21 +1,38 @@
 package com.seekerclaw.app.config
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ModelInfo(
     val id: String,
     val displayName: String,
 )
 
-// Position [0] is the fallback target: SetupScreen coerces any saved model ID
-// not present in this list to availableModels[0].id. Keep the freshest / default
-// model at the top so coercion and fresh-install defaults stay symmetric.
-val availableModels = listOf(
-    ModelInfo("claude-opus-4-7", "Opus 4.7"),
-    ModelInfo("claude-opus-4-6", "Opus 4.6"),
-    ModelInfo("claude-sonnet-4-6", "Sonnet 4.6"),
-    ModelInfo("claude-haiku-4-5", "Haiku 4.5"),
-)
+/**
+ * Backward-compat alias for the Claude model list. Pre-BAT-517 this
+ * was the canonical "available models" list (Claude was the only
+ * provider). Today it's just the Claude entry's `models` from the
+ * registry, exposed as a property getter so callers that import it
+ * directly keep working without churn.
+ *
+ * Property getter (NOT eager top-level val) so each access reads
+ * AFTER `ModelRegistry.init()` has run — Codex v2.1 finding.
+ */
+val availableModels: List<ModelInfo>
+    get() = ModelRegistry.providerById("claude").models
 
-fun modelDisplayName(modelId: String?): String {
-    if (modelId.isNullOrBlank()) return "Not configured"
-    return availableModels.find { it.id == modelId }?.displayName ?: modelId
-}
+/**
+ * Render a model id as its display label.
+ *
+ * Searches EVERY provider's `models` AND every `modelsByAuth` list
+ * (Codex v2 finding 5). Pre-BAT-517 this only searched the Claude
+ * list, so `modelDisplayName("gpt-5.4")` returned the raw id when
+ * the user was on OpenAI; post-BAT-517 it returns `"GPT-5.4"`.
+ *
+ * Behaviour summary:
+ *  - null/blank → `"Not configured"` (preserved)
+ *  - found in any provider's effective list → the registry display name
+ *  - not found (freeform / future / unknown) → the raw id verbatim
+ */
+fun modelDisplayName(modelId: String?): String =
+    ModelRegistry.modelDisplayName(modelId)

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -59,6 +59,17 @@ object ModelRegistry {
     @Volatile
     private var initialized = false
     private val initLock = Any()
+
+    // BAT-517 R1 Copilot: must be @Volatile. The `providers` getter reads
+    // `_providers` without taking `initLock` (and without consulting
+    // `initialized`), so without volatile semantics the JIT can reorder
+    // the writes inside `init` such that a reader on another thread sees
+    // `initialized == true` (or just sees a non-null check pass and
+    // immediately afterwards null) while `_providers` is still null /
+    // partially-constructed. @Volatile on `_providers` gives the
+    // happens-before edge that pairs with the `synchronized(initLock)`
+    // write so any non-null read after init publication is well-defined.
+    @Volatile
     private var _providers: List<ProviderInfo>? = null
 
     private val json = Json {

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -109,6 +109,13 @@ object ModelRegistry {
      */
     @androidx.annotation.VisibleForTesting
     internal fun initForTest(providers: List<ProviderInfo>) {
+        // BAT-517 R3 Copilot: mirror the runtime loader's minimal-validation
+        // shape so a misused test seam fails with a clear message instead
+        // of an obscure IndexOutOfBoundsException at the next
+        // `providerById` call (which falls back to `list[0]`).
+        require(providers.isNotEmpty()) {
+            "initForTest requires a non-empty providers list"
+        }
         synchronized(initLock) {
             _providers = providers
             initialized = true
@@ -138,6 +145,22 @@ object ModelRegistry {
     fun providerById(id: String): ProviderInfo {
         val list = providers
         return list.find { it.id == id } ?: list[0]
+    }
+
+    /**
+     * Strict lookup variant — throws if the named provider is missing.
+     *
+     * Use for backward-compat aliases that name a SPECIFIC provider
+     * ([availableModels] = "claude", [OPENROUTER_DEFAULT_MODEL] =
+     * "openrouter"): these aliases mean "this provider's data" by
+     * contract, so the silent fallback in [providerById] would let a
+     * malformed registry (claude removed, openrouter renamed) silently
+     * return the wrong provider's data instead of failing fast at app
+     * startup. BAT-517 R3 Copilot finding.
+     */
+    internal fun requireProviderById(id: String): ProviderInfo {
+        return providers.find { it.id == id }
+            ?: error("ModelRegistry is missing required provider: $id")
     }
 
     /**
@@ -262,6 +285,12 @@ fun defaultModelForProvider(providerId: String, authType: String?): String =
  * Default for OpenRouter — kept as a top-level alias for the call
  * sites that imported it directly pre-BAT-517. Sourced from the
  * registry instead of a hardcoded const.
+ *
+ * Uses the strict [ModelRegistry.requireProviderById] lookup (NOT the
+ * fall-back-tolerant `providerById`) — the alias is by name "the
+ * OpenRouter default", so a missing/renamed `openrouter` entry must
+ * fail fast rather than silently return another provider's default
+ * (BAT-517 R3 Copilot finding).
  */
 val OPENROUTER_DEFAULT_MODEL: String
-    get() = ModelRegistry.providerById("openrouter").defaultModel
+    get() = ModelRegistry.requireProviderById("openrouter").defaultModel

--- a/app/src/main/java/com/seekerclaw/app/config/Providers.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/Providers.kt
@@ -1,113 +1,256 @@
 package com.seekerclaw.app.config
 
+import android.content.Context
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
 /**
- * Provider registry for multi-provider support (BAT-315).
- * Adding a new provider = 1 entry here + 1 model list.
+ * Provider + model registry shared between Kotlin and Node (BAT-517).
+ *
+ * Source of truth: `app/src/main/assets/nodejs-project/model-registry.json`.
+ * Both runtimes read the SAME file:
+ *  - Kotlin: `context.assets.open("nodejs-project/model-registry.json")`
+ *  - Node:   `path.join(__dirname, 'model-registry.json')` after the
+ *            APK→filesDir extraction in NodeBridge.
+ *
+ * Adding a new provider or model = ONE edit to the JSON file. The
+ * pre-BAT-517 layout had the same data encoded twice — once in this
+ * file and once in `model-catalog.js` — and it had already drifted
+ * during BAT-509. Centralizing here keeps both sides in sync.
+ *
+ * ## Read-only by design
+ *
+ * The registry ships with the APK and is never mutated at runtime —
+ * model data only changes via app updates. So no [com.seekerclaw.app.util.CrossProcessStore],
+ * no FileObserver, no atomic-RMW: this is just a JSON-backed lookup
+ * table.
  */
+@Serializable
 data class ProviderInfo(
     val id: String,
     val displayName: String,
     val authTypes: List<String>,
     val keyHint: String,
     val consoleUrl: String,
-    val keysUrl: String = consoleUrl,
+    val keysUrl: String,
+    val freeform: Boolean,
+    val defaultModel: String,
+    val models: List<ModelInfo>,
+    /**
+     * Per-auth-type override map. Optional — most providers don't need
+     * it. Today only OpenAI uses this (`oauth` exposes an extra
+     * `gpt-5.4-mini` that the API-key flow doesn't have access to).
+     * Default `emptyMap()` so providers that omit the field parse
+     * cleanly via kotlinx-serialization (Codex v2.1 finding).
+     */
+    val modelsByAuth: Map<String, List<ModelInfo>> = emptyMap(),
 )
 
-val availableProviders = listOf(
-    ProviderInfo(
-        id = "openai",
-        displayName = "OpenAI",
-        authTypes = listOf("api_key", "oauth"),
-        keyHint = "sk-proj-…",
-        consoleUrl = "https://platform.openai.com",
-        keysUrl = "https://platform.openai.com/api-keys",
-    ),
-    ProviderInfo(
-        id = "claude",
-        displayName = "Anthropic",
-        authTypes = listOf("api_key", "setup_token"),
-        keyHint = "sk-ant-api03-…",
-        consoleUrl = "https://console.anthropic.com",
-        keysUrl = "https://console.anthropic.com/settings/keys",
-    ),
-    ProviderInfo(
-        id = "openrouter",
-        displayName = "OpenRouter",
-        authTypes = listOf("api_key"),
-        keyHint = "sk-or-v1-…",
-        consoleUrl = "https://openrouter.ai",
-        keysUrl = "https://openrouter.ai/keys",
-    ),
-    ProviderInfo(
-        id = "custom",
-        displayName = "Custom",
-        authTypes = listOf("api_key"),
-        keyHint = "your-api-key",
-        consoleUrl = "https://seekerclaw.xyz/docs/custom-provider",
-        keysUrl = "https://seekerclaw.xyz/docs/custom-provider",
-    ),
+@Serializable
+private data class ModelRegistryFile(
+    val version: Int,
+    val providers: List<ProviderInfo>,
 )
 
-// Display order: freshest first for UX. Default selection is NOT tied
-// to list order — see defaultModelForProvider() below. Callers seeding
-// a default must use that helper, not `firstOrNull()`, so newer models
-// can appear at the top of the picker without accidentally becoming
-// the default for tier-gated users.
-val openaiModels = listOf(
-    ModelInfo("gpt-5.5", "GPT-5.5"),
-    ModelInfo("gpt-5.4", "GPT-5.4"),
-    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
-)
+object ModelRegistry {
+    private const val ASSET_PATH = "nodejs-project/model-registry.json"
+    private const val EXPECTED_VERSION = 1
 
-val openaiOAuthModels = listOf(
-    ModelInfo("gpt-5.5", "GPT-5.5"),
-    ModelInfo("gpt-5.4", "GPT-5.4"),
-    ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini"),
-    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
-)
+    @Volatile
+    private var initialized = false
+    private val initLock = Any()
+    private var _providers: List<ProviderInfo>? = null
 
-/** Default model for freeform providers (OpenRouter) where model list is empty. */
-const val OPENROUTER_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
-
-/**
- * Resolve the model list for a given provider.
- *
- * For OpenAI, `authType` MUST be an explicit "oauth" or "api_key" — passing null or
- * any other value throws so call sites can't accidentally fall through to the API-key
- * model list while the user is in OAuth mode. For other providers `authType` is
- * advisory/ignored.
- */
-fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> = when (providerId) {
-    "openai" -> when (authType) {
-        "oauth" -> openaiOAuthModels
-        "api_key" -> openaiModels
-        null -> throw IllegalArgumentException("authType is required for providerId=openai")
-        else -> throw IllegalArgumentException("Unsupported authType '$authType' for providerId=openai")
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
     }
-    "openrouter", "custom" -> emptyList() // Freeform: user types model ID
-    else -> availableModels
+
+    /**
+     * Idempotent. Call from [com.seekerclaw.app.SeekerClawApplication.onCreate]
+     * BEFORE any code that touches `ConfigManager` / provider helpers,
+     * and OUTSIDE any `isMainProcess` guard — both the main UI process
+     * AND the `:node` service process need the registry available
+     * (Codex v2 finding).
+     *
+     * Load-and-validate first, publish-after-success: a failed parse
+     * (bad JSON, schema mismatch, missing required field) throws and
+     * leaves [initialized] = false so a retry can re-attempt the load
+     * (Codex v2.1 finding).
+     */
+    fun init(context: Context) {
+        if (initialized) return
+        synchronized(initLock) {
+            if (initialized) return
+            // loadAndValidate may throw on bad JSON or schema mismatch.
+            // Until publication on the next two lines, `initialized`
+            // stays false and any retry caller starts from scratch.
+            val loaded = loadAndValidate(context.applicationContext)
+            _providers = loaded
+            initialized = true
+        }
+    }
+
+    /**
+     * Test seam — bypass the asset load and inject a synthetic
+     * registry. Used by `ModelRegistryTest` to exercise edge cases
+     * without a real Android Context.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun initForTest(providers: List<ProviderInfo>) {
+        synchronized(initLock) {
+            _providers = providers
+            initialized = true
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun resetForTest() {
+        synchronized(initLock) {
+            _providers = null
+            initialized = false
+        }
+    }
+
+    val providers: List<ProviderInfo>
+        get() = _providers
+            ?: error("ModelRegistry.init(context) must be called before use")
+
+    /**
+     * Look up a provider by id. Falls back to the FIRST provider in the
+     * registry for unknown ids — preserves the pre-BAT-517 behaviour
+     * where unknown id → `availableProviders[0]` (which today is
+     * `openai`). The fallback is intentional: code paths that use
+     * `providerById` for branding / display never crash on a corrupt
+     * persisted provider id.
+     */
+    fun providerById(id: String): ProviderInfo {
+        val list = providers
+        return list.find { it.id == id } ?: list[0]
+    }
+
+    /**
+     * Resolve the model list for a given provider+auth combination.
+     *
+     * For OpenAI specifically, [authType] MUST be either `"api_key"` or
+     * `"oauth"` — passing null or any other value throws so callers
+     * can't accidentally fall through to the API-key model list while
+     * the user is in OAuth mode. This mirrors the pre-BAT-517 Kotlin
+     * behaviour and is intentionally asymmetric with Node (which
+     * returns `[]` instead of throwing — Node tools can't crash the
+     * chat turn). For other providers [authType] is advisory; we
+     * always return the base `models` list (or per-auth override if
+     * present and the auth matches), and freeform providers get `[]`.
+     */
+    fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> {
+        val provider = providers.find { it.id == providerId } ?: return emptyList()
+        if (provider.freeform) return emptyList()
+        if (provider.id == "openai") {
+            return when (authType) {
+                "oauth" -> provider.modelsByAuth["oauth"] ?: provider.models
+                "api_key" -> provider.models
+                null -> throw IllegalArgumentException("authType is required for providerId=openai")
+                else -> throw IllegalArgumentException("Unsupported authType '$authType' for providerId=openai")
+            }
+        }
+        // Other providers: per-auth override wins if present, else base models.
+        if (authType != null) {
+            provider.modelsByAuth[authType]?.let { return it }
+        }
+        return provider.models
+    }
+
+    /**
+     * Recommended default model for a given provider. Decoupled from
+     * [ProviderInfo.models] order — explicit registry value, not
+     * `models[0]`. The display order in the picker can put a
+     * tier-gated model at the top without it silently becoming the
+     * fresh-install default.
+     *
+     * No per-auth defaults today; if a future provider needs them,
+     * extend the schema with `defaultModelByAuth` symmetric to
+     * `modelsByAuth`.
+     */
+    fun defaultModelForProvider(providerId: String, @Suppress("UNUSED_PARAMETER") authType: String?): String {
+        val provider = providers.find { it.id == providerId } ?: return ""
+        return provider.defaultModel
+    }
+
+    /**
+     * Render a model id as its display label by searching every
+     * provider's [ProviderInfo.models] AND every
+     * [ProviderInfo.modelsByAuth] list. First match wins. Falls back
+     * to the raw id verbatim for freeform / future / unknown models —
+     * so an OpenRouter id like `anthropic/claude-sonnet-4-6` displays
+     * as itself rather than a confusing "Not configured" or empty
+     * string. Pre-BAT-517 this only searched the Claude list, so
+     * `modelDisplayName("gpt-5.4")` returned the raw id; post-BAT-517
+     * it returns `"GPT-5.4"`. Codex v2 finding 5.
+     */
+    fun modelDisplayName(modelId: String?): String {
+        if (modelId.isNullOrBlank()) return "Not configured"
+        for (provider in providers) {
+            provider.models.find { it.id == modelId }?.let { return it.displayName }
+            for (overrideList in provider.modelsByAuth.values) {
+                overrideList.find { it.id == modelId }?.let { return it.displayName }
+            }
+        }
+        return modelId
+    }
+
+    /**
+     * Internal load + minimal-validation entry point. Throws on:
+     *  - missing asset / IO failure
+     *  - JSON parse error
+     *  - version mismatch
+     *  - empty providers list (a valid registry MUST list at least
+     *    one provider so [providerById]'s fallback is well-defined)
+     *
+     * Heavier invariants (default-model membership, no-duplicate-ids,
+     * `modelsByAuth` keys ⊆ `authTypes`) are pinned by
+     * `ModelRegistryTest` rather than enforced at load — failing hard
+     * on a malformed bundled asset is the right call (it's a build-
+     * time bug), but we don't want the runtime loader doing every
+     * check the test suite does.
+     */
+    private fun loadAndValidate(applicationContext: Context): List<ProviderInfo> {
+        val raw = applicationContext.assets.open(ASSET_PATH)
+            .use { it.bufferedReader().readText() }
+        val parsed = json.decodeFromString(ModelRegistryFile.serializer(), raw)
+        require(parsed.version == EXPECTED_VERSION) {
+            "model-registry.json version=${parsed.version}, expected=$EXPECTED_VERSION"
+        }
+        require(parsed.providers.isNotEmpty()) {
+            "model-registry.json has no providers"
+        }
+        return parsed.providers
+    }
 }
 
-fun providerById(id: String): ProviderInfo =
-    availableProviders.find { it.id == id } ?: availableProviders[0]
+// ─── Backward-compatible top-level API ──────────────────────────────
+//
+// Pre-BAT-517 callers across UI/config code import these names. They
+// stay as property getters / delegating functions so the existing
+// import statements keep working without churn. The implementations
+// route through ModelRegistry — getters specifically (NOT eager top-
+// level vals) so each access reads after `ModelRegistry.init()` has
+// run, even for a caller that ran before init() (Codex v2.1 finding).
+
+val availableProviders: List<ProviderInfo>
+    get() = ModelRegistry.providers
+
+fun providerById(id: String): ProviderInfo = ModelRegistry.providerById(id)
+
+fun modelsForProvider(providerId: String, authType: String?): List<ModelInfo> =
+    ModelRegistry.modelsForProvider(providerId, authType)
+
+fun defaultModelForProvider(providerId: String, authType: String?): String =
+    ModelRegistry.defaultModelForProvider(providerId, authType)
 
 /**
- * Recommended default model for a given provider/authType.
- *
- * Decoupled from list order (intentionally) so the display list can prioritize
- * the newest/most-exciting model at the top while the default stays on a known-
- * safe, broadly-available choice. Rule of thumb: if a brand-new model is added
- * that's tier-gated (e.g. only available on ChatGPT Pro), leave this alone —
- * users on lower tiers must never hit a default that their plan can't reach.
- *
- * Call sites that seed an initial model (SetupScreen, provider/auth switches)
- * should use this helper instead of `modelsForProvider(...).firstOrNull()`.
+ * Default for OpenRouter — kept as a top-level alias for the call
+ * sites that imported it directly pre-BAT-517. Sourced from the
+ * registry instead of a hardcoded const.
  */
-fun defaultModelForProvider(providerId: String, authType: String?): String = when (providerId) {
-    // GPT-5.4 is available on every ChatGPT subscription tier AND via API key.
-    // GPT-5.5 is tier-gated on some plans as of 2026-04 — don't pick it as a default.
-    "openai" -> "gpt-5.4"
-    "openrouter" -> OPENROUTER_DEFAULT_MODEL
-    "custom" -> ""
-    else -> availableModels.firstOrNull()?.id ?: ""
-}
+val OPENROUTER_DEFAULT_MODEL: String
+    get() = ModelRegistry.providerById("openrouter").defaultModel

--- a/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
@@ -1,0 +1,371 @@
+package com.seekerclaw.app.config
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pure JVM tests for [ModelRegistry] (BAT-517).
+ *
+ * The asset-loading path (`assets.open(...)`) needs a real Android
+ * Context, so we don't exercise it here — it's covered by device test
+ * + the build's smoke check (asset must be present in the APK or
+ * Application.onCreate would throw at first launch).
+ *
+ * Instead, these tests use the [ModelRegistry.initForTest] seam to
+ * inject a synthetic registry and pin every contract that lives ABOVE
+ * the asset boundary:
+ *  - schema invariants (per-auth default-model, no dupes, modelsByAuth
+ *    keys ⊆ authTypes)
+ *  - resolution rules (modelsForProvider, defaultModelForProvider,
+ *    modelDisplayName, providerById fallback)
+ *  - the OpenAI strict-authType throw vs other providers' permissive
+ *    behaviour
+ *
+ * `LiveRegistryParitiesTest` in the same file uses the embedded
+ * fixture below to also pin the actual production data shape — if
+ * someone edits `model-registry.json` and one of the live invariants
+ * breaks, this test fails before the merge.
+ */
+class ModelRegistryTest {
+
+    /**
+     * Mirror of the production `model-registry.json` so the unit test
+     * can exercise real-data shape without an Android Context. If this
+     * drifts from the asset, the parity tests below fail loudly.
+     */
+    private val productionProviders: List<ProviderInfo> = listOf(
+        ProviderInfo(
+            id = "openai",
+            displayName = "OpenAI",
+            authTypes = listOf("api_key", "oauth"),
+            keyHint = "sk-proj-…",
+            consoleUrl = "https://platform.openai.com",
+            keysUrl = "https://platform.openai.com/api-keys",
+            freeform = false,
+            defaultModel = "gpt-5.4",
+            models = listOf(
+                ModelInfo("gpt-5.5", "GPT-5.5"),
+                ModelInfo("gpt-5.4", "GPT-5.4"),
+                ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
+            ),
+            modelsByAuth = mapOf(
+                "oauth" to listOf(
+                    ModelInfo("gpt-5.5", "GPT-5.5"),
+                    ModelInfo("gpt-5.4", "GPT-5.4"),
+                    ModelInfo("gpt-5.4-mini", "GPT-5.4 Mini"),
+                    ModelInfo("gpt-5.3-codex", "GPT-5.3 Codex"),
+                ),
+            ),
+        ),
+        ProviderInfo(
+            id = "claude",
+            displayName = "Anthropic",
+            authTypes = listOf("api_key", "setup_token"),
+            keyHint = "sk-ant-api03-…",
+            consoleUrl = "https://console.anthropic.com",
+            keysUrl = "https://console.anthropic.com/settings/keys",
+            freeform = false,
+            defaultModel = "claude-opus-4-7",
+            models = listOf(
+                ModelInfo("claude-opus-4-7", "Opus 4.7"),
+                ModelInfo("claude-opus-4-6", "Opus 4.6"),
+                ModelInfo("claude-sonnet-4-6", "Sonnet 4.6"),
+                ModelInfo("claude-haiku-4-5", "Haiku 4.5"),
+            ),
+        ),
+        ProviderInfo(
+            id = "openrouter",
+            displayName = "OpenRouter",
+            authTypes = listOf("api_key"),
+            keyHint = "sk-or-v1-…",
+            consoleUrl = "https://openrouter.ai",
+            keysUrl = "https://openrouter.ai/keys",
+            freeform = true,
+            defaultModel = "anthropic/claude-sonnet-4-6",
+            models = emptyList(),
+        ),
+        ProviderInfo(
+            id = "custom",
+            displayName = "Custom",
+            authTypes = listOf("api_key"),
+            keyHint = "your-api-key",
+            consoleUrl = "https://seekerclaw.xyz/docs/custom-provider",
+            keysUrl = "https://seekerclaw.xyz/docs/custom-provider",
+            freeform = true,
+            defaultModel = "",
+            models = emptyList(),
+        ),
+    )
+
+    @Before
+    fun setUp() {
+        ModelRegistry.resetForTest()
+        ModelRegistry.initForTest(productionProviders)
+    }
+
+    @After
+    fun tearDown() {
+        ModelRegistry.resetForTest()
+    }
+
+    // ---- Schema invariants ----------------------------------------------
+
+    @Test
+    fun `every non-freeform provider has defaultModel in every effective auth list`() {
+        // Codex v2 finding 4: invariant must hold against effective list,
+        // not just the base `models` array. For non-freeform providers
+        // and EVERY authType in `authTypes`:
+        //   effective = modelsByAuth[authType] ?: models
+        //   defaultModel must appear in effective
+        for (provider in productionProviders.filterNot { it.freeform }) {
+            for (authType in provider.authTypes) {
+                val effective = provider.modelsByAuth[authType] ?: provider.models
+                val ids = effective.map { it.id }
+                assertTrue(
+                    "${provider.id}/${authType}: defaultModel '${provider.defaultModel}' " +
+                        "not in effective list ${ids}",
+                    provider.defaultModel in ids,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `freeform providers have empty models list`() {
+        for (provider in productionProviders.filter { it.freeform }) {
+            assertTrue("${provider.id} is freeform but models is non-empty", provider.models.isEmpty())
+        }
+    }
+
+    @Test
+    fun `no duplicate provider ids`() {
+        val ids = productionProviders.map { it.id }
+        assertEquals("duplicate provider ids: $ids", ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun `no duplicate model ids within a provider's effective lists`() {
+        for (provider in productionProviders) {
+            val combined = provider.models + provider.modelsByAuth.values.flatten()
+            val ids = combined.map { it.id }
+            // Distinct IDs across union — freeform allowed empty.
+            assertEquals(
+                "${provider.id} has duplicate model ids in effective union: ${ids}",
+                ids.toSet().size,
+                ids.size.coerceAtMost(ids.toSet().size + 0).let { ids.toSet().size }, // identity sanity
+            )
+            // Per-list: each list has unique ids
+            assertEquals(
+                "${provider.id}.models has duplicates",
+                provider.models.size,
+                provider.models.map { it.id }.toSet().size,
+            )
+            for ((auth, list) in provider.modelsByAuth) {
+                assertEquals(
+                    "${provider.id}.modelsByAuth[$auth] has duplicates",
+                    list.size,
+                    list.map { it.id }.toSet().size,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `modelsByAuth keys are all in authTypes`() {
+        for (provider in productionProviders) {
+            for (authKey in provider.modelsByAuth.keys) {
+                assertTrue(
+                    "${provider.id}: modelsByAuth key '$authKey' not in authTypes ${provider.authTypes}",
+                    authKey in provider.authTypes,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every provider has non-empty authTypes`() {
+        for (provider in productionProviders) {
+            assertTrue("${provider.id} has empty authTypes", provider.authTypes.isNotEmpty())
+        }
+    }
+
+    // ---- Resolution rules -----------------------------------------------
+
+    @Test
+    fun `modelsForProvider openai api_key returns 3-model list`() {
+        val list = ModelRegistry.modelsForProvider("openai", "api_key")
+        assertEquals(listOf("gpt-5.5", "gpt-5.4", "gpt-5.3-codex"), list.map { it.id })
+    }
+
+    @Test
+    fun `modelsForProvider openai oauth returns 4-model list with mini`() {
+        val list = ModelRegistry.modelsForProvider("openai", "oauth")
+        assertEquals(
+            listOf("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"),
+            list.map { it.id },
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `modelsForProvider openai null authType throws`() {
+        // Pre-BAT-517 Kotlin behaviour preserved (asymmetric with Node which returns []).
+        ModelRegistry.modelsForProvider("openai", null)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `modelsForProvider openai unsupported authType throws`() {
+        ModelRegistry.modelsForProvider("openai", "telepathy")
+    }
+
+    @Test
+    fun `modelsForProvider claude api_key and setup_token return same list`() {
+        val viaApiKey = ModelRegistry.modelsForProvider("claude", "api_key")
+        val viaSetupToken = ModelRegistry.modelsForProvider("claude", "setup_token")
+        // Same content; the registry only encodes one models list for Claude
+        // since both auth flows hit the same model availability.
+        assertEquals(viaApiKey.map { it.id }, viaSetupToken.map { it.id })
+    }
+
+    @Test
+    fun `modelsForProvider freeform returns empty`() {
+        assertTrue(ModelRegistry.modelsForProvider("openrouter", "api_key").isEmpty())
+        assertTrue(ModelRegistry.modelsForProvider("custom", "api_key").isEmpty())
+    }
+
+    @Test
+    fun `modelsForProvider unknown provider returns empty`() {
+        assertTrue(ModelRegistry.modelsForProvider("not-a-provider", "api_key").isEmpty())
+    }
+
+    @Test
+    fun `defaultModelForProvider returns explicit registry value`() {
+        assertEquals("gpt-5.4", ModelRegistry.defaultModelForProvider("openai", "api_key"))
+        assertEquals("gpt-5.4", ModelRegistry.defaultModelForProvider("openai", "oauth"))
+        assertEquals("claude-opus-4-7", ModelRegistry.defaultModelForProvider("claude", "api_key"))
+        assertEquals("anthropic/claude-sonnet-4-6", ModelRegistry.defaultModelForProvider("openrouter", "api_key"))
+        assertEquals("", ModelRegistry.defaultModelForProvider("custom", "api_key"))
+    }
+
+    @Test
+    fun `defaultModelForProvider unknown returns empty`() {
+        assertEquals("", ModelRegistry.defaultModelForProvider("not-a-provider", "api_key"))
+    }
+
+    @Test
+    fun `providerById falls back to providers index 0 for unknown id`() {
+        // BAT-517 Codex finding 1: production fallback must be openai
+        // (preserved from pre-BAT-517 `availableProviders[0]`).
+        val fallback = ModelRegistry.providerById("not-a-provider")
+        assertEquals("openai", fallback.id)
+    }
+
+    @Test
+    fun `providerById returns the matching provider for known id`() {
+        assertEquals("Anthropic", ModelRegistry.providerById("claude").displayName)
+        assertEquals("OpenRouter", ModelRegistry.providerById("openrouter").displayName)
+    }
+
+    // ---- modelDisplayName (Codex v2 finding 5) --------------------------
+
+    @Test
+    fun `modelDisplayName returns Not configured for null or blank`() {
+        assertEquals("Not configured", ModelRegistry.modelDisplayName(null))
+        assertEquals("Not configured", ModelRegistry.modelDisplayName(""))
+        assertEquals("Not configured", ModelRegistry.modelDisplayName("   "))
+    }
+
+    @Test
+    fun `modelDisplayName finds OpenAI api_key model in models list`() {
+        assertEquals("GPT-5.4", ModelRegistry.modelDisplayName("gpt-5.4"))
+    }
+
+    @Test
+    fun `modelDisplayName finds OpenAI oauth-only model in modelsByAuth list`() {
+        // gpt-5.4-mini only exists in modelsByAuth.oauth — the lookup must
+        // recurse into modelsByAuth.values, not just `models`.
+        assertEquals("GPT-5.4 Mini", ModelRegistry.modelDisplayName("gpt-5.4-mini"))
+    }
+
+    @Test
+    fun `modelDisplayName finds Claude model`() {
+        assertEquals("Haiku 4.5", ModelRegistry.modelDisplayName("claude-haiku-4-5"))
+    }
+
+    @Test
+    fun `modelDisplayName falls back to raw id for freeform unknown model`() {
+        // Pre-BAT-517 always fell back; post-BAT-517 only falls back when
+        // the id is genuinely unknown (typically OpenRouter freeform ids).
+        assertEquals(
+            "anthropic/claude-sonnet-4-6",
+            ModelRegistry.modelDisplayName("anthropic/claude-sonnet-4-6"),
+        )
+        assertEquals("brand-new-model", ModelRegistry.modelDisplayName("brand-new-model"))
+    }
+
+    // ---- Backward-compat shims ------------------------------------------
+
+    @Test
+    fun `availableProviders shim delegates to ModelRegistry`() {
+        assertSame(ModelRegistry.providers, availableProviders)
+    }
+
+    @Test
+    fun `availableModels shim returns Claude provider's models`() {
+        val expected = ModelRegistry.providerById("claude").models
+        assertEquals(expected, availableModels)
+    }
+
+    @Test
+    fun `top-level providerById delegates to ModelRegistry`() {
+        assertEquals(
+            ModelRegistry.providerById("openai").displayName,
+            providerById("openai").displayName,
+        )
+    }
+
+    @Test
+    fun `top-level modelsForProvider and defaultModelForProvider delegate to ModelRegistry`() {
+        assertEquals(
+            ModelRegistry.modelsForProvider("openai", "api_key"),
+            modelsForProvider("openai", "api_key"),
+        )
+        assertEquals(
+            ModelRegistry.defaultModelForProvider("claude", "api_key"),
+            defaultModelForProvider("claude", "api_key"),
+        )
+    }
+
+    @Test
+    fun `OPENROUTER_DEFAULT_MODEL alias matches registry value`() {
+        assertEquals(
+            ModelRegistry.providerById("openrouter").defaultModel,
+            OPENROUTER_DEFAULT_MODEL,
+        )
+    }
+
+    // ---- Provider order pin (Codex v1+v2 finding) -----------------------
+
+    @Test
+    fun `provider order is openai claude openrouter custom`() {
+        assertEquals(
+            listOf("openai", "claude", "openrouter", "custom"),
+            productionProviders.map { it.id },
+        )
+    }
+
+    @Test
+    fun `unknown id fallback resolves to openai (preserves pre-BAT-517 behaviour)`() {
+        // Defense-in-depth alongside the providerById test above — pin the
+        // chain explicitly so a future schema reorder doesn't silently flip
+        // the fallback target.
+        assertEquals("openai", productionProviders.first().id)
+        assertSame(productionProviders.first(), ModelRegistry.providerById("garbage"))
+    }
+}

--- a/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
@@ -373,4 +373,72 @@ class ModelRegistryTest {
         assertEquals("openai", productionProviders.first().id)
         assertSame(productionProviders.first(), ModelRegistry.providerById("garbage"))
     }
+
+    // ---- Strict lookups + initForTest validation (R3 Copilot) -----------
+
+    @Test
+    fun `requireProviderById throws if provider missing`() {
+        // Pin the strict-lookup contract used by availableModels +
+        // OPENROUTER_DEFAULT_MODEL: a malformed registry must surface
+        // immediately, not silently return providers[0].
+        try {
+            ModelRegistry.requireProviderById("not-a-provider")
+            fail("requireProviderById must throw on missing id")
+        } catch (e: IllegalStateException) {
+            assertTrue(
+                "error message should name the missing provider, was: ${e.message}",
+                (e.message ?: "").contains("not-a-provider"),
+            )
+        }
+    }
+
+    @Test
+    fun `availableModels fails fast when claude provider is removed from registry`() {
+        // Re-init with a registry that omits `claude`. Pre-R3, this would
+        // silently fall back to providers[0].models (openai's list).
+        // Post-R3 it must throw.
+        ModelRegistry.resetForTest()
+        ModelRegistry.initForTest(productionProviders.filter { it.id != "claude" })
+        try {
+            availableModels.size  // force getter evaluation
+            fail("availableModels must throw when claude provider missing")
+        } catch (e: IllegalStateException) {
+            assertTrue((e.message ?: "").contains("claude"))
+        } finally {
+            ModelRegistry.resetForTest()
+            ModelRegistry.initForTest(productionProviders)
+        }
+    }
+
+    @Test
+    fun `OPENROUTER_DEFAULT_MODEL fails fast when openrouter provider is removed from registry`() {
+        ModelRegistry.resetForTest()
+        ModelRegistry.initForTest(productionProviders.filter { it.id != "openrouter" })
+        try {
+            OPENROUTER_DEFAULT_MODEL.length  // force getter evaluation
+            fail("OPENROUTER_DEFAULT_MODEL must throw when openrouter provider missing")
+        } catch (e: IllegalStateException) {
+            assertTrue((e.message ?: "").contains("openrouter"))
+        } finally {
+            ModelRegistry.resetForTest()
+            ModelRegistry.initForTest(productionProviders)
+        }
+    }
+
+    @Test
+    fun `initForTest rejects empty providers list`() {
+        // Mirror the runtime loader's `parsed.providers.isNotEmpty()`
+        // guard so a misused test seam fails clearly instead of
+        // surfacing as IndexOutOfBoundsException at the next
+        // providerById call.
+        ModelRegistry.resetForTest()
+        try {
+            ModelRegistry.initForTest(emptyList())
+            fail("initForTest must reject empty providers list")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        } finally {
+            ModelRegistry.initForTest(productionProviders)
+        }
+    }
 }

--- a/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/config/ModelRegistryTest.kt
@@ -28,17 +28,25 @@ import org.junit.Test
  *  - the OpenAI strict-authType throw vs other providers' permissive
  *    behaviour
  *
- * `LiveRegistryParitiesTest` in the same file uses the embedded
- * fixture below to also pin the actual production data shape — if
- * someone edits `model-registry.json` and one of the live invariants
- * breaks, this test fails before the merge.
+ * The embedded `productionProviders` fixture below mirrors the live
+ * `model-registry.json` shape closely enough to exercise these
+ * contracts on the JVM without an Android Context. It is a HAND-KEPT
+ * mirror, NOT a parity-against-the-asset check — keep it aligned by
+ * convention when editing the JSON. Asset-loading is exercised on
+ * device by `SeekerClawApplication.onCreate` calling
+ * `ModelRegistry.init(context)`, which throws on a malformed bundled
+ * file (Codex v2.1 finding 1) — that's the live-asset gate, not this
+ * test file. Node-side parity is enforced by
+ * `tests/nodejs-project/model-catalog.test.js`, which loads the same
+ * JSON file and asserts the same invariants.
  */
 class ModelRegistryTest {
 
     /**
-     * Mirror of the production `model-registry.json` so the unit test
-     * can exercise real-data shape without an Android Context. If this
-     * drifts from the asset, the parity tests below fail loudly.
+     * Production-shaped fixture used to exercise registry behavior on
+     * the JVM without an Android Context. Hand-kept aligned with
+     * `model-registry.json`; this file does not provide direct asset
+     * parity verification (see class KDoc).
      */
     private val productionProviders: List<ProviderInfo> = listOf(
         ProviderInfo(
@@ -151,25 +159,22 @@ class ModelRegistryTest {
     }
 
     @Test
-    fun `no duplicate model ids within a provider's effective lists`() {
+    fun `no duplicate model ids within each provider's lists`() {
+        // BAT-517 R1 Copilot: the previous version of this test asserted
+        // uniqueness across the UNION of `models` + `modelsByAuth.values`,
+        // which is incompatible with the live OpenAI shape — `modelsByAuth.oauth`
+        // is a SUPERSET of `models` (same api_key ids + extras like
+        // `gpt-5.4-mini`), so the union always has duplicates by design.
+        // The actual invariant is: no duplicates WITHIN any single list.
         for (provider in productionProviders) {
-            val combined = provider.models + provider.modelsByAuth.values.flatten()
-            val ids = combined.map { it.id }
-            // Distinct IDs across union — freeform allowed empty.
             assertEquals(
-                "${provider.id} has duplicate model ids in effective union: ${ids}",
-                ids.toSet().size,
-                ids.size.coerceAtMost(ids.toSet().size + 0).let { ids.toSet().size }, // identity sanity
-            )
-            // Per-list: each list has unique ids
-            assertEquals(
-                "${provider.id}.models has duplicates",
+                "${provider.id}.models has duplicate ids",
                 provider.models.size,
                 provider.models.map { it.id }.toSet().size,
             )
             for ((auth, list) in provider.modelsByAuth) {
                 assertEquals(
-                    "${provider.id}.modelsByAuth[$auth] has duplicates",
+                    "${provider.id}.modelsByAuth[$auth] has duplicate ids",
                     list.size,
                     list.map { it.id }.toSet().size,
                 )

--- a/tests/nodejs-project/model-catalog.test.js
+++ b/tests/nodejs-project/model-catalog.test.js
@@ -244,6 +244,88 @@ check('PROVIDER_DISPLAY_NAMES matches registry',
     Object.fromEntries(REGISTRY.providers.map((p) => [p.id, p.displayName])));
 
 console.log();
+console.log('── _validateRegistry: explicit failure paths (BAT-517 R4 Copilot) ──');
+// Pin the loader-side validation Copilot asked for: duplicate provider
+// ids and missing required providers must throw clear errors at
+// require-time, not surface as obscure "Cannot read properties of
+// undefined" TypeErrors when the constant derivations dereference
+// _byId.{claude,openai,openrouter}.
+function expectThrow(label, fn, messageSubstring) {
+    try {
+        fn();
+    } catch (e) {
+        if (typeof e.message === 'string' && e.message.includes(messageSubstring)) {
+            console.log(`PASS: ${label}`);
+            return;
+        }
+        console.log(`FAIL: ${label} — wrong error message: ${e.message}`);
+        failures++;
+        return;
+    }
+    console.log(`FAIL: ${label} — did not throw`);
+    failures++;
+}
+
+const baseRegistry = JSON.parse(JSON.stringify(REGISTRY));
+const _validate = mc._validateRegistry;
+
+expectThrow(
+    'rejects null',
+    () => _validate(null),
+    'is not a JSON object',
+);
+expectThrow(
+    'rejects bad version',
+    () => _validate({ ...baseRegistry, version: 999 }),
+    'version=999',
+);
+expectThrow(
+    'rejects empty providers',
+    () => _validate({ version: 1, providers: [] }),
+    'has no providers',
+);
+expectThrow(
+    'rejects duplicate provider ids',
+    () => _validate({
+        version: 1,
+        providers: [...baseRegistry.providers, baseRegistry.providers[0]],
+    }),
+    'duplicate provider ids',
+);
+expectThrow(
+    'rejects missing required claude',
+    () => _validate({
+        version: 1,
+        providers: baseRegistry.providers.filter((p) => p.id !== 'claude'),
+    }),
+    'missing required provider(s): claude',
+);
+expectThrow(
+    'rejects missing required openai',
+    () => _validate({
+        version: 1,
+        providers: baseRegistry.providers.filter((p) => p.id !== 'openai'),
+    }),
+    'missing required provider(s): openai',
+);
+expectThrow(
+    'rejects missing required openrouter',
+    () => _validate({
+        version: 1,
+        providers: baseRegistry.providers.filter((p) => p.id !== 'openrouter'),
+    }),
+    'missing required provider(s): openrouter',
+);
+// And the happy path: live registry passes validation.
+try {
+    _validate(baseRegistry);
+    console.log('PASS: live registry passes _validateRegistry');
+} catch (e) {
+    console.log(`FAIL: live registry rejected by _validateRegistry — ${e.message}`);
+    failures++;
+}
+
+console.log();
 if (failures === 0) {
     console.log('ALL TESTS PASS');
     process.exit(0);

--- a/tests/nodejs-project/model-catalog.test.js
+++ b/tests/nodejs-project/model-catalog.test.js
@@ -226,9 +226,16 @@ console.log('── exported constants match registry-derived values (drift guar
 // hardcodes a value), this guard catches the drift between exports and
 // the JSON source of truth.
 const byId = Object.fromEntries(REGISTRY.providers.map((p) => [p.id, p]));
+// BAT-517 R3 Copilot: mirror the production code's optional handling
+// of `modelsByAuth` here too. Direct `.modelsByAuth.oauth` access would
+// TypeError and ABORT the test run if a future registry omits the
+// override; the guarded access lets `check()` report a clean FAIL
+// instead.
+const expectedOpenaiOauthModels =
+    (byId.openai.modelsByAuth && byId.openai.modelsByAuth.oauth) || byId.openai.models;
 check('CLAUDE_MODELS == registry.claude.models', mc.CLAUDE_MODELS, byId.claude.models);
 check('OPENAI_API_KEY_MODELS == registry.openai.models', mc.OPENAI_API_KEY_MODELS, byId.openai.models);
-check('OPENAI_OAUTH_MODELS == registry.openai.modelsByAuth.oauth', mc.OPENAI_OAUTH_MODELS, byId.openai.modelsByAuth.oauth);
+check('OPENAI_OAUTH_MODELS == registry.openai.modelsByAuth.oauth (or fallback to models)', mc.OPENAI_OAUTH_MODELS, expectedOpenaiOauthModels);
 check('CLAUDE_DEFAULT_MODEL matches registry', mc.CLAUDE_DEFAULT_MODEL, byId.claude.defaultModel);
 check('OPENAI_DEFAULT_MODEL matches registry', mc.OPENAI_DEFAULT_MODEL, byId.openai.defaultModel);
 check('OPENROUTER_DEFAULT_MODEL matches registry', mc.OPENROUTER_DEFAULT_MODEL, byId.openrouter.defaultModel);

--- a/tests/nodejs-project/model-catalog.test.js
+++ b/tests/nodejs-project/model-catalog.test.js
@@ -138,6 +138,103 @@ check('includes claude', mc.KNOWN_PROVIDERS.includes('claude'), true);
 check('includes openai', mc.KNOWN_PROVIDERS.includes('openai'), true);
 check('includes openrouter', mc.KNOWN_PROVIDERS.includes('openrouter'), true);
 check('includes custom', mc.KNOWN_PROVIDERS.includes('custom'), true);
+// Provider order pin (BAT-517 Codex finding 1): preserve fallback target.
+check('KNOWN_PROVIDERS[0] is openai (preserves pre-BAT-517 unknown-id fallback)', mc.KNOWN_PROVIDERS[0], 'openai');
+
+console.log();
+console.log('── BAT-517 schema invariants (model-registry.json contract) ──');
+// Re-read the registry directly so we can pin schema-level invariants
+// independent of the derived export shape — if a future edit breaks
+// the registry's own rules, this catches it BEFORE we ever shipped a
+// catalog with garbage values. Mirrors ModelRegistryTest.kt.
+const fs = require('fs');
+const path = require('path');
+const REGISTRY_PATH = path.join(
+    __dirname, '..', '..',
+    'app', 'src', 'main', 'assets', 'nodejs-project', 'model-registry.json',
+);
+const REGISTRY = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+
+check('registry version is 1', REGISTRY.version, 1);
+check('registry has providers array', Array.isArray(REGISTRY.providers), true);
+check('registry has 4 providers', REGISTRY.providers.length, 4);
+
+// Per-auth default-model invariant (Codex v2 Fix 4): for every
+// non-freeform provider AND every authType in `authTypes`,
+// `defaultModel` must appear in `modelsByAuth[authType] ?? models`.
+let perAuthInvariantOk = true;
+let perAuthFailures = [];
+for (const p of REGISTRY.providers) {
+    if (p.freeform) continue;
+    for (const auth of p.authTypes) {
+        const effective = (p.modelsByAuth && p.modelsByAuth[auth]) || p.models;
+        const ids = effective.map((m) => m.id);
+        if (!ids.includes(p.defaultModel)) {
+            perAuthInvariantOk = false;
+            perAuthFailures.push(`${p.id}/${auth}: defaultModel '${p.defaultModel}' not in [${ids.join(', ')}]`);
+        }
+    }
+}
+check('per-auth defaultModel invariant holds (Codex Fix 4)', perAuthInvariantOk, true);
+if (!perAuthInvariantOk) {
+    console.log('  failures:');
+    for (const f of perAuthFailures) console.log('    - ' + f);
+}
+
+// modelsByAuth keys must be a subset of authTypes.
+let authKeysOk = true;
+for (const p of REGISTRY.providers) {
+    if (!p.modelsByAuth) continue;
+    for (const k of Object.keys(p.modelsByAuth)) {
+        if (!p.authTypes.includes(k)) {
+            authKeysOk = false;
+            console.log(`  ${p.id}: modelsByAuth key '${k}' not in authTypes [${p.authTypes.join(', ')}]`);
+        }
+    }
+}
+check('modelsByAuth keys ⊆ authTypes', authKeysOk, true);
+
+// Freeform providers MUST have empty `models`.
+let freeformShapeOk = true;
+for (const p of REGISTRY.providers) {
+    if (p.freeform && p.models.length !== 0) {
+        freeformShapeOk = false;
+        console.log(`  ${p.id}: freeform but models has ${p.models.length} entries`);
+    }
+}
+check('freeform providers have empty models list', freeformShapeOk, true);
+
+// No duplicate provider ids; no duplicate model ids within a provider.
+const providerIds = REGISTRY.providers.map((p) => p.id);
+check('no duplicate provider ids', providerIds.length, new Set(providerIds).size);
+let dupeModelOk = true;
+for (const p of REGISTRY.providers) {
+    const allLists = [p.models, ...Object.values(p.modelsByAuth || {})];
+    for (const list of allLists) {
+        const ids = list.map((m) => m.id);
+        if (new Set(ids).size !== ids.length) {
+            dupeModelOk = false;
+            console.log(`  ${p.id}: duplicate ids in [${ids.join(', ')}]`);
+        }
+    }
+}
+check('no duplicate model ids within any per-provider list', dupeModelOk, true);
+
+console.log();
+console.log('── exported constants match registry-derived values (drift guard) ──');
+// If someone touches the catalog code without re-running the loader (or
+// hardcodes a value), this guard catches the drift between exports and
+// the JSON source of truth.
+const byId = Object.fromEntries(REGISTRY.providers.map((p) => [p.id, p]));
+check('CLAUDE_MODELS == registry.claude.models', mc.CLAUDE_MODELS, byId.claude.models);
+check('OPENAI_API_KEY_MODELS == registry.openai.models', mc.OPENAI_API_KEY_MODELS, byId.openai.models);
+check('OPENAI_OAUTH_MODELS == registry.openai.modelsByAuth.oauth', mc.OPENAI_OAUTH_MODELS, byId.openai.modelsByAuth.oauth);
+check('CLAUDE_DEFAULT_MODEL matches registry', mc.CLAUDE_DEFAULT_MODEL, byId.claude.defaultModel);
+check('OPENAI_DEFAULT_MODEL matches registry', mc.OPENAI_DEFAULT_MODEL, byId.openai.defaultModel);
+check('OPENROUTER_DEFAULT_MODEL matches registry', mc.OPENROUTER_DEFAULT_MODEL, byId.openrouter.defaultModel);
+check('PROVIDER_DISPLAY_NAMES matches registry',
+    mc.PROVIDER_DISPLAY_NAMES,
+    Object.fromEntries(REGISTRY.providers.map((p) => [p.id, p.displayName])));
 
 console.log();
 if (failures === 0) {


### PR DESCRIPTION
## Summary

Eliminates the duplicate provider+model tables that were maintained twice — once in Kotlin (`Providers.kt` + `Models.kt`) and once in Node (`model-catalog.js`). Both runtimes now load the same JSON file: `app/src/main/assets/nodejs-project/model-registry.json`.

Adding a new provider or model is **one edit to that JSON**. Pre-BAT-517, the two sides had already drifted during BAT-509 — this is the structural fix.

## Implementation contract (Codex v2.1 approved)

**Source of truth**
- `app/src/main/assets/nodejs-project/model-registry.json`
- Kotlin: `context.assets.open("nodejs-project/model-registry.json")` via `ModelRegistry.init(context)` in `SeekerClawApplication.onCreate`
- Node: `path.join(__dirname, 'model-registry.json')` (after the APK→filesDir extraction)

**Provider order pin** — `openai, claude, openrouter, custom`. `providerById` falls back to `providers[0]` for unknown ids; reordering would silently change the fallback, so the order is locked by tests.

**Schema invariants** (pinned by tests on both sides)
- For every provider, `defaultModel ∈ (modelsByAuth[authType] ?: models)` for every authType — guarantees first-launch fresh-install always picks a valid model
- No duplicate model ids inside a provider
- `modelsByAuth` keys ⊆ `authTypes`
- Freeform providers have `models: []`

**Resolution rules**
- `modelsForProvider(providerId, authType)`:
  - OpenAI strict: `null` → throws (Kotlin) / `[]` (Node) — asymmetric on purpose (tools can't crash a chat turn). `'oauth'` → `modelsByAuth.oauth ?? models`. `'api_key'` → `models`. Other → throws / `[]`.
  - Other providers: per-auth override wins if present, else base `models`. Freeform → `[]`.
- `defaultModelForProvider(providerId, authType)` — explicit registry value, NOT `models[0]`. So display order can put a tier-gated model at the top without it becoming the fresh-install default.
- `modelDisplayName(modelId)` — searches every provider's `models` AND `modelsByAuth`. First match wins. Falls back to raw id (so OpenRouter freeform ids render as themselves). Pre-BAT-517 only searched the Claude list, so post-BAT-517 `gpt-5.4` no longer renders as raw id when the user is on OpenAI.

**Init pattern** — load-and-validate-then-publish. A failed parse throws and leaves `initialized = false` so a retry can re-attempt the load. `init` is idempotent (double-checked under `synchronized(initLock)`). Called from `onCreate` BEFORE `Analytics.init` / `ConfigManager.loadConfig` and OUTSIDE the `isMainProcess` guard — both the main UI process and the `:node` service process need the registry available (Codex v2 finding 2).

**Backward-compat shims** — `availableModels`, `availableProviders`, `OPENROUTER_DEFAULT_MODEL`, the standalone `providerById`/`modelsForProvider`/etc. functions are all preserved as **property getters** (NOT eager top-level vals — Codex v2.1 finding 4) so each access reads after `ModelRegistry.init()` has run, even from a caller that ran before init.

**Read-only by design** — registry ships in the APK and is never mutated at runtime. Model data only changes via app updates. So no CrossProcessStore, no FileObserver, no atomic-RMW.

## Test plan

- [x] **`bash scripts/pre-push-check.sh`** — ALL CHECKS PASSED (Node smoke + Kotlin compile)
- [x] **`./gradlew :app:testDappStoreDebugUnitTest`** — 148/148 passed (was 119 on BAT-514 head, +29 new `ModelRegistryTest` cases)
- [x] **`node tests/nodejs-project/model-catalog.test.js`** — ALL TESTS PASS (existing tests preserved + extended with BAT-517 schema invariants and drift guards)
- [ ] Device test — deferred until Copilot review is clean (per dev-workflow Step 10)

## Test coverage

`ModelRegistryTest.kt` (29 cases) — exercises the registry via the `initForTest` seam (no Android Context needed):
- per-auth default-model invariant on the full live registry
- no-duplicate-ids, modelsByAuth ⊆ authTypes
- freeform providers return `[]` for any auth
- OpenAI null/'oauth'/'api_key'/other resolution
- `modelDisplayName` for base, modelsByAuth-only (`gpt-5.4-mini`), freeform (`anthropic/claude-sonnet-4-6`), null/blank
- `providerById` fallback to first provider (pinned to openai)
- backward-compat shim delegations

`model-catalog.test.js` — extended:
- live-JSON schema invariants on `model-registry.json`
- drift guards: `CLAUDE_MODELS === registry.claude.models`, `OPENAI_API_KEY_MODELS`, `OPENAI_OAUTH_MODELS`, etc.
- `KNOWN_PROVIDERS[0] === 'openai'` provider-order pin
- existing ID/display tests preserved verbatim

## Known limitations

- Device test deferred until review is clean — same staged approach used for BAT-512/513/514. Read-only data path means low device-specific risk, but the smoke test (open Settings → Provider, scroll Anthropic / OpenAI / OpenRouter, verify model lists render) is still required before merge.
- `hasCredentialsFor` in `model-catalog.js` deliberately unchanged — that's loader-side runtime-config-key mapping, not registry data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)