### PR TITLE
docs: add Extended Thinking, Env Vars, Activity rows to README Features table

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ SeekerClaw embeds a Node.js AI agent inside an Android app, running 24/7 as a fo
 | | Feature | What it does |
 |---|---|---|
 | :robot: | **AI Engine** | Claude, OpenAI (API key + Codex OAuth), OpenRouter, or any OpenAI-compatible gateway (Custom). Multi-turn tool use, extended thinking on supported models |
+| :thought_balloon: | **Extended Thinking** | Toggle in Settings → AI Provider → Reasoning or via `/think` from chat. Supported models (Opus 4.7, Sonnet 4.6, GPT-5.5, GPT-5.4, Codex) think across tool calls, with reasoning preserved across `/resume` and tool-loop turns |
 | :speech_balloon: | **Channels** | Telegram (full bot — reactions, file sharing, inline keyboards) or Discord (Gateway v10 — DMs, media, reply threading) |
 | :link: | **Solana Wallet** | Swaps, limit orders, DCA, transfers via Jupiter + MWA |
 | :iphone: | **Device Control** | Battery, GPS, camera, SMS, calls, clipboard, TTS |
@@ -46,6 +47,8 @@ SeekerClaw embeds a Node.js AI agent inside an Android app, running 24/7 as a fo
 | :alarm_clock: | **Scheduling** | Cron jobs with natural language ("remind me in 30 min") |
 | :globe_with_meridians: | **Web Intel** | Search (Brave / Perplexity / Exa / Tavily / Firecrawl), fetch, caching |
 | :gear: | **Live Settings** | Switch model or provider from Telegram with `/model` and `/provider`; no app reopen needed |
+| :key: | **Env Vars** | Plug arbitrary API keys into the agent via Settings → Env Vars (single add or `.env`-style bulk paste). Skills and tools read them at runtime via `process.env.KEY`; values masked from debug logs. Skills can gate on `requires.env` so missing keys block activation cleanly |
+| :bar_chart: | **Activity** | 26-week heatmap of your agent's API requests on the System screen — see when it's active, spot quiet days. Up to 13 months of daily history persisted on-device |
 | :electric_plug: | **Extensible** | 35+ partner skills + custom skills + MCP remote tools |
 
 <details>


### PR DESCRIPTION
## Summary

PR #358 README sweep covered the architecture/on-device stack section but missed three user-visible features in the Features table itself.

## What's added

| Row | Feature | Why it matters |
|---|---|---|
| :thought_balloon: **Extended Thinking** | Settings → Reasoning + `/think` chat command, supported models, preserved across `/resume` | BAT-549 — tagline mentioned "extended thinking" but Features had no row |
| :key: **Env Vars** | Settings → Env Vars (single add + bulk `.env` paste), `process.env.KEY` access, log redaction, `requires.env` skill gating | BAT-495 PR #332 — same gap shape as the CHANGELOG miss caught in PR #360 |
| :bar_chart: **Activity** | 26-week System-screen heatmap of API requests, 13 months persisted on-device | BAT-500 — polished UI shipped without README mention |

## Cross-reference

The agent's self-knowledge layer (system prompt + DIAGNOSTICS) already covers all three:
- BAT-500 Activity Heatmap door — added in SAB-AUDIT-v23
- BAT-525 graceful Stop, /model + /provider, MAX_STEPS — added in SAB-AUDIT-v24

So the agent knew about these. Only the public-facing README didn't.

## Test Plan

- [x] Diff visual-check: 3 rows inserted in logical positions (Extended Thinking next to AI Engine, Env Vars next to Live Settings, Activity before Extensible)
- [ ] CI build — N/A (doc-only)
- [ ] Device test — N/A (doc-only)

`SAB-N/A: README polish; no agent surface touched.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)