### PR TITLE
feat: migrate searchProvider + agentName to CrossProcessStore (BAT-515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Migrate searchProvider + agentName to CrossProcessStore (BAT-515)** — both fields move out of process-local SharedPreferences into a shared `agent_preferences.json` file, mirroring the BAT-513/BAT-514 pattern.
+  - Settings UI changes are LIVE across processes — provider switch + agent-name edit take effect on the next AI turn / `web_search` / `/status` without a service restart. The `:node` process reads `agent_preferences.json` per call via the new `getAgentName()` / `getSearchProvider()` getters in `config.js`.
+  - `saveConfig` now atomically dual-writes prefs + RuntimeStateStore + AgentPreferencesStore. Pre-validation runs before persistence; if the second cross-process write (AgentPreferencesStore) fails, the rollback path restores prefs (5 keys + `setup_complete`) AND undoes the RuntimeStateStore forward update via a captured pre-forward snapshot — keeps all three stores convergent on FS failure.
+  - Migration of an existing over-cap `agentName` is preserved verbatim with a single WARN — the 64-char cap applies only to NEW writes, not migration paths (BAT-515 v3 §1, Codex final guard via context-sensitive `validateForWrite`).
+  - `tools/session.js` `webSearchProvider` now reports the live provider — replaces the long-stale `'duckduckgo'` fallback (BAT-481 dropped DDG, the report didn't follow).
+  - Settings > Search Provider switch follows the BAT-549 R14/R17/R24 pattern (StateFlow `collectAsState` + optimistic local override + `Dispatchers.IO` + clear-on-failure) so taps feel instant and survive concurrent cross-process writes without lost-update-clobber.
 - **Reasoning content preservation across all 4 providers (BAT-549)** — captures and (when supported) replays provider-native reasoning artifacts across tool-loop turns so multi-step thinking survives `/resume` and tool calls without re-prompting. Each provider preserves its own wire shape byte-exact:
   - Anthropic: `thinking` / `redacted_thinking` blocks with signature byte-exact, replayed with the `interleaved-thinking-2025-05-14` beta header
   - OpenAI Responses: full reasoning items with `encrypted_content` for `store:false` (OAuth/Codex) and api_key paths via `include:["reasoning.encrypted_content"]`

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -168,6 +168,7 @@ SeekerClaw is an Android app built for the Solana Seeker phone (also works on an
 - **Channel abstraction** — `channel.js` module provides a unified `sendMessage()`/`sendTyping()`/`sendReaction()` interface. Adding a new channel requires only a new adapter module — core agent logic is channel-agnostic.
 
 ### App (Android)
+- **Live cross-process state** — Provider/authType/model (BAT-513), MCP servers (BAT-514), and agent name + search provider (BAT-515) all live in CrossProcessStore-backed JSON files (`runtime_state.json`, `mcp_servers.json`, `agent_preferences.json`). Settings UI and `:node` see each other's writes without a service restart. Atomic-rollback in `saveConfig` keeps prefs and the cross-process files convergent on FS failure.
 - **Single theme** — DarkOps (dark navy + crimson red + green status), 12dp corners
 - **Setup wizard** — QR scan or manual API key entry, OAuth/setup token support, haptic feedback
 - **Dashboard** — Status with pulse animation (running) + dimming (stopped), uptime, message stats, active uplinks, mini terminal, API health monitoring (green/amber/red), dismissible error/network banners, deploy button disabled state when config incomplete
@@ -279,6 +280,7 @@ User (Telegram/Discord) <--HTTPS/WSS--> Channel API <--polling/WS--> Node.js Gat
 
 | Date | Feature | PR |
 |------|---------|-----|
+| 2026-04-30 | Feat: Migrate searchProvider + agentName to CrossProcessStore (BAT-515). Settings UI provider switch + agent name edit are live across processes — no service restart required. saveConfig atomically dual-writes prefs + RuntimeStateStore + AgentPreferencesStore with full rollback on failure. Node `getAgentName()` / `getSearchProvider()` walk the precedence chain `agent_preferences.json` (live) → `config.json` (cold-start) → defaults per call. | TBD |
 | 2026-04-21 | Feat: Add Claude Opus 4.7 + bump cc_version masquerade to 2.1.116 (BAT-498). Opus 4.7 becomes Anthropic default. Drop Sonnet 4.5 from dropdown/docs. | TBD |
 | 2026-04-17 | Feat: Env Vars — user-managed env var store (BAT-495). Feeds `process.env` + unlocks skill `requires.env` gates. New `env_list` tool (names only). Paste-`.env` bulk import. Skills screen inverse surfacing. | #332 |
 | 2026-04-15 | Fix: Settings defaults to OpenAI+OAuth + redesigned OAuth callback page (BAT-495) | #330 |

--- a/app/src/main/assets/nodejs-project/agent-preferences.js
+++ b/app/src/main/assets/nodejs-project/agent-preferences.js
@@ -1,0 +1,271 @@
+// SeekerClaw — agent-preferences.js (BAT-515)
+//
+// Node-side helper around cross-process-store.js for the BAT-515
+// agent-preferences state (searchProvider / agentName). The Kotlin
+// singleton `AgentPreferencesStore` (com.seekerclaw.app.state) and
+// this module both read/write the SAME absolute file at
+// `<filesDir>/agent_preferences.json`. Pattern mirrors
+// runtime-state.js (BAT-513) almost verbatim — same flat filesDir-
+// relative basename, same DEFAULTS-merge via read().
+//
+// ## Contract (mirrors AgentPreferencesStore.kt + BAT-515 v3 §5)
+//
+//  - `read()` — synchronous; returns DEFAULTS-merged value for direct
+//    callers who want a usable value regardless of file state.
+//    Mirrors runtime-state.read(): partial-shape file values get
+//    merged over defaults, so missing-fields-from-old-build files
+//    still return usable values.
+//
+//  - `readLiveOrNull()` — synchronous; returns the parsed object
+//    when the file exists AND parses cleanly AND has valid types,
+//    otherwise `null`. Used by `config.js`'s precedence-chain
+//    getters (`getAgentName` / `getSearchProvider`) to fall through
+//    to `config.json` cold-start fallback when the live file is
+//    unavailable. NEVER returns DEFAULTS — that's read()'s job.
+//
+//  - `write(value)` — atomic temp+rename via cross-process-store.
+//    Validates the allowlist for searchProvider and non-blank for
+//    agentName at the new-edit boundary. THROWS `Error` synchronously
+//    on validation failure; returns `true` on persisted, `false` on
+//    caught FS failure. Partial-update merge so callers with
+//    legacy 1-field shape don't drop new fields. Sanitize-on-merge
+//    heals corrupt persisted values.
+//
+//  - `update(transform)` — read-modify-write. Same throw/Boolean
+//    shape as write since it ends in a write call.
+//
+// ## DEFAULTS lock-step rule
+//
+// Defaults MUST match `AgentPreferences.kt` (data class field
+// defaults + companion constants). If either side drifts, the
+// dual-side fixture exchange test catches it.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { createStore } = require('./cross-process-store');
+
+const DEFAULTS = Object.freeze({
+    searchProvider: 'brave',
+    agentName: 'MyAgent',
+});
+
+// Allowlist of known search providers — must match
+// AgentPreferences.KNOWN_SEARCH_PROVIDERS (Kotlin). The Kotlin Settings
+// picker constrains user input to this set, but a manually-edited
+// agent_preferences.json or a future-build value rolled back to the
+// current build needs runtime defense too.
+const KNOWN_SEARCH_PROVIDERS = Object.freeze(new Set([
+    'brave', 'perplexity', 'exa', 'tavily', 'firecrawl',
+]));
+
+// agentName cap matches Kotlin's AgentPreferences.AGENT_NAME_MAX. v3 §1
+// + Codex final guard: cap applies to NEW writes; existing migrated
+// over-cap names are preserved verbatim by Kotlin's seedFromPrefs and
+// observed-on-Node-side via the file's actual content (the wire shape
+// has no cap encoded — it's a string).
+const AGENT_NAME_MAX = 64;
+
+/**
+ * Resolve the absolute path of `agent_preferences.json` from `workDir`.
+ * Same derivation as runtime-state.js — Kotlin sets argv[2] =
+ * `filesDir/workspace`, so the file lives at `path.dirname(workDir) +
+ * '/agent_preferences.json'` which is `filesDir/agent_preferences.json`.
+ */
+function resolveFilePath(workDir) {
+    if (typeof workDir !== 'string' || !workDir) {
+        throw new TypeError('agent-preferences: workDir must be a non-empty string');
+    }
+    return path.join(path.dirname(workDir), 'agent_preferences.json');
+}
+
+/**
+ * Validate searchProvider against the allowlist. Throws on unknown.
+ * Used by `write` and `update`; not used by `readLiveOrNull` (which
+ * returns null for invalid shape — see §5 of v3 contract).
+ */
+function _validateSearchProvider(value) {
+    if (typeof value !== 'string') {
+        throw new Error(`agent-preferences: searchProvider must be string, got ${typeof value}`);
+    }
+    if (!KNOWN_SEARCH_PROVIDERS.has(value)) {
+        throw new Error(
+            `agent-preferences: invalid searchProvider=${JSON.stringify(value)} ` +
+            `— must be one of ${JSON.stringify(Array.from(KNOWN_SEARCH_PROVIDERS))}`
+        );
+    }
+}
+
+/**
+ * Validate agentName: non-blank string, ≤ cap. Throws on violation.
+ * Skipped at write() time when the value matches current — see §1 + Codex
+ * final guard re: existing migrated over-cap names. The Kotlin side
+ * does the same context-sensitive skip.
+ */
+function _validateAgentName(value) {
+    if (typeof value !== 'string') {
+        throw new Error(`agent-preferences: agentName must be string, got ${typeof value}`);
+    }
+    if (value.trim().length === 0) {
+        throw new Error('agent-preferences: agentName must not be blank');
+    }
+    if (value.length > AGENT_NAME_MAX) {
+        throw new Error(
+            `agent-preferences: agentName length ${value.length} exceeds max ${AGENT_NAME_MAX}`
+        );
+    }
+}
+
+/**
+ * Build a Node-side handle for the file under [workDir]'s parent.
+ *
+ * Returns an object with `read()`, `readLiveOrNull()`, `write(value)`,
+ * `update(transform)`, and `filePath`.
+ */
+function open(workDir) {
+    const filePath = resolveFilePath(workDir);
+    const store = createStore(filePath, DEFAULTS);
+
+    /**
+     * Defaults-merged read for direct callers. Behaviour:
+     *  - File absent / parse fail / empty / non-object → DEFAULTS
+     *  - File present with partial shape (e.g., only one of the two
+     *    fields) → DEFAULTS for the missing field
+     *  - File present with both fields valid → those values
+     *
+     * Never throws.
+     */
+    function read() {
+        const raw = store.read();
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULTS };
+        const merged = { ...DEFAULTS };
+        for (const key of Object.keys(DEFAULTS)) {
+            if (Object.prototype.hasOwnProperty.call(raw, key) && raw[key] !== undefined) {
+                merged[key] = raw[key];
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * Live-or-null read for precedence-chain callers (BAT-515 v3 §5).
+     * Returns null when the file is genuinely unusable so the caller
+     * can fall through to the next source (config.json cold-start →
+     * hardcoded defaults).
+     *
+     * Treats the file as live-valid only if:
+     *  - file exists at filePath
+     *  - parses as JSON
+     *  - is a plain object (not null / array / primitive)
+     *  - both fields present AND of correct type
+     *  - `searchProvider` is in the known-providers allowlist
+     *  - `agentName` is a non-blank string
+     *
+     * NB: this does NOT enforce the 64-char cap on agentName because
+     * migration paths legitimately carry over-cap values (see v3 §1).
+     * The cap only applies at the NEW-edit boundary in `write()`.
+     *
+     * Goes through `fs.readFileSync` directly rather than via the
+     * cross-process-store helper so we can distinguish "file genuinely
+     * absent" (null fallback) from "file corrupt" (also null fallback)
+     * from "file valid" (return parsed). The store helper conflates
+     * absent + corrupt by returning defaults; this read MUST distinguish
+     * so the caller's precedence chain works correctly.
+     */
+    function readLiveOrNull() {
+        let text;
+        try {
+            text = fs.readFileSync(filePath, 'utf8');
+        } catch (e) {
+            // ENOENT / permission / etc. — treat as live-absent.
+            return null;
+        }
+        if (typeof text !== 'string' || text.trim().length === 0) return null;
+        let parsed;
+        try {
+            parsed = JSON.parse(text);
+        } catch (_) {
+            return null;
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+        const sp = parsed.searchProvider;
+        const an = parsed.agentName;
+        if (typeof sp !== 'string' || !KNOWN_SEARCH_PROVIDERS.has(sp)) return null;
+        if (typeof an !== 'string' || an.trim().length === 0) return null;
+        return { searchProvider: sp, agentName: an };
+    }
+
+    /**
+     * Persist `value` atomically. Validates ALL incoming fields (this
+     * is a NEW-write entry point — the unchanged-skip optimisation
+     * lives at the Kotlin caller layer; on the Node side `write()`
+     * goes through the same validation regardless of what's currently
+     * persisted).
+     *
+     * Returns true on persisted, false on FS failure (logged by
+     * cross-process-store). Throws on validation failure.
+     *
+     * Allowlist-merge with sanitize-on-merge mirrors runtime-state.js's
+     * legacy-3-field-write protection: only fields named in DEFAULTS
+     * survive; corrupt persisted values heal back to defaults on
+     * legacy partial writes.
+     */
+    function write(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            throw new Error('agent-preferences: write expects a plain object');
+        }
+        if (Object.prototype.hasOwnProperty.call(value, 'searchProvider')) {
+            _validateSearchProvider(value.searchProvider);
+        }
+        if (Object.prototype.hasOwnProperty.call(value, 'agentName')) {
+            _validateAgentName(value.agentName);
+        }
+        // Partial-update merge (mirrors runtime-state.js R2 fix). Legacy
+        // callers writing only one field don't drop the other.
+        const persisted = read();
+        const merged = {};
+        for (const key of Object.keys(DEFAULTS)) {
+            if (Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined) {
+                merged[key] = value[key];
+            } else if (Object.prototype.hasOwnProperty.call(persisted, key)) {
+                merged[key] = persisted[key];
+            } else {
+                merged[key] = DEFAULTS[key];
+            }
+        }
+        // Sanitize-on-merge (mirrors runtime-state.js R5 fix). If
+        // `persisted` carried a wrong-type value forward, drop to
+        // default. The merged object hits the wire in correct shape.
+        if (typeof merged.searchProvider !== 'string'
+            || !KNOWN_SEARCH_PROVIDERS.has(merged.searchProvider)) {
+            merged.searchProvider = DEFAULTS.searchProvider;
+        }
+        if (typeof merged.agentName !== 'string' || merged.agentName.trim().length === 0) {
+            merged.agentName = DEFAULTS.agentName;
+        }
+        return store.write(merged);
+    }
+
+    function update(transform) {
+        const current = read();
+        const next = transform(current);
+        return write(next);
+    }
+
+    return {
+        read,
+        readLiveOrNull,
+        write,
+        update,
+        filePath,
+    };
+}
+
+module.exports = {
+    open,
+    resolveFilePath,
+    DEFAULTS,
+    KNOWN_SEARCH_PROVIDERS,
+    AGENT_NAME_MAX,
+};

--- a/app/src/main/assets/nodejs-project/agent-preferences.js
+++ b/app/src/main/assets/nodejs-project/agent-preferences.js
@@ -197,11 +197,20 @@ function open(workDir) {
     }
 
     /**
-     * Persist `value` atomically. Validates ALL incoming fields (this
-     * is a NEW-write entry point — the unchanged-skip optimisation
-     * lives at the Kotlin caller layer; on the Node side `write()`
-     * goes through the same validation regardless of what's currently
-     * persisted).
+     * Persist `value` atomically. Validates ALL incoming fields that
+     * ACTUALLY DIFFER from the currently-persisted value — mirrors
+     * Kotlin's [AgentPreferencesStore.validateForWrite] context-
+     * sensitive contract (BAT-515 v3 §1 + Codex final guard).
+     *
+     * Why context-sensitive: an existing migrated over-cap `agentName`
+     * is preserved verbatim by Kotlin's seedFromPrefs and lands in the
+     * persisted file. A future Node-side caller doing
+     * `update(c => ({...c, searchProvider: 'exa'}))` would have its
+     * transform return both fields (the over-cap name copied from
+     * `current` AND the new searchProvider). Validating every present
+     * field unconditionally would throw on the unchanged over-cap
+     * name even though the cap only applies to genuinely-new edits.
+     * R2 Copilot caught this as the Node ↔ Kotlin asymmetry.
      *
      * Returns true on persisted, false on FS failure (logged by
      * cross-process-store). Throws on validation failure.
@@ -215,15 +224,20 @@ function open(workDir) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) {
             throw new Error('agent-preferences: write expects a plain object');
         }
-        if (Object.prototype.hasOwnProperty.call(value, 'searchProvider')) {
+        // R2 Copilot: read the persisted state FIRST so validation
+        // can be context-sensitive. The same `persisted` value drives
+        // the partial-merge below — single read, two uses.
+        const persisted = read();
+        if (Object.prototype.hasOwnProperty.call(value, 'searchProvider')
+            && value.searchProvider !== persisted.searchProvider) {
             _validateSearchProvider(value.searchProvider);
         }
-        if (Object.prototype.hasOwnProperty.call(value, 'agentName')) {
+        if (Object.prototype.hasOwnProperty.call(value, 'agentName')
+            && value.agentName !== persisted.agentName) {
             _validateAgentName(value.agentName);
         }
         // Partial-update merge (mirrors runtime-state.js R2 fix). Legacy
         // callers writing only one field don't drop the other.
-        const persisted = read();
         const merged = {};
         for (const key of Object.keys(DEFAULTS)) {
             if (Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined) {

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -350,25 +350,46 @@ const MODEL = _runtimeModel || config.model || _defaultModel;
 //      under normal flow because saveConfig writes the cold-start
 //      keys for any user past Setup.
 
+// R1 Copilot: normalize + validate the cold-start fallback. Without
+// this, a malformed `config.json` field could escape past the live
+// readLiveOrNull check and reach callers — `tools/web.js` would hit
+// the `default:` branch with "Unknown search provider X", and
+// `/status` could surface a whitespace-only agent name. The live
+// path goes through readLiveOrNull which already enforces these
+// rules; the fallbacks need the same.
+function _normalizeAgentName(value) {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+}
+
+function _normalizeSearchProvider(value) {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim().toLowerCase();
+    // Reuse the same allowlist agent-preferences.js's readLiveOrNull
+    // applies — keeps the live-vs-cold-start gates symmetric so a
+    // value that the live file would reject can't slip through the
+    // fallback either.
+    return _agentPreferencesModule.KNOWN_SEARCH_PROVIDERS.has(normalized)
+        ? normalized
+        : null;
+}
+
 function getAgentName() {
     const live = _agentPreferences.readLiveOrNull();
-    if (live && typeof live.agentName === 'string' && live.agentName) {
-        return live.agentName;
-    }
-    if (typeof config.agentName === 'string' && config.agentName) {
-        return config.agentName;
-    }
+    const liveName = live ? _normalizeAgentName(live.agentName) : null;
+    if (liveName) return liveName;
+    const coldName = _normalizeAgentName(config.agentName);
+    if (coldName) return coldName;
     return 'SeekerClaw';
 }
 
 function getSearchProvider() {
     const live = _agentPreferences.readLiveOrNull();
-    if (live && typeof live.searchProvider === 'string' && live.searchProvider) {
-        return live.searchProvider;
-    }
-    if (typeof config.searchProvider === 'string' && config.searchProvider) {
-        return config.searchProvider;
-    }
+    const liveProvider = live ? _normalizeSearchProvider(live.searchProvider) : null;
+    if (liveProvider) return liveProvider;
+    const coldProvider = _normalizeSearchProvider(config.searchProvider);
+    if (coldProvider) return coldProvider;
     return 'brave';
 }
 

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -188,6 +188,13 @@ let OWNER_ID = CHANNEL === 'discord'
 // (createStore preserved its own atomicity contract).
 const _runtimeStateModule = require('./runtime-state');
 const _runtimeState = _runtimeStateModule.open(workDir);
+// BAT-515: open the agent-preferences handle alongside runtime-state.
+// `getAgentName` / `getSearchProvider` below read this per-call so live
+// edits from the Settings UI (cross-process write to
+// agent_preferences.json) flow into the running agent on the next
+// inbound message — no service restart needed.
+const _agentPreferencesModule = require('./agent-preferences');
+const _agentPreferences = _agentPreferencesModule.open(workDir);
 let _runtimeStateValues = null;
 if (fs.existsSync(_runtimeState.filePath)) {
     try {
@@ -323,7 +330,47 @@ const _runtimeModel = (_runtimeStateValues && typeof _runtimeStateValues.model =
     ? _runtimeStateValues.model.trim()
     : '';
 const MODEL = _runtimeModel || config.model || _defaultModel;
-const AGENT_NAME = config.agentName || 'SeekerClaw';
+
+// BAT-515: agentName + searchProvider are no longer startup-frozen
+// constants — they're resolved per-call via the precedence chain below
+// so a Settings UI edit (cross-process write to agent_preferences.json)
+// takes effect on the next AI turn / next web_search call without a
+// service restart. See agent-preferences.js for the file shape and
+// AgentPreferencesStore.kt (Kotlin singleton) for the writer-side
+// contract.
+//
+// Precedence per BAT-515 v3 §3:
+//   1. agent_preferences.json (live, validated by readLiveOrNull) —
+//      what Settings/Telegram-flow writes update.
+//   2. config.json `agentName` / `searchProvider` (cold-start
+//      fallback) — what saveConfig.writeConfigJson last wrote. Stays
+//      readable across service restarts even if the live file is
+//      genuinely absent or corrupt.
+//   3. Hardcoded fallback ('SeekerClaw' / 'brave') — unreachable
+//      under normal flow because saveConfig writes the cold-start
+//      keys for any user past Setup.
+
+function getAgentName() {
+    const live = _agentPreferences.readLiveOrNull();
+    if (live && typeof live.agentName === 'string' && live.agentName) {
+        return live.agentName;
+    }
+    if (typeof config.agentName === 'string' && config.agentName) {
+        return config.agentName;
+    }
+    return 'SeekerClaw';
+}
+
+function getSearchProvider() {
+    const live = _agentPreferences.readLiveOrNull();
+    if (live && typeof live.searchProvider === 'string' && live.searchProvider) {
+        return live.searchProvider;
+    }
+    if (typeof config.searchProvider === 'string' && config.searchProvider) {
+        return config.searchProvider;
+    }
+    return 'brave';
+}
 
 /**
  * Resolve the currently-active model — the agent_settings.json overlay
@@ -460,7 +507,7 @@ if (!OWNER_ID) {
         'This is expected on first run; use the Android setup flow to set or reset the owner.', 'WARN');
 } else {
     const authLabel = PROVIDER === 'claude' ? (AUTH_TYPE === 'setup_token' ? 'setup-token' : 'api-key') : 'api-key';
-    log(`Agent: ${AGENT_NAME} | Provider: ${PROVIDER} | Model: ${MODEL} | Auth: ${authLabel} | Owner: ${OWNER_ID}`, 'DEBUG');
+    log(`Agent: ${getAgentName()} | Provider: ${PROVIDER} | Model: ${MODEL} | Auth: ${authLabel} | Owner: ${OWNER_ID}`, 'DEBUG');
 }
 
 function parseCustomHeaders(raw) {
@@ -758,7 +805,13 @@ module.exports = {
     AUTH_TYPE,
     MODEL,
     resolveActiveModel,
-    AGENT_NAME,
+    // BAT-515: per-call getters replace the startup-frozen `AGENT_NAME` /
+    // `config.searchProvider` reads. Consumers (main.js startup banner,
+    // message-handler /status, tools/session.js session_status,
+    // tools/web.js web_search) call these per-turn so a Settings UI
+    // edit takes effect on the next AI turn without a service restart.
+    getAgentName,
+    getSearchProvider,
     BRIDGE_TOKEN,
     USER_AGENT,
     MCP_SERVERS,

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -346,9 +346,13 @@ const MODEL = _runtimeModel || config.model || _defaultModel;
 //      fallback) — what saveConfig.writeConfigJson last wrote. Stays
 //      readable across service restarts even if the live file is
 //      genuinely absent or corrupt.
-//   3. Hardcoded fallback ('SeekerClaw' / 'brave') — unreachable
-//      under normal flow because saveConfig writes the cold-start
-//      keys for any user past Setup.
+//   3. Hardcoded fallback ('MyAgent' / 'brave') — unreachable under
+//      normal flow because saveConfig writes the cold-start keys for
+//      any user past Setup. R9 Copilot: lock-step with
+//      `AgentPreferences.DEFAULT_AGENT_NAME` (Kotlin) and
+//      `agent-preferences.js DEFAULTS.agentName` so the agent
+//      reports the same name across all three sources if the
+//      precedence chain bottoms out.
 
 // R1 Copilot: normalize + validate the cold-start fallback. Without
 // this, a malformed `config.json` field could escape past the live
@@ -381,7 +385,17 @@ function getAgentName() {
     if (liveName) return liveName;
     const coldName = _normalizeAgentName(config.agentName);
     if (coldName) return coldName;
-    return 'SeekerClaw';
+    // R9 Copilot: lock-step with the shared default. Pre-BAT-515 this
+    // returned 'SeekerClaw' (a Node-only value that diverged from
+    // Kotlin's `AgentPreferences.DEFAULT_AGENT_NAME = "MyAgent"` and
+    // `agent-preferences.js DEFAULTS.agentName = "MyAgent"`). The
+    // unreachable-under-normal-flow caveat still holds (saveConfig
+    // writes both the live file and config.json for any user past
+    // Setup) but keeping all three sources in sync means a
+    // hypothetical full-corruption scenario doesn't surface
+    // inconsistent agent names across `:node` startup banner,
+    // `/status`, and the Android UI.
+    return _agentPreferencesModule.DEFAULTS.agentName;
 }
 
 function getSearchProvider() {
@@ -390,7 +404,11 @@ function getSearchProvider() {
     if (liveProvider) return liveProvider;
     const coldProvider = _normalizeSearchProvider(config.searchProvider);
     if (coldProvider) return coldProvider;
-    return 'brave';
+    // R9 Copilot: lock-step with the shared default (currently
+    // 'brave' — same as the prior literal, but reading from the
+    // module so a future default change happens in one place across
+    // Kotlin + Node).
+    return _agentPreferencesModule.DEFAULTS.searchProvider;
 }
 
 /**

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 // ============================================================================
 
 const {
-    ANTHROPIC_KEY, AUTH_TYPE, MODEL, AGENT_NAME, PROVIDER, CHANNEL,
+    ANTHROPIC_KEY, AUTH_TYPE, MODEL, getAgentName, PROVIDER, CHANNEL,
     MCP_SERVERS, REACTION_NOTIFICATIONS,
     MEMORY_DIR,
     localTimestamp, log, setRedactFn,
@@ -688,7 +688,7 @@ telegram('getMe')
             // Condensed startup banner (Phase 4 — single INFO line replaces 10+ verbose startup lines)
             const _skillCount = loadSkills().length;
             const _cronCount = cronService.store?.jobs?.length || 0;
-            log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | @${result.result.username} | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
+            log(`${getAgentName()} | ${PROVIDER}/${MODEL} | @${result.result.username} | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
 
             // Initialize SQL.js database before polling (non-fatal if WASM fails)
             await initDatabase();
@@ -709,9 +709,13 @@ telegram('getMe')
                 lastIncomingMessages,
             });
 
-            // Wire message handler deps: inject all dependencies into message-handler.js
+            // Wire message handler deps: inject all dependencies into message-handler.js.
+            // BAT-515: getAgentName is a function reference (not a frozen value)
+            // so message-handler reads the latest live name per /status — a
+            // Settings UI edit while the bot is running shows the new name on
+            // the next /status response without a restart.
             initMessageHandler({
-                AGENT_NAME, MODEL, MEMORY_DIR, REACTION_NOTIFICATIONS,
+                getAgentName, MODEL, MEMORY_DIR, REACTION_NOTIFICATIONS,
                 log, debugLog,
                 getOwnerId, setOwnerId,
                 config,
@@ -832,7 +836,7 @@ telegram('getMe')
     // Condensed startup banner
     const _skillCount = loadSkills().length;
     const _cronCount = cronService.store?.jobs?.length || 0;
-    log(`${AGENT_NAME} | ${PROVIDER}/${MODEL} | Discord | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
+    log(`${getAgentName()} | ${PROVIDER}/${MODEL} | Discord | ${_skillCount} skills | ${_resolveMcpConfigs().length} MCP | ${_cronCount} cron`, 'INFO');
 
     // Initialize SQL.js database (non-fatal if WASM fails)
     initDatabase().then(() => {
@@ -853,9 +857,10 @@ telegram('getMe')
             lastIncomingMessages,
         });
 
-        // Wire message handler deps
+        // Wire message handler deps. BAT-515: getAgentName is a function
+        // reference so /status reads the latest live name per-invocation.
         initMessageHandler({
-            AGENT_NAME, MODEL, MEMORY_DIR, REACTION_NOTIFICATIONS,
+            getAgentName, MODEL, MEMORY_DIR, REACTION_NOTIFICATIONS,
             log, debugLog,
             getOwnerId, setOwnerId,
             config,

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -223,7 +223,7 @@ Use YAML frontmatter with \`name\`, \`description\`, and \`triggers\` fields.`;
                 } catch (_) {}
             }
             return `**SeekerClaw**
-Agent: \`${deps.AGENT_NAME}\`
+Agent: \`${deps.getAgentName()}\`
 Package: \`${pkgVersion}\`
 Model: \`${resolveActiveModel()}\`
 Node.js: \`${nodeVer}\`

--- a/app/src/main/assets/nodejs-project/tools/session.js
+++ b/app/src/main/assets/nodejs-project/tools/session.js
@@ -1,7 +1,7 @@
 // tools/session.js — session_status handler
 
 const {
-    log, config, localDateStr,
+    log, localDateStr,
     getAgentName, getSearchProvider, resolveActiveModel,
 } = require('../config');
 

--- a/app/src/main/assets/nodejs-project/tools/session.js
+++ b/app/src/main/assets/nodejs-project/tools/session.js
@@ -2,7 +2,7 @@
 
 const {
     log, config, localDateStr,
-    AGENT_NAME, resolveActiveModel,
+    getAgentName, getSearchProvider, resolveActiveModel,
 } = require('../config');
 
 const { getDb } = require('../database');
@@ -31,7 +31,7 @@ const handlers = {
         conversations.forEach(conv => totalMessages += conv.length);
 
         const result = {
-            agent: AGENT_NAME,
+            agent: getAgentName(),
             model: resolveActiveModel(),
             uptime: {
                 seconds: uptime,
@@ -54,7 +54,12 @@ const handlers = {
             },
             features: {
                 webSearch: true,
-                webSearchProvider: config.braveApiKey ? 'brave' : 'duckduckgo',
+                // BAT-515: report the LIVE configured provider (read per
+                // session_status call), not a stale config.json snapshot
+                // and not the long-removed 'duckduckgo' (BAT-481 dropped
+                // DDG). getSearchProvider() walks the precedence chain
+                // agent_preferences.json → config.json → 'brave'.
+                webSearchProvider: getSearchProvider(),
                 reminders: true,
                 skills: loadSkills().length
             }

--- a/app/src/main/assets/nodejs-project/tools/web.js
+++ b/app/src/main/assets/nodejs-project/tools/web.js
@@ -1,7 +1,7 @@
 // tools/web.js — web_search, web_fetch handlers
 
 const {
-    log, config,
+    log, config, getSearchProvider,
 } = require('../config');
 
 const {
@@ -26,7 +26,7 @@ const tools = [
                 provider: {
                     type: 'string',
                     enum: ['auto', 'brave', 'perplexity', 'exa', 'tavily', 'firecrawl'],
-                    description: 'Search provider. "auto" uses the configured default (config.searchProvider).',
+                    description: 'Search provider. "auto" uses the live configured default from agent_preferences.json (Settings > Search Provider) — picks up Settings UI changes without a restart.',
                     default: 'auto',
                 },
                 count: { type: 'number', description: 'Number of results (1-10, default 5). Applies to Brave, Exa, Tavily, Firecrawl. Perplexity returns a single synthesized answer.' },
@@ -53,10 +53,14 @@ const tools = [
 
 const handlers = {
     async web_search(input, chatId) {
-        // Resolve provider: explicit override or configured default
+        // Resolve provider: explicit override or live configured default.
+        // BAT-515: getSearchProvider() reads agent_preferences.json per-call
+        // (precedence: live → config.json cold-start → 'brave'), so a
+        // Settings UI provider switch takes effect on the next web_search
+        // without a service restart.
         const rawProvider = (typeof input.provider === 'string' ? input.provider.trim().toLowerCase() : 'auto');
         const provider = rawProvider === 'auto'
-            ? (config.searchProvider || 'brave')
+            ? getSearchProvider()
             : rawProvider;
         const safeCount = Math.min(Math.max(Number(input.count) || 5, 1), 10);
 

--- a/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
+++ b/app/src/main/java/com/seekerclaw/app/SeekerClawApplication.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.content.ContextCompat
 import com.seekerclaw.app.config.ConfigManager
+import com.seekerclaw.app.state.AgentPreferencesStore
 import com.seekerclaw.app.state.McpServersStore
 import com.seekerclaw.app.state.RuntimeStateStore
 import com.seekerclaw.app.util.Analytics
@@ -84,6 +85,14 @@ class SeekerClawApplication : Application() {
             // `KEY_MCP_SERVERS_ENC` tokens into per-id encrypted files
             // and seeds the file. Sweeps orphan tokens after.
             McpServersStore.init(this)
+            // BAT-515: own searchProvider + agentName prefs cross-process
+            // (`agent_preferences.json`). Main process only — `:node`
+            // reads the same file directly via agent-preferences.js.
+            // Seed from existing `KEY_SEARCH_PROVIDER` / `KEY_AGENT_NAME`
+            // SharedPrefs values so existing-user upgrades are seamless
+            // (BAT-515 v3 §2). Migration preserves over-cap agentName
+            // verbatim with WARN — never truncates (BAT-515 v3 §1).
+            AgentPreferencesStore.init(this)
             registerConfigChangedReceiver()
         }
     }

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -706,6 +706,22 @@ object ConfigManager {
             else rollback.remove(KEY_AUTH_TYPE)
             if (oldModel != null) rollback.putString(KEY_MODEL, oldModel)
             else rollback.remove(KEY_MODEL)
+            // R5 Copilot: BAT-515 added KEY_AGENT_NAME / KEY_SEARCH_PROVIDER
+            // to the same `editor.commit()` block above (lines 367, 389).
+            // The pre-BAT-515 rollback only covered the BAT-513 runtime
+            // keys, so a RuntimeStateStore failure left prefs holding the
+            // NEW agentName/searchProvider while runtime_state.json kept
+            // the OLD values — and agent_preferences.json (which the
+            // saveConfig flow hasn't reached yet at this point) also has
+            // the old values. Without these two extra rollback lines,
+            // prefs and the cross-process files would diverge on the
+            // RuntimeStateStore-failure path, undoing the v3 §4 atomicity
+            // contract. Mirror the same put-or-remove shape the later
+            // AgentPreferencesStore-failure rollback already uses.
+            if (oldAgentName != null) rollback.putString(KEY_AGENT_NAME, oldAgentName)
+            else rollback.remove(KEY_AGENT_NAME)
+            if (oldSearchProvider != null) rollback.putString(KEY_SEARCH_PROVIDER, oldSearchProvider)
+            else rollback.remove(KEY_SEARCH_PROVIDER)
             rollback.putBoolean(KEY_SETUP_COMPLETE, oldSetupComplete)
             val rollbackOk = rollback.commit()
             if (!rollbackOk) {
@@ -716,7 +732,7 @@ object ConfigManager {
                 // still gets `false` so the UI surfaces the failure.
                 LogCollector.append(
                     "[Config] Rollback commit() returned false — prefs may be in inconsistent state " +
-                        "(some runtime fields possibly half-rolled-back)",
+                        "(some fields possibly half-rolled-back)",
                     LogLevel.ERROR,
                 )
             }
@@ -726,8 +742,9 @@ object ConfigManager {
             // second bump corrects the snapshot).
             bumpConfigVersionOnMain()
             LogCollector.append(
-                "[Config] RuntimeStateStore.write failed — rolled back prefs runtime fields " +
-                    "to (provider=$oldProvider, authType=$oldAuthType, model=$oldModel) " +
+                "[Config] RuntimeStateStore.write failed — rolled back prefs to " +
+                    "(provider=$oldProvider, authType=$oldAuthType, model=$oldModel, " +
+                    "agentName=$oldAgentName, searchProvider=$oldSearchProvider) " +
                     "and KEY_SETUP_COMPLETE to $oldSetupComplete (commit_ok=$rollbackOk)",
                 LogLevel.WARN,
             )

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -365,8 +365,31 @@ object ConfigManager {
         // so the three persistent stores either all reflect the new
         // config or all keep the prior one. Same atomicity reasoning
         // as oldProvider/oldAuthType/oldModel above (BAT-513).
-        val oldAgentName = sp.getString(KEY_AGENT_NAME, null)
-        val oldSearchProvider = sp.getString(KEY_SEARCH_PROVIDER, null)
+        //
+        // R7 Copilot: read from AgentPreferencesStore (the authoritative
+        // cross-process state, kept fresh by R3.1's sync-update on
+        // every successful write/update) rather than prefs. Prefs
+        // legitimately lag agent_preferences.json while the observe-
+        // and-mirror collector mirrors asynchronously — a recent
+        // Settings > Search Provider tap (which writes
+        // agent_preferences.json first via
+        // `AgentPreferencesStore.update` and only mirrors prefs after
+        // the collector fires) would leave prefs at the OLD value for
+        // ~50–200 ms. Snapshotting prefs in that window captures a
+        // stale value; a rollback firing here would revert the user's
+        // just-applied cross-process change AND leave prefs diverged
+        // from the file. Snapshotting from the store closes the race.
+        //
+        // Falls back to prefs only when the store isn't initialized —
+        // i.e., in `:node` (where AgentPreferencesStore.init never
+        // runs). On the main process, init runs from
+        // SeekerClawApplication.onCreate before any UI surface can
+        // call saveConfig, so the fallback path doesn't fire.
+        val oldAgentPrefs = if (AgentPreferencesStore.isInitialized) {
+            AgentPreferencesStore.read()
+        } else null
+        val oldAgentName = oldAgentPrefs?.agentName ?: sp.getString(KEY_AGENT_NAME, null)
+        val oldSearchProvider = oldAgentPrefs?.searchProvider ?: sp.getString(KEY_SEARCH_PROVIDER, null)
 
         // BAT-515 v3 §4 step 2: pre-validate agent-preferences fields
         // BEFORE any persistence. The cap/allowlist gates inside

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -13,6 +13,8 @@ import android.util.Log
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.core.content.ContextCompat
 import com.seekerclaw.app.BuildConfig
+import com.seekerclaw.app.state.AgentPreferences
+import com.seekerclaw.app.state.AgentPreferencesStore
 import com.seekerclaw.app.state.CustomConfigSignature
 import com.seekerclaw.app.state.RuntimeState
 import com.seekerclaw.app.state.RuntimeStateStore
@@ -355,6 +357,48 @@ object ConfigManager {
         // is on first-install failures, which now correctly stay in the
         // "setup not complete" state until a successful retry.
         val oldSetupComplete = sp.getBoolean(KEY_SETUP_COMPLETE, false)
+        // BAT-515 v3 §4: snapshot the OLD agent-preferences fields (the
+        // second cross-process write site after RuntimeStateStore). If
+        // AgentPreferencesStore.update fails AFTER prefs.commit and
+        // RuntimeStateStore.update have both succeeded, we roll prefs
+        // back to these values AND undo the RuntimeStateStore write —
+        // so the three persistent stores either all reflect the new
+        // config or all keep the prior one. Same atomicity reasoning
+        // as oldProvider/oldAuthType/oldModel above (BAT-513).
+        val oldAgentName = sp.getString(KEY_AGENT_NAME, null)
+        val oldSearchProvider = sp.getString(KEY_SEARCH_PROVIDER, null)
+
+        // BAT-515 v3 §4 step 2: pre-validate agent-preferences fields
+        // BEFORE any persistence. The cap/allowlist gates inside
+        // AgentPreferencesStore.update would fire AFTER prefs.commit
+        // (and possibly RuntimeStateStore.update) had already
+        // succeeded — leaving prefs holding values the file refuses
+        // to take. Up-front gate keeps all three stores
+        // either fully-saved or fully-unchanged.
+        //
+        // Validation is context-sensitive (Codex final guard): only
+        // fields that genuinely DIFFER from the current
+        // AgentPreferencesStore state hit the cap/allowlist. An
+        // existing migrated long agentName that the UI is just
+        // carrying through (unchanged from the live store) does NOT
+        // fail here.
+        if (AgentPreferencesStore.isInitialized) {
+            try {
+                AgentPreferencesStore.validateForWrite(
+                    next = AgentPreferences(
+                        searchProvider = config.searchProvider,
+                        agentName = config.agentName,
+                    ),
+                    current = AgentPreferencesStore.read(),
+                )
+            } catch (e: IllegalArgumentException) {
+                LogCollector.append(
+                    "[Config] saveConfig rejected agent preferences: ${e.message}",
+                    LogLevel.WARN,
+                )
+                return false
+            }
+        }
 
         val encApiKey = KeystoreHelper.encrypt(config.anthropicApiKey)
         val encBotToken = KeystoreHelper.encrypt(config.telegramBotToken)
@@ -582,10 +626,21 @@ object ConfigManager {
         //   - When the new sig != current.customConfigSignature, reset
         //     customEchoReasoning to false (gateway-specific contract;
         //     see RuntimeState.kt KDoc). Otherwise carry forward.
+        // BAT-515 v3 §4 step 5 rollback: capture the RuntimeState as it
+        // existed at the moment our forward `update {}` ran (the value
+        // passed in as `current`). If AgentPreferencesStore.update fails
+        // later, we restore THIS snapshot via a second `update {}` so
+        // runtime_state.json reverts to where it was before saveConfig
+        // touched it. Captured inside the lambda — outside-the-lock
+        // RuntimeStateStore.read() could observe a different value if
+        // a concurrent /think writer landed between the read and our
+        // update's writeLock acquisition.
+        var preForwardRuntime: RuntimeState? = null
         var loggedSigReset = false
         val runtimeWritten = if (RuntimeStateStore.isInitialized) try {
             kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
                 RuntimeStateStore.update { current ->
+                    preForwardRuntime = current
                     val newCustomSig = if (config.provider == "custom") {
                         CustomConfigSignature.compute(
                             customModel = config.model,
@@ -628,22 +683,6 @@ object ConfigManager {
             // sync in `:node` happens at the runtime-state.js write
             // sites (/provider, /model), not here.
             true
-        }
-        // R4 Copilot: gate the reset-log on `runtimeWritten`. The
-        // `loggedSigReset` flag is set inside the `update {}`
-        // transform, but the transform can run even when the
-        // ultimate `update()` returns false (FS write failure
-        // after the in-lock state mutation). Logging unconditionally
-        // would tell the user "reset to false" even though the
-        // reset never persisted — misleading. Gating on
-        // `runtimeWritten` ensures the log only fires when the
-        // change actually reached disk.
-        if (loggedSigReset && runtimeWritten) {
-            LogCollector.append(
-                "[Config] BAT-549: Custom config signature changed — reset " +
-                    "customEchoReasoning to false (re-enable in Settings on the new gateway)",
-                LogLevel.INFO,
-            )
         }
         if (!runtimeWritten) {
             // Roll back prefs runtime fields AND KEY_SETUP_COMPLETE to
@@ -694,6 +733,139 @@ object ConfigManager {
             )
             return false
         }
+
+        // BAT-515 v3 §4 step 5: AgentPreferencesStore.update is the
+        // SECOND cross-process write site. By this point prefs and
+        // runtime_state.json already reflect the new config. If THIS
+        // write fails, agent_preferences.json is the only persistent
+        // store still holding the OLD values — the three would
+        // diverge (a downgrade would land on prefs values that never
+        // reached agent_preferences.json). The rollback below restores
+        // the prior state across ALL THREE stores.
+        //
+        // PROCESS GUARD: AgentPreferencesStore.init only runs in the
+        // main process (mirrors RuntimeStateStore.isInitialized
+        // gating above). In `:node`, AgentPreferencesStore.update
+        // would always return false → saveConfig would always fail —
+        // breaking AndroidBridge / service-process callers. Treat
+        // uninitialized as no-op success; agent_preferences.json sync
+        // in `:node` happens at the agent-preferences.js write sites
+        // directly.
+        //
+        // Defense-in-depth catch: pre-validation above should have
+        // already caught any allowlist/cap violation. The catch here
+        // covers the narrow race where the observe-and-mirror
+        // collector pulled in a DIFFERENT current value between
+        // pre-validation and this update {}'s writeLock — making the
+        // (next, current-inside-lock) pair newly-invalid. Rare, but
+        // the rollback path keeps things atomic if it happens.
+        val agentPrefsWritten = if (AgentPreferencesStore.isInitialized) try {
+            kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
+                AgentPreferencesStore.update { current ->
+                    current.copy(
+                        searchProvider = config.searchProvider,
+                        agentName = config.agentName,
+                    )
+                }
+            }
+        } catch (e: IllegalArgumentException) {
+            LogCollector.append(
+                "[Config] saveConfig produced invalid AgentPreferences (defense-in-depth): " +
+                    "${e.message}",
+                LogLevel.WARN,
+            )
+            false
+        } else {
+            // `:node` — see PROCESS GUARD comment above.
+            true
+        }
+        if (!agentPrefsWritten) {
+            // Roll back ALL prefs touched by this saveConfig (the
+            // runtime fields AND the new agent-prefs fields AND
+            // KEY_SETUP_COMPLETE) so the user's pre-save state is
+            // restored. Then undo the RuntimeStateStore.update from
+            // step 4 by writing the captured `preForwardRuntime`
+            // snapshot back into the file via a second `update {}`.
+            //
+            // The second update's lambda IGNORES the latest `current`
+            // (passes `_` and returns the snapshot) — by-design per
+            // v3 §4, "undo step 4 → restore prior runtime state". A
+            // concurrent /think writer that landed between our forward
+            // update and this rollback gets clobbered; that's the
+            // intentional rollback semantic. /think writes are
+            // tolerable to lose under this rare path; preferring user-
+            // intent atomicity over inter-update concurrent retention.
+            val rollback = sp.edit()
+            if (oldProvider != null) rollback.putString(KEY_PROVIDER, oldProvider)
+            else rollback.remove(KEY_PROVIDER)
+            if (oldAuthType != null) rollback.putString(KEY_AUTH_TYPE, oldAuthType)
+            else rollback.remove(KEY_AUTH_TYPE)
+            if (oldModel != null) rollback.putString(KEY_MODEL, oldModel)
+            else rollback.remove(KEY_MODEL)
+            if (oldAgentName != null) rollback.putString(KEY_AGENT_NAME, oldAgentName)
+            else rollback.remove(KEY_AGENT_NAME)
+            if (oldSearchProvider != null) rollback.putString(KEY_SEARCH_PROVIDER, oldSearchProvider)
+            else rollback.remove(KEY_SEARCH_PROVIDER)
+            rollback.putBoolean(KEY_SETUP_COMPLETE, oldSetupComplete)
+            val rollbackOk = rollback.commit()
+            if (!rollbackOk) {
+                LogCollector.append(
+                    "[Config] Rollback commit() returned false — prefs may be in inconsistent state " +
+                        "(some runtime/agent fields possibly half-rolled-back)",
+                    LogLevel.ERROR,
+                )
+            }
+            // Undo the RuntimeStateStore forward update by restoring
+            // the captured snapshot. Skip when preForwardRuntime is
+            // null (RuntimeStateStore wasn't initialized OR an
+            // IllegalArgumentException short-circuited the lambda
+            // before assignment — in that latter case the forward
+            // update never persisted, so there's nothing to undo).
+            val runtimeUndone = if (RuntimeStateStore.isInitialized && preForwardRuntime != null) try {
+                kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
+                    RuntimeStateStore.update { _ -> preForwardRuntime!! }
+                }
+            } catch (e: IllegalArgumentException) {
+                // Should not happen — preForwardRuntime came out of
+                // RuntimeStateStore itself, so its (provider,authType)
+                // is guaranteed valid. Defense-in-depth log.
+                LogCollector.append(
+                    "[Config] RuntimeStateStore rollback rejected snapshot (unexpected): ${e.message}",
+                    LogLevel.ERROR,
+                )
+                false
+            } else true
+            bumpConfigVersionOnMain()
+            LogCollector.append(
+                "[Config] AgentPreferencesStore.update failed — rolled back prefs to " +
+                    "(provider=$oldProvider, authType=$oldAuthType, model=$oldModel, " +
+                    "agentName=$oldAgentName, searchProvider=$oldSearchProvider) and " +
+                    "KEY_SETUP_COMPLETE to $oldSetupComplete " +
+                    "(commit_ok=$rollbackOk, runtime_undone=$runtimeUndone)",
+                LogLevel.WARN,
+            )
+            return false
+        }
+
+        // R4 Copilot (BAT-549) + BAT-515 v3 §4 step 5: gate the
+        // BAT-549 reset-log on BOTH stores succeeding. The
+        // `loggedSigReset` flag is set inside the RuntimeStateStore
+        // forward `update {}` lambda — but if AgentPreferencesStore
+        // failed afterwards, the rollback path above already restored
+        // RuntimeStateStore via the `preForwardRuntime` snapshot,
+        // including reverting `customEchoReasoning` to whatever it
+        // was. Logging "reset to false" in that case would tell the
+        // user about a reset that didn't actually persist. Gating on
+        // `runtimeWritten && agentPrefsWritten` ensures the log fires
+        // only when the change actually reached disk in BOTH stores.
+        if (loggedSigReset && runtimeWritten && agentPrefsWritten) {
+            LogCollector.append(
+                "[Config] BAT-549: Custom config signature changed — reset " +
+                    "customEchoReasoning to false (re-enable in Settings on the new gateway)",
+                LogLevel.INFO,
+            )
+        }
+
         // BAT-513 round-9: write the overlay AND broadcast the change
         // ONLY after both prefs commit + RuntimeStateStore.write
         // succeeded. The overlay persists provider/authType/model too;
@@ -924,6 +1096,24 @@ object ConfigManager {
             ""
         }
 
+        // BAT-515 v3 §4: prefer live AgentPreferencesStore values over
+        // raw prefs. The observe-and-mirror collector already keeps
+        // prefs in sync with `agent_preferences.json`, but a fresh
+        // file write hasn't necessarily round-tripped to prefs by the
+        // time loadConfig runs (collector dispatch latency, or a
+        // racing reader between the file write and the prefs commit).
+        // Reading from the in-memory StateFlow guarantees this
+        // loadConfig sees the latest value the store holds — no
+        // staleness window.
+        //
+        // Falls back to the prefs read for `:node` (where
+        // AgentPreferencesStore.init never ran) and for the rare
+        // pre-init main-process load (config.json cold-start path
+        // before the collector kicks in). The defaults at the bottom
+        // ("MyAgent", "brave") match AgentPreferences.DEFAULT_*.
+        val livePrefs: AgentPreferences? = if (AgentPreferencesStore.isInitialized) {
+            AgentPreferencesStore.read()
+        } else null
         val fromPrefs = AppConfig(
             anthropicApiKey = apiKey,
             setupToken = setupToken,
@@ -931,9 +1121,9 @@ object ConfigManager {
             telegramBotToken = botToken,
             telegramOwnerId = loadOwnerIdFromFile(context, "telegram"),
             model = p.getString(KEY_MODEL, "claude-opus-4-7") ?: "claude-opus-4-7",
-            agentName = p.getString(KEY_AGENT_NAME, "MyAgent") ?: "MyAgent",
+            agentName = livePrefs?.agentName ?: (p.getString(KEY_AGENT_NAME, "MyAgent") ?: "MyAgent"),
             braveApiKey = braveApiKey,
-            searchProvider = p.getString(KEY_SEARCH_PROVIDER, "brave") ?: "brave",
+            searchProvider = livePrefs?.searchProvider ?: (p.getString(KEY_SEARCH_PROVIDER, "brave") ?: "brave"),
             perplexityApiKey = perplexityApiKey,
             exaApiKey = exaApiKey,
             tavilyApiKey = tavilyApiKey,

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferences.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferences.kt
@@ -1,0 +1,77 @@
+package com.seekerclaw.app.state
+
+import kotlinx.serialization.Serializable
+
+/**
+ * User-typed agent preferences that cross the UI ↔ `:node` boundary
+ * (BAT-515). Two fields move out of `SharedPreferences` (which is
+ * process-local and read-cached, so the `:node` side never sees
+ * UI-side writes without a service restart) into a
+ * [com.seekerclaw.app.util.CrossProcessStore]-backed file:
+ *
+ *  - [agentName] — display name + system-prompt identity. Live-updateable
+ *    so a Settings change takes effect on the next AI turn without a
+ *    service restart. Surfaces: System screen Agent row, Dashboard,
+ *    Settings summary, `/status` Telegram reply, Node `buildSystemBlocks`
+ *    per-turn.
+ *
+ *  - [searchProvider] — which web search backend the `web_search` tool
+ *    uses (brave / perplexity / exa / tavily / firecrawl). Live-updateable
+ *    so the next `web_search` call uses the new provider. Surfaces:
+ *    Settings > Search Provider config screen, Node `tools/web.js` per
+ *    `web_search` call, `session_status.features.webSearchProvider`.
+ *
+ * ## Storage
+ *
+ *  - File: `<filesDir>/agent_preferences.json`
+ *  - Pattern mirrors BAT-513's `runtime_state.json` (see [RuntimeState]
+ *    + [RuntimeStateStore]).
+ *  - Decoded with `ignoreUnknownKeys = true` (configured in
+ *    [com.seekerclaw.app.util.CrossProcessStore]) so a future build
+ *    that adds a new field can roll back to a current build without
+ *    crashing its own data.
+ *
+ * ## Validation
+ *
+ * Validation lives in [AgentPreferencesStore.write] / `update`:
+ *  - `searchProvider` must be in `KNOWN_SEARCH_PROVIDERS` (allowlist).
+ *  - `agentName` must be non-blank for new edits; ≤ [AGENT_NAME_MAX]
+ *    characters for new edits. Migration of an existing >cap name is
+ *    preserved verbatim with a WARN — never truncated, never thrown
+ *    (BAT-515 v3 §1).
+ *
+ * ## Defaults
+ *
+ * Match the values [com.seekerclaw.app.config.ConfigManager.loadConfig]
+ * has historically returned for absent prefs. Changing these defaults
+ * would be a user-visible behaviour change for fresh installs.
+ */
+@Serializable
+data class AgentPreferences(
+    val searchProvider: String = DEFAULT_SEARCH_PROVIDER,
+    val agentName: String = DEFAULT_AGENT_NAME,
+) {
+    companion object {
+        const val DEFAULT_SEARCH_PROVIDER = "brave"
+        const val DEFAULT_AGENT_NAME = "MyAgent"
+
+        /**
+         * 64-char cap on `agentName` for NEW edits via Settings UI /
+         * fresh setup / config import. Migration of an existing
+         * over-cap name is preserved verbatim (BAT-515 v3 §1) — the
+         * cap applies only when the incoming write is genuinely
+         * changing the value.
+         */
+        const val AGENT_NAME_MAX = 64
+
+        /**
+         * Allowlist of known search providers. Mirrors the IDs Kotlin
+         * exposes via the Settings Search Provider picker. Custom
+         * gateways are NOT in this list — Custom uses the AI provider
+         * config, not the search provider.
+         */
+        val KNOWN_SEARCH_PROVIDERS: Set<String> = setOf(
+            "brave", "perplexity", "exa", "tavily", "firecrawl",
+        )
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferences.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferences.kt
@@ -9,11 +9,14 @@ import kotlinx.serialization.Serializable
  * UI-side writes without a service restart) into a
  * [com.seekerclaw.app.util.CrossProcessStore]-backed file:
  *
- *  - [agentName] — display name + system-prompt identity. Live-updateable
- *    so a Settings change takes effect on the next AI turn without a
- *    service restart. Surfaces: System screen Agent row, Dashboard,
- *    Settings summary, `/status` Telegram reply, Node `buildSystemBlocks`
- *    per-turn.
+ *  - [agentName] — display/runtime identity label. Live-updateable so
+ *    a Settings change is reflected without a service restart in
+ *    surfaces that read this store. Surfaces: System screen Agent
+ *    row, Dashboard, Settings summary, `/status` Telegram reply, Node
+ *    startup banner (Telegram + Discord paths in `main.js`), and
+ *    `session_status.agent` (R11 Copilot — the agent's CORE identity
+ *    in the system prompt comes from `IDENTITY.md`, not this field;
+ *    `buildSystemBlocks` does not currently reference `agentName`).
  *
  *  - [searchProvider] — which web search backend the `web_search` tool
  *    uses (brave / perplexity / exa / tavily / firecrawl). Live-updateable

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -79,8 +79,15 @@ object AgentPreferencesStore {
     // [com.seekerclaw.app.config.ConfigManager]. They are duplicated
     // here so AgentPreferencesStore stays self-contained for tests
     // (no Context required to resolve the constants). If ConfigManager
-    // ever changes any of these, change them here too — the matching
-    // tests in AgentPreferencesStoreTest will catch the drift.
+    // ever changes any of these, change them here too. R11 Copilot:
+    // `AgentPreferencesStoreTest` exercises behavior against these
+    // literal keys but does NOT independently assert parity with
+    // `ConfigManager`'s constants — a hypothetical edit to either
+    // side's strings would not fail the test suite. Drift is caught
+    // by code review and the warning above; a future refactor that
+    // pulls the keys into a shared object on [AgentPreferences] (the
+    // schema) would let both files reference one source of truth and
+    // make the drift impossible.
     private const val PREFS_NAME = "seekerclaw_prefs"
     private const val FILE_NAME = "agent_preferences.json"
     private const val KEY_AGENT_NAME = "agent_name"

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -270,9 +270,30 @@ object AgentPreferencesStore {
      * `synchronized(writeLock)` block — atomic w.r.t. both concurrent
      * `update {}` calls AND concurrent `write()` calls in the same
      * process.
+     *
+     * The "current" value passed to the transform is re-derived from
+     * the file via [parseFileStrictOrNull] inside the writeLock,
+     * NOT from the lambda's `current` arg. CrossProcessStore.read()
+     * (which feeds the lambda's `current`) returns its
+     * construction-time `initialSnapshot` on JSON decode failure —
+     * so a corrupted `agent_preferences.json` would feed the
+     * launch-time seed into the transform, and a partial update
+     * (e.g., changing only `searchProvider`) would silently regress
+     * the user's chosen `agentName` to the seed (R4 Copilot caught
+     * this as a regression vector matching the collector-path bug
+     * R1.3 already fixed).
+     *
+     * Falls back to `_state.value` (this wrapper's last-valid
+     * snapshot, kept fresh by the R3 sync-update path) when the
+     * file is corrupt or absent. Concurrent in-process updates
+     * still serialize correctly: the writeLock guarantees update2
+     * enters AFTER update1's persist completes, so update2's
+     * `parseFileStrictOrNull` reads update1's just-persisted value
+     * — no lost-update.
      */
     suspend fun update(transform: (AgentPreferences) -> AgentPreferences): Boolean {
         val s = store ?: return false
+        val ctx = appContext ?: return false
         // R3 Copilot: capture the value persisted by the transform (the
         // `next` returned inside the writeLock) so we can sync-update
         // `_state` after the underlying write succeeds. Without this,
@@ -280,7 +301,13 @@ object AgentPreferencesStore {
         // until the collector path fires (~50-200ms later) — same race
         // [write] had pre-fix.
         var persisted: AgentPreferences? = null
-        val ok = s.update { current ->
+        val ok = s.update { _ ->
+            // R4 Copilot: re-derive `current` via strict file parse
+            // (with `_state.value` fallback for corrupt/absent files)
+            // to bypass CrossProcessStore.read()'s decode-failure →
+            // initialSnapshot regression. See KDoc above.
+            val current = parseFileStrictOrNull(File(ctx.filesDir, FILE_NAME))
+                ?: _state.value
             val next = transform(current)
             validateForWrite(next, current)
             persisted = next

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -12,6 +12,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -86,6 +89,12 @@ object AgentPreferencesStore {
     private val _state = MutableStateFlow(AgentPreferences())
     private var appContext: Context? = null
 
+    // R1 Copilot: lenient `Json` mirroring `CrossProcessStore`'s
+    // `ignoreUnknownKeys = true`. Used by the strict file-parse path
+    // in the collector so a forward-build's extra fields don't fail
+    // the parse on a downgrade.
+    private val strictJson = Json { ignoreUnknownKeys = true }
+
     /**
      * Last valid [AgentPreferences] observed. UI binds to this;
      * invalid file content (manual edit, corrupted JSON, future-build
@@ -139,8 +148,66 @@ object AgentPreferencesStore {
                         "app proceeds with in-memory seed; a later save will retry",
                 )
             }
-            cps.state.collect { observed -> observeFromCollector(observed, sp) }
+            // R1 Copilot: use cps.state emissions as a TRIGGER, not a
+            // source of truth. CrossProcessStore.read() returns the
+            // construction-time `initialSnapshot` on JSON decode
+            // failure — so a corrupted `agent_preferences.json` would
+            // surface as a "valid" seeded value, regress `_state`
+            // from the user's actual chosen value back to the
+            // launch-time seed, and overwrite prefs (BAT-515 v3 §2
+            // contract violation: corruption MUST NOT silently reset
+            // a user's name).
+            //
+            // Fix: re-parse the file ourselves with strict semantics
+            // matching `agent-preferences.js` `readLiveOrNull` — null
+            // on absent / unreadable / parse-fail / wrong-type /
+            // unknown-provider / blank-name / missing-field. On null,
+            // skip the dispatch entirely so `_state` and prefs stay
+            // at the last valid value.
+            cps.state.collect { _ ->
+                val strict = parseFileStrictOrNull(File(app.filesDir, FILE_NAME))
+                if (strict != null) {
+                    observeFromCollector(strict, sp)
+                }
+                // null = corrupt or absent → keep last valid state,
+                // skip mirror, skip broadcast (BAT-515 v3 §2 + §3).
+            }
         }
+    }
+
+    /**
+     * Strict file parse mirroring `agent-preferences.js`
+     * `readLiveOrNull` — returns the parsed value only if the file
+     * exists, parses as a JSON object, has both string fields, the
+     * `searchProvider` is in the allowlist, and the `agentName` is
+     * non-blank. Migration paths legitimately carry over-cap names,
+     * so the cap is NOT enforced here (mirrors v3 §1).
+     *
+     * Returns null in every other case so the collector path can
+     * skip dispatch and avoid regressing live state on corruption.
+     *
+     * `internal` so unit tests can pin the parse contract directly
+     * — the corruption-doesn't-regress invariant is the whole point
+     * of this function existing, so it needs explicit test coverage.
+     */
+    internal fun parseFileStrictOrNull(file: File): AgentPreferences? {
+        if (!file.exists()) return null
+        val text = try { file.readText() } catch (_: Exception) { return null }
+        if (text.isBlank()) return null
+        val element = try { strictJson.parseToJsonElement(text) } catch (_: Exception) { return null }
+        val obj = element as? JsonObject ?: return null
+        // Both fields must be PRESENT and STRING — an empty `{}` or a
+        // missing field would deserialize to AgentPreferences defaults
+        // via kotlinx.serialization, which is exactly the "silent
+        // reset" we're trying to avoid. Pull primitives manually so a
+        // partial-shape file is rejected up front.
+        val sp = (obj["searchProvider"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: return null
+        val an = (obj["agentName"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: return null
+        if (sp !in AgentPreferences.KNOWN_SEARCH_PROVIDERS) return null
+        if (an.isBlank()) return null
+        return AgentPreferences(searchProvider = sp, agentName = an)
     }
 
     /**

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -1,0 +1,351 @@
+package com.seekerclaw.app.state
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import com.seekerclaw.app.util.CrossProcessStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Singleton store for [AgentPreferences] (BAT-515). Mirror of
+ * [RuntimeStateStore]'s shape with simpler invariants:
+ *  - No matrix gate (no two fields whose combination must be valid)
+ *  - Context-sensitive validation: existing-preserved fields skip the
+ *    cap; only newly-changing fields go through the cap check (BAT-515
+ *    v3 §1 + Codex final implementation guard).
+ *  - Migration preserves existing long agent names verbatim with WARN
+ *    rather than throwing/truncating.
+ *
+ * ## First-launch / install-over-existing behaviour
+ *
+ * 1. [init] runs once from `SeekerClawApplication.onCreate` (main
+ *    process only).
+ * 2. [seedFromPrefs] reads `KEY_AGENT_NAME` and `KEY_SEARCH_PROVIDER`
+ *    from SharedPreferences (the legacy storage). For an upgrade, the
+ *    user's existing values are preserved here — including over-cap
+ *    `agentName` (BAT-515 v3 §1: never truncate during migration).
+ * 3. The CrossProcessStore is constructed with `seeded` as the initial
+ *    value, so [state] immediately exposes the seed even before the
+ *    file lands on disk.
+ * 4. The migration write (file absent → write seeded value) runs on
+ *    the owned IO scope so `Application.onCreate` doesn't block on
+ *    disk.
+ * 5. The observe-and-mirror collector kicks in after migration. On
+ *    every emission of a valid observed file value:
+ *    - The wrapper `_state` updates.
+ *    - If the observed value differs from current prefs, the prefs
+ *      mirror runs (KEY_AGENT_NAME + KEY_SEARCH_PROVIDER) AND
+ *      `ConfigManager.signalConfigChanged` fires so existing
+ *      `loadConfig`-based UI surfaces recompose.
+ *    - Redundant emissions skip both steps. Invalid observations
+ *      (corrupt JSON, wrong types) are filtered before any mirror so
+ *      the UI / prefs never see a transiently-bad value.
+ *
+ * ## Visible-state contract (BAT-515 v3 §2)
+ *
+ * If `agent_preferences.json` is missing OR corrupt, [state] continues
+ * to expose the seeded value (from prefs/config). It NEVER falls back
+ * to hardcoded defaults if any persisted source has a valid prior
+ * value — corruption shouldn't silently reset a user's name to
+ * "MyAgent".
+ *
+ * ## Cross-process broadcast (BAT-515 v3 §3)
+ *
+ * The mirror calls
+ * [com.seekerclaw.app.config.ConfigManager.signalConfigChanged] only
+ * when a valid observation actually changed prefs. Redundant or
+ * invalid observations skip the broadcast. Mirrors [RuntimeStateStore]'s
+ * pattern so existing Compose surfaces that recompose on
+ * `configVersion` (Dashboard, System, Settings summary) auto-refresh
+ * after a Node-side write.
+ */
+object AgentPreferencesStore {
+
+    private const val TAG = "AgentPreferencesStore"
+    // PREFS_NAME and the legacy keys MUST match
+    // [com.seekerclaw.app.config.ConfigManager]. They are duplicated
+    // here so AgentPreferencesStore stays self-contained for tests
+    // (no Context required to resolve the constants). If ConfigManager
+    // ever changes any of these, change them here too — the matching
+    // tests in AgentPreferencesStoreTest will catch the drift.
+    private const val PREFS_NAME = "seekerclaw_prefs"
+    private const val FILE_NAME = "agent_preferences.json"
+    private const val KEY_AGENT_NAME = "agent_name"
+    private const val KEY_SEARCH_PROVIDER = "search_provider"
+
+    private val initialized = AtomicBoolean(false)
+    private val _state = MutableStateFlow(AgentPreferences())
+    private var appContext: Context? = null
+
+    /**
+     * Last valid [AgentPreferences] observed. UI binds to this;
+     * invalid file content (manual edit, corrupted JSON, future-build
+     * fields with unknown types) is filtered out so the UI never sees
+     * a transiently-bad state.
+     */
+    val state: StateFlow<AgentPreferences> = _state.asStateFlow()
+
+    /**
+     * `true` once [init] has wired up the cross-process store. Callers
+     * that run in BOTH processes (e.g., `:node` reconcile) gate
+     * main-only work on this — the `:node` process never calls
+     * [init], so [write] would always return `false` there.
+     */
+    val isInitialized: Boolean get() = store != null
+
+    private var ownedScope: CoroutineScope? = null
+    private var store: CrossProcessStore<AgentPreferences>? = null
+
+    /**
+     * Idempotent. Call once from `SeekerClawApplication.onCreate`.
+     */
+    fun init(context: Context) {
+        if (!initialized.compareAndSet(false, true)) return
+        val app = context.applicationContext
+        appContext = app
+        val sp = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val seeded = seedFromPrefs(sp)
+        _state.value = seeded
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        ownedScope = scope
+        val cps = CrossProcessStore(
+            context = app,
+            fileName = FILE_NAME,
+            serializer = AgentPreferences.serializer(),
+            initial = seeded,
+            parentScope = scope,
+        )
+        store = cps
+        scope.launch {
+            // First-launch migration: if the file is absent (fresh
+            // install OR pre-BAT-515 build that never wrote it), seed
+            // it from the prefs/in-memory seed. Failure is non-fatal:
+            // _state already holds the seed, so UI proceeds with a
+            // valid value; a later user-driven save will retry.
+            val file = File(app.filesDir, FILE_NAME)
+            if (!file.exists() && !cps.write(seeded)) {
+                Log.w(
+                    TAG,
+                    "first-launch migration write to $FILE_NAME failed — " +
+                        "app proceeds with in-memory seed; a later save will retry",
+                )
+            }
+            cps.state.collect { observed -> observeFromCollector(observed, sp) }
+        }
+    }
+
+    /**
+     * Production-side wrapper that fires
+     * [com.seekerclaw.app.config.ConfigManager.signalConfigChanged]
+     * when the mirror actually changed prefs (BAT-515 v3 §3). Mirror
+     * + broadcast are no-ops on redundant or invalid observations.
+     */
+    private fun observeFromCollector(observed: AgentPreferences, sp: SharedPreferences) {
+        val applied = onObserved(observed, sp)
+        if (applied) {
+            appContext?.let { com.seekerclaw.app.config.ConfigManager.signalConfigChanged(it) }
+        }
+    }
+
+    /**
+     * Returns the last valid [AgentPreferences] (the same value [state]
+     * exposes).
+     */
+    fun read(): AgentPreferences = _state.value
+
+    /**
+     * Persist [value] atomically. Throws [IllegalArgumentException]
+     * BEFORE persisting if any field that DIFFERS from the current
+     * value fails validation:
+     *  - `searchProvider`: must be in [AgentPreferences.KNOWN_SEARCH_PROVIDERS]
+     *  - `agentName`: must be non-blank AND ≤ [AgentPreferences.AGENT_NAME_MAX]
+     *
+     * Per the BAT-515 v3 + final-guard contract: if a field is
+     * UNCHANGED from the current persisted value, validation skips
+     * that field even if it's over-cap (existing migrated long names
+     * survive snapshots that don't touch them).
+     *
+     * Returns the underlying [CrossProcessStore.write] result —
+     * `true` on persisted-and-published, `false` on caught FS failure.
+     * Returns `false` if [init] wasn't called (`:node` process).
+     */
+    fun write(value: AgentPreferences): Boolean {
+        validateForWrite(value, _state.value)
+        return store?.write(value) ?: false
+    }
+
+    /**
+     * Read-modify-write under the underlying [CrossProcessStore]'s
+     * `synchronized(writeLock)` block — atomic w.r.t. both concurrent
+     * `update {}` calls AND concurrent `write()` calls in the same
+     * process.
+     */
+    suspend fun update(transform: (AgentPreferences) -> AgentPreferences): Boolean {
+        val s = store ?: return false
+        return s.update { current ->
+            val next = transform(current)
+            validateForWrite(next, current)
+            next
+        }
+    }
+
+    /**
+     * Validate [next] against [current]. Throws
+     * [IllegalArgumentException] if any field that ACTUALLY CHANGES
+     * (`next.field != current.field`) violates its rule. Unchanged
+     * fields skip validation — this is what allows a saveConfig call
+     * carrying an existing migrated long agentName to succeed
+     * (BAT-515 v3 §1 + Codex final guard).
+     *
+     * Public so `ConfigManager.saveConfig` can pre-validate before
+     * any persistence (BAT-515 v3 §4) without first needing to call
+     * [write].
+     */
+    fun validateForWrite(next: AgentPreferences, current: AgentPreferences) {
+        if (next.searchProvider != current.searchProvider) {
+            require(next.searchProvider in AgentPreferences.KNOWN_SEARCH_PROVIDERS) {
+                "Invalid searchProvider=${next.searchProvider} — must be one of " +
+                    AgentPreferences.KNOWN_SEARCH_PROVIDERS
+            }
+        }
+        if (next.agentName != current.agentName) {
+            require(next.agentName.isNotBlank()) { "agentName must not be blank" }
+            require(next.agentName.length <= AgentPreferences.AGENT_NAME_MAX) {
+                "agentName length ${next.agentName.length} exceeds max " +
+                    "${AgentPreferences.AGENT_NAME_MAX}"
+            }
+        }
+    }
+
+    /**
+     * Build the seed [AgentPreferences] from the legacy SharedPreferences
+     * keys. Existing values are preserved verbatim — including
+     * over-cap `agentName` (BAT-515 v3 §1: migration NEVER truncates).
+     * Logs a single WARN if a long name is detected so future triage
+     * can correlate.
+     *
+     * If both keys are absent, returns the data class defaults
+     * (fresh-install path).
+     */
+    internal fun seedFromPrefs(prefs: SharedPreferences): AgentPreferences {
+        val rawName = prefs.getString(KEY_AGENT_NAME, null)
+        val rawSearch = prefs.getString(KEY_SEARCH_PROVIDER, null)
+        val agentName = if (!rawName.isNullOrBlank()) {
+            if (rawName.length > AgentPreferences.AGENT_NAME_MAX) {
+                Log.w(
+                    TAG,
+                    "seedFromPrefs: existing agentName length ${rawName.length} > " +
+                        "${AgentPreferences.AGENT_NAME_MAX} — preserving verbatim, no truncation " +
+                        "(BAT-515 v3 §1)",
+                )
+            }
+            rawName
+        } else {
+            AgentPreferences.DEFAULT_AGENT_NAME
+        }
+        val searchProvider = if (!rawSearch.isNullOrBlank()
+            && rawSearch in AgentPreferences.KNOWN_SEARCH_PROVIDERS
+        ) {
+            rawSearch
+        } else {
+            // Unknown / corrupt prefs value falls back to default rather
+            // than poisoning the file. The user's next Settings save
+            // (with the picker constraining to the allowlist) will
+            // produce a valid value.
+            if (rawSearch != null) {
+                Log.w(
+                    TAG,
+                    "seedFromPrefs: unknown searchProvider=$rawSearch — falling back to default",
+                )
+            }
+            AgentPreferences.DEFAULT_SEARCH_PROVIDER
+        }
+        return AgentPreferences(searchProvider = searchProvider, agentName = agentName)
+    }
+
+    /**
+     * Apply the validity gate AND the redundancy guard, then update
+     * the wrapper StateFlow + mirror to prefs. Extracted from the
+     * collector so unit tests can drive it directly without spinning
+     * up a CrossProcessStore.
+     *
+     * Returns `true` iff the mirror to prefs actually applied (i.e.
+     * the observed state was valid AND differed from current prefs
+     * values). The production [observeFromCollector] uses this signal
+     * to decide whether to fire `signalConfigChanged`.
+     *
+     * "Valid" here means the persisted shape parses, AND
+     * `searchProvider` is a known provider. An unknown searchProvider
+     * is treated as invalid (visible state stays at last-valid; no
+     * mirror) because letting it through would write garbage into
+     * prefs and let `tools/web.js` route to a non-existent provider.
+     * `agentName` length is NOT validated at the observation gate —
+     * an over-cap name is allowed to reach state because migration
+     * paths legitimately carry over-cap values.
+     */
+    internal fun onObserved(observed: AgentPreferences, prefs: SharedPreferences): Boolean {
+        if (observed.searchProvider !in AgentPreferences.KNOWN_SEARCH_PROVIDERS) {
+            Log.w(
+                TAG,
+                "observed invalid searchProvider=${observed.searchProvider} — " +
+                    "UI keeps last valid; prefs unchanged",
+            )
+            return false
+        }
+        if (observed.agentName.isBlank()) {
+            Log.w(TAG, "observed blank agentName — UI keeps last valid; prefs unchanged")
+            return false
+        }
+        _state.value = observed
+        return mirrorIfChanged(prefs, observed)
+    }
+
+    /**
+     * Mirror prefs iff at least one field of [observed] differs from
+     * the current prefs value. Returns `true` iff anything was written
+     * (used by the redundancy-guard + broadcast-gate logic).
+     */
+    internal fun mirrorIfChanged(prefs: SharedPreferences, observed: AgentPreferences): Boolean {
+        val curName = prefs.getString(KEY_AGENT_NAME, null)
+        val curSearch = prefs.getString(KEY_SEARCH_PROVIDER, null)
+        if (curName == observed.agentName && curSearch == observed.searchProvider) return false
+        val editor = prefs.edit()
+        if (curName != observed.agentName) editor.putString(KEY_AGENT_NAME, observed.agentName)
+        if (curSearch != observed.searchProvider) editor.putString(KEY_SEARCH_PROVIDER, observed.searchProvider)
+        editor.apply()
+        return true
+    }
+
+    /**
+     * Test seam: bypass [init]'s real CrossProcessStore wiring and
+     * just seed [_state] so unit tests can assert the collector path
+     * without a [Context]. Production code MUST NOT call this.
+     */
+    internal fun initForTest(injectedSeed: AgentPreferences) {
+        if (!initialized.compareAndSet(false, true)) return
+        _state.value = injectedSeed
+    }
+
+    /**
+     * Test seam: drop all state so the next test case can re-init
+     * from scratch.
+     */
+    internal fun resetForTest() {
+        ownedScope?.cancel()
+        ownedScope = null
+        store?.close()
+        store = null
+        appContext = null
+        _state.value = AgentPreferences()
+        initialized.set(false)
+    }
+}

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -247,7 +247,22 @@ object AgentPreferencesStore {
      */
     fun write(value: AgentPreferences): Boolean {
         validateForWrite(value, _state.value)
-        return store?.write(value) ?: false
+        val ok = store?.write(value) ?: false
+        // R3 Copilot: sync-update [_state] on successful persistence so
+        // same-process callers reading via [read] (= `_state.value`)
+        // see the new value immediately. Pre-fix the collector path
+        // was the only writer to `_state`, leaving a brief window
+        // where [read] returned stale — a hazard for
+        // `ConfigManager.loadConfig` (which now overlays `read()`)
+        // when called by code that just performed an update.
+        //
+        // The collector still fires its own update later via
+        // [parseFileStrictOrNull] → [observeFromCollector]; it'll
+        // observe the same value already in `_state`, so
+        // [mirrorIfChanged]'s redundancy guard skips the prefs mirror
+        // and broadcast (no double-mirror).
+        if (ok) _state.value = value
+        return ok
     }
 
     /**
@@ -258,11 +273,21 @@ object AgentPreferencesStore {
      */
     suspend fun update(transform: (AgentPreferences) -> AgentPreferences): Boolean {
         val s = store ?: return false
-        return s.update { current ->
+        // R3 Copilot: capture the value persisted by the transform (the
+        // `next` returned inside the writeLock) so we can sync-update
+        // `_state` after the underlying write succeeds. Without this,
+        // [update]'s same-process callers see a stale [read] result
+        // until the collector path fires (~50-200ms later) — same race
+        // [write] had pre-fix.
+        var persisted: AgentPreferences? = null
+        val ok = s.update { current ->
             val next = transform(current)
             validateForWrite(next, current)
+            persisted = next
             next
         }
+        if (ok) persisted?.let { _state.value = it }
+        return ok
     }
 
     /**

--- a/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/AgentPreferencesStore.kt
@@ -247,8 +247,16 @@ object AgentPreferencesStore {
      * Returns `false` if [init] wasn't called (`:node` process).
      */
     fun write(value: AgentPreferences): Boolean {
+        // R8 Copilot: gate on `store` BEFORE validating. KDoc promises
+        // `:node`-process callers (where init never ran) get a quiet
+        // `false` — running `validateForWrite` first would throw
+        // `IllegalArgumentException` for any invalid value even when
+        // there's no store to write to, breaking the documented
+        // contract. Same shape as [update]'s `val s = store ?: return
+        // false` early-out.
+        val initializedStore = store ?: return false
         validateForWrite(value, _state.value)
-        val ok = store?.write(value) ?: false
+        val ok = initializedStore.write(value)
         // R3 Copilot: sync-update [_state] on successful persistence so
         // same-process callers reading via [read] (= `_state.value`)
         // see the new value immediately. Pre-fix the collector path

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
@@ -188,7 +188,25 @@ fun SearchProviderConfigScreen(onBack: () -> Unit) {
             SectionLabel("${activeProvider.displayName} Settings")
             Spacer(modifier = Modifier.height(10.dp))
 
-            val activeApiKey: String? = config?.activeSearchApiKey
+            // R1 Copilot: derive the API key from `effectiveProvider`
+            // (the optimistic value), NOT `config.activeSearchApiKey`
+            // (which still reads the lagging `config.searchProvider`).
+            // During the optimistic window between the tap and the
+            // configVersion bump, `activeProvider.displayName` shows
+            // the new provider while `config.activeSearchApiKey`
+            // would still resolve to the OLD provider's key — a
+            // confusing visible mismatch. Looking up via
+            // `effectiveProvider` keeps the section label, masked-key
+            // value, and "missing key" warning all internally
+            // consistent for whichever provider is currently
+            // displayed as Active.
+            val activeApiKey: String? = when (effectiveProvider) {
+                "perplexity" -> config?.perplexityApiKey
+                "exa" -> config?.exaApiKey
+                "tavily" -> config?.tavilyApiKey
+                "firecrawl" -> config?.firecrawlApiKey
+                else -> config?.braveApiKey
+            }
             val isKeyMissing = activeApiKey.isNullOrBlank()
 
             Column(

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
@@ -2,6 +2,7 @@ package com.seekerclaw.app.ui.settings
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -43,6 +44,8 @@ import com.seekerclaw.app.config.searchProviderById
 import com.seekerclaw.app.state.AgentPreferencesStore
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.util.LogCollector
+import com.seekerclaw.app.util.LogLevel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -138,15 +141,53 @@ fun SearchProviderConfigScreen(onBack: () -> Unit) {
                                     // mid-flight.
                                     optimisticProvider = provider.id
                                     scope.launch(Dispatchers.IO) {
+                                        // R10 Copilot: capture the
+                                        // failure cause for the log
+                                        // path so a field issue is
+                                        // diagnosable from device logs
+                                        // (FS error vs validation
+                                        // error are different bugs to
+                                        // chase).
+                                        var validationError: String? = null
                                         val ok = try {
                                             AgentPreferencesStore.update {
                                                 it.copy(searchProvider = provider.id)
                                             }
-                                        } catch (_: IllegalArgumentException) {
+                                        } catch (e: IllegalArgumentException) {
+                                            validationError = e.message
                                             false
                                         }
                                         withContext(Dispatchers.Main) {
-                                            if (!ok) optimisticProvider = null
+                                            if (!ok) {
+                                                optimisticProvider = null
+                                                // R10 Copilot: surface
+                                                // the failure so a
+                                                // silent revert
+                                                // doesn't look like
+                                                // the tap was
+                                                // ignored. Toast for
+                                                // user-visible feedback
+                                                // (mirrors the failure-
+                                                // surface pattern other
+                                                // Settings screens use
+                                                // for irrecoverable
+                                                // saves); LogCollector
+                                                // entry for post-hoc
+                                                // triage when a user
+                                                // reports "the picker
+                                                // doesn't stick".
+                                                Toast.makeText(
+                                                    context,
+                                                    "Couldn't switch search provider — try again",
+                                                    Toast.LENGTH_SHORT,
+                                                ).show()
+                                                LogCollector.append(
+                                                    "[Settings] Search provider switch to '${provider.id}' failed " +
+                                                        (validationError?.let { "(validation: $it)" }
+                                                            ?: "(FS error or store uninitialized)"),
+                                                    LogLevel.WARN,
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SearchProviderConfigScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.material3.HorizontalDivider
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,8 +40,12 @@ import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.SearchProviderInfo
 import com.seekerclaw.app.config.availableSearchProviders
 import com.seekerclaw.app.config.searchProviderById
+import com.seekerclaw.app.state.AgentPreferencesStore
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun SearchProviderConfigScreen(onBack: () -> Unit) {
@@ -47,7 +53,20 @@ fun SearchProviderConfigScreen(onBack: () -> Unit) {
     val configVer by ConfigManager.configVersion
     var config by remember(configVer) { mutableStateOf(ConfigManager.loadConfig(context)) }
 
-    val activeProvider: SearchProviderInfo = searchProviderById(config?.searchProvider ?: "brave")
+    // BAT-515 v3 §4 + R14: bind activeProvider directly to the
+    // AgentPreferencesStore StateFlow so cross-process writes (Telegram
+    // /provider when we add it, Node-side switch from the future
+    // session_status flow) flow through to the UI without a configVersion
+    // bump. The optimistic local override gives instant visual feedback
+    // on tap while the IO dispatch persists. Note: SearchProviderConfigScreen
+    // is a main-process-only UI surface, so AgentPreferencesStore.isInitialized
+    // is always true here — no fallback to config?.searchProvider needed.
+    val agentPrefs by AgentPreferencesStore.state.collectAsState()
+    val scope = rememberCoroutineScope()
+    var optimisticProvider by remember(agentPrefs.searchProvider) { mutableStateOf<String?>(null) }
+    val effectiveProvider = optimisticProvider ?: agentPrefs.searchProvider
+    val activeProvider: SearchProviderInfo = searchProviderById(effectiveProvider)
+
     var editField by remember { mutableStateOf<String?>(null) }
     var editLabel by remember { mutableStateOf("") }
     var editValue by remember { mutableStateOf("") }
@@ -101,7 +120,35 @@ fun SearchProviderConfigScreen(onBack: () -> Unit) {
                             .fillMaxWidth()
                             .clickable {
                                 if (!isActive) {
-                                    saveField("searchProvider", provider.id, needsRestart = true)
+                                    // BAT-515 v3 §4 + R14/R17/R24: optimistic
+                                    // local override + IO-dispatched atomic
+                                    // update. Switching is LIVE — `:node`
+                                    // reads `agent_preferences.json` per
+                                    // web_search call, so the next search
+                                    // uses the new provider without a
+                                    // service restart. R24 reasoning
+                                    // applies: AgentPreferencesStore.update
+                                    // re-reads inside the writeLock so a
+                                    // concurrent cross-process write isn't
+                                    // clobbered by a stale `current` from
+                                    // outside the lock. R17: clear the
+                                    // optimistic override on failure rather
+                                    // than reverting to the prior id — the
+                                    // canonical state may have changed
+                                    // mid-flight.
+                                    optimisticProvider = provider.id
+                                    scope.launch(Dispatchers.IO) {
+                                        val ok = try {
+                                            AgentPreferencesStore.update {
+                                                it.copy(searchProvider = provider.id)
+                                            }
+                                        } catch (_: IllegalArgumentException) {
+                                            false
+                                        }
+                                        withContext(Dispatchers.Main) {
+                                            if (!ok) optimisticProvider = null
+                                        }
+                                    }
                                 }
                             }
                             .padding(horizontal = 16.dp, vertical = 14.dp),

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -358,22 +358,25 @@ fun SettingsScreen(
         }
     }
 
-    // Fields whose value is re-read live from agent_settings.json on the Node
-    // side (no service restart needed). Keep in sync with live-pickup readers
-    // in main.js (heartbeat) and ai.js (maxStepsPerTurn).
-    //
-    // BAT-515 v3: agentName joins this set. saveConfig now dual-writes the
-    // value into the cross-process AgentPreferencesStore, which the `:node`
-    // process reads per-AI-turn via agent-preferences.js — no service
-    // restart required for the Identity line in the system prompt to pick
-    // up the new value. searchProvider is edited from
-    // SearchProviderConfigScreen, not here, but the same live-update
-    // contract applies.
+    // Fields the `:node` process re-reads live without a service restart.
+    // Two routes feed this set:
+    //   1. agent_settings.json overlay — main.js (heartbeat) and ai.js
+    //      (maxStepsPerTurn) read these per-turn from the workspace
+    //      overlay file written by ConfigManager.writeAgentSettingsJson.
+    //   2. agent_preferences.json (BAT-515) — agent-preferences.js
+    //      `getAgentName()` / `getSearchProvider()` read this per-call
+    //      from the CrossProcessStore-backed file. saveConfig dual-writes
+    //      to AgentPreferencesStore, the Settings UI provider switch
+    //      writes to it directly via the BAT-549 R14/R17/R24 optimistic
+    //      pattern.
+    // R3 Copilot: header comment kept in sync with both routes so a
+    // future field addition to either store doesn't accidentally
+    // get classified by the obsolete "agent_settings.json" wording.
     val liveUpdateFields = setOf(
-        "maxStepsPerTurn",
-        "heartbeatIntervalMinutes",
-        "agentName",
-        "searchProvider",
+        "maxStepsPerTurn",            // → agent_settings.json overlay
+        "heartbeatIntervalMinutes",   // → agent_settings.json overlay
+        "agentName",                  // → agent_preferences.json (BAT-515)
+        "searchProvider",             // → agent_preferences.json (BAT-515)
     )
 
     fun saveField(field: String, value: String) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -361,7 +361,20 @@ fun SettingsScreen(
     // Fields whose value is re-read live from agent_settings.json on the Node
     // side (no service restart needed). Keep in sync with live-pickup readers
     // in main.js (heartbeat) and ai.js (maxStepsPerTurn).
-    val liveUpdateFields = setOf("maxStepsPerTurn", "heartbeatIntervalMinutes")
+    //
+    // BAT-515 v3: agentName joins this set. saveConfig now dual-writes the
+    // value into the cross-process AgentPreferencesStore, which the `:node`
+    // process reads per-AI-turn via agent-preferences.js — no service
+    // restart required for the Identity line in the system prompt to pick
+    // up the new value. searchProvider is edited from
+    // SearchProviderConfigScreen, not here, but the same live-update
+    // contract applies.
+    val liveUpdateFields = setOf(
+        "maxStepsPerTurn",
+        "heartbeatIntervalMinutes",
+        "agentName",
+        "searchProvider",
+    )
 
     fun saveField(field: String, value: String) {
         ConfigManager.updateConfigField(context, field, value)

--- a/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
@@ -462,7 +462,15 @@ class AgentPreferencesStoreTest {
         val putCounts = mutableMapOf<String, Int>()
 
         override fun getAll(): MutableMap<String, *> = map.toMutableMap()
-        override fun getString(key: String, defValue: String?): String? = map[key] ?: defValue
+        // R13 Copilot: distinguish "key absent" from "key present with
+        // stored null" so the fake matches SharedPreferences contract.
+        // `map[key] ?: defValue` would return `defValue` for both
+        // cases, hiding bugs where a present-but-null value should
+        // surface as null (the real platform never lets a key carry
+        // null since putString(key, null) removes — see FakeEditor
+        // putString below — but defensive symmetry costs nothing).
+        override fun getString(key: String, defValue: String?): String? =
+            if (map.containsKey(key)) map[key] else defValue
         override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? = defValues
         override fun getInt(key: String, defValue: Int): Int = defValue
         override fun getLong(key: String, defValue: Long): Long = defValue
@@ -479,7 +487,19 @@ class AgentPreferencesStoreTest {
             private val removals = mutableSetOf<String>()
             private var clearAll = false
             override fun putString(key: String, value: String?): SharedPreferences.Editor {
-                pending[key] = value
+                // R13 Copilot: real `SharedPreferences.Editor.putString`
+                // treats `value == null` as a remove. Mapping it the
+                // same way here keeps `contains()` / `getString()`
+                // semantics consistent between the fake and prod —
+                // and matches how `mirrorIfChanged` would later
+                // round-trip such a value.
+                if (value == null) {
+                    pending.remove(key)
+                    removals += key
+                } else {
+                    removals.remove(key)
+                    pending[key] = value
+                }
                 putCounts[key] = (putCounts[key] ?: 0) + 1
                 return this
             }

--- a/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
@@ -293,9 +293,168 @@ class AgentPreferencesStoreTest {
         assertFalse("redundant observation should not trigger mirror/broadcast", applied)
     }
 
+    // ── parseFileStrictOrNull (R1 Copilot — collector strict gate) ─
+
+    @Test
+    fun `parseFileStrictOrNull returns null on absent file`() {
+        val tmpDir = createTempDir()
+        try {
+            val absent = java.io.File(tmpDir, "agent_preferences.json")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(absent))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on parse failure`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("{not valid json}")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on empty object (missing fields)`() {
+        // BAT-515 v3 §2 + R1 Copilot: kotlinx.serialization would
+        // happily decode `{}` to AgentPreferences defaults via the
+        // data class defaults. That's exactly the silent-reset path
+        // we're guarding against — both fields must be PRESENT.
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("{}")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on JSON null`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("null")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on JSON array`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("[1,2,3]")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on non-string agentName`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"brave","agentName":12345}""")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on unknown searchProvider`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"duckduckgo","agentName":"Cortana"}""")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull returns null on blank agentName`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"brave","agentName":""}""")
+            assertNull(AgentPreferencesStore.parseFileStrictOrNull(file))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull accepts valid file with both fields`() {
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"exa","agentName":"Cortana"}""")
+            val parsed = AgentPreferencesStore.parseFileStrictOrNull(file)
+            assertNotNull(parsed)
+            assertEquals("exa", parsed!!.searchProvider)
+            assertEquals("Cortana", parsed.agentName)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull accepts over-cap agentName from migration paths`() {
+        // v3 §1: migration paths legitimately carry over-cap names;
+        // the cap only applies at the NEW-edit boundary. The strict
+        // parse must allow them through so an existing user's long
+        // name survives a downgrade or a service restart.
+        val longName = "A".repeat(100)
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"brave","agentName":"$longName"}""")
+            val parsed = AgentPreferencesStore.parseFileStrictOrNull(file)
+            assertNotNull(parsed)
+            assertEquals(100, parsed!!.agentName.length)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `parseFileStrictOrNull tolerates unknown forward-build keys`() {
+        // ignoreUnknownKeys = true mirrors CrossProcessStore — a
+        // future build that adds new fields can roll back to current
+        // build without crashing its own data.
+        val tmpDir = createTempDir()
+        try {
+            val file = java.io.File(tmpDir, "agent_preferences.json")
+            file.writeText("""{"searchProvider":"brave","agentName":"X","futureField":"v2"}""")
+            val parsed = AgentPreferencesStore.parseFileStrictOrNull(file)
+            assertNotNull(parsed)
+            assertEquals("X", parsed!!.agentName)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
     // --- helpers ---
 
     private fun fail(msg: String): Nothing = throw AssertionError(msg)
+
+    private fun createTempDir(): java.io.File {
+        val dir = java.io.File.createTempFile("bat515-test-", "")
+        if (!dir.delete()) throw java.io.IOException("Failed to delete tmp file before mkdir")
+        if (!dir.mkdir()) throw java.io.IOException("Failed to create tmp dir")
+        return dir
+    }
 
     private class FakePrefs : SharedPreferences {
         private val map = mutableMapOf<String, String?>()

--- a/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/state/AgentPreferencesStoreTest.kt
@@ -1,0 +1,343 @@
+package com.seekerclaw.app.state
+
+import android.content.SharedPreferences
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pure JVM tests for AgentPreferencesStore (BAT-515). Mirrors
+ * RuntimeStateStoreTest's pattern: the Android-specific surfaces
+ * (FileObserver, BroadcastReceiver) are validated by device test;
+ * here we drive the singleton's internal helpers
+ * ([AgentPreferencesStore.seedFromPrefs], [onObserved], [mirrorIfChanged],
+ * [validateForWrite]) directly.
+ *
+ * Pinned contracts:
+ *  - v3 §1: migration preserves over-cap agentName verbatim with WARN
+ *  - v3 §2: missing/corrupt file → state stays at seeded value, never
+ *    silently resets to hardcoded defaults if a persisted source had
+ *    a valid prior value
+ *  - v3 §3: mirror to prefs only when actually changed; broadcast
+ *    only when mirror actually changed prefs
+ *  - v3 §4: validateForWrite is context-sensitive (skips cap on
+ *    unchanged fields) so saveConfig with an existing migrated long
+ *    name doesn't fail just because some unrelated field changed
+ *  - v3 §5: write/update validation matches
+ */
+class AgentPreferencesStoreTest {
+
+    private lateinit var prefs: FakePrefs
+
+    @Before
+    fun setUp() {
+        prefs = FakePrefs()
+        AgentPreferencesStore.resetForTest()
+    }
+
+    @After
+    fun tearDown() {
+        AgentPreferencesStore.resetForTest()
+    }
+
+    // ── data class defaults ─────────────────────────────────────────
+
+    @Test
+    fun `defaults match expected user-visible values`() {
+        val ap = AgentPreferences()
+        assertEquals("MyAgent", ap.agentName)
+        assertEquals("brave", ap.searchProvider)
+    }
+
+    @Test
+    fun `companion AGENT_NAME_MAX is 64`() {
+        assertEquals(64, AgentPreferences.AGENT_NAME_MAX)
+    }
+
+    @Test
+    fun `companion KNOWN_SEARCH_PROVIDERS contains the 5 expected`() {
+        val expected = setOf("brave", "perplexity", "exa", "tavily", "firecrawl")
+        assertEquals(expected, AgentPreferences.KNOWN_SEARCH_PROVIDERS)
+    }
+
+    // ── seedFromPrefs (BAT-515 v3 §1, §2) ──────────────────────────
+
+    @Test
+    fun `seedFromPrefs uses defaults on fresh install (no prefs keys)`() {
+        // Fresh install: no agent_name or search_provider in prefs
+        val seed = AgentPreferencesStore.seedFromPrefs(prefs)
+        assertEquals(AgentPreferences(), seed)
+    }
+
+    @Test
+    fun `seedFromPrefs preserves existing prefs value (upgrade path)`() {
+        prefs.edit()
+            .putString("agent_name", "Cortana")
+            .putString("search_provider", "exa")
+            .apply()
+        val seed = AgentPreferencesStore.seedFromPrefs(prefs)
+        assertEquals("Cortana", seed.agentName)
+        assertEquals("exa", seed.searchProvider)
+    }
+
+    @Test
+    fun `seedFromPrefs preserves existing long agentName verbatim - never truncates (v3 §1)`() {
+        // BAT-515 v3 §1 + Codex final guard: existing 100-char name MUST survive migration
+        // unchanged. A previous truncate-with-WARN proposal was rejected by Codex as data loss.
+        val longName = "A".repeat(100)
+        prefs.edit().putString("agent_name", longName).apply()
+        val seed = AgentPreferencesStore.seedFromPrefs(prefs)
+        assertEquals(100, seed.agentName.length)
+        assertEquals(longName, seed.agentName)
+    }
+
+    @Test
+    fun `seedFromPrefs falls back to default for unknown searchProvider`() {
+        // If prefs got corrupted with an unknown provider id (e.g., from a future
+        // build that added a provider then rolled back), fall back rather than
+        // poisoning the file.
+        prefs.edit().putString("search_provider", "unknown-future-provider").apply()
+        val seed = AgentPreferencesStore.seedFromPrefs(prefs)
+        assertEquals("brave", seed.searchProvider)
+    }
+
+    @Test
+    fun `seedFromPrefs falls back to default for blank agentName`() {
+        prefs.edit().putString("agent_name", "").apply()
+        val seed = AgentPreferencesStore.seedFromPrefs(prefs)
+        assertEquals("MyAgent", seed.agentName)
+    }
+
+    // ── validateForWrite context-sensitive (BAT-515 v3 §1 final guard) ──
+
+    @Test
+    fun `validateForWrite accepts known searchProvider`() {
+        AgentPreferences.KNOWN_SEARCH_PROVIDERS.forEach { provider ->
+            val current = AgentPreferences()
+            val next = current.copy(searchProvider = provider)
+            // Should NOT throw
+            AgentPreferencesStore.validateForWrite(next, current)
+        }
+    }
+
+    @Test
+    fun `validateForWrite rejects unknown searchProvider when changing`() {
+        val current = AgentPreferences()
+        val next = current.copy(searchProvider = "duckduckgo")
+        try {
+            AgentPreferencesStore.validateForWrite(next, current)
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(
+                "error message should mention searchProvider",
+                e.message?.contains("searchProvider") == true,
+            )
+        }
+    }
+
+    @Test
+    fun `validateForWrite rejects empty agentName when changing`() {
+        val current = AgentPreferences(agentName = "Cortana")
+        val next = current.copy(agentName = "")
+        try {
+            AgentPreferencesStore.validateForWrite(next, current)
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("agentName") == true)
+        }
+    }
+
+    @Test
+    fun `validateForWrite rejects 65-char agentName when changing`() {
+        val current = AgentPreferences(agentName = "Cortana")
+        val next = current.copy(agentName = "A".repeat(65))
+        try {
+            AgentPreferencesStore.validateForWrite(next, current)
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("length") == true)
+        }
+    }
+
+    @Test
+    fun `validateForWrite accepts existing long agentName when unchanged (Codex final guard)`() {
+        // CRITICAL: this is the Codex final implementation guard.
+        // A user with a pre-existing 100-char name calls saveConfig
+        // changing some unrelated provider/auth field. The
+        // saveConfig-built AgentPreferences carries the same 100-char
+        // agentName. validateForWrite must NOT reject just because
+        // the name is over-cap — it's unchanged.
+        val longName = "A".repeat(100)
+        val current = AgentPreferences(agentName = longName)
+        val next = current.copy(searchProvider = "exa") // unrelated field changes
+        // Must NOT throw
+        AgentPreferencesStore.validateForWrite(next, current)
+    }
+
+    @Test
+    fun `validateForWrite rejects new 65-char even when current is over-cap`() {
+        // Existing name is 100 chars (migrated). User edits to a NEW 65-char name.
+        // The new name IS a change, so it goes through the cap → rejected.
+        val current = AgentPreferences(agentName = "A".repeat(100))
+        val next = current.copy(agentName = "B".repeat(65))
+        try {
+            AgentPreferencesStore.validateForWrite(next, current)
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("length") == true)
+        }
+    }
+
+    @Test
+    fun `validateForWrite accepts blank old searchProvider unchanged`() {
+        // Defensive: if persisted state somehow has an empty searchProvider
+        // (shouldn't happen — data class defaults to brave), unchanged-skip
+        // means no validation. This proves the skip is purely on equality.
+        val current = AgentPreferences(searchProvider = "")
+        val next = current.copy(agentName = "NewName")
+        // Must NOT throw on the (unchanged) blank searchProvider
+        AgentPreferencesStore.validateForWrite(next, current)
+    }
+
+    // ── mirrorIfChanged (BAT-515 v3 §3 redundancy guard) ───────────
+
+    @Test
+    fun `mirrorIfChanged returns false when prefs already match`() {
+        prefs.edit()
+            .putString("agent_name", "Cortana")
+            .putString("search_provider", "exa")
+            .apply()
+        val initialApplyCount = prefs.applyCount
+        val observed = AgentPreferences(agentName = "Cortana", searchProvider = "exa")
+        val applied = AgentPreferencesStore.mirrorIfChanged(prefs, observed)
+        assertFalse("redundant emission should be no-op", applied)
+        assertEquals(
+            "no editor.apply() should fire on redundant emission",
+            initialApplyCount, prefs.applyCount,
+        )
+    }
+
+    @Test
+    fun `mirrorIfChanged writes only changed field`() {
+        prefs.edit()
+            .putString("agent_name", "Cortana")
+            .putString("search_provider", "exa")
+            .apply()
+        val observed = AgentPreferences(agentName = "Cortana", searchProvider = "tavily")
+        // Reset put counts (FakePrefs accumulated them from the seed apply above)
+        prefs.putCounts.clear()
+        val applied = AgentPreferencesStore.mirrorIfChanged(prefs, observed)
+        assertTrue(applied)
+        assertEquals("agent_name unchanged → no write", null, prefs.putCounts["agent_name"])
+        assertEquals("search_provider changed → 1 write", 1, prefs.putCounts["search_provider"])
+    }
+
+    @Test
+    fun `mirrorIfChanged writes both when both differ`() {
+        // Fresh prefs (no values yet)
+        val observed = AgentPreferences(agentName = "Athena", searchProvider = "perplexity")
+        val applied = AgentPreferencesStore.mirrorIfChanged(prefs, observed)
+        assertTrue(applied)
+        assertEquals("Athena", prefs.getString("agent_name", null))
+        assertEquals("perplexity", prefs.getString("search_provider", null))
+    }
+
+    // ── onObserved validity gate (BAT-515 v3 §3) ───────────────────
+
+    @Test
+    fun `onObserved rejects unknown searchProvider - no state update no mirror`() {
+        AgentPreferencesStore.initForTest(AgentPreferences()) // current state = defaults
+        val invalid = AgentPreferences(searchProvider = "unknown")
+        val applied = AgentPreferencesStore.onObserved(invalid, prefs)
+        assertFalse(applied)
+        // _state unchanged
+        assertEquals(AgentPreferences(), AgentPreferencesStore.read())
+    }
+
+    @Test
+    fun `onObserved rejects blank agentName - no state update`() {
+        AgentPreferencesStore.initForTest(AgentPreferences())
+        val invalid = AgentPreferences(agentName = "")
+        val applied = AgentPreferencesStore.onObserved(invalid, prefs)
+        assertFalse(applied)
+        assertEquals(AgentPreferences(), AgentPreferencesStore.read())
+    }
+
+    @Test
+    fun `onObserved accepts over-cap agentName from migration paths`() {
+        // Migration legitimately carries over-cap names. The gate at
+        // observation must not reject — only NEW user edits via
+        // write/update enforce the cap.
+        AgentPreferencesStore.initForTest(AgentPreferences())
+        val migrated = AgentPreferences(agentName = "A".repeat(100), searchProvider = "exa")
+        val applied = AgentPreferencesStore.onObserved(migrated, prefs)
+        assertTrue(applied)
+        assertEquals(100, AgentPreferencesStore.read().agentName.length)
+    }
+
+    @Test
+    fun `onObserved valid unchanged emission updates state but mirror returns false`() {
+        // Seed prefs to match the observation
+        prefs.edit()
+            .putString("agent_name", "Cortana")
+            .putString("search_provider", "exa")
+            .apply()
+        AgentPreferencesStore.initForTest(AgentPreferences(agentName = "Cortana", searchProvider = "exa"))
+        val same = AgentPreferences(agentName = "Cortana", searchProvider = "exa")
+        val applied = AgentPreferencesStore.onObserved(same, prefs)
+        assertFalse("redundant observation should not trigger mirror/broadcast", applied)
+    }
+
+    // --- helpers ---
+
+    private fun fail(msg: String): Nothing = throw AssertionError(msg)
+
+    private class FakePrefs : SharedPreferences {
+        private val map = mutableMapOf<String, String?>()
+        var applyCount = 0
+        val putCounts = mutableMapOf<String, Int>()
+
+        override fun getAll(): MutableMap<String, *> = map.toMutableMap()
+        override fun getString(key: String, defValue: String?): String? = map[key] ?: defValue
+        override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? = defValues
+        override fun getInt(key: String, defValue: Int): Int = defValue
+        override fun getLong(key: String, defValue: Long): Long = defValue
+        override fun getFloat(key: String, defValue: Float): Float = defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = defValue
+        override fun contains(key: String): Boolean = map.containsKey(key)
+        override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+
+        override fun edit(): SharedPreferences.Editor = FakeEditor()
+
+        private inner class FakeEditor : SharedPreferences.Editor {
+            private val pending = mutableMapOf<String, String?>()
+            private val removals = mutableSetOf<String>()
+            private var clearAll = false
+            override fun putString(key: String, value: String?): SharedPreferences.Editor {
+                pending[key] = value
+                putCounts[key] = (putCounts[key] ?: 0) + 1
+                return this
+            }
+            override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor = this
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor = this
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor = this
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor = this
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor = this
+            override fun remove(key: String): SharedPreferences.Editor { removals += key; return this }
+            override fun clear(): SharedPreferences.Editor { clearAll = true; return this }
+            override fun commit(): Boolean { apply(); return true }
+            override fun apply() {
+                if (clearAll) map.clear()
+                for (k in removals) map.remove(k)
+                map.putAll(pending)
+                applyCount++
+            }
+        }
+    }
+}

--- a/tests/nodejs-project/agent-preferences.test.js
+++ b/tests/nodejs-project/agent-preferences.test.js
@@ -169,6 +169,49 @@ ok('update() applies transform',
 eq('update result', handle.read(),
     { searchProvider: 'brave', agentName: 'NewName' });
 
+console.log();
+console.log('── R2: write() context-sensitive validation (parity with Kotlin validateForWrite) ──');
+// BAT-515 v3 §1: migration paths legitimately carry over-cap names; the
+// 64-char cap only applies to NEW edits. Kotlin's validateForWrite skips
+// per-field validation when the field is unchanged from the persisted
+// current value. The Node side must match.
+//
+// Setup: persist an over-cap agentName the way Kotlin's seedFromPrefs
+// would (existing user upgraded from pre-BAT-515 with a long name).
+// Bypass the JS write() validation by writing the file directly — this
+// simulates the migration write coming from the Kotlin side.
+writeFile(JSON.stringify({ searchProvider: 'brave', agentName: 'A'.repeat(100) }));
+
+// Pre-fix: write({searchProvider: 'exa'}) alone passed (agentName not
+// in input → not validated). That works fine — keep it green.
+ok('partial write {searchProvider} succeeds with persisted over-cap name',
+    handle.write({ searchProvider: 'exa' }) === true);
+eq('after partial searchProvider write — over-cap name preserved',
+    handle.read(),
+    { searchProvider: 'exa', agentName: 'A'.repeat(100) });
+
+// The bug: a JS caller doing `update(c => ({...c, searchProvider: 'X'}))`
+// would have its transform return BOTH fields (over-cap name copied
+// from `current` AND the new searchProvider). Pre-fix this threw on
+// the unchanged over-cap name; post-fix the unchanged name skips the
+// cap check.
+ok('update() copying over-cap name + changing searchProvider succeeds (R2 fix)',
+    handle.update((current) => ({ ...current, searchProvider: 'tavily' })) === true);
+eq('after update — both fields land correctly',
+    handle.read(),
+    { searchProvider: 'tavily', agentName: 'A'.repeat(100) });
+
+// Sibling: changing the over-cap name to a NEW over-cap name still throws
+// (the cap applies to NEW edits, even if the prior was also over-cap).
+expectThrow('write rejects NEW over-cap agentName even when current is over-cap',
+    () => handle.write({ searchProvider: 'tavily', agentName: 'B'.repeat(100) }),
+    'exceeds max');
+
+// Sibling: changing searchProvider to an unknown one still throws.
+expectThrow('write rejects unknown new searchProvider even when other field unchanged',
+    () => handle.write({ searchProvider: 'duckduckgo', agentName: 'A'.repeat(100) }),
+    'invalid searchProvider');
+
 // Cleanup
 try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
 

--- a/tests/nodejs-project/agent-preferences.test.js
+++ b/tests/nodejs-project/agent-preferences.test.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// agent-preferences.test.js — pin BAT-515 agent-preferences.js
+// invariants per v3 §5 + final guard.
+//
+// What this guards:
+//   - DEFAULTS match Kotlin AgentPreferences companion values
+//   - read() returns DEFAULTS-merged for direct callers
+//   - readLiveOrNull() returns null on absent / parse-fail / wrong-type
+//     / unknown-provider / blank-name (precedence-chain caller path)
+//   - write() validates types + allowlist + non-blank for all incoming
+//     fields (Node-side write is the NEW-edit boundary; unchanged-skip
+//     lives in the Kotlin caller layer)
+//   - Partial-update merge: write({searchProvider}) preserves agentName
+//   - Sanitize-on-merge: corrupt persisted value heals on next legacy
+//     partial-write
+//
+// Run:  node tests/nodejs-project/agent-preferences.test.js
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bat515-agentprefs-'));
+const workDir = path.join(tmpRoot, 'workspace');
+fs.mkdirSync(workDir, { recursive: true });
+
+const agentPreferencesModule = require('../../app/src/main/assets/nodejs-project/agent-preferences');
+
+let failures = 0;
+function ok(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+function eq(label, actual, expected) {
+    const a = JSON.stringify(actual), e = JSON.stringify(expected);
+    if (a === e) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}\n  actual:   ${a}\n  expected: ${e}`); failures++; }
+}
+function expectThrow(label, fn, fragment) {
+    try { fn(); ok(`${label} (did NOT throw)`, false); }
+    catch (e) {
+        ok(label, (e.message || '').includes(fragment),
+            `wrong message: ${e.message}`);
+    }
+}
+
+console.log('── DEFAULTS lock-step with Kotlin ──');
+eq('DEFAULTS.searchProvider = brave', agentPreferencesModule.DEFAULTS.searchProvider, 'brave');
+eq('DEFAULTS.agentName = MyAgent', agentPreferencesModule.DEFAULTS.agentName, 'MyAgent');
+eq('AGENT_NAME_MAX = 64', agentPreferencesModule.AGENT_NAME_MAX, 64);
+ok('KNOWN_SEARCH_PROVIDERS contains brave',
+    agentPreferencesModule.KNOWN_SEARCH_PROVIDERS.has('brave'));
+ok('KNOWN_SEARCH_PROVIDERS contains all 5 expected',
+    ['brave', 'perplexity', 'exa', 'tavily', 'firecrawl']
+        .every((p) => agentPreferencesModule.KNOWN_SEARCH_PROVIDERS.has(p)));
+
+console.log();
+console.log('── read() returns DEFAULTS when file absent ──');
+const handle = agentPreferencesModule.open(workDir);
+eq('read() on fresh dir', handle.read(), {
+    searchProvider: 'brave',
+    agentName: 'MyAgent',
+});
+
+console.log();
+console.log('── readLiveOrNull() returns null on absent file ──');
+ok('readLiveOrNull on absent file', handle.readLiveOrNull() === null);
+
+console.log();
+console.log('── write() validates types + allowlist + non-blank ──');
+expectThrow('write rejects unknown searchProvider',
+    () => handle.write({ searchProvider: 'duckduckgo', agentName: 'X' }),
+    'invalid searchProvider');
+expectThrow('write rejects non-string searchProvider',
+    () => handle.write({ searchProvider: 12345, agentName: 'X' }),
+    'searchProvider must be string');
+expectThrow('write rejects blank agentName',
+    () => handle.write({ searchProvider: 'brave', agentName: '' }),
+    'must not be blank');
+expectThrow('write rejects whitespace-only agentName',
+    () => handle.write({ searchProvider: 'brave', agentName: '   ' }),
+    'must not be blank');
+expectThrow('write rejects 65-char agentName',
+    () => handle.write({ searchProvider: 'brave', agentName: 'A'.repeat(65) }),
+    'exceeds max');
+expectThrow('write rejects non-string agentName',
+    () => handle.write({ searchProvider: 'brave', agentName: 42 }),
+    'agentName must be string');
+expectThrow('write rejects non-object value',
+    () => handle.write('not an object'),
+    'plain object');
+
+console.log();
+console.log('── write() valid value persists + roundtrips ──');
+ok('write({brave, Cortana}) persists',
+    handle.write({ searchProvider: 'brave', agentName: 'Cortana' }) === true);
+eq('read() returns persisted', handle.read(), {
+    searchProvider: 'brave',
+    agentName: 'Cortana',
+});
+eq('readLiveOrNull() returns same shape',
+    handle.readLiveOrNull(),
+    { searchProvider: 'brave', agentName: 'Cortana' });
+
+console.log();
+console.log('── readLiveOrNull() rejects various corrupt shapes ──');
+function writeFile(json) {
+    fs.writeFileSync(handle.filePath, json, 'utf8');
+}
+writeFile('{not valid json}');
+ok('parse-fail file → null', handle.readLiveOrNull() === null);
+writeFile('null');
+ok('JSON null → null', handle.readLiveOrNull() === null);
+writeFile('"a string"');
+ok('JSON string → null', handle.readLiveOrNull() === null);
+writeFile('[1,2,3]');
+ok('JSON array → null', handle.readLiveOrNull() === null);
+writeFile('{}');
+ok('empty object (missing fields) → null', handle.readLiveOrNull() === null);
+writeFile(JSON.stringify({ searchProvider: 'brave', agentName: 12345 }));
+ok('agentName non-string → null', handle.readLiveOrNull() === null);
+writeFile(JSON.stringify({ searchProvider: 'duckduckgo', agentName: 'X' }));
+ok('searchProvider not in allowlist → null', handle.readLiveOrNull() === null);
+writeFile(JSON.stringify({ searchProvider: 'brave', agentName: '' }));
+ok('blank agentName → null', handle.readLiveOrNull() === null);
+
+console.log();
+console.log('── readLiveOrNull() accepts over-cap agentName from migration paths ──');
+// BAT-515 v3 §1: migration paths legitimately carry over-cap names.
+// readLiveOrNull MUST accept them (the cap only applies to NEW writes).
+writeFile(JSON.stringify({ searchProvider: 'brave', agentName: 'A'.repeat(100) }));
+const overCap = handle.readLiveOrNull();
+ok('over-cap agentName → not null', overCap !== null);
+eq('over-cap agentName preserved verbatim', overCap?.agentName?.length, 100);
+
+console.log();
+console.log('── Partial-update merge ──');
+// Reset to a known state
+handle.write({ searchProvider: 'exa', agentName: 'Athena' });
+ok('legacy 1-field write preserves the other field',
+    handle.write({ searchProvider: 'brave' }) === true);
+eq('after partial searchProvider write — agentName preserved',
+    handle.read(),
+    { searchProvider: 'brave', agentName: 'Athena' });
+ok('legacy 1-field agentName write preserves searchProvider',
+    handle.write({ agentName: 'Donna' }) === true);
+eq('after partial agentName write — searchProvider preserved',
+    handle.read(),
+    { searchProvider: 'brave', agentName: 'Donna' });
+
+console.log();
+console.log('── Sanitize-on-merge for corrupt persisted values ──');
+// Manually write a corrupt file (non-string searchProvider) then do a
+// legacy partial write. The merge should heal the corrupt field.
+writeFile(JSON.stringify({ searchProvider: 12345, agentName: 'Donna' }));
+ok('legacy partial write heals corrupt searchProvider',
+    handle.write({ agentName: 'Athena' }) === true);
+eq('after heal — searchProvider back to default, agentName updated',
+    handle.read(),
+    { searchProvider: 'brave', agentName: 'Athena' });
+
+console.log();
+console.log('── update(transform) reads, modifies, writes ──');
+handle.write({ searchProvider: 'brave', agentName: 'Cortana' });
+ok('update() applies transform',
+    handle.update((current) => ({ ...current, agentName: 'NewName' })) === true);
+eq('update result', handle.read(),
+    { searchProvider: 'brave', agentName: 'NewName' });
+
+// Cleanup
+try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
+
+console.log();
+if (failures === 0) {
+    console.log('ALL TESTS PASS');
+    process.exit(0);
+} else {
+    console.log(`${failures} TEST(S) FAILED`);
+    process.exit(1);
+}

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -80,6 +80,11 @@ const LOAD_TARGETS = [
     // no top-level IO. Loaded here so the smoke harness catches a syntax
     // or top-level throw on every commit.
     'custom-config-signature.js',
+    // BAT-515: agent-preferences.js is a thin wrapper around
+    // cross-process-store + read()/readLiveOrNull()/write()/update().
+    // No top-level IO; read calls happen only when `open(workDir)` is
+    // invoked by config.js with a real workDir.
+    'agent-preferences.js',
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which


### PR DESCRIPTION
## Summary

- Both `searchProvider` and `agentName` move out of process-local SharedPreferences into a shared `agent_preferences.json` file (BAT-513/514 pattern). Settings UI edits are now LIVE across processes — provider switch + agent-name edit take effect on the next AI turn / `web_search` / `/status` without a service restart.
- `saveConfig` now atomically dual-writes prefs + RuntimeStateStore + AgentPreferencesStore. Pre-validation runs before persistence; if the second cross-process write fails, the rollback path restores prefs (5 keys + `setup_complete`) AND undoes the RuntimeStateStore forward update via a captured pre-forward snapshot.
- Migration of an existing over-cap `agentName` is preserved verbatim with a single WARN — the 64-char cap applies only to NEW writes (BAT-515 v3 §1 + Codex final-guard via context-sensitive `validateForWrite`).

## Implementation contract (v3 §1-5, Codex signed)

**Phase 1 — Kotlin foundation**
- `AgentPreferences.kt`: `@Serializable` data class. Defaults match historical ConfigManager values. `AGENT_NAME_MAX = 64`. `KNOWN_SEARCH_PROVIDERS` allowlist.
- `AgentPreferencesStore.kt`: singleton mirroring `RuntimeStateStore`. `seedFromPrefs` preserves over-cap names verbatim with WARN (v3 §1, never truncates). `validateForWrite(next, current)` is context-sensitive — only fields that ACTUALLY change vs current persisted state hit the cap/allowlist (Codex final guard). Observe-and-mirror collector calls `signalConfigChanged` only when the mirror actually applied (v3 §3).
- `SeekerClawApplication.onCreate` wires `AgentPreferencesStore.init` in main-process block.

**Phase 2 — Node foundation**
- `agent-preferences.js`: `open(workDir)` returns `{ read, readLiveOrNull, write, update, filePath }`. `read()` defaults-merged. `readLiveOrNull()` distinguishes absent / corrupt / wrong-type / unknown-provider / blank-name from valid (returns null in all bad cases). `write()` validates allowlist + non-blank for incoming fields. Partial-update merge + sanitize-on-merge mirror runtime-state.js R2/R5 fixes.

**Phase 3 — ConfigManager `saveConfig` atomic dual-write**
- Snapshot `oldAgentName` + `oldSearchProvider` alongside BAT-513 snapshots.
- Pre-validate via `AgentPreferencesStore.validateForWrite` BEFORE any persistence.
- Forward writes execute in order: `prefs.commit()` → `RuntimeStateStore.update {}` → `AgentPreferencesStore.update {}`. Forward RuntimeState update captures `preForwardRuntime` (the value seen inside writeLock) so rollback can undo it.
- Rollback path on AgentPreferencesStore failure restores prefs (5 keys + `KEY_SETUP_COMPLETE`) AND undoes the RuntimeStateStore forward update.
- `loadConfig` overlays `AgentPreferencesStore.read()` so callers see live values without depending on the prefs-mirror collector having fired.
- BAT-549 customEcho reset log gates on `runtimeWritten && agentPrefsWritten` (was just `runtimeWritten`).

**Phase 4 — Settings UI live-update**
- `SettingsScreen.liveUpdateFields` adds `agentName` + `searchProvider` (suppresses the "restart required" dialog).
- `SearchProviderConfigScreen` provider switch uses BAT-549 R14/R17/R24 pattern (`collectAsState` + optimistic + Dispatchers.IO + clear-on-failure).
- API key edits keep `needsRestart = true` (live-pickup of keys is out of scope).

**Phase 5 — Node consumers per-call**
- `config.js`: drop `AGENT_NAME` startup-frozen const; add `getAgentName()` / `getSearchProvider()` walking the precedence chain `agent_preferences.json` (live) → `config.json` (cold-start) → defaults.
- `main.js`: pass `getAgentName` (function ref) through `initMessageHandler` deps so `/status` reads the latest live name per-invocation.
- `message-handler.js` `/status`, `tools/session.js` `session_status`, `tools/web.js` `web_search`: all switched to per-call getters. Bonus fix: `tools/session.js` `webSearchProvider` no longer reports the long-stale `'duckduckgo'` fallback (BAT-481 dropped DDG).

## Test plan

- [x] `node tests/nodejs-project/agent-preferences.test.js` — all assertions passed (DEFAULTS lock-step with Kotlin, validity gate, redundancy guard, over-cap migration, partial-update merge, sanitize-on-merge, update-transform)
- [x] `node tests/nodejs-project/smoke.js` — 51/51 syntax + 11/11 modules load cleanly (added `agent-preferences.js` to `LOAD_TARGETS`)
- [x] `./gradlew :app:testDappStoreDebugUnitTest --tests AgentPreferencesStoreTest` — passed (~20 tests covering Codex final-guard "unchanged-skips-cap", migration verbatim, mirror-only-on-actual-change)
- [x] `./gradlew :app:testDappStoreDebugUnitTest --tests RuntimeStateStoreTest --tests McpServersStoreTest` — adjacent BAT-513/514 contracts still pass
- [x] `./gradlew :app:compileDappStoreDebugKotlin` — passed
- [x] `scripts/pre-push-check.sh` — passed
- [ ] **Device install + Settings UI flow** — pending, runs after Copilot review signs off. Expected: provider switch is instant (no restart prompt); agent-name edit takes effect on next `/status` without restart; existing-user upgrade preserves their name verbatim (incl. an over-cap name if any).

## Known limitations

- 5 pre-existing `CrossProcessStoreTest` "drift" guard tests fail on `origin/main` too (brittle source-pattern regexes around the `write()` body). Not introduced by this PR; out of scope.
- The 64-char cap on `agentName` applies only to NEW writes via Settings UI / fresh setup. Migration of an existing over-cap name is preserved verbatim with WARN — by design (v3 §1).
- `tools/web.js` per-provider API keys are still process-local prefs reads (not in `agent_preferences.json`). API key edits in Settings still require a service restart. Migration of API keys to a cross-process store is out of scope for BAT-515.

## Self-Awareness Checklist

- [x] **N/A** — buildSystemBlocks NOT touched (agent identity comes from IDENTITY.md, not AGENT_NAME). `tools/web.js` description updated to reference live `agent_preferences.json` so the agent self-reports the right behavior. `tools/session.js` `webSearchProvider` now reflects the live provider. No new error log sites introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)