### PR TITLE
feat: cross-provider reasoning hotfix (BAT-558, BAT-559)

### DIFF
--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2347,10 +2347,23 @@ async function chat(chatId, userMessage, options = {}) {
             } else {
                 _authForRegistry = AUTH_TYPE;
             }
+            // BAT-558 v4 R2 — synthetic-turn marker at the chat() boundary.
+            // Heartbeat (and future synthetic turns: summaries, etc.) pass
+            // `reasoningMode: 'off'` so app-controlled optional reasoning is
+            // suppressed across all providers. The defensive `__heartbeat__`
+            // override here is belt-and-suspenders for any code path that
+            // forgets to pass the option explicitly — the canonical contract
+            // is the explicit option at the call site (main.js heartbeat).
+            // R3 transport-required exceptions (OpenAI OAuth/Codex) are
+            // preserved at the adapter layer, not overridden here.
+            const isHeartbeatChat = chatId === '__heartbeat__';
+            const callerReasoningMode = (options && options.reasoningMode === 'off') ? 'off' : 'normal';
+            const effectiveReasoningMode = isHeartbeatChat ? 'off' : callerReasoningMode;
             const requestOptions = {
                 reasoningEnabled: !!(_liveRtState && _liveRtState.reasoningEnabled),
                 reasoningSupport: reasoningSupportFor(_registryProviderId, activeModel, _authForRegistry),
                 customEchoOverride: !!(_liveRtState && _liveRtState.customEchoReasoning),
+                reasoningMode: effectiveReasoningMode,
             };
 
             // Convert neutral messages to provider API format for the request.
@@ -2375,10 +2388,19 @@ async function chat(chatId, userMessage, options = {}) {
             // helper (telegram.js) which has a 500ms debounce (so
             // fast non-thinking turns never flash) and NO min-visible
             // hold (so cleanup never delays the final answer).
+            //
+            // BAT-558 v4 R2/R4: synthetic turns (heartbeat, future
+            // summaries) ALSO suppress the bubble — heartbeats are
+            // invisible liveness probes, a flickering "Thinking..."
+            // every 30 min would be a confusing UX surprise. The
+            // adapter layer already suppresses the wire-side reasoning
+            // request when reasoningMode='off' (R3 matrix); this gate
+            // just stops the local UI artifact too.
             const showThinkingStatus = !!(
                 requestOptions
                 && requestOptions.reasoningEnabled === true
                 && requestOptions.reasoningSupport === 'yes'
+                && requestOptions.reasoningMode !== 'off'
                 && _liveRtState
                 && _liveRtState.reasoningDisplayInChat === true
             );

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1534,13 +1534,16 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
                     // BAT-253: Add ±25% jitter to prevent thundering herd; respect server retry-after exactly
                     const jitteredBackoff = Math.round(backoffMs * (0.75 + Math.random() * 0.5));
                     const waitMs = retryAfterMs > 0 ? retryAfterMs : jitteredBackoff;
-                    // BAT-559: log the active provider's display name (Claude /
-                    // OpenAI / OpenRouter / Custom) instead of the pre-multi-
-                    // provider hardcoded "Claude API". Misleading observability
-                    // noticed during BAT-515 device test — an OpenAI 429 from a
-                    // rate-limited account was logged as "Claude API 429",
-                    // making "why is Claude rate limiting me" support tickets
-                    // ambiguous about which provider actually returned the error.
+                    // BAT-559: log the active provider's registry display name
+                    // (Anthropic / OpenAI / OpenRouter / Custom — the registry
+                    // maps `claude → Anthropic` since "Anthropic" is the
+                    // company; "Claude" is the model family) instead of the
+                    // pre-multi-provider hardcoded "Claude API". Misleading
+                    // observability noticed during BAT-515 device test — an
+                    // OpenAI 429 from a rate-limited account was logged as
+                    // "Claude API 429", making "why is Claude rate limiting me"
+                    // support tickets ambiguous about which provider actually
+                    // returned the error.
                     log(`[Retry] ${displayNameForProvider(PROVIDER)} API ${res.status} (${errClass.type}), retry ${retries + 1}/${MAX_RETRIES}, base ${backoffMs}ms, waiting ${waitMs}ms`, 'WARN');
                     if (!background) updateAgentHealth('degraded', { type: errClass.type, status: res.status, message: errClass.userMessage });
                     retries++;

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2391,24 +2391,50 @@ async function chat(chatId, userMessage, options = {}) {
                 synthetic: effectiveSynthetic,
             };
 
-            // R1.3 Copilot: emit the SYNTHETIC_HEARTBEAT suppression log
-            // once per process so the v4 contract claim ("one INFO line
-            // per process per reason") actually surfaces in the Logs
-            // screen. Without this call site the SUPPRESSION_REASONS
-            // entry was exported but never written; field reports of
-            // "why did my heartbeat not reason" would have no
-            // discoverable signal. Dedup is per-process, so 30-min
-            // heartbeats don't flood the screen — the second probe
-            // onwards goes to DEBUG (filtered out of default view).
+            // R1.3 + R2.2 Copilot: emit the SYNTHETIC_HEARTBEAT
+            // suppression log once per process — but ONLY when the
+            // suppression actually has effect. The log says
+            // "[Reasoning] suppressed: synthetic-heartbeat", so it
+            // would mislead the reader if it fired in cases where
+            // the adapter still emits reasoning regardless:
             //
-            // The reason key only fires for heartbeat synthetic turns
-            // today; if a future synthetic class (e.g., 'summary')
-            // wants its own discoverable entry, add a SUPPRESSION_REASONS
-            // value and a branch here.
-            if (effectiveReasoningMode === 'off' && effectiveSynthetic === 'heartbeat') {
+            //   - User reasoning toggle is off OR registry support is
+            //     'no' / 'unknown' → no app-controlled emission was
+            //     ever queued, so 'off' is a no-op. Logging
+            //     "suppressed" implies an action that didn't happen.
+            //   - OpenAI OAuth/Codex transport-required path — the
+            //     Codex endpoint MUST receive `body.reasoning` or it
+            //     returns `output: []`. v4 R3 explicitly preserves
+            //     this exception. The synthetic 'off' marker is a
+            //     no-op here for the wire shape, so the log would
+            //     mislead.
+            //   - OpenAI api_key + codex model — same model-id-driven
+            //     hardcode, transport-required.
+            //
+            // Logging fires when ALL of these are true:
+            //   1. effectiveReasoningMode === 'off'
+            //   2. effectiveSynthetic === 'heartbeat'
+            //   3. user toggle would have triggered emission
+            //      (reasoningEnabled && reasoningSupport === 'yes')
+            //   4. no transport-required exception applies
+            //
+            // Detail string includes provider/auth/channel so a field
+            // report has the full context to triage from one log line.
+            const _userToggleWouldEmit = requestOptions.reasoningEnabled
+                && requestOptions.reasoningSupport === 'yes';
+            const _modelIsCodex = typeof activeModel === 'string'
+                && activeModel.includes('codex');
+            const _transportRequiresReasoning = (PROVIDER === 'openai'
+                && (OPENAI_AUTH_TYPE === 'oauth' || _modelIsCodex));
+            if (effectiveReasoningMode === 'off'
+                && effectiveSynthetic === 'heartbeat'
+                && _userToggleWouldEmit
+                && !_transportRequiresReasoning) {
                 _logSuppression(
                     _SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT,
-                    `chatId=${String(chatId).slice(0, 32)}`,
+                    `chatId=${String(chatId).slice(0, 32)} provider=${PROVIDER} `
+                    + `auth=${PROVIDER === 'openai' ? OPENAI_AUTH_TYPE : AUTH_TYPE} `
+                    + `model=${String(activeModel).slice(0, 48)}`,
                 );
             }
 

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -19,7 +19,7 @@ const {
     config: _config,
     runtimeState: _runtimeState,
 } = require('./config');
-const { reasoningSupportFor } = require('./model-catalog');
+const { reasoningSupportFor, displayNameForProvider } = require('./model-catalog');
 
 const { redactSecrets } = require('./security');
 // Channel abstraction — routes to telegram.js or discord.js based on config
@@ -1495,7 +1495,7 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
                         // these writes relied on database.js's now-removed 60s
                         // setInterval safety net.
                         markDbDirty();
-                    } catch (e) { log(`[Claude] Failed to log network error to DB: ${e.message}`, 'WARN'); }
+                    } catch (e) { log(`[${displayNameForProvider(PROVIDER)}] Failed to log network error to DB: ${e.message}`, 'WARN'); }
                 }
                 if (!background) updateAgentHealth('error', { type: isTimeoutClass ? 'timeout' : 'network', status: -1, message: networkErr.message });
                 throw networkErr;
@@ -1533,7 +1533,14 @@ async function claudeApiCall(body, chatId, traceCtx = {}) {
                     // BAT-253: Add ±25% jitter to prevent thundering herd; respect server retry-after exactly
                     const jitteredBackoff = Math.round(backoffMs * (0.75 + Math.random() * 0.5));
                     const waitMs = retryAfterMs > 0 ? retryAfterMs : jitteredBackoff;
-                    log(`[Retry] Claude API ${res.status} (${errClass.type}), retry ${retries + 1}/${MAX_RETRIES}, base ${backoffMs}ms, waiting ${waitMs}ms`, 'WARN');
+                    // BAT-559: log the active provider's display name (Claude /
+                    // OpenAI / OpenRouter / Custom) instead of the pre-multi-
+                    // provider hardcoded "Claude API". Misleading observability
+                    // noticed during BAT-515 device test — an OpenAI 429 from a
+                    // rate-limited account was logged as "Claude API 429",
+                    // making "why is Claude rate limiting me" support tickets
+                    // ambiguous about which provider actually returned the error.
+                    log(`[Retry] ${displayNameForProvider(PROVIDER)} API ${res.status} (${errClass.type}), retry ${retries + 1}/${MAX_RETRIES}, base ${backoffMs}ms, waiting ${waitMs}ms`, 'WARN');
                     if (!background) updateAgentHealth('degraded', { type: errClass.type, status: res.status, message: errClass.userMessage });
                     retries++;
                     await new Promise(r => setTimeout(r, waitMs));

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2424,16 +2424,34 @@ async function chat(chatId, userMessage, options = {}) {
                 && requestOptions.reasoningSupport === 'yes';
             const _modelIsCodex = typeof activeModel === 'string'
                 && activeModel.includes('codex');
-            const _transportRequiresReasoning = (PROVIDER === 'openai'
-                && (OPENAI_AUTH_TYPE === 'oauth' || _modelIsCodex));
+            // R3 Copilot: Custom with CUSTOM_FORMAT='responses' DELEGATES
+            // to openai.formatRequest, which carries OpenAI's transport-
+            // required exceptions (OAuth + codex models). Pre-fix the
+            // gate only checked `PROVIDER === 'openai'`, so a
+            // Custom-Responses gateway pointing at a `*-codex` model
+            // would still trigger the suppression log even though the
+            // delegate emits `body.reasoning` regardless. Treating
+            // Custom-Responses as the OpenAI Responses transport here
+            // mirrors what the delegate actually does, so the log
+            // reflects effective behavior.
+            const _usesOpenAIResponsesTransport = (PROVIDER === 'openai')
+                || (PROVIDER === 'custom' && CUSTOM_FORMAT === 'responses');
+            const _effectiveTransportProvider = _usesOpenAIResponsesTransport
+                ? 'openai'
+                : PROVIDER;
+            const _effectiveTransportAuth = _usesOpenAIResponsesTransport
+                ? OPENAI_AUTH_TYPE
+                : AUTH_TYPE;
+            const _transportRequiresReasoning = _usesOpenAIResponsesTransport
+                && (_effectiveTransportAuth === 'oauth' || _modelIsCodex);
             if (effectiveReasoningMode === 'off'
                 && effectiveSynthetic === 'heartbeat'
                 && _userToggleWouldEmit
                 && !_transportRequiresReasoning) {
                 _logSuppression(
                     _SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT,
-                    `chatId=${String(chatId).slice(0, 32)} provider=${PROVIDER} `
-                    + `auth=${PROVIDER === 'openai' ? OPENAI_AUTH_TYPE : AUTH_TYPE} `
+                    `chatId=${String(chatId).slice(0, 32)} provider=${_effectiveTransportProvider} `
+                    + `auth=${_effectiveTransportAuth} `
                     + `model=${String(activeModel).slice(0, 48)}`,
                 );
             }

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -20,6 +20,7 @@ const {
     runtimeState: _runtimeState,
 } = require('./config');
 const { reasoningSupportFor, displayNameForProvider } = require('./model-catalog');
+const { logSuppression: _logSuppression, SUPPRESSION_REASONS: _SUPPRESSION_REASONS } = require('./reasoning-gating');
 
 const { redactSecrets } = require('./security');
 // Channel abstraction — routes to telegram.js or discord.js based on config
@@ -2363,15 +2364,53 @@ async function chat(chatId, userMessage, options = {}) {
             // is the explicit option at the call site (main.js heartbeat).
             // R3 transport-required exceptions (OpenAI OAuth/Codex) are
             // preserved at the adapter layer, not overridden here.
+            //
+            // R1.1 Copilot: `synthetic` is the metadata marker the v4
+            // contract calls out for telemetry / future channel-renderer
+            // hooks. Threading it through `requestOptions` makes the
+            // option actually read — without this it would be a contract
+            // surface promised by main.js's call site but unused below
+            // ai.js. The current consumer is the SYNTHETIC_HEARTBEAT
+            // suppression log (see R1.3 / R4 dedup helper); future
+            // surfaces (e.g., a "background" tag in the api_request_log
+            // database) can read the same marker.
             const isHeartbeatChat = chatId === '__heartbeat__';
             const callerReasoningMode = (options && options.reasoningMode === 'off') ? 'off' : 'normal';
             const effectiveReasoningMode = isHeartbeatChat ? 'off' : callerReasoningMode;
+            const callerSynthetic = (options && typeof options.synthetic === 'string')
+                ? options.synthetic : null;
+            // Defensive: any `__heartbeat__` chat counts as synthetic
+            // 'heartbeat' for log/telemetry purposes, even if the caller
+            // forgot to pass the marker explicitly.
+            const effectiveSynthetic = isHeartbeatChat ? 'heartbeat' : callerSynthetic;
             const requestOptions = {
                 reasoningEnabled: !!(_liveRtState && _liveRtState.reasoningEnabled),
                 reasoningSupport: reasoningSupportFor(_registryProviderId, activeModel, _authForRegistry),
                 customEchoOverride: !!(_liveRtState && _liveRtState.customEchoReasoning),
                 reasoningMode: effectiveReasoningMode,
+                synthetic: effectiveSynthetic,
             };
+
+            // R1.3 Copilot: emit the SYNTHETIC_HEARTBEAT suppression log
+            // once per process so the v4 contract claim ("one INFO line
+            // per process per reason") actually surfaces in the Logs
+            // screen. Without this call site the SUPPRESSION_REASONS
+            // entry was exported but never written; field reports of
+            // "why did my heartbeat not reason" would have no
+            // discoverable signal. Dedup is per-process, so 30-min
+            // heartbeats don't flood the screen — the second probe
+            // onwards goes to DEBUG (filtered out of default view).
+            //
+            // The reason key only fires for heartbeat synthetic turns
+            // today; if a future synthetic class (e.g., 'summary')
+            // wants its own discoverable entry, add a SUPPRESSION_REASONS
+            // value and a branch here.
+            if (effectiveReasoningMode === 'off' && effectiveSynthetic === 'heartbeat') {
+                _logSuppression(
+                    _SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT,
+                    `chatId=${String(chatId).slice(0, 32)}`,
+                );
+            }
 
             // Convert neutral messages to provider API format for the request.
             // BAT-549 R2 thread 3: pass `activeModel` as 2nd arg so the

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -1085,7 +1085,20 @@ async function runHeartbeat() {
             // (reads HEARTBEAT.md for state, not conversation history)
             clearConversation(HEARTBEAT_CHAT_ID);
 
-            const response = await chat(HEARTBEAT_CHAT_ID, HEARTBEAT_PROMPT);
+            // BAT-558 v4 R5 — heartbeat is a synthetic liveness probe, not a
+            // user reasoning turn. Pass `reasoningMode: 'off'` so app-controlled
+            // optional reasoning is suppressed across all providers (Claude
+            // omits `thinking`; OpenAI api_key omits `body.reasoning`+`include`;
+            // OpenRouter emits `reasoning.effort:'none'`; Custom Responses
+            // follows OpenAI). Pass `synthetic: 'heartbeat'` so the channel
+            // renderer suppresses the "Thinking..." bubble (heartbeats are
+            // invisible to the user; a flickering bubble would be confusing).
+            // ai.js ALSO defensively forces these for `chatId === '__heartbeat__'`
+            // (belt-and-suspenders), but the explicit pass here is the contract.
+            const response = await chat(HEARTBEAT_CHAT_ID, HEARTBEAT_PROMPT, {
+                reasoningMode: 'off',
+                synthetic: 'heartbeat',
+            });
             // Strip protocol tokens the agent may have mixed into content (OpenClaw parity 2026.3.1)
             if (containsSilentReply(response)) log('[Audit] Heartbeat sent SILENT_REPLY', 'DEBUG');
             const hadToken = /\bHEARTBEAT_OK\b/i.test(response);

--- a/app/src/main/assets/nodejs-project/providers/claude.js
+++ b/app/src/main/assets/nodejs-project/providers/claude.js
@@ -3,6 +3,35 @@
 // message format and Claude Messages API format.
 
 const { log } = require('../config');
+const { logSuppression, SUPPRESSION_REASONS } = require('../reasoning-gating');
+
+// BAT-558 R1 — Claude extended-thinking clamp constants.
+//
+// Anthropic Messages API requires `thinking.budget_tokens < max_tokens`,
+// AND the thinking budget itself has a 1024-token floor. A naive
+// `min(DEFAULT, max_tokens - 1)` formula satisfies the validator but
+// can leave only single-digit tokens for the actual response on small
+// turns — useless. The `* 0.5` rule below splits the budget so every
+// emitted thinking turn has at least `ANTHROPIC_MIN_BUDGET` tokens for
+// thinking AND at least `MIN_THINKING_TURN - ANTHROPIC_MIN_BUDGET`
+// tokens left over for the final answer.
+//
+// The `MIN_THINKING_TURN < 2048 → omit thinking` short-circuit is the
+// load-bearing piece. Without it, a `max_tokens=1100` turn would emit
+// `budget_tokens=1024` and have 76 tokens for the answer — technically
+// valid Anthropic API, useless to the user. Skipping thinking entirely
+// for these small turns is the contract Codex signed off on (v3
+// amendment 1, ratified into v4).
+//
+// Practical sizing examples (max_tokens × 0.5, clamped to [1024, 16000]):
+//   1024 → omit (below MIN_THINKING_TURN floor)
+//   1536 → omit (below MIN_THINKING_TURN floor; v3 gap-case)
+//   2048 → 1024 budget, 1024 answer room
+//   4096 → 2048 budget, 2048 answer room (the heartbeat case)
+//   32000 → 16000 budget (DEFAULT_THINKING_BUDGET cap kicks in)
+const ANTHROPIC_MIN_BUDGET = 1024;
+const DEFAULT_THINKING_BUDGET = 16000;
+const MIN_THINKING_TURN = 2048;
 
 // ── Neutral ↔ Claude message translation ────────────────────────────────────
 
@@ -221,14 +250,33 @@ function formatTools(tools) {
 /**
  * Build full Claude API request body.
  *
- * BAT-549 Commit 3c: the optional 6th `requestOptions` arg gates extended
- * thinking. Emit `body.thinking` only when BOTH the user toggle
- * (`reasoningEnabled === true`) AND the registry confirms the model
- * supports it (`reasoningSupport === "yes"`). The "yes" gate is critical:
- *   - Haiku 4.5 returns 400 if `thinking` is sent → registry says "no".
- *   - Unknown models default to "unknown" → don't send (avoid surprise 400).
- * Existing call sites (vision/summary) that don't pass requestOptions get
- * the same no-`thinking` behavior as before — additive change.
+ * BAT-549 Commit 3c gated `body.thinking` emission on the user toggle
+ * (`reasoningEnabled === true`) AND registry confirmation
+ * (`reasoningSupport === "yes"`). BAT-558 v4 R1 layered a request-level
+ * BUDGET CLAMP on top of that: the budget must be `< max_tokens` per
+ * Anthropic, and `>= 1024` per Anthropic's thinking-budget floor — so
+ * the budget is sized as `floor(maxTokens * 0.5)` clamped to
+ * `[ANTHROPIC_MIN_BUDGET, DEFAULT_THINKING_BUDGET]`, and turns with
+ * `maxTokens < MIN_THINKING_TURN` (2048) skip thinking entirely so the
+ * answer always has at least `ANTHROPIC_MIN_BUDGET` tokens of room.
+ *
+ * Pre-clamp, this code emitted `budget_tokens=16000` regardless of
+ * `max_tokens`. ai.js calls `formatRequest(..., 4096, ...)` for normal
+ * chat, which Anthropic rejects with HTTP 400 ("max_tokens must be
+ * greater than thinking.budget_tokens"). The heartbeat path hit it
+ * first because the watchdog made the 400s visible; real user chats
+ * with Extended thinking on were silently failing too.
+ *
+ * BAT-558 v4 R3 also adds `reasoningMode: 'off'` short-circuit — when
+ * the caller (heartbeat / future synthetic turns) marks the request
+ * as opted out of app-controlled reasoning, skip thinking even when
+ * the user toggle is on. R2 documents this contract at the chat()
+ * boundary; ai.js threads it through `requestOptions` per BAT-549's
+ * existing pattern.
+ *
+ * Existing call sites (vision/summary) that pass small `maxTokens`
+ * (256, 500) or no `requestOptions` continue to emit no `thinking` —
+ * additive change.
  */
 function formatRequest(model, maxTokens, systemBlocks, messages, tools, requestOptions) {
     const body = {
@@ -239,17 +287,39 @@ function formatRequest(model, maxTokens, systemBlocks, messages, tools, requestO
         messages,
     };
     if (tools && tools.length > 0) body.tools = tools;
-    if (requestOptions
+
+    // BAT-558 v4 R3 — synthetic / opt-out short-circuit. Heartbeats
+    // pass `reasoningMode: 'off'` explicitly; ai.js also defensively
+    // sets it for `chatId === '__heartbeat__'`. Either path skips the
+    // thinking block regardless of user-toggle / registry-support state
+    // (those gates apply to the OPTIONAL emission below this).
+    const reasoningOff = !!(requestOptions && requestOptions.reasoningMode === 'off');
+    const userWantsReasoning = !!(requestOptions
         && requestOptions.reasoningEnabled === true
-        && requestOptions.reasoningSupport === 'yes') {
-        // budget_tokens is the upper bound on thinking output. 16K is the
-        // BAT-549 v4.1 default — large enough for non-trivial multi-step
-        // reasoning, capped well under Claude 4.x's 32K thinking ceiling
-        // so a runaway thinking pass doesn't burn the entire 200K context
-        // window before the user-facing response. Future Settings UI may
-        // expose this; until then it's a sensible single value.
-        body.thinking = { type: 'enabled', budget_tokens: 16000 };
+        && requestOptions.reasoningSupport === 'yes');
+    if (reasoningOff || !userWantsReasoning) {
+        return JSON.stringify(body);
     }
+
+    // BAT-558 v4 R1 — small-turn skip. `max_tokens < 2048` doesn't have
+    // headroom for both the 1024-floor budget AND a usable answer, so
+    // thinking is skipped (rate-limited INFO log so the suppression is
+    // discoverable in field reports without flooding the Logs screen).
+    if (maxTokens < MIN_THINKING_TURN) {
+        logSuppression(
+            SUPPRESSION_REASONS.MAX_TOKENS_BELOW_FLOOR,
+            `claude maxTokens=${maxTokens}`,
+        );
+        return JSON.stringify(body);
+    }
+
+    // BAT-558 v4 R1 — clamp budget to [ANTHROPIC_MIN_BUDGET,
+    // DEFAULT_THINKING_BUDGET], scaled at half of `maxTokens` so the
+    // final answer always has the other half. See module-level constant
+    // block for the worked-examples table.
+    const cap = Math.min(DEFAULT_THINKING_BUDGET, Math.floor(maxTokens * 0.5));
+    const budget = Math.max(ANTHROPIC_MIN_BUDGET, cap);
+    body.thinking = { type: 'enabled', budget_tokens: budget };
     return JSON.stringify(body);
 }
 

--- a/app/src/main/assets/nodejs-project/providers/openai.js
+++ b/app/src/main/assets/nodejs-project/providers/openai.js
@@ -359,7 +359,17 @@ function formatRequest(model, maxTokens, instructions, input, tools, requestOpti
     // path: api_key calls to non-codex reasoning models (e.g., raw
     // gpt-5.4) when the user has explicitly toggled reasoning on AND
     // the registry confirms support.
-    const userToggleEnabled = !!(requestOptions
+    //
+    // BAT-558 v4 R3 — `reasoningMode: 'off'` (heartbeats / future
+    // synthetic turns) suppresses the OPTIONAL user-toggle path so
+    // app-controlled reasoning isn't requested for liveness probes.
+    // The TRANSPORT-required paths (OAuth/Codex endpoint OR a `*-codex`
+    // model id) MUST remain unconditional — the Codex endpoint returns
+    // `output: []` without `reasoning`, breaking Codex/OAuth users
+    // entirely. Pinned exception per BAT-485 (the original Codex OAuth
+    // contract); v4 R3 explicitly preserves it.
+    const reasoningOff = !!(requestOptions && requestOptions.reasoningMode === 'off');
+    const userToggleEnabled = !reasoningOff && !!(requestOptions
         && requestOptions.reasoningEnabled === true
         && requestOptions.reasoningSupport === 'yes');
     const wantReasoning = isOAuth

--- a/app/src/main/assets/nodejs-project/providers/openrouter.js
+++ b/app/src/main/assets/nodejs-project/providers/openrouter.js
@@ -5,6 +5,7 @@
 // Uses top-level cache_control for automatic prompt caching across providers.
 
 const { log, OPENROUTER_FALLBACK_MODEL } = require('../config');
+const { logSuppression, SUPPRESSION_REASONS } = require('../reasoning-gating');
 
 // ── Neutral ↔ Chat Completions message translation ─────────────────────────
 
@@ -350,7 +351,27 @@ function formatRequest(model, maxTokens, systemPrompt, messages, tools, requestO
     // "yes") can flip it on without further adapter changes. Until then
     // OpenRouter relies on the OR-side default behavior of any reasoning
     // models the user picks (most pass through provider defaults).
-    if (requestOptions
+    //
+    // BAT-558 v4 R3 — `reasoningMode: 'off'` (heartbeats / synthetic) emits
+    // `body.reasoning = { effort: 'none' }` as an EXPLICIT app-controlled
+    // disablement signal per OpenRouter's reasoning docs
+    // (https://openrouter.ai/docs/use-cases/reasoning-tokens). This is
+    // STRONGER than just omitting the field because some OR reasoning
+    // models reason by default — the `reasoning` key IS sent, carrying
+    // the disable signal. Beats the "off=omit" naive approach for OR.
+    //
+    // Take precedence over the user-toggle branch below: if both
+    // `reasoningMode==='off'` AND `reasoningEnabled===true` somehow
+    // coexist (shouldn't happen at the chat() boundary, defensive),
+    // the off signal wins because the caller marked the turn synthetic.
+    const reasoningOff = !!(requestOptions && requestOptions.reasoningMode === 'off');
+    if (reasoningOff) {
+        body.reasoning = { effort: 'none' };
+        logSuppression(
+            SUPPRESSION_REASONS.OPENROUTER_EFFORT_NONE,
+            `model=${model}`,
+        );
+    } else if (requestOptions
         && requestOptions.reasoningEnabled === true
         && requestOptions.reasoningSupport === 'yes') {
         body.reasoning = { effort: 'medium' };

--- a/app/src/main/assets/nodejs-project/reasoning-gating.js
+++ b/app/src/main/assets/nodejs-project/reasoning-gating.js
@@ -1,19 +1,38 @@
-// SeekerClaw — reasoning-gating.js (BAT-549)
+// SeekerClaw — reasoning-gating.js (BAT-549, extended for BAT-558)
 //
-// Conservative model-gating for the Custom adapter's reasoning-echo behavior.
+// Cross-cutting reasoning helpers. Two responsibilities:
 //
-// Codex v4.1 review finding 4 explicitly rejected blanket sniff-and-passthrough.
-// DeepSeek R1/reasoner returns 400 if `reasoning_content` is echoed; DeepSeek
-// V4-pro returns 400 if it ISN'T echoed after a tool call. Opposite contracts
-// on similar-looking field names — we MUST gate by model.
+// 1. (BAT-549) Conservative model-gating for the Custom adapter's
+//    reasoning-echo behavior. DeepSeek R1/reasoner returns 400 if
+//    `reasoning_content` is echoed; DeepSeek V4-pro returns 400 if it
+//    ISN'T echoed after a tool call. Opposite contracts on similar-
+//    looking field names — we MUST gate by model. Other "thinking"
+//    families (Qwen3, Mistral large-2407, Gemini deep-think, Llama 4
+//    thinking) start as `unknown` and capture-only until tested against
+//    their actual gateway contract.
 //
-// Other "thinking" model families (Qwen3-thinking, Mistral large-2407, Gemini
-// deep-think, Llama 4 thinking) start as `unknown` and capture-only until
-// tested against their actual gateway contract. User can flip the per-Custom-
-// config advanced override (`customEchoReasoning`) if their gateway requires
-// it.
+// 2. (BAT-558) Rate-limited logging for cross-provider reasoning
+//    suppression events. Heartbeat fires every 30 min by default, so
+//    naively logging a `synthetic-heartbeat` suppression on every probe
+//    would flood the Logs screen with ~48 INFO lines/day — actively
+//    HARMFUL signal-to-noise post-hotfix. The dedup `Set` here logs
+//    each `(process, reason)` pair once at INFO (so the reason stays
+//    discoverable in default views) and demotes subsequent occurrences
+//    to DEBUG (filtered out of the Logs screen by default). Reset on
+//    process restart by virtue of being module-level (intentional —
+//    restarts re-surface the configuration that triggered the
+//    suppression).
 
 'use strict';
+
+// `log` is intentionally lazy-loaded inside [logSuppression] (NOT at the
+// top of this file). reasoning-gating.js is included in the smoke
+// harness (`tests/nodejs-project/smoke.js` LOAD_TARGETS) which require()s
+// modules in a bare Node process without `config.json` on disk — a
+// top-level `require('./config')` would crash the smoke load. Lazy
+// loading keeps the module side-effect-free at top-level while still
+// resolving cleanly in production (where config.js loads at process
+// start, well before any chat() turn fires logSuppression).
 
 /**
  * Decide echo behavior for a Custom-adapter request.
@@ -133,7 +152,74 @@ function stripReasoningForCustomGating(messages, behavior) {
     });
 }
 
+// ─── Rate-limited suppression logger (BAT-558 R4) ─────────────────────────
+
+/**
+ * Reasons emitted by the per-provider adapters today. Centralized here as
+ * a closed enum so consumer call sites stay aligned and a typo doesn't
+ * defeat the dedup gate (a misspelt reason would surface as a "new"
+ * reason on every call → INFO every time, defeating the rate-limit).
+ *
+ * Add new reasons here when extending the matrix. Keep the list short
+ * and intentional — every entry shows up at INFO at least once per
+ * process, so adding a noisy reason will be visible in production logs.
+ */
+const SUPPRESSION_REASONS = Object.freeze({
+    // R1 clamp — Claude turn's maxTokens leaves no headroom for both
+    // a thinking budget AND a final answer (< MIN_THINKING_TURN = 2048).
+    MAX_TOKENS_BELOW_FLOOR: 'maxTokens-below-floor',
+    // R2/R3 — heartbeat AI turn carries reasoningMode='off'; no app-
+    // controlled optional reasoning emitted (heartbeats are liveness
+    // probes, not user reasoning turns).
+    SYNTHETIC_HEARTBEAT: 'synthetic-heartbeat',
+    // R3 OpenRouter — `body.reasoning = { effort: 'none' }` emitted as
+    // an explicit app-controlled disablement signal. Stronger than
+    // omitting the field because some OR reasoning models reason by
+    // default.
+    OPENROUTER_EFFORT_NONE: 'openrouter-effort-none',
+});
+
+const _seenSuppressionReasons = new Set();
+
+/**
+ * Log a reasoning-suppression event with per-(process, reason) dedup.
+ * First occurrence per reason fires at INFO (visible in the Logs
+ * screen's default view); subsequent occurrences with the same reason
+ * fire at DEBUG (filtered out unless the user toggles the DEBUG
+ * filter on).
+ *
+ * @param {string} reason — one of [SUPPRESSION_REASONS] values.
+ *                          A typo is silently allowed (treated as a
+ *                          new reason and INFO'd once); use the
+ *                          exported constants to avoid drift.
+ * @param {string} [detail] — short, redaction-safe context (e.g.
+ *                            `maxTokens=1536` or `chatId=__heartbeat__`).
+ *                            Concatenated into the log line; do NOT
+ *                            include secrets, raw user input, or PII.
+ */
+function logSuppression(reason, detail) {
+    const level = _seenSuppressionReasons.has(reason) ? 'DEBUG' : 'INFO';
+    _seenSuppressionReasons.add(reason);
+    const suffix = detail ? ` (${detail})` : '';
+    // Lazy require to keep this module side-effect-free at top-level
+    // (smoke harness compatibility — see file-header note).
+    const { log } = require('./config');
+    log(`[Reasoning] suppressed: ${reason}${suffix}`, level);
+}
+
+/**
+ * Test seam — clear the dedup set so unit tests can pin first/repeat
+ * behavior in isolation. Production code MUST NOT call this. Exported
+ * with a leading underscore to flag intent.
+ */
+function _resetSuppressionLogForTest() {
+    _seenSuppressionReasons.clear();
+}
+
 module.exports = {
     detectCustomEchoBehavior,
     stripReasoningForCustomGating,
+    SUPPRESSION_REASONS,
+    logSuppression,
+    _resetSuppressionLogForTest,
 };

--- a/tests/nodejs-project/reasoning-gating.test.js
+++ b/tests/nodejs-project/reasoning-gating.test.js
@@ -16,6 +16,17 @@
 
 'use strict';
 
+// BAT-558: reasoning-gating now imports `log` from config.js to power the
+// rate-limited suppression logger. Stub config.js with a no-op log so this
+// gating-specific test doesn't spin up the real config loader (which would
+// require a config.json fixture).
+const path = require('path');
+const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {} },
+};
+
 const {
     detectCustomEchoBehavior,
     stripReasoningForCustomGating,

--- a/tests/nodejs-project/reasoning-request-enablement.test.js
+++ b/tests/nodejs-project/reasoning-request-enablement.test.js
@@ -620,6 +620,21 @@ body = JSON.parse(customResp.formatRequest('gpt-5.4', 4096, 'sys', [], [], {
 ok('Custom Responses reasoningMode=off: body.reasoning NOT emitted (delegates to OpenAI optional-off)',
     body.reasoning === undefined);
 
+// R3 Copilot: Custom Responses + codex model + reasoningMode='off'
+// MUST PRESERVE body.reasoning — the codex model-id-driven hardcode
+// in the openai delegate is transport-required (Codex endpoint
+// returns `output: []` without `body.reasoning`). The same exception
+// applies to Custom Responses because the delegation IS the OpenAI
+// Responses transport. Pinning this prevents a future refactor from
+// silently breaking Codex through a Custom-Responses gateway.
+body = JSON.parse(customResp.formatRequest('gpt-5.3-codex', 4096, 'sys', [], [], {
+    reasoningEnabled: false, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('Custom Responses + codex model + reasoningMode=off: body.reasoning STILL emitted (codex transport hardcode)',
+    body.reasoning && body.reasoning.effort === 'medium',
+    `actual: ${JSON.stringify(body.reasoning)}`);
+
 // ── BAT-558 v4 R4 — log dedup ────────────────────────────────────────
 // First occurrence per (process, reason) at INFO; subsequent at DEBUG.
 // Pin the level-selection logic so a future refactor doesn't regress

--- a/tests/nodejs-project/reasoning-request-enablement.test.js
+++ b/tests/nodejs-project/reasoning-request-enablement.test.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 // reasoning-request-enablement.test.js — pin BAT-549 Commit 3c per-adapter
-// request-side reasoning enablement gating:
+// request-side reasoning enablement gating, EXTENDED for BAT-558 v4:
+// per-request budget clamp on Claude, synthetic-turn marker
+// (`reasoningMode: 'off'`) suppression matrix, OpenRouter explicit
+// `effort: 'none'` disablement signal.
 //
 //  Adapter contract: each adapter's formatRequest accepts an optional 6th
 //  `requestOptions` argument. When BOTH `reasoningEnabled === true` AND
@@ -8,15 +11,20 @@
 //  specific reasoning param. Any other combination MUST NOT emit (the
 //  registry's "yes" gate is authoritative; "no"/"unknown" never sends).
 //
-//  Per-adapter body shapes:
-//   - claude.js → body.thinking = {type:"enabled", budget_tokens:16000}
+//  Per-adapter body shapes (BAT-549 baseline + BAT-558 v4 R1/R3):
+//   - claude.js → body.thinking = {type:"enabled", budget_tokens: <clamped>}
+//                  where <clamped> = min(16000, floor(maxTokens*0.5))
+//                  AND maxTokens >= 2048 (smaller turns SKIP thinking entirely)
 //   - openai.js (api_key) → body.reasoning = {effort:"medium", summary:"auto"}
 //                          + body.include = ["reasoning.encrypted_content"]
-//   - openrouter.js → body.reasoning = {effort:"medium"}
+//   - openrouter.js → body.reasoning = {effort:"medium"} OR
+//                     {effort:"none"} on `reasoningMode:'off'` (BAT-558 R3)
 //   - custom.js → forwards to delegate (or no-op for chat-completions)
 //
 //  Preservation of existing hardcodes (don't regress):
-//   - openai OAuth/Codex path: body.reasoning ALWAYS set (transport req)
+//   - openai OAuth/Codex path: body.reasoning ALWAYS set, even on
+//     `reasoningMode:'off'` — transport-required exception per BAT-485.
+//     v4 R3 explicitly preserves this; we pin it as a regression guard.
 //   - claude headers: anthropic-beta now includes interleaved-thinking-2025-05-14
 //
 //  Backward compat: callers that don't pass requestOptions get the same
@@ -71,12 +79,13 @@ function eq(label, actual, expected) {
 
 console.log('── claude.js: thinking gate ──');
 
-// reasoningEnabled + support===yes → emit
+// reasoningEnabled + support===yes + maxTokens=4096 → emit, BAT-558 R1 clamp
+// kicks in: budget = floor(4096*0.5) = 2048 (NOT the pre-558 unconditional 16000)
 let body = JSON.parse(claude.formatRequest('claude-opus-4-7', 4096, [], [], [], {
     reasoningEnabled: true, reasoningSupport: 'yes',
 }));
-eq('Claude yes/yes: body.thinking emitted',
-    body.thinking, { type: 'enabled', budget_tokens: 16000 });
+eq('Claude yes/yes maxTokens=4096: body.thinking emitted with clamped budget (BAT-558 R1)',
+    body.thinking, { type: 'enabled', budget_tokens: 2048 });
 
 // reasoningEnabled but support===no (Haiku) → DO NOT emit
 body = JSON.parse(claude.formatRequest('claude-haiku-4-5', 4096, [], [], [], {
@@ -433,6 +442,238 @@ ok("Delegate routing target: 'gpt-5.4' under 'openai' api_key is 'yes'",
     `actual: ${rsf('openai', 'gpt-5.4', 'api_key')}`);
 ok("Delegate-id robustness: unknown model id under 'openai' stays 'unknown'",
     rsf('openai', 'some-unknown-deepseek-id', 'api_key') === 'unknown');
+
+// ── BAT-558 v4 R1 — Claude budget clamp + small-turn skip ─────────────
+// Pinned per the v4 §R6 acceptance matrix. ai.js calls
+// formatRequest(..., 4096, ...) for normal chat — this 4096 is the
+// real-world value that surfaced the unclamped 16000 budget bug. Each
+// case here is taken from the v4 worked-examples table.
+
+console.log();
+console.log('── BAT-558 v4 R1: Claude budget clamp ──');
+
+// maxTokens=2048 → budget = floor(1024) = 1024 (Anthropic floor), answer room 1024.
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 2048, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+}));
+eq('Claude maxTokens=2048: budget clamped to floor (1024)',
+    body.thinking, { type: 'enabled', budget_tokens: 1024 });
+
+// maxTokens=1536 → SKIP thinking entirely (v3 amendment 1 gap-case Codex called out).
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 1536, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+}));
+ok('Claude maxTokens=1536: thinking SKIPPED (BAT-558 R1 small-turn floor)',
+    body.thinking === undefined,
+    `actual: ${JSON.stringify(body.thinking)}`);
+
+// maxTokens=1024 → SKIP thinking entirely (below MIN_THINKING_TURN=2048).
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 1024, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+}));
+ok('Claude maxTokens=1024: thinking SKIPPED',
+    body.thinking === undefined);
+
+// maxTokens=32000 → DEFAULT_THINKING_BUDGET cap (16000); not floor(32000*0.5)=16000.
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 32000, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+}));
+eq('Claude maxTokens=32000: budget at DEFAULT cap (16000)',
+    body.thinking, { type: 'enabled', budget_tokens: 16000 });
+
+// maxTokens=64000 → DEFAULT_THINKING_BUDGET cap (16000); leaves 48000 for answer.
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 64000, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+}));
+eq('Claude maxTokens=64000: budget still at DEFAULT cap (16000)',
+    body.thinking, { type: 'enabled', budget_tokens: 16000 });
+
+// Final invariant guard: across the entire matrix above, when emitted,
+// budget_tokens is ALWAYS strictly less than max_tokens (Anthropic's
+// hard requirement). This is the bug class the original 400 surfaced.
+const claudeBudgetCases = [
+    { maxTokens: 2048,  expectEmit: true },
+    { maxTokens: 4096,  expectEmit: true },
+    { maxTokens: 32000, expectEmit: true },
+    { maxTokens: 64000, expectEmit: true },
+];
+for (const c of claudeBudgetCases) {
+    const cb = JSON.parse(claude.formatRequest('claude-opus-4-7', c.maxTokens, [], [], [], {
+        reasoningEnabled: true, reasoningSupport: 'yes',
+    }));
+    if (c.expectEmit) {
+        ok(`Claude maxTokens=${c.maxTokens}: budget < max_tokens (Anthropic invariant)`,
+            cb.thinking && cb.thinking.budget_tokens < c.maxTokens,
+            `budget=${cb.thinking?.budget_tokens}, max=${c.maxTokens}`);
+        ok(`Claude maxTokens=${c.maxTokens}: budget >= ANTHROPIC_MIN_BUDGET (1024)`,
+            cb.thinking && cb.thinking.budget_tokens >= 1024,
+            `budget=${cb.thinking?.budget_tokens}`);
+    }
+}
+
+// ── BAT-558 v4 R3 — synthetic-turn marker `reasoningMode: 'off'` ──────
+// Per-provider behavior matrix from v4 R3. Heartbeat call site sends this;
+// ai.js also defensively forces it for chatId === '__heartbeat__'.
+
+console.log();
+console.log('── BAT-558 v4 R3: reasoningMode=off matrix ──');
+
+// Claude — OFF skips thinking even when toggle+support would emit.
+body = JSON.parse(claude.formatRequest('claude-opus-4-7', 4096, [], [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('Claude reasoningMode=off: thinking NOT emitted (synthetic suppression)',
+    body.thinking === undefined);
+
+// OpenAI api_key non-Codex — OFF suppresses body.reasoning + body.include.
+// Reload openai with api_key for this branch.
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openai')];
+_openaiAuthType = 'api_key';
+const openaiApiKey = require('../../app/src/main/assets/nodejs-project/providers/openai');
+body = JSON.parse(openaiApiKey.formatRequest('gpt-5.4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('OpenAI api_key reasoningMode=off: body.reasoning NOT emitted',
+    body.reasoning === undefined);
+ok('OpenAI api_key reasoningMode=off: body.include NOT emitted',
+    body.include === undefined);
+
+// OpenAI OAuth/Codex — OFF MUST PRESERVE body.reasoning (transport-required).
+// This is the BAT-485 invariant pinned exception: Codex endpoint returns
+// `output: []` without reasoning, so suppressing it would break Codex
+// users entirely. v4 R3 explicitly excludes OAuth from synthetic suppression.
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openai')];
+_openaiAuthType = 'oauth';
+const openaiOauthOff = require('../../app/src/main/assets/nodejs-project/providers/openai');
+body = JSON.parse(openaiOauthOff.formatRequest('gpt-5.4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('OpenAI OAuth reasoningMode=off: body.reasoning STILL emitted (BAT-485 transport invariant)',
+    body.reasoning && body.reasoning.effort === 'medium',
+    `actual: ${JSON.stringify(body.reasoning)}`);
+
+// OpenAI api_key + codex model — OFF MUST PRESERVE (model-id-driven hardcode).
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openai')];
+_openaiAuthType = 'api_key';
+const openaiCodexOff = require('../../app/src/main/assets/nodejs-project/providers/openai');
+body = JSON.parse(openaiCodexOff.formatRequest('gpt-5.3-codex', 4096, 'sys', [], [], {
+    reasoningEnabled: false, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('OpenAI api_key + codex model + reasoningMode=off: body.reasoning STILL emitted (codex hardcode)',
+    body.reasoning && body.reasoning.effort === 'medium');
+
+// OpenRouter — OFF emits explicit disablement signal `effort: 'none'`.
+// This is STRONGER than just omitting (some OR reasoning models reason by
+// default per OR docs). The `reasoning` key IS present, with the disable
+// signal — that's the v4 R3 contract.
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openrouter')];
+const openrouterOff = require('../../app/src/main/assets/nodejs-project/providers/openrouter');
+body = JSON.parse(openrouterOff.formatRequest('openai/gpt-5.4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+eq("OpenRouter reasoningMode=off: body.reasoning = { effort: 'none' } (explicit disable signal)",
+    body.reasoning, { effort: 'none' });
+
+// OpenRouter — OFF takes precedence over user-toggle (defensive, contract-belt).
+// If somehow both reasoningMode='off' AND reasoningEnabled=true coexist,
+// the off signal wins because the caller marked the turn synthetic.
+body = JSON.parse(openrouterOff.formatRequest('openai/gpt-5.4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+eq("OpenRouter reasoningMode=off + toggle on: off STILL wins",
+    body.reasoning, { effort: 'none' });
+
+// Custom chat-completions — already doesn't emit body.reasoning; OFF unchanged.
+const customPath = require.resolve('../../app/src/main/assets/nodejs-project/providers/custom');
+delete require.cache[customPath];
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openai')];
+_openaiAuthType = 'api_key';
+// Force chat_completions format
+const config2 = require.cache[configPath].exports;
+config2.CUSTOM_FORMAT = 'chat_completions';
+const customChat = require('../../app/src/main/assets/nodejs-project/providers/custom');
+body = JSON.parse(customChat.formatRequest('deepseek-v4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('Custom chat-completions reasoningMode=off: body.reasoning NOT emitted (no regression)',
+    body.reasoning === undefined);
+
+// Custom Responses — delegates to openai.formatRequest, follows OpenAI
+// optional-off behavior (suppress body.reasoning + body.include for
+// non-OAuth/non-codex). Pin the round-trip.
+delete require.cache[customPath];
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/providers/openai')];
+_openaiAuthType = 'api_key';
+config2.CUSTOM_FORMAT = 'responses';
+const customResp = require('../../app/src/main/assets/nodejs-project/providers/custom');
+body = JSON.parse(customResp.formatRequest('gpt-5.4', 4096, 'sys', [], [], {
+    reasoningEnabled: true, reasoningSupport: 'yes',
+    reasoningMode: 'off',
+}));
+ok('Custom Responses reasoningMode=off: body.reasoning NOT emitted (delegates to OpenAI optional-off)',
+    body.reasoning === undefined);
+
+// ── BAT-558 v4 R4 — log dedup ────────────────────────────────────────
+// First occurrence per (process, reason) at INFO; subsequent at DEBUG.
+// Pin the level-selection logic so a future refactor doesn't regress
+// the rate limit (heartbeat probes every 30 min would otherwise flood
+// the Logs screen).
+
+console.log();
+console.log('── BAT-558 v4 R4: suppression-log dedup ──');
+
+// Capture log calls instead of printing them. Replace the test stub's
+// log() with a recorder. The reasoning-gating module already imported
+// log from config, but since we control config's exports via require.cache,
+// swap it now.
+const _logRecord = [];
+require.cache[configPath].exports.log = (msg, level) => {
+    _logRecord.push({ msg, level });
+};
+delete require.cache[require.resolve('../../app/src/main/assets/nodejs-project/reasoning-gating')];
+const rg = require('../../app/src/main/assets/nodejs-project/reasoning-gating');
+
+rg._resetSuppressionLogForTest();
+_logRecord.length = 0;
+
+rg.logSuppression(rg.SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT, 'first');
+rg.logSuppression(rg.SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT, 'second');
+rg.logSuppression(rg.SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT, 'third');
+ok('Dedup: first call to same reason → INFO',
+    _logRecord[0] && _logRecord[0].level === 'INFO',
+    `actual: ${JSON.stringify(_logRecord[0])}`);
+ok('Dedup: second call to same reason → DEBUG',
+    _logRecord[1] && _logRecord[1].level === 'DEBUG',
+    `actual: ${JSON.stringify(_logRecord[1])}`);
+ok('Dedup: third call to same reason → DEBUG',
+    _logRecord[2] && _logRecord[2].level === 'DEBUG');
+
+// Different reason → fresh INFO regardless of prior reasons.
+rg.logSuppression(rg.SUPPRESSION_REASONS.MAX_TOKENS_BELOW_FLOOR, 'first');
+ok('Dedup: different reason → INFO again',
+    _logRecord[3] && _logRecord[3].level === 'INFO');
+
+// Reset clears the dedup state.
+rg._resetSuppressionLogForTest();
+_logRecord.length = 0;
+rg.logSuppression(rg.SUPPRESSION_REASONS.SYNTHETIC_HEARTBEAT, 'after-reset');
+ok('Dedup: after _resetSuppressionLogForTest, same reason → INFO again',
+    _logRecord[0] && _logRecord[0].level === 'INFO');
+
+// Detail string is concatenated into the log line.
+rg._resetSuppressionLogForTest();
+_logRecord.length = 0;
+rg.logSuppression(rg.SUPPRESSION_REASONS.MAX_TOKENS_BELOW_FLOOR, 'claude maxTokens=1024');
+ok('Dedup: detail string appears in log message',
+    _logRecord[0] && _logRecord[0].msg.includes('maxTokens=1024'),
+    `actual: ${_logRecord[0]?.msg}`);
 
 console.log();
 if (failures === 0) {

--- a/tests/nodejs-project/retry-log-provider-label.test.js
+++ b/tests/nodejs-project/retry-log-provider-label.test.js
@@ -28,8 +28,14 @@
 
 const path = require('path');
 
-// Stub config.js with no-op log so model-catalog loads cleanly (it
-// imports config transitively via dependencies).
+// Defensive config.js stub. R1 Copilot: model-catalog.js does NOT
+// currently import config (it only requires fs/path and reads
+// model-registry.json), so the stub is not load-bearing today. It's
+// kept as a guard for future model-catalog edits that might bring in
+// a config dependency — without it, those tests would silently start
+// requiring a config.json fixture on disk and fail in CI with a
+// confusing "config.json not found" trace. Cheap insurance against
+// a hard-to-diagnose future regression.
 const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
 require.cache[configPath] = {
     id: configPath, filename: configPath, loaded: true,

--- a/tests/nodejs-project/retry-log-provider-label.test.js
+++ b/tests/nodejs-project/retry-log-provider-label.test.js
@@ -45,6 +45,7 @@ require.cache[configPath] = {
 const {
     displayNameForProvider,
     PROVIDER_DISPLAY_NAMES,
+    KNOWN_PROVIDERS,
 } = require('../../app/src/main/assets/nodejs-project/model-catalog');
 
 let failures = 0;
@@ -76,25 +77,25 @@ for (const [providerId, expectedLabel] of Object.entries(expectations)) {
         displayNameForProvider(providerId), expectedLabel);
 }
 
-// Every known provider must have an entry in PROVIDER_DISPLAY_NAMES.
+// Every registered provider must have an entry in PROVIDER_DISPLAY_NAMES.
 // If a future provider lands in the registry but forgets a displayName,
-// the helper falls back to a Capitalized id — flag that here so the
-// retry log doesn't end up surfacing a raw lowercase id like "[Retry]
-// foobar API 429".
+// `displayNameForProvider` falls back to a Capitalized id — surfacing as
+// "[Retry] Foobar API 429" in the user-visible Logs screen. Catch this
+// regression by iterating the AUTHORITATIVE provider list (`KNOWN_PROVIDERS`,
+// derived from registry.providers[].id), not the display-names map keys —
+// the map-keys iteration was tautological because it only visited providers
+// that already had a mapping (R2 Copilot finding).
 console.log();
-console.log('── BAT-559: every known provider has a display name (no Capitalized fallback) ──');
-const knownProviderIds = Object.keys(PROVIDER_DISPLAY_NAMES);
+console.log('── BAT-559: every registry provider has an explicit displayName ──');
 ok('At least 4 providers known to the registry',
-    knownProviderIds.length >= 4,
-    `actual count: ${knownProviderIds.length}`);
-for (const id of knownProviderIds) {
-    const label = displayNameForProvider(id);
-    ok(`${id} has explicit registry displayName (not the Capitalized fallback)`,
-        typeof label === 'string' && label.length > 0 && label !== (id.charAt(0).toUpperCase() + id.slice(1)) ||
-        // Allow Capitalized fallback IF it matches the registry value (e.g., 'Custom'
-        // happens to be the capitalized form of 'custom', and that's correct).
-        PROVIDER_DISPLAY_NAMES[id] === label,
-        `label="${label}", capitalized="${id.charAt(0).toUpperCase() + id.slice(1)}"`);
+    Array.isArray(KNOWN_PROVIDERS) && KNOWN_PROVIDERS.length >= 4,
+    `actual count: ${KNOWN_PROVIDERS?.length}`);
+for (const id of KNOWN_PROVIDERS) {
+    ok(`Registry provider '${id}' has an entry in PROVIDER_DISPLAY_NAMES`,
+        Object.prototype.hasOwnProperty.call(PROVIDER_DISPLAY_NAMES, id)
+            && typeof PROVIDER_DISPLAY_NAMES[id] === 'string'
+            && PROVIDER_DISPLAY_NAMES[id].length > 0,
+        `actual: ${JSON.stringify(PROVIDER_DISPLAY_NAMES[id])}`);
 }
 
 // Robustness: unknown / malformed provider id must not crash the log

--- a/tests/nodejs-project/retry-log-provider-label.test.js
+++ b/tests/nodejs-project/retry-log-provider-label.test.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// retry-log-provider-label.test.js — pin BAT-559 observability fix.
+//
+// Pre-fix, ai.js's retry/network log paths hardcoded "[Retry] Claude API
+// <status>" / "[Claude] Failed to log network error" regardless of which
+// provider actually returned the error. An OpenAI 429 from a rate-limited
+// account was logged as "Claude API 429" — misleading the user about the
+// failure source. BAT-559 swaps the literal "Claude" for
+// `displayNameForProvider(PROVIDER)` so each provider's logs label
+// themselves correctly:
+//   - claude → "Claude" (registry exception: provider id 'claude' has
+//              displayName 'Anthropic' in the registry, so the actual
+//              label rendered is "Anthropic")
+//   - openai → "OpenAI"
+//   - openrouter → "OpenRouter"
+//   - custom → "Custom"
+//
+// Per BAT-559 PM contract: test the LABEL function (displayNameForProvider)
+// directly. ai.js's retry path is hard to drive in a unit test (it requires
+// mocking the full http transport, retry budget, error classifier). The
+// label function is the load-bearing piece for this fix; pinning it
+// catches the same-class-bug if a future refactor swaps in a different
+// helper or hardcodes a label literal.
+//
+// Run:  node tests/nodejs-project/retry-log-provider-label.test.js
+
+'use strict';
+
+const path = require('path');
+
+// Stub config.js with no-op log so model-catalog loads cleanly (it
+// imports config transitively via dependencies).
+const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {} },
+};
+
+const {
+    displayNameForProvider,
+    PROVIDER_DISPLAY_NAMES,
+} = require('../../app/src/main/assets/nodejs-project/model-catalog');
+
+let failures = 0;
+function eq(label, actual, expected) {
+    const a = JSON.stringify(actual);
+    const e = JSON.stringify(expected);
+    if (a === e) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}\n  actual:   ${a}\n  expected: ${e}`); failures++; }
+}
+function ok(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+
+console.log('── BAT-559: provider-label substitution covers all known providers ──');
+
+// Each known provider must produce a non-empty, non-lowercase-id label.
+// The exact label text comes from model-registry.json's provider entries;
+// drift between the registry and these expected values is intentionally
+// flagged here so a registry rename surfaces in tests.
+const expectations = {
+    claude: 'Anthropic',     // registry chooses 'Anthropic' for the company
+    openai: 'OpenAI',
+    openrouter: 'OpenRouter',
+    custom: 'Custom',
+};
+for (const [providerId, expectedLabel] of Object.entries(expectations)) {
+    eq(`displayNameForProvider('${providerId}') → '${expectedLabel}'`,
+        displayNameForProvider(providerId), expectedLabel);
+}
+
+// Every known provider must have an entry in PROVIDER_DISPLAY_NAMES.
+// If a future provider lands in the registry but forgets a displayName,
+// the helper falls back to a Capitalized id — flag that here so the
+// retry log doesn't end up surfacing a raw lowercase id like "[Retry]
+// foobar API 429".
+console.log();
+console.log('── BAT-559: every known provider has a display name (no Capitalized fallback) ──');
+const knownProviderIds = Object.keys(PROVIDER_DISPLAY_NAMES);
+ok('At least 4 providers known to the registry',
+    knownProviderIds.length >= 4,
+    `actual count: ${knownProviderIds.length}`);
+for (const id of knownProviderIds) {
+    const label = displayNameForProvider(id);
+    ok(`${id} has explicit registry displayName (not the Capitalized fallback)`,
+        typeof label === 'string' && label.length > 0 && label !== (id.charAt(0).toUpperCase() + id.slice(1)) ||
+        // Allow Capitalized fallback IF it matches the registry value (e.g., 'Custom'
+        // happens to be the capitalized form of 'custom', and that's correct).
+        PROVIDER_DISPLAY_NAMES[id] === label,
+        `label="${label}", capitalized="${id.charAt(0).toUpperCase() + id.slice(1)}"`);
+}
+
+// Robustness: unknown / malformed provider id must not crash the log
+// path. Pre-fix this never came up because the literal "Claude" was
+// always emitted. Post-fix it could surface if PROVIDER ever
+// contained an unexpected value (config import bug, env override, etc.).
+console.log();
+console.log('── BAT-559: unknown / malformed input fallback ──');
+ok('Empty string → "Unknown" (defensive)',
+    displayNameForProvider('') === 'Unknown');
+ok('null → "Unknown"',
+    displayNameForProvider(null) === 'Unknown');
+ok('undefined → "Unknown"',
+    displayNameForProvider(undefined) === 'Unknown');
+eq("Unknown provider id 'foobar' → Capitalized fallback",
+    displayNameForProvider('foobar'), 'Foobar');
+
+// Smoke the actual log-line shape so a future refactor that swaps the
+// template breaks loudly. This is the literal `[Retry] <Provider> API
+// <status> ...` shape the user sees on the Logs screen.
+console.log();
+console.log('── BAT-559: composed log-line shape (the user-visible template) ──');
+const composedRetry = (provider, status) =>
+    `[Retry] ${displayNameForProvider(provider)} API ${status} (rate_limit), retry 1/3, base 2000ms, waiting 1500ms`;
+ok('OpenAI retry log starts with "[Retry] OpenAI API ..."',
+    composedRetry('openai', 429).startsWith('[Retry] OpenAI API 429'),
+    `actual: ${composedRetry('openai', 429)}`);
+ok('OpenRouter retry log starts with "[Retry] OpenRouter API ..."',
+    composedRetry('openrouter', 502).startsWith('[Retry] OpenRouter API 502'));
+ok('Claude retry log uses registry "Anthropic" label (not literal "Claude")',
+    composedRetry('claude', 529).startsWith('[Retry] Anthropic API 529'),
+    `actual: ${composedRetry('claude', 529)}`);
+ok('Custom retry log starts with "[Retry] Custom API ..."',
+    composedRetry('custom', 503).startsWith('[Retry] Custom API 503'));
+
+const composedNetwork = (provider) =>
+    `[${displayNameForProvider(provider)}] Failed to log network error to DB: connection reset`;
+ok('OpenAI network-error DB log uses "[OpenAI]" tag',
+    composedNetwork('openai').startsWith('[OpenAI]'),
+    `actual: ${composedNetwork('openai')}`);
+ok('Claude network-error DB log uses registry "[Anthropic]" tag',
+    composedNetwork('claude').startsWith('[Anthropic]'),
+    `actual: ${composedNetwork('claude')}`);
+
+console.log();
+if (failures === 0) {
+    console.log('ALL TESTS PASS');
+    process.exit(0);
+} else {
+    console.log(`${failures} TEST(S) FAILED`);
+    process.exit(1);
+}


### PR DESCRIPTION
Fixes BAT-558. Fixes BAT-559.

## Summary

Two commits, one PR (per Codex's BAT-559 fold-in directive):

- **Commit 1 — BAT-558**: cross-provider reasoning hotfix. Claude `formatRequest` now clamps `thinking.budget_tokens` per request so it never violates Anthropic's `budget < max_tokens` invariant. Heartbeat (and any future synthetic turn) explicitly opts out of app-controlled reasoning via a new `chat()` boundary option. Per-provider matrix (Claude clamp / OpenAI api_key suppress / OpenAI OAuth preserve / OpenRouter `effort:'none'` / Custom inherits) wired through. Rate-limited suppression logger so heartbeat probes don't flood the Logs screen.
- **Commit 2 — BAT-559**: retry/network log provider-label cleanup. Two `ai.js` log sites that hardcoded `[Retry] Claude API ...` regardless of active provider now use `displayNameForProvider(PROVIDER)`.

## Implementation contract

**v4 contract on Linear:** [BAT-558 v4 comment](https://linear.app/batcave/issue/BAT-558/fix-heartbeat-ai-turn-fails-with-400-when-extended-thinking-is-enabled#comment-76826d38) (Codex signed off; v3 amendments incorporated; BAT-559 folded in as Commit 2).

**R1 (Claude clamp):**
```
maxTokens < 2048 → omit thinking
otherwise budget = clamp(floor(maxTokens * 0.5), [1024, 16000])
```
Worked examples — 4096 → budget 2048 / answer 2048 (was budget 16000, instant 400). 32000 → 16000 cap. 1536 → omit (gap-case, v3 amendment).

**R2 (synthetic-turn marker):** `chat(chatId, prompt, { reasoningMode: 'off', synthetic: 'heartbeat' })`. ai.js defensively forces `'off'` for `chatId === '__heartbeat__'`. Thinking bubble gate adds `reasoningMode !== 'off'` so synthetic turns don't flicker the indicator.

**R3 (per-provider matrix):**

| Provider | Normal turn | `reasoningMode: 'off'` |
|---|---|---|
| Claude | R1 clamp | omit `thinking` |
| OpenAI api_key (non-Codex) | toggle/support gate | omit `body.reasoning` + `include` |
| OpenAI OAuth/Codex | transport-required | **PRESERVE** (BAT-485 invariant pinned) |
| OpenRouter | toggle/support gate | `body.reasoning = { effort: 'none' }` |
| Custom chat-completions | no app body reasoning | unchanged |
| Custom Responses | delegate to OpenAI | follows OpenAI optional-off |
| Custom user headers | preserved | preserved |

**R4 (rate-limited logging):** `reasoning-gating.js` exports `logSuppression(reason, detail)` with per-(process, reason) dedup — first occurrence INFO, subsequent DEBUG. Three reasons: `MAX_TOKENS_BELOW_FLOOR`, `SYNTHETIC_HEARTBEAT`, `OPENROUTER_EFFORT_NONE`. Lazy-loads `log` from config to keep the module side-effect-free at top-level (smoke harness compatibility).

**R5 (heartbeat call site):** `main.js runHeartbeat()` passes `{ reasoningMode: 'off', synthetic: 'heartbeat' }` explicitly.

**BAT-559 (provider label):** ai.js:1498 + ai.js:1536 use `displayNameForProvider(PROVIDER)` from model-catalog. Note: the registry maps `claude → Anthropic` (the company, not the model family), so post-fix Claude logs say `[Retry] Anthropic API <status>` — deliberate single-source-of-truth choice with Settings UI.

## Test plan

- [x] `node tests/nodejs-project/reasoning-request-enablement.test.js` — all pass; extended with 16+ new assertions (R1 worked-examples table, R3 reasoningMode='off' matrix per provider, OAuth/Codex preserve regression guard, R4 log-dedup level selection)
- [x] `node tests/nodejs-project/reasoning-gating.test.js` — all pass; config.js stubbed since reasoning-gating now lazy-imports `log`
- [x] `node tests/nodejs-project/retry-log-provider-label.test.js` — new test covering BAT-559: 4-known-provider label substitution, "Unknown" fallback for null/empty, Capitalized fallback for unknown ids, composed log-line shape pinning
- [x] `node tests/nodejs-project/smoke.js` — 51/51 syntax + 11/11 modules load cleanly
- [x] All 27 Node test files pass (full sweep)
- [x] `scripts/pre-push-check.sh` — pass (Node smoke + Kotlin compile)
- [ ] **Device test** — pending after Copilot review:
  - Anthropic + Opus 4.7 + Extended thinking ON + wait 30 min for heartbeat → no 400 in logs
  - Anthropic + Opus 4.7 + Extended thinking ON + send real chat → response succeeds
  - Anthropic + Opus 4.7 + Extended thinking ON + 4096-token chat → succeeds (pre-fix would 400)
  - OpenAI Codex/OAuth + heartbeat → still works (transport exception preserved)
  - OpenRouter freeform model + heartbeat → no 400; `reasoning.effort: 'none'` emitted
  - Logs screen shows ONE `[Reasoning] suppressed: synthetic-heartbeat` INFO per process lifetime, not per probe
  - OpenAI 429 retry log says `[Retry] OpenAI API 429` (BAT-559)

## Known limitations

- Out-of-scope per v4 R7 (deferred to follow-ups): tool-payload skip on synthetic turns (heartbeat sends 80KB of tools per probe), cron reasoning policy product decision, OAuth/Codex synthetic-turn reasoning suppression, user-facing budget tuning UI.
- BAT-559 leaves comments / KDoc / DIAGNOSTICS.md / `http.js` / `mcp-client.js` "Claude API" mentions alone (out of scope per BAT-559 PM contract).
- Pre-existing `CrossProcessStoreTest` drift-guard failures on origin/main (regex source-pattern brittleness) — same status as BAT-515 PR.

## Self-Awareness Checklist

- [x] **N/A** — no `buildSystemBlocks()` change. The agent's identity / tool descriptions are unchanged. Wire-shape changes don't surface in self-knowledge surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)