### PR TITLE
[Part 2/2] feat(x402): v2 settle path — PAYMENT-SIGNATURE + partially-signed tx (BAT-582 v1.6 Phase 5)

### DIFF
--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -615,8 +615,13 @@ function _buildV2UsdcTransferTx(burnerPubkey58, recipientPubkey58, facilitatorPu
     ]);
 
     // Two empty 64-byte signature slots (facilitator at 0, burner at 1).
-    // Caller fills slot 1 via Android KeyVault bridge (sign-transaction
-    // with slotIndex=1) before sending PAYMENT-SIGNATURE.
+    // Caller fills slot 1 via the Android KeyVault bridge before sending
+    // PAYMENT-SIGNATURE. The bridge does NOT take an explicit slot index
+    // — SolanaTxSigner locates the burner's slot by matching the burner
+    // pubkey against the tx's account_keys in the first
+    // numRequiredSignatures positions. To opt into partial-sign mode
+    // (slot 0 left empty for the facilitator), agent_pay sends
+    // `allowPartiallySigned: true` on the /burner/sign-transaction call.
     const tx = Buffer.concat([
         _encodeCompactU16(2),       // 2 sig slots
         Buffer.alloc(64),           // slot 0 (facilitator, empty)

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -687,11 +687,24 @@ function _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64) {
     // captures). Normalize to the v2 object shape — facilitators require
     // it. If only a string is present, treat it as `url` with sensible
     // empty defaults for description + mimeType.
+    //
+    // BAT-582 v1.6 R-pr367-fix-1: fail closed when the resource URL is
+    // missing/empty. Pre-fix we emitted PAYMENT-SIGNATURE with
+    // `resource.url: ''` which is spec-invalid (and would let a server
+    // accept an ambiguous proof). Returning a stable error code lets
+    // agent_pay surface "v2 challenge missing required resource" instead
+    // of sending a malformed header.
     let resource = req.resource;
     if (typeof resource === 'string') {
         resource = { url: resource, description: req.description || '', mimeType: 'application/json' };
     } else if (!resource || typeof resource !== 'object') {
-        resource = { url: '', description: req.description || '', mimeType: 'application/json' };
+        resource = null; // signal below
+    }
+    if (!resource || typeof resource.url !== 'string' || resource.url.length === 0) {
+        return {
+            error: 'v2_settle_missing_resource',
+            reason: 'paymentMeta.requirement.resource.url not present — required for v2 PAYMENT-SIGNATURE proof per spec',
+        };
     }
 
     const payload = {
@@ -1129,9 +1142,31 @@ class X402Protocol extends PaymentProtocol {
                     reason: 'v2 challenge has no extra.feePayer — required for the partially-signed flow',
                 };
             }
-            const memoString = (typeof extra.memo === 'string' && extra.memo.length > 0)
-                ? extra.memo
-                : _generateRandomMemoNonce();
+            // BAT-582 v1.6 R-pr367-fix-2: bound server-controlled memo
+            // length. `extra.memo` flows verbatim into both the Memo
+            // instruction (Solana tx size cap is 1232 bytes) and the
+            // base64-encoded PAYMENT-SIGNATURE header (HTTP header cap
+            // varies, typically 8K). Without a length bound, a buggy or
+            // malicious server could force oversize allocations or
+            // exceed Solana's per-tx byte cap (which would just reject
+            // the tx, but waste a sign call). 256 bytes is generous for
+            // any plausible memo (payment ID, order ref, etc.) while
+            // far below any wire-format limit. Reject loud if exceeded
+            // so the agent surfaces a clear error.
+            const MAX_MEMO_BYTES = 256;
+            let memoString;
+            if (typeof extra.memo === 'string' && extra.memo.length > 0) {
+                const memoBytes = Buffer.byteLength(extra.memo, 'utf8');
+                if (memoBytes > MAX_MEMO_BYTES) {
+                    return {
+                        error: 'memo_too_large',
+                        reason: `challenge extra.memo is ${memoBytes} bytes (UTF-8); max ${MAX_MEMO_BYTES}`,
+                    };
+                }
+                memoString = extra.memo;
+            } else {
+                memoString = _generateRandomMemoNonce();
+            }
             try {
                 built = _buildV2UsdcTransferTx(
                     burnerPubkey58, recipient, facilitatorPubkey58,
@@ -1165,11 +1200,22 @@ class X402Protocol extends PaymentProtocol {
             x402Version: negotiatedVersion,
             // Store a short-lived ref to the original requirement so settle()
             // can echo back any extension fields if the server requires them.
+            //
+            // BAT-582 v1.6 R-pr367-fix: `resource` lives at the TOP LEVEL
+            // of the v2 challenge payload (per the Coinbase spec and
+            // confirmed against the real Tripadvisor/Textbelt/CoinGecko
+            // captures), NOT inside the chosen `accepts[]` entry. Pre-fix
+            // we read it as `r.resource` which is always `null` for real
+            // v2 challenges — the v2 PAYMENT-SIGNATURE header then went
+            // out with `resource.url: ''` (spec-invalid). Read from the
+            // extracted payload instead, fall back to the requirement
+            // entry only for v1-shaped challenges where it might legacily
+            // live there.
             requirement: {
                 scheme: r.scheme || 'exact',
                 network: r.network || 'solana',
                 payTo: r.payTo,
-                resource: r.resource,
+                resource: extracted.payload.resource || r.resource,
                 description: r.description,
                 maxTimeoutSeconds: r.maxTimeoutSeconds,
                 extra: r.extra,                   // v2 settle needs `extra.feePayer`

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -326,10 +326,18 @@ const _MEMO_PROGRAM_ID_BYTES           = _base58Decode(MEMO_PROGRAM_ID);
 //   tag (1 byte) = 0x02
 //   units (u32 LE) = 4 bytes
 // Total: 5 bytes.
+//
+// BAT-582 v1.6 R-pr367-fix-5: validate `limit` is a positive u32 integer.
+// Pre-fix used `limit >>> 0` which silently coerces negatives (-1 → 0xFFFFFFFF)
+// and non-integers, producing unintended compute-unit limits. Throw a clear
+// error instead so misuse fails loudly at build time.
 function _buildCuLimitData(limit) {
+    if (!Number.isInteger(limit) || limit <= 0 || limit > 0xFFFFFFFF) {
+        throw new Error(`_buildCuLimitData: limit must be a positive integer in u32 range, got ${String(limit)}`);
+    }
     const data = Buffer.alloc(5);
     data.writeUInt8(0x02, 0);
-    data.writeUInt32LE(limit >>> 0, 1);
+    data.writeUInt32LE(limit, 1);
     return data;
 }
 
@@ -522,7 +530,20 @@ function _buildV2UsdcTransferTx(burnerPubkey58, recipientPubkey58, facilitatorPu
     // modest priority fee that helps with mainnet congestion without
     // burning much fee. Override via opts only if a specific facilitator
     // requires higher.
-    const cuLimit         = (opts.cuLimit | 0) || 50_000;
+    //
+    // BAT-582 v1.6 R-pr367-fix-5: validate opts.cuLimit explicitly rather
+    // than bitwise-coercing. Pre-fix `(opts.cuLimit | 0) || 50_000` allowed
+    // negative values (truthy after | 0) and silently truncated non-integers
+    // to i32. Throw on anything outside positive u32 range so a buggy
+    // caller fails loudly instead of producing nonsense limits.
+    let cuLimit = 50_000;
+    if (opts.cuLimit !== undefined && opts.cuLimit !== null) {
+        const parsed = Number(opts.cuLimit);
+        if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 0xFFFFFFFF) {
+            throw new Error(`v2: opts.cuLimit must be a positive integer in u32 range, got ${String(opts.cuLimit)}`);
+        }
+        cuLimit = parsed;
+    }
     const cuPriceMicroLam = (opts.cuPriceMicroLamports != null) ? BigInt(opts.cuPriceMicroLamports) : 1000n;
 
     // Account-keys layout (see header comment).
@@ -678,6 +699,14 @@ function _buildV2UsdcTransferTx(burnerPubkey58, recipientPubkey58, facilitatorPu
 function _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64) {
     if (!paymentMeta || typeof paymentMeta !== 'object') {
         return { error: 'v2_settle_missing_meta', reason: 'paymentMeta is null or not an object' };
+    }
+    // BAT-582 v1.6 R-pr367-fix-5: fail-closed when signedTxBase64 is not a
+    // usable string. Pre-fix we'd happily emit PAYMENT-SIGNATURE with
+    // `payload.transaction: undefined/null/''`, producing a spec-invalid
+    // proof that's hard to diagnose downstream (facilitator just returns a
+    // generic "invalid tx"). Surface a stable error code instead.
+    if (typeof signedTxBase64 !== 'string' || signedTxBase64.length === 0) {
+        return { error: 'v2_settle_missing_signed_tx', reason: 'signedTxBase64 must be a non-empty string' };
     }
     const req = paymentMeta.requirement || {};
     const extra = req.extra || {};

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -37,12 +37,17 @@
 //   - v1 (paymentMeta.x402Version === 1): replays request with
 //     `x-payment` base64-JSON header per the canonical fixture
 //     tests/payment/fixtures/paysh-sandbox-success.json. SHIPPED.
-//   - v2 (paymentMeta.x402Version === 2): REJECTS with
-//     `v2_settle_not_implemented` until a real-wire success capture
-//     pins the v2 proof-header path (Phase 5 of v1.6 implementation).
-//     Agent_pay caller surfaces this to the user as "v2 endpoint
-//     detected but settlement not yet supported." This is the
-//     fixture-first gate Codex required.
+//   - v2 (paymentMeta.x402Version === 2): replays request with
+//     `PAYMENT-SIGNATURE` base64-JSON header carrying a structured
+//     PaymentPayload per Coinbase x402 v2 spec — outer keys:
+//     `x402Version`, `resource`, `accepted` (singular, the chosen
+//     requirement from `accepts[]`), `payload.transaction`. Parses
+//     `PAYMENT-RESPONSE` header on 200 to surface the on-chain
+//     signature (`SettlementResponse.transaction`) and explicitly
+//     fails as `settle_failed` when SettlementResponse.success=false.
+//     Successful v2 end-to-end requires Android bridge multi-sig
+//     signing (Phase 5d) so the burner signs slot 1 (facilitator
+//     signs slot 0 server-side). SHIPPED at Phase 5c.
 //
 // PRE-FLIGHT REJECTIONS (HTTPS-only, private-IP, DNS rebinding, max
 // body, etc.) happen in the agent_pay tool before detect(). This
@@ -305,6 +310,52 @@ function _buildSplTransferCheckedData(amountAtomic, decimals) {
     return data;
 }
 
+// ── x402 v2: ComputeBudget + Memo instruction builders ───────────────────────
+// Solana well-known program IDs (base58):
+const COMPUTE_BUDGET_PROGRAM_ID = 'ComputeBudget111111111111111111111111111111';
+const MEMO_PROGRAM_ID           = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+
+// Pre-decoded program-ID bytes — same hoisting pattern as USDC_MINT
+// (avoids re-decoding on every v2 tx build).
+const _COMPUTE_BUDGET_PROGRAM_ID_BYTES = _base58Decode(COMPUTE_BUDGET_PROGRAM_ID);
+const _MEMO_PROGRAM_ID_BYTES           = _base58Decode(MEMO_PROGRAM_ID);
+
+// ComputeBudgetProgram::SetComputeUnitLimit
+//   tag (1 byte) = 0x02
+//   units (u32 LE) = 4 bytes
+// Total: 5 bytes.
+function _buildCuLimitData(limit) {
+    const data = Buffer.alloc(5);
+    data.writeUInt8(0x02, 0);
+    data.writeUInt32LE(limit >>> 0, 1);
+    return data;
+}
+
+// ComputeBudgetProgram::SetComputeUnitPrice
+//   tag (1 byte) = 0x03
+//   micro_lamports (u64 LE) = 8 bytes
+// Total: 9 bytes.
+function _buildCuPriceData(microLamports) {
+    const data = Buffer.alloc(9);
+    data.writeUInt8(0x03, 0);
+    data.writeBigUInt64LE(BigInt(microLamports), 1);
+    return data;
+}
+
+// Memo program v2 takes the memo content as raw UTF-8 bytes (no
+// discriminator). Per BAT-582 v1.6 contract amendment 4 + x402 v2 spec:
+// the client MUST include a Memo instruction containing either
+// `extra.memo` from the challenge (if present) or a random ≥16-byte
+// hex nonce. We use 32 hex chars (16 bytes of entropy) when generating.
+function _buildMemoData(memoString) {
+    return Buffer.from(String(memoString), 'utf8');
+}
+
+function _generateRandomMemoNonce() {
+    // 16 bytes random → 32 hex chars. Spec minimum.
+    return crypto.randomBytes(16).toString('hex');
+}
+
 // ── Build a legacy USDC SPL transfer transaction ─────────────────────────────
 // Returns { txBuffer, paymentMeta }. Caller serializes to base64.
 //
@@ -409,6 +460,264 @@ function _buildUsdcTransferTx(burnerPubkey58, recipientPubkey58, amountAtomic, r
             mint: USDC_MINT,
         },
     };
+}
+
+// ── x402 v2 USDC transfer transaction builder ────────────────────────────────
+// Per Coinbase x402 v2 spec (specs/schemes/exact/scheme_exact_svm.md):
+//
+// PARTIALLY-SIGNED versioned (v0) transaction with 4 instructions in
+// this exact order:
+//   1. ComputeBudgetProgram::SetComputeUnitLimit
+//   2. ComputeBudgetProgram::SetComputeUnitPrice
+//   3. SPL TransferChecked (USDC, burner → recipient ATA)
+//   4. Memo with `extra.memo` from challenge OR random ≥16-byte hex nonce
+//
+// Two required signers:
+//   - slot 0: facilitator (feePayer, signer + writable) — left empty;
+//     server co-signs after receiving PAYMENT-SIGNATURE.
+//   - slot 1: burner (signer + readonly) — caller fills this slot.
+//
+// Account-keys order (Solana convention — writable signers first, then
+// readonly signers, then writable non-signers, then readonly non-signers):
+//   idx 0: facilitator    (signer, writable, feePayer)
+//   idx 1: burner         (signer, readonly — only authorizes SPL transfer)
+//   idx 2: source ATA     (writable)
+//   idx 3: dest ATA       (writable)
+//   idx 4: USDC mint      (readonly)
+//   idx 5: ComputeBudget  (readonly program)
+//   idx 6: Token program  (readonly program)
+//   idx 7: Memo program   (readonly program)
+//
+// Header: numRequiredSignatures=2, numReadonlySigned=1 (burner),
+//         numReadonlyUnsigned=4 (mint + 3 programs).
+//
+// Returns { txBuffer, paymentMeta } — caller writes burner sig at slot 1
+// (offset = 1 + 64 = 65 of the tx buffer), then base64-encodes.
+//
+// Default compute-budget values are conservative for a TransferChecked +
+// Memo flow. Caller can override via opts if a service demands higher.
+function _buildV2UsdcTransferTx(burnerPubkey58, recipientPubkey58, facilitatorPubkey58, amountAtomic, recentBlockhash58, memoString, opts = {}) {
+    const burnerBytes      = _decodeSolanaPubkey(burnerPubkey58);
+    const recipientBytes   = _decodeSolanaPubkey(recipientPubkey58);
+    const facilitatorBytes = _decodeSolanaPubkey(facilitatorPubkey58);
+    if (!burnerBytes)      throw new Error(`v2: invalid burner pubkey: ${burnerPubkey58}`);
+    if (!recipientBytes)   throw new Error(`v2: invalid recipient pubkey: ${recipientPubkey58}`);
+    if (!facilitatorBytes) throw new Error(`v2: invalid facilitator pubkey: ${facilitatorPubkey58}`);
+
+    const mintBytes          = _USDC_MINT_BYTES;
+    const tokenProgramBytes  = _TOKEN_PROGRAM_ID_BYTES;
+    const cuProgramBytes     = _COMPUTE_BUDGET_PROGRAM_ID_BYTES;
+    const memoProgramBytes   = _MEMO_PROGRAM_ID_BYTES;
+
+    const sourceAta = _findAssociatedTokenAddress(burnerBytes, mintBytes).address;
+    const destAta   = _findAssociatedTokenAddress(recipientBytes, mintBytes).address;
+
+    const blockhashBytes = _base58Decode(recentBlockhash58);
+    if (blockhashBytes.length !== 32) throw new Error(`v2: blockhash must decode to 32 bytes, got ${blockhashBytes.length}`);
+
+    // Compute-budget defaults. 50000 CU is generous for a TransferChecked
+    // + Memo (each is a few hundred CU); 1000 microlamports/CU is a
+    // modest priority fee that helps with mainnet congestion without
+    // burning much fee. Override via opts only if a specific facilitator
+    // requires higher.
+    const cuLimit         = (opts.cuLimit | 0) || 50_000;
+    const cuPriceMicroLam = (opts.cuPriceMicroLamports != null) ? BigInt(opts.cuPriceMicroLamports) : 1000n;
+
+    // Account-keys layout (see header comment).
+    const accountKeys = [
+        facilitatorBytes,    // 0: feePayer (signer, writable)
+        burnerBytes,         // 1: burner   (signer, readonly)
+        sourceAta,           // 2: source ATA (writable)
+        destAta,             // 3: dest ATA   (writable)
+        mintBytes,           // 4: USDC mint  (readonly)
+        cuProgramBytes,      // 5: ComputeBudget program
+        tokenProgramBytes,   // 6: Token program
+        memoProgramBytes,    // 7: Memo program
+    ];
+
+    // Header per Solana message format.
+    const header = Buffer.from([
+        2, // numRequiredSignatures (facilitator + burner)
+        1, // numReadonlySignedAccounts (burner is readonly-signer)
+        4, // numReadonlyUnsignedAccounts (mint, ComputeBudget, Token, Memo)
+    ]);
+
+    // Instructions (4 total, in spec-required order).
+    const ixCuLimit = (() => {
+        const data = _buildCuLimitData(cuLimit);
+        return Buffer.concat([
+            Buffer.from([5]),                       // programIdIndex = ComputeBudget (idx 5)
+            _encodeCompactU16(0),                   // no accounts
+            _encodeCompactU16(data.length),
+            data,
+        ]);
+    })();
+    const ixCuPrice = (() => {
+        const data = _buildCuPriceData(cuPriceMicroLam);
+        return Buffer.concat([
+            Buffer.from([5]),                       // programIdIndex = ComputeBudget
+            _encodeCompactU16(0),
+            _encodeCompactU16(data.length),
+            data,
+        ]);
+    })();
+    const ixTransferChecked = (() => {
+        const data = _buildSplTransferCheckedData(amountAtomic, USDC_DECIMALS);
+        // accounts: source ATA (2), mint (4), dest ATA (3), owner=burner (1)
+        const ixAccounts = Buffer.from([2, 4, 3, 1]);
+        return Buffer.concat([
+            Buffer.from([6]),                       // programIdIndex = Token (idx 6)
+            _encodeCompactU16(ixAccounts.length),
+            ixAccounts,
+            _encodeCompactU16(data.length),
+            data,
+        ]);
+    })();
+    const ixMemo = (() => {
+        const data = _buildMemoData(memoString);
+        // Memo can run without specifying accounts. Per Solana convention,
+        // including the burner (signer) makes the memo verifiable as
+        // authored by them — useful for downstream tooling. We include it.
+        const ixAccounts = Buffer.from([1]);
+        return Buffer.concat([
+            Buffer.from([7]),                       // programIdIndex = Memo (idx 7)
+            _encodeCompactU16(ixAccounts.length),
+            ixAccounts,
+            _encodeCompactU16(data.length),
+            data,
+        ]);
+    })();
+
+    const accountKeysBuf = Buffer.concat([
+        _encodeCompactU16(accountKeys.length),
+        ...accountKeys,
+    ]);
+    const instructionsBuf = Buffer.concat([
+        _encodeCompactU16(4),
+        ixCuLimit,
+        ixCuPrice,
+        ixTransferChecked,
+        ixMemo,
+    ]);
+    // Address Lookup Tables section (v0 only). Empty: compact-u16(0).
+    const altBuf = _encodeCompactU16(0);
+
+    // v0 versioned message: prefix byte 0x80 | 0 = 0x80, then standard
+    // message bytes, then ALT section.
+    const versionByte = Buffer.from([0x80]);
+    const message = Buffer.concat([
+        versionByte,
+        header,
+        accountKeysBuf,
+        blockhashBytes,
+        instructionsBuf,
+        altBuf,
+    ]);
+
+    // Two empty 64-byte signature slots (facilitator at 0, burner at 1).
+    // Caller fills slot 1 via Android KeyVault bridge (sign-transaction
+    // with slotIndex=1) before sending PAYMENT-SIGNATURE.
+    const tx = Buffer.concat([
+        _encodeCompactU16(2),       // 2 sig slots
+        Buffer.alloc(64),           // slot 0 (facilitator, empty)
+        Buffer.alloc(64),           // slot 1 (burner, empty until signed)
+        message,
+    ]);
+
+    return {
+        txBuffer: tx,
+        paymentMeta: {
+            x402Version: 2,
+            amountAtomic: BigInt(amountAtomic),
+            recipient: recipientPubkey58,
+            facilitator: facilitatorPubkey58,
+            sourceAta: _base58Encode(sourceAta),
+            destAta:   _base58Encode(destAta),
+            blockhash: recentBlockhash58,
+            mint: USDC_MINT,
+            memo: memoString,
+            burnerSigSlot: 1,                 // for Android bridge: sign slot 1
+            cuLimit,
+            cuPriceMicroLamports: cuPriceMicroLam.toString(),
+        },
+    };
+}
+
+// ── x402 v2: PAYMENT-SIGNATURE header builder ────────────────────────────────
+// Per Coinbase x402 v2 spec (specs/transports-v2/http.md +
+// specs/schemes/exact/scheme_exact_svm.md): the proof header carries
+// a base64-encoded `PaymentPayload` with this exact shape (note
+// `accepted` is SINGULAR — the chosen requirement from the challenge's
+// `accepts` array):
+//
+//   {
+//     "x402Version": 2,
+//     "resource": { url, description, mimeType },
+//     "accepted": {
+//       "scheme": "exact",
+//       "network": "solana:<genesis>",
+//       "amount": "10000",
+//       "asset": "EPjFW...",
+//       "payTo": "<recipient>",
+//       "maxTimeoutSeconds": 300,
+//       "extra": { "feePayer": "<facilitator>", "memo": "..." }
+//     },
+//     "payload": { "transaction": "<base64 signed tx>" }
+//   }
+//
+// Returns { value: <base64 string> } on success or { error, reason }
+// if paymentMeta is missing required fields (defensive — build()
+// should have provided everything).
+function _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64) {
+    if (!paymentMeta || typeof paymentMeta !== 'object') {
+        return { error: 'v2_settle_missing_meta', reason: 'paymentMeta is null or not an object' };
+    }
+    const req = paymentMeta.requirement || {};
+    const extra = req.extra || {};
+    if (typeof extra.feePayer !== 'string' || !_decodeSolanaPubkey(extra.feePayer)) {
+        return { error: 'v2_settle_missing_facilitator', reason: 'paymentMeta.requirement.extra.feePayer not present' };
+    }
+    if (typeof paymentMeta.memo !== 'string' || paymentMeta.memo.length === 0) {
+        return { error: 'v2_settle_missing_memo', reason: 'paymentMeta.memo not present (build should have set it)' };
+    }
+    if (typeof paymentMeta.amountAtomic !== 'bigint') {
+        return { error: 'v2_settle_missing_amount', reason: 'paymentMeta.amountAtomic missing or not BigInt' };
+    }
+    // Resource may be an object (per spec) or a string (older v1-shaped
+    // captures). Normalize to the v2 object shape — facilitators require
+    // it. If only a string is present, treat it as `url` with sensible
+    // empty defaults for description + mimeType.
+    let resource = req.resource;
+    if (typeof resource === 'string') {
+        resource = { url: resource, description: req.description || '', mimeType: 'application/json' };
+    } else if (!resource || typeof resource !== 'object') {
+        resource = { url: '', description: req.description || '', mimeType: 'application/json' };
+    }
+
+    const payload = {
+        x402Version: 2,
+        resource,
+        accepted: {
+            scheme: req.scheme || 'exact',
+            // Use the CAIP-2 wire-form network the challenge actually sent.
+            // paymentMeta.negotiatedNetwork is the preserved wire string
+            // ("solana" or "solana:<genesis>"); we echo it back verbatim.
+            network: paymentMeta.negotiatedNetwork || req.network || 'solana',
+            amount: paymentMeta.amountAtomic.toString(),
+            asset: paymentMeta.asset || USDC_MINT,
+            payTo: req.payTo || paymentMeta.recipient,
+            maxTimeoutSeconds: typeof req.maxTimeoutSeconds === 'number' ? req.maxTimeoutSeconds : 300,
+            extra: {
+                feePayer: extra.feePayer,
+                memo: paymentMeta.memo,
+            },
+        },
+        payload: {
+            transaction: signedTxBase64,
+        },
+    };
+    const value = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+    return { value };
 }
 
 // ── Payment requirement parsing per pay.sh fixture ───────────────────────────
@@ -804,11 +1113,40 @@ class X402Protocol extends PaymentProtocol {
         try { recentBlockhash = await _fetchRecentBlockhash(); }
         catch (e) { return { error: 'blockhash_fetch_failed', reason: e.message }; }
 
+        const negotiatedVersion = versionCheck.version;
         let built;
-        try {
-            built = _buildUsdcTransferTx(burnerPubkey58, recipient, demand, recentBlockhash);
-        } catch (e) {
-            return { error: 'tx_build_failed', reason: e.message };
+        if (negotiatedVersion === 2) {
+            // BAT-582 v1.6 Phase 5b: v2 challenges produce v2-shape txs.
+            // v2 requires the facilitator's pubkey from `extra.feePayer`
+            // (the server-side co-signer who pays gas + submits the tx)
+            // and a Memo instruction containing either the challenge's
+            // `extra.memo` or a fresh random ≥16-byte hex nonce per spec.
+            const extra = r.extra || {};
+            const facilitatorPubkey58 = extra.feePayer;
+            if (typeof facilitatorPubkey58 !== 'string' || !_decodeSolanaPubkey(facilitatorPubkey58)) {
+                return {
+                    error: 'missing_facilitator',
+                    reason: 'v2 challenge has no extra.feePayer — required for the partially-signed flow',
+                };
+            }
+            const memoString = (typeof extra.memo === 'string' && extra.memo.length > 0)
+                ? extra.memo
+                : _generateRandomMemoNonce();
+            try {
+                built = _buildV2UsdcTransferTx(
+                    burnerPubkey58, recipient, facilitatorPubkey58,
+                    demand, recentBlockhash, memoString,
+                );
+            } catch (e) {
+                return { error: 'tx_build_failed', reason: e.message };
+            }
+        } else {
+            // v1: single-signer legacy tx, burner pays gas + signs slot 0.
+            try {
+                built = _buildUsdcTransferTx(burnerPubkey58, recipient, demand, recentBlockhash);
+            } catch (e) {
+                return { error: 'tx_build_failed', reason: e.message };
+            }
         }
 
         const txBase64 = built.txBuffer.toString('base64');
@@ -817,9 +1155,7 @@ class X402Protocol extends PaymentProtocol {
         // string from the requirement (could be bare "solana" or
         // "solana:<genesis>"). settle() uses these to decide whether to
         // emit a v1 proof header (existing path, fixture-pinned) or to
-        // reject as v2_settle_not_implemented (until Phase 5 captures a
-        // real v2 success and pins the v2 proof header).
-        const negotiatedVersion = versionCheck.version;
+        // build a v2 PAYMENT-SIGNATURE proof (Phase 5c).
         const meta = {
             ...built.paymentMeta,
             scheme: 'exact',
@@ -836,6 +1172,7 @@ class X402Protocol extends PaymentProtocol {
                 resource: r.resource,
                 description: r.description,
                 maxTimeoutSeconds: r.maxTimeoutSeconds,
+                extra: r.extra,                   // v2 settle needs `extra.feePayer`
             },
         };
         return { txBase64, paymentMeta: meta };
@@ -859,49 +1196,43 @@ class X402Protocol extends PaymentProtocol {
         const { parsed, pinnedIp, pinnedFamily, timeoutLeftMs } = originalRequest || {};
         if (!parsed) return { error: 'missing_request_context', reason: 'originalRequest.parsed missing' };
 
-        // BAT-582 R22 / v1.6 Codex clarification 1: settle() ONLY handles
-        // x402 v1's proof-header path right now. v1 emits a plaintext-ish
-        // JSON via the `x-payment` header, pinned against the existing
-        // tests/payment/fixtures/paysh-sandbox-success.json fixture.
-        //
-        // v2's proof-header path is NOT YET pinned by a real-wire
-        // success capture (Phase 4 of v1.6 implementation — requires a
-        // real $0.01 payment against Tripadvisor or similar to record
-        // the success response and determine whether v2 uses `x-payment`,
-        // `payment-signature`, or some other header form). Until that
-        // capture is committed, settle() refuses v2 explicitly with a
-        // stable error code so callers (agent_pay tool) can surface a
-        // clear "v2 settlement not yet implemented" message instead of
-        // sending a malformed v1-shaped proof to a v2 endpoint.
+        // BAT-582 v1.6 Phase 5c: settle() dispatches v1 vs v2 proof-header
+        // paths per paymentMeta.x402Version.
+        //   v1: legacy `x-payment` header carrying a flat PaymentPayload
+        //       (x402Version, scheme, network, payload.transaction).
+        //       Pinned against tests/payment/fixtures/paysh-sandbox-success.json.
+        //   v2: `PAYMENT-SIGNATURE` header carrying a structured
+        //       PaymentPayload (x402Version, resource, accepted, payload).
+        //       Per Coinbase x402 v2 spec
+        //       (specs/transports-v2/http.md +
+        //        specs/schemes/exact/scheme_exact_svm.md).
         const negotiatedVersion = paymentMeta && paymentMeta.x402Version;
-        if (negotiatedVersion === 2) {
-            return {
-                error: 'v2_settle_not_implemented',
-                reason: 'x402 v2 settlement proof-header path is gated on a real-wire success capture (BAT-582 Phase 5). detect() and build() accept v2 challenges, but the agent cannot complete payment on v2 endpoints until the success fixture is committed.',
-            };
-        }
-        if (negotiatedVersion !== 1) {
-            // Should be impossible — build() rejects unsupported versions
-            // before producing paymentMeta. Defensive fail-closed.
+        if (negotiatedVersion !== 1 && negotiatedVersion !== 2) {
             return {
                 error: 'unsupported_settle_version',
                 reason: `paymentMeta.x402Version=${negotiatedVersion} is not a settleable version`,
             };
         }
 
-        const xPaymentPayload = {
-            x402Version: 1,
-            scheme: 'exact',
-            network: 'solana',
-            payload: {
-                transaction: signedTxBase64,
-            },
-        };
-        const xPaymentHeader = Buffer.from(JSON.stringify(xPaymentPayload), 'utf8').toString('base64');
+        let proofHeaders;
+        if (negotiatedVersion === 2) {
+            const built = _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64);
+            if (built.error) return built;
+            proofHeaders = { 'payment-signature': built.value };
+        } else {
+            const xPaymentPayload = {
+                x402Version: 1,
+                scheme: 'exact',
+                network: 'solana',
+                payload: {
+                    transaction: signedTxBase64,
+                },
+            };
+            const xPaymentHeader = Buffer.from(JSON.stringify(xPaymentPayload), 'utf8').toString('base64');
+            proofHeaders = { 'x-payment': xPaymentHeader };
+        }
 
-        const resp = await fetchFn(parsed, pinnedIp, pinnedFamily, {
-            'x-payment': xPaymentHeader,
-        }, timeoutLeftMs || 30000);
+        const resp = await fetchFn(parsed, pinnedIp, pinnedFamily, proofHeaders, timeoutLeftMs || 30000);
 
         if (resp.error) return { error: resp.error, reason: resp.reason };
         if (resp.status === 402) {
@@ -911,23 +1242,47 @@ class X402Protocol extends PaymentProtocol {
             return { error: 'settle_http_error', reason: `server returned ${resp.status} after payment` };
         }
 
-        // Settlement signature: pay.sh returns a `X-Payment-Response` header
-        // (base64-encoded JSON) on success. We surface the on-chain signature
-        // if present so the agent can show a Solscan link.
+        // Settlement signature: server returns the on-chain payment
+        // signature on a successful 200 via a base64-encoded response
+        // header. The header NAME differs by version:
+        //   v1: `X-Payment-Response` (pay.sh sandbox-success fixture)
+        //   v2: `PAYMENT-RESPONSE` (per Coinbase x402 v2 spec — a
+        //       `SettlementResponse` object: { success, transaction,
+        //       network, payer } or { success: false, errorReason, ... }).
+        // The inner JSON shape converged across versions enough that we
+        // can read `.transaction` (v1 & v2 both use that key for the
+        // signature) — fall back to `.signature` for any legacy variant.
+        // We check both header names to be liberal in what we accept.
         let signature = null;
-        const respHeader = resp.headers && (resp.headers['x-payment-response'] || resp.headers['X-Payment-Response']);
+        let v2SettlementResponse = null;
+        const respHeader = resp.headers && (
+            resp.headers['payment-response'] ||       // v2 (lowercased by Node)
+            resp.headers['PAYMENT-RESPONSE'] ||       // v2 (defensive)
+            resp.headers['x-payment-response'] ||     // v1
+            resp.headers['X-Payment-Response']        // v1 (defensive)
+        );
         if (typeof respHeader === 'string') {
             try {
                 const decoded = JSON.parse(Buffer.from(respHeader, 'base64').toString('utf8'));
                 if (decoded && typeof decoded.transaction === 'string') signature = decoded.transaction;
                 else if (decoded && typeof decoded.signature === 'string') signature = decoded.signature;
-            } catch (_) { /* leave null */ }
+                // v2 spec: SettlementResponse with explicit success boolean.
+                // When success=false the on-chain tx didn't land — surface
+                // as an error rather than a fake success.
+                if (negotiatedVersion === 2 && decoded && decoded.success === false) {
+                    return {
+                        error: 'settle_failed',
+                        reason: `facilitator reported failure: ${decoded.errorReason || 'no reason given'}`,
+                        response: resp,
+                    };
+                }
+                if (negotiatedVersion === 2) v2SettlementResponse = decoded;
+            } catch (_) { /* leave signature null */ }
         }
 
-        return {
-            response: resp,
-            signature,
-        };
+        const out = { response: resp, signature };
+        if (v2SettlementResponse) out.settlementResponse = v2SettlementResponse;
+        return out;
     }
 }
 
@@ -938,6 +1293,14 @@ module.exports = {
     TOKEN_PROGRAM_ID,
     ASSOCIATED_TOKEN_PROGRAM_ID,
     _buildUsdcTransferTx,
+    _buildV2UsdcTransferTx,
+    _buildCuLimitData,
+    _buildCuPriceData,
+    _buildMemoData,
+    _generateRandomMemoNonce,
+    _buildV2PaymentSignatureHeader,
+    COMPUTE_BUDGET_PROGRAM_ID,
+    MEMO_PROGRAM_ID,
     _findAssociatedTokenAddress,
     _isOnCurve,
     _decodeSolanaPubkey,

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -4,9 +4,11 @@
 //
 // CONTRACT (per BAT-582 v1.6 — Codex sign-off 2026-05-10)
 // -------------------------------------------------------
-// Detect + build support BOTH x402 v1 AND v2. Settle currently
-// implements ONLY v1; v2 settle is gated on a real-wire success
-// capture (Phase 5).
+// detect + build + settle all support BOTH x402 v1 AND v2.
+// Per-version mechanics in the settle() docs below. The bridge
+// multi-sig piece (Android-side signing of partially-signed v2 txs)
+// lives in SolanaTxSigner + the /burner/sign-transaction endpoint
+// with allowPartiallySigned=true.
 //
 // detect(response):
 //   - true when response.status === 402 AND a usable Solana mainnet

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -756,8 +756,16 @@ function _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64) {
             asset: paymentMeta.asset || USDC_MINT,
             payTo: req.payTo || paymentMeta.recipient,
             maxTimeoutSeconds: typeof req.maxTimeoutSeconds === 'number' ? req.maxTimeoutSeconds : 300,
+            // BAT-582 v1.6 R-pr367-fix-7: preserve all server-provided
+            // extension fields by shallow-cloning `extra`, then override
+            // `memo` with the value actually used in the tx (build() may
+            // have generated a random nonce if none was supplied).
+            // feePayer is part of `extra` already and is preserved by the
+            // spread. Future-proofs against facilitators adding new fields
+            // (signing nonces, fee tiers, expiration hints, etc.) without
+            // requiring a client change.
             extra: {
-                feePayer: extra.feePayer,
+                ...extra,
                 memo: paymentMeta.memo,
             },
         },

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -774,6 +774,20 @@ function _buildV2PaymentSignatureHeader(paymentMeta, signedTxBase64) {
         },
     };
     const value = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+    // BAT-582 v1.6 R-pr367-fix-8: cap header size to defend against a
+    // hostile/buggy facilitator inflating server-controlled fields
+    // (extra.*, resource.description, mimeType) to force oversized
+    // PAYMENT-SIGNATURE headers. Common HTTP server limits cap individual
+    // headers at 8KB; 8192 bytes here is well above any legitimate proof
+    // size (~1-2 KB) and below typical server limits. Fail closed before
+    // the network call instead of letting the request blow up with a
+    // generic 431/400 from an upstream proxy.
+    if (value.length > 8192) {
+        return {
+            error: 'v2_settle_proof_too_large',
+            reason: `PAYMENT-SIGNATURE header serialized to ${value.length} bytes (max 8192) — server may be inflating extra/resource fields`,
+        };
+    }
     return { value };
 }
 

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -516,9 +516,21 @@ async function _handle(input /* , chatId */) {
     const reservationId = reserveRes.reservationId;
 
     // 9. Sign via burner.
+    //
+    // BAT-582 v1.6 Phase 5d/5e: x402 v2 challenges produce partially-
+    // signed txs (facilitator co-signs slot 0 server-side after we send
+    // PAYMENT-SIGNATURE). The burner signs slot 1 only; the wire tx
+    // leaving the device has slot 0 still empty. We must opt in to the
+    // bridge's partial-sign mode for v2 — otherwise SolanaTxSigner
+    // rejects with `additional_signers_required`. v1 callers (and
+    // legacy v1-shaped pay.sh services) skip the flag and use the
+    // fully-signed-only path.
+    const isV2 = paymentMeta && paymentMeta.x402Version === 2;
     let signedTxBase64;
     try {
-        const signed = await burner.signer().signTransaction(txBase64, { reservationId });
+        const signOpts = { reservationId };
+        if (isV2) signOpts.allowPartiallySigned = true;
+        const signed = await burner.signer().signTransaction(txBase64, signOpts);
         if (!signed || signed.error) {
             await _release(reservationId, signed && signed.error ? signed.error : 'sign_failed');
             return {

--- a/app/src/main/assets/nodejs-project/wallet/burner-signer.js
+++ b/app/src/main/assets/nodejs-project/wallet/burner-signer.js
@@ -28,10 +28,19 @@ class BurnerSigner extends Signer {
         if (!opts.reservationId) {
             return { error: 'missing_reservation', reason: 'reservationId required for sign-only flow' };
         }
-        const res = await androidBridgeCall('/burner/sign-transaction', {
+        const body = {
             txBase64,
             reservationId: opts.reservationId,
-        }, 15000);
+        };
+        // BAT-582 v1.6 Phase 5d: when the caller is signing a partially-
+        // signed x402 v2 tx (facilitator co-signs server-side), set the
+        // bridge flag so SolanaTxSigner skips its v1 "all other signers
+        // must be cosigned" check. Default false preserves v1 behavior
+        // for every existing caller (Jupiter Ultra swap, v1 x402, etc.).
+        if (opts.allowPartiallySigned === true) {
+            body.allowPartiallySigned = true;
+        }
+        const res = await androidBridgeCall('/burner/sign-transaction', body, 15000);
         return res;
     }
 

--- a/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
@@ -248,7 +248,14 @@ class BurnerBridgeEndpoints internal constructor(
     private fun handleSignTransaction(params: JSONObject): EndpointResult {
         val txB64 = params.optString("txBase64", "").trim()
         val reservationId = params.optString("reservationId", "").trim()
-        return handleSignTransactionInternal(txB64, reservationId)
+        // BAT-582 v1.6 Phase 5d: optional `allowPartiallySigned` flag.
+        // x402 v2 callers (agent_pay paying a v2 endpoint) set this to
+        // true — the facilitator co-signs server-side after we send
+        // PAYMENT-SIGNATURE, so the wire tx is partially signed by
+        // design. Default false preserves v1 behavior for every
+        // existing caller (Jupiter Ultra swap, v1 x402, etc.).
+        val allowPartiallySigned = params.optBoolean("allowPartiallySigned", false)
+        return handleSignTransactionInternal(txB64, reservationId, allowPartiallySigned)
     }
 
     /**
@@ -270,7 +277,7 @@ class BurnerBridgeEndpoints internal constructor(
      * sweep auto-releases it if the caller crashes between sign and commit.
      */
     @androidx.annotation.VisibleForTesting
-    internal fun handleSignTransactionInternal(txB64: String, reservationId: String): EndpointResult {
+    internal fun handleSignTransactionInternal(txB64: String, reservationId: String, allowPartiallySigned: Boolean = false): EndpointResult {
         if (txB64.isEmpty() || reservationId.isEmpty()) {
             return invalidInput("txBase64 and reservationId required")
         }
@@ -291,7 +298,7 @@ class BurnerBridgeEndpoints internal constructor(
             return invalidInput("txBase64 is not valid base64")
         }
 
-        return signTransactionInner(reservationId, txBytes)
+        return signTransactionInner(reservationId, txBytes, allowPartiallySigned)
     }
 
     /**
@@ -308,10 +315,10 @@ class BurnerBridgeEndpoints internal constructor(
      * to this method MUST have already validated the reservation.
      */
     @androidx.annotation.VisibleForTesting
-    internal fun signTransactionInner(@Suppress("UNUSED_PARAMETER") reservationId: String, txBytes: ByteArray): EndpointResult {
+    internal fun signTransactionInner(@Suppress("UNUSED_PARAMETER") reservationId: String, txBytes: ByteArray, allowPartiallySigned: Boolean = false): EndpointResult {
         return runBlocking {
             try {
-                val signed = keyVault.signTransaction(BURNER_ID, txBytes)
+                val signed = keyVault.signTransaction(BURNER_ID, txBytes, allowPartiallySigned)
                 val signedB64 = android.util.Base64.encodeToString(signed, android.util.Base64.NO_WRAP)
                 EndpointResult(200, mapOf("signedTxBase64" to signedB64))
             } catch (e: SigningException) {

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/EncryptedPrefsKeyVault.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/EncryptedPrefsKeyVault.kt
@@ -238,7 +238,7 @@ class EncryptedPrefsKeyVault(
         }
     }
 
-    override suspend fun signTransaction(id: String, txBytes: ByteArray): ByteArray {
+    override suspend fun signTransaction(id: String, txBytes: ByteArray, allowPartiallySigned: Boolean): ByteArray {
         val expanded = loadKey(id)
             ?: throw SigningException("burner_not_configured", "No burner key stored")
         if (expanded.size != 64) {
@@ -260,7 +260,7 @@ class EncryptedPrefsKeyVault(
                 Arrays.fill(seed, 0.toByte())
             }
             try {
-                return SolanaTxSigner.insertSignature(txBytes, parsed, burnerPubkey, signature)
+                return SolanaTxSigner.insertSignature(txBytes, parsed, burnerPubkey, signature, allowPartiallySigned)
             } finally {
                 // Pubkey isn't a secret; signature isn't a secret. No
                 // wipe needed for those.

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/KeyVault.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/KeyVault.kt
@@ -54,8 +54,17 @@ interface KeyVault {
      * signed payload is returned as a fresh ByteArray. The internally
      * loaded secret key bytes are zeroed before return. Callers may
      * safely reuse [txBytes] (in contrast to [store]'s [expanded64]).
+     *
+     * @param allowPartiallySigned BAT-582 v1.6 Phase 5d: when `true`,
+     *   allows signing a multi-signer tx whose other required-signer
+     *   slots are still empty. Used for x402 v2 where the facilitator
+     *   co-signs server-side AFTER receiving the PAYMENT-SIGNATURE
+     *   header — the wire tx that leaves the device is partially
+     *   signed by design. When `false` (default — v1 behavior), all
+     *   other signer slots must already contain a non-zero signature
+     *   or the call rejects with `additional_signers_required`.
      */
-    suspend fun signTransaction(id: String, txBytes: ByteArray): ByteArray
+    suspend fun signTransaction(id: String, txBytes: ByteArray, allowPartiallySigned: Boolean = false): ByteArray
 
     /**
      * Derive and return the 32-byte Ed25519 public key as a base58 string.

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
@@ -32,6 +32,8 @@ object SolanaTxSigner {
         val signaturesStartOffset: Int = 0,
         /** Where each individual signature byte-slot begins, inside the signature array. */
         val signatureSlotOffsets: List<Int>,
+        /** true if the tx is a v0 versioned tx (message starts with 0x80); false for legacy. */
+        val isV0: Boolean,
     )
 
     /**
@@ -139,6 +141,7 @@ object SolanaTxSigner {
             messageStartOffset = messageStart,
             signaturesStartOffset = 0,
             signatureSlotOffsets = sigSlotOffsets,
+            isV0 = isV0,
         )
     }
 
@@ -214,6 +217,20 @@ object SolanaTxSigner {
                 }
             } else {
                 // Partial-sign mode: enforce the x402 v2 invariants.
+                //
+                // BAT-582 v1.6 R-pr367-fix-6: x402 v2 uses ONLY v0 versioned
+                // txs (per Coinbase spec scheme_exact_svm.md). Reject legacy
+                // txs even if the 2-signer slot layout coincidentally
+                // matches — there is no legitimate v1 caller that should
+                // ever set allowPartiallySigned=true. This narrows the
+                // attack surface so an attacker can't smuggle a legacy
+                // multisig tx through the v2-only path.
+                if (!parsed.isV0) {
+                    throw SigningException(
+                        "unexpected_partial_sign_layout",
+                        "allowPartiallySigned requires a v0 versioned tx (x402 v2); got legacy tx",
+                    )
+                }
                 if (parsed.numRequiredSignatures != 2) {
                     throw SigningException(
                         "unexpected_partial_sign_layout",

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
@@ -191,13 +191,51 @@ object SolanaTxSigner {
         // Phase 5d: x402 v2 explicitly opts out via `allowPartiallySigned`
         // (facilitator co-signs server-side; the tx is partially signed
         // by design when it leaves the device).
-        if (parsed.numRequiredSignatures > 1 && !allowPartiallySigned) {
-            for (i in 0 until parsed.numRequiredSignatures) {
-                if (i == burnerIndex) continue
-                if (isZero(parsed.signatures[i])) {
+        //
+        // BAT-582 v1.6 R-pr367-fix-4: when allowPartiallySigned=true,
+        // ENFORCE the x402 v2 layout invariants — pre-fix the flag was a
+        // blanket "skip the safeguard for any multi-signer tx" toggle,
+        // which would let a malicious/buggy caller get the burner to
+        // partially-sign ARBITRARY multisig txs (e.g., a 3-signer
+        // governance tx). The flag is purpose-built for x402 v2, which
+        // is ALWAYS a 2-signer layout with facilitator at slot 0 and
+        // burner at slot 1. Reject anything else as
+        // `unexpected_partial_sign_layout`.
+        if (parsed.numRequiredSignatures > 1) {
+            if (!allowPartiallySigned) {
+                for (i in 0 until parsed.numRequiredSignatures) {
+                    if (i == burnerIndex) continue
+                    if (isZero(parsed.signatures[i])) {
+                        throw SigningException(
+                            "additional_signers_required",
+                            "Slot $i has no signature (caller must opt in via allowPartiallySigned for x402 v2)",
+                        )
+                    }
+                }
+            } else {
+                // Partial-sign mode: enforce the x402 v2 invariants.
+                if (parsed.numRequiredSignatures != 2) {
                     throw SigningException(
-                        "additional_signers_required",
-                        "Slot $i has no signature (caller must opt in via allowPartiallySigned for x402 v2)",
+                        "unexpected_partial_sign_layout",
+                        "allowPartiallySigned requires exactly 2 required signers (x402 v2); got ${parsed.numRequiredSignatures}",
+                    )
+                }
+                if (burnerIndex != 1) {
+                    throw SigningException(
+                        "unexpected_partial_sign_layout",
+                        "allowPartiallySigned requires burner at slot 1 (facilitator at slot 0); burner found at slot $burnerIndex",
+                    )
+                }
+                // Slot 0 (facilitator) must remain empty — server co-signs
+                // after receiving PAYMENT-SIGNATURE. If already filled,
+                // something is off: either we're being asked to re-sign a
+                // tx the facilitator already touched (which would
+                // invalidate their sig over our message bytes) or the tx
+                // came from a non-x402 source.
+                if (!isZero(parsed.signatures[0])) {
+                    throw SigningException(
+                        "unexpected_partial_sign_layout",
+                        "allowPartiallySigned requires slot 0 (facilitator) to be empty; found pre-existing signature",
                     )
                 }
             }

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaTxSigner.kt
@@ -147,17 +147,26 @@ object SolanaTxSigner {
      * [original] and return the updated transaction bytes. Preserves any
      * pre-existing signatures from co-signers.
      *
+     * @param allowPartiallySigned When `true`, other signer slots may
+     *   remain all-zero (used for x402 v2 where the facilitator
+     *   co-signs server-side AFTER receiving PAYMENT-SIGNATURE — the
+     *   wire tx that leaves the device is partially signed by design).
+     *   When `false` (default — v1 behavior), all other required
+     *   signer slots must already contain a non-zero signature.
+     *
      * Throws [SigningException]:
      *   - `burner_not_required_signer` if [burnerPubkey] is not in the
      *     first numRequiredSignatures account-key slots.
-     *   - `additional_signers_required` when numRequiredSignatures > 1
-     *     AND any other signer slot is still all-zeros.
+     *   - `additional_signers_required` when numRequiredSignatures > 1,
+     *     `allowPartiallySigned` is false, AND any other signer slot
+     *     is still all-zeros.
      */
     fun insertSignature(
         original: ByteArray,
         parsed: ParsedTx,
         burnerPubkey: ByteArray,
         signature: ByteArray,
+        allowPartiallySigned: Boolean = false,
     ): ByteArray {
         require(burnerPubkey.size == 32) { "burnerPubkey must be 32 bytes" }
         require(signature.size == 64) { "signature must be 64 bytes" }
@@ -178,15 +187,17 @@ object SolanaTxSigner {
         }
 
         // V1 co-sign rule: if there are additional required signers, they
-        // must already have non-zero signatures present. We don't attempt
-        // any kind of multi-party signing.
-        if (parsed.numRequiredSignatures > 1) {
+        // must already have non-zero signatures present. BAT-582 v1.6
+        // Phase 5d: x402 v2 explicitly opts out via `allowPartiallySigned`
+        // (facilitator co-signs server-side; the tx is partially signed
+        // by design when it leaves the device).
+        if (parsed.numRequiredSignatures > 1 && !allowPartiallySigned) {
             for (i in 0 until parsed.numRequiredSignatures) {
                 if (i == burnerIndex) continue
                 if (isZero(parsed.signatures[i])) {
                     throw SigningException(
                         "additional_signers_required",
-                        "Slot $i has no signature (V1 supports single or pre-cosigned only)",
+                        "Slot $i has no signature (caller must opt in via allowPartiallySigned for x402 v2)",
                     )
                 }
             }

--- a/app/src/test/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpointsTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpointsTest.kt
@@ -420,7 +420,10 @@ private object TestEndpointBuilder {
 
     private object NoopKeyVault : com.seekerclaw.app.data.wallet.KeyVault {
         override suspend fun store(id: String, expanded64: ByteArray) = Unit
-        override suspend fun signTransaction(id: String, txBytes: ByteArray): ByteArray =
+        // BAT-582 v1.6 Phase 5d: signTransaction grew an allowPartiallySigned
+        // param. Default values only apply at call sites; overrides must
+        // explicitly declare the param to match the interface contract.
+        override suspend fun signTransaction(id: String, txBytes: ByteArray, allowPartiallySigned: Boolean): ByteArray =
             throw NotImplementedError()
         override suspend fun getPubkey(id: String): String? = null
         override suspend fun wipe(id: String) = Unit
@@ -438,7 +441,10 @@ private object TestEndpointBuilder {
             private set
 
         override suspend fun store(id: String, expanded64: ByteArray) = Unit
-        override suspend fun signTransaction(id: String, txBytes: ByteArray): ByteArray {
+        // BAT-582 v1.6 Phase 5d: signTransaction grew an allowPartiallySigned
+        // param. Recording stub ignores the flag — call-count is what these
+        // tests assert.
+        override suspend fun signTransaction(id: String, txBytes: ByteArray, allowPartiallySigned: Boolean): ByteArray {
             signCount++
             // Return fake "signed" bytes — base64 encoding is stubbed in
             // unit tests (returnDefaultValues=true) so the exact contents

--- a/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
@@ -247,20 +247,21 @@ class SolanaTxSignerTest {
     }
 
     @Test
-    fun `BAT-582 v1_6 Phase 5d - multi-signer tx with allowPartiallySigned=true is accepted`() {
+    fun `BAT-582 v1_6 Phase 5d - v0 multi-signer tx with allowPartiallySigned=true is accepted`() {
         // x402 v2 case: facilitator is fee-payer at slot 0 (server
         // co-signs after receiving PAYMENT-SIGNATURE), burner is the
-        // SECOND signer at slot 1 (we fill it on-device). Order matters:
-        // R-pr367-fix-3 — the previous version put burner at slot 0
-        // which failed to exercise the actual v2 slot layout.
+        // SECOND signer at slot 1 (we fill it on-device). Tx is v0
+        // versioned per Coinbase x402 v2 spec.
+        // R-pr367-fix-6: tightened to v0-only (was legacy in R-pr367-fix-3).
         val facilitator = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
-        val tx = buildLegacyTxMultiSigner(
+        val tx = buildV0TxMultiSigner(
             signerPubkeys = listOf(facilitator, burnerPubkey),  // facilitator FIRST (slot 0)
             preSignedSignatures = listOf(null, null),           // both empty — partial sign scenario
             blockhash = ByteArray(32),
         )
         val parsed = SolanaTxSigner.parse(tx)
         assertEquals(2, parsed.numRequiredSignatures)
+        assertTrue("must be v0 versioned", parsed.isV0)
         // Sanity: facilitator is slot 0, burner is slot 1.
         assertEquals("facilitator must be slot 0", facilitator.toList(), parsed.accountKeys[0].toList())
         assertEquals("burner must be slot 1",      burnerPubkey.toList(), parsed.accountKeys[1].toList())
@@ -277,13 +278,36 @@ class SolanaTxSignerTest {
     }
 
     @Test
+    fun `BAT-582 R-pr367-fix-6 - allowPartiallySigned rejects legacy (non-v0) tx`() {
+        // x402 v2 is ALWAYS a v0 versioned tx per Coinbase spec. A legacy
+        // tx that happens to match the 2-signer slot layout must still be
+        // rejected — there's no legitimate caller that should opt into
+        // partial signing for a legacy tx. Narrows the signing surface.
+        val facilitator = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(facilitator, burnerPubkey),
+            preSignedSignatures = listOf(null, null),
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        assertEquals("must be parsed as legacy (not v0)", false, parsed.isV0)
+        try {
+            SolanaTxSigner.insertSignature(tx, parsed, burnerPubkey, ByteArray(64), allowPartiallySigned = true)
+            fail("Expected unexpected_partial_sign_layout for legacy tx")
+        } catch (e: SigningException) {
+            assertEquals("unexpected_partial_sign_layout", e.code)
+            assertTrue("error must mention v0", e.message?.contains("v0") == true)
+        }
+    }
+
+    @Test
     fun `BAT-582 R-pr367-fix-4 - allowPartiallySigned rejects 3-signer layout`() {
         // Defense against the flag becoming a "skip safeguard for any
         // multisig" toggle. x402 v2 is ALWAYS exactly 2 signers; a
         // 3-signer tx (e.g., governance) must reject even with the flag.
         val cosigner1 = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
         val cosigner2 = KeyImporter.derivePubkey(ByteArray(32) { (it + 13).toByte() })
-        val tx = buildLegacyTxMultiSigner(
+        val tx = buildV0TxMultiSigner(
             signerPubkeys = listOf(cosigner1, burnerPubkey, cosigner2),
             preSignedSignatures = listOf(null, null, null),
             blockhash = ByteArray(32),
@@ -304,7 +328,7 @@ class SolanaTxSignerTest {
         // the burner at slot 1. A tx where the burner is at slot 0
         // doesn't match the v2 layout and must reject even with the flag.
         val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
-        val tx = buildLegacyTxMultiSigner(
+        val tx = buildV0TxMultiSigner(
             signerPubkeys = listOf(burnerPubkey, cosigner),     // burner at slot 0 — wrong!
             preSignedSignatures = listOf(null, null),
             blockhash = ByteArray(32),
@@ -325,7 +349,7 @@ class SolanaTxSignerTest {
         // facilitator already signed (invalidating their sig), or the tx
         // came from a non-x402 source. Either way, reject.
         val facilitator = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
-        val tx = buildLegacyTxMultiSigner(
+        val tx = buildV0TxMultiSigner(
             signerPubkeys = listOf(facilitator, burnerPubkey),
             preSignedSignatures = listOf(ByteArray(64) { 0x42.toByte() }, null),  // slot 0 pre-filled
             blockhash = ByteArray(32),
@@ -555,6 +579,33 @@ class SolanaTxSignerTest {
         for (pk in signerPubkeys) out.write(pk)
         out.write(blockhash)
         out.write(0x00)
+        return out.toByteArray()
+    }
+
+    /**
+     * Build a multi-signer v0 versioned tx. Same shape as
+     * buildLegacyTxMultiSigner but with the 0x80 version byte after
+     * signatures and a trailing 0x00 address-lookup-tables count.
+     */
+    private fun buildV0TxMultiSigner(
+        signerPubkeys: List<ByteArray>,
+        preSignedSignatures: List<ByteArray?>,
+        blockhash: ByteArray,
+    ): ByteArray {
+        require(signerPubkeys.size == preSignedSignatures.size)
+        val n = signerPubkeys.size
+        val out = ByteArrayOutputStream()
+        out.write(n)
+        for (sig in preSignedSignatures) {
+            out.write(sig ?: ByteArray(64))
+        }
+        out.write(0x80)  // v0 version byte
+        out.write(n); out.write(0x00); out.write(0x00)  // header
+        out.write(n)
+        for (pk in signerPubkeys) out.write(pk)
+        out.write(blockhash)
+        out.write(0x00)  // 0 instructions
+        out.write(0x00)  // 0 ALT entries
         return out.toByteArray()
     }
 

--- a/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
@@ -248,31 +248,32 @@ class SolanaTxSignerTest {
 
     @Test
     fun `BAT-582 v1_6 Phase 5d - multi-signer tx with allowPartiallySigned=true is accepted`() {
-        // x402 v2 case: burner signs slot 1 first (or any slot they
-        // occupy), facilitator co-signs slot 0 server-side after
-        // receiving PAYMENT-SIGNATURE. The wire tx that leaves the
-        // device is intentionally partial; only the burner's slot
-        // gets filled.
-        val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        // x402 v2 case: facilitator is fee-payer at slot 0 (server
+        // co-signs after receiving PAYMENT-SIGNATURE), burner is the
+        // SECOND signer at slot 1 (we fill it on-device). Order matters:
+        // R-pr367-fix-3 — the previous version put burner at slot 0
+        // which failed to exercise the actual v2 slot layout.
+        val facilitator = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
         val tx = buildLegacyTxMultiSigner(
-            signerPubkeys = listOf(burnerPubkey, cosigner),
-            preSignedSignatures = listOf(null, null),  // both empty — partial sign scenario
+            signerPubkeys = listOf(facilitator, burnerPubkey),  // facilitator FIRST (slot 0)
+            preSignedSignatures = listOf(null, null),           // both empty — partial sign scenario
             blockhash = ByteArray(32),
         )
         val parsed = SolanaTxSigner.parse(tx)
         assertEquals(2, parsed.numRequiredSignatures)
+        // Sanity: facilitator is slot 0, burner is slot 1.
+        assertEquals("facilitator must be slot 0", facilitator.toList(), parsed.accountKeys[0].toList())
+        assertEquals("burner must be slot 1",      burnerPubkey.toList(), parsed.accountKeys[1].toList())
+
         val burnerSig = ByteArray(64) { ((it + 0x42) and 0xFF).toByte() }
         val signed = SolanaTxSigner.insertSignature(
             tx, parsed, burnerPubkey, burnerSig, allowPartiallySigned = true
         )
-        // Burner's slot got filled at the correct offset; cosigner's slot
-        // remains zero (facilitator will fill it server-side).
+        // Burner's signature lands at slot 1; facilitator's slot 0 stays
+        // ALL-ZERO (server fills it after receiving PAYMENT-SIGNATURE).
         val signedParsed = SolanaTxSigner.parse(signed)
-        val burnerIdx = signedParsed.accountKeys.indexOfFirst { it.contentEquals(burnerPubkey) }
-        assertEquals(burnerSig.toList(), signedParsed.signatures[burnerIdx].toList())
-        val cosignerIdx = signedParsed.accountKeys.indexOfFirst { it.contentEquals(cosigner) }
-        // Cosigner slot must remain ALL-ZERO (waiting for facilitator).
-        assertTrue("cosigner slot must remain zero", signedParsed.signatures[cosignerIdx].all { it == 0.toByte() })
+        assertTrue("facilitator slot 0 must remain zero", signedParsed.signatures[0].all { it == 0.toByte() })
+        assertEquals("burner slot 1 must hold signature", burnerSig.toList(), signedParsed.signatures[1].toList())
     }
 
     @Test

--- a/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
@@ -247,6 +247,54 @@ class SolanaTxSignerTest {
     }
 
     @Test
+    fun `BAT-582 v1_6 Phase 5d - multi-signer tx with allowPartiallySigned=true is accepted`() {
+        // x402 v2 case: burner signs slot 1 first (or any slot they
+        // occupy), facilitator co-signs slot 0 server-side after
+        // receiving PAYMENT-SIGNATURE. The wire tx that leaves the
+        // device is intentionally partial; only the burner's slot
+        // gets filled.
+        val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(burnerPubkey, cosigner),
+            preSignedSignatures = listOf(null, null),  // both empty — partial sign scenario
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        assertEquals(2, parsed.numRequiredSignatures)
+        val burnerSig = ByteArray(64) { ((it + 0x42) and 0xFF).toByte() }
+        val signed = SolanaTxSigner.insertSignature(
+            tx, parsed, burnerPubkey, burnerSig, allowPartiallySigned = true
+        )
+        // Burner's slot got filled at the correct offset; cosigner's slot
+        // remains zero (facilitator will fill it server-side).
+        val signedParsed = SolanaTxSigner.parse(signed)
+        val burnerIdx = signedParsed.accountKeys.indexOfFirst { it.contentEquals(burnerPubkey) }
+        assertEquals(burnerSig.toList(), signedParsed.signatures[burnerIdx].toList())
+        val cosignerIdx = signedParsed.accountKeys.indexOfFirst { it.contentEquals(cosigner) }
+        // Cosigner slot must remain ALL-ZERO (waiting for facilitator).
+        assertTrue("cosigner slot must remain zero", signedParsed.signatures[cosignerIdx].all { it == 0.toByte() })
+    }
+
+    @Test
+    fun `BAT-582 v1_6 Phase 5d - default allowPartiallySigned=false preserves v1 behavior`() {
+        // Same multi-signer tx, but without opting in — must reject as
+        // before (regression guard against accidentally weakening v1).
+        val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(burnerPubkey, cosigner),
+            preSignedSignatures = listOf(null, null),
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        try {
+            SolanaTxSigner.insertSignature(tx, parsed, burnerPubkey, ByteArray(64))
+            fail("Expected additional_signers_required when allowPartiallySigned defaults to false")
+        } catch (e: SigningException) {
+            assertEquals("additional_signers_required", e.code)
+        }
+    }
+
+    @Test
     fun `multi-signer tx with cosigner already signed is accepted`() {
         val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
         val cosignerSig = ByteArray(64) { ((it + 1) and 0xFF).toByte() }  // non-zero

--- a/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/data/wallet/SolanaTxSignerTest.kt
@@ -277,6 +277,69 @@ class SolanaTxSignerTest {
     }
 
     @Test
+    fun `BAT-582 R-pr367-fix-4 - allowPartiallySigned rejects 3-signer layout`() {
+        // Defense against the flag becoming a "skip safeguard for any
+        // multisig" toggle. x402 v2 is ALWAYS exactly 2 signers; a
+        // 3-signer tx (e.g., governance) must reject even with the flag.
+        val cosigner1 = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val cosigner2 = KeyImporter.derivePubkey(ByteArray(32) { (it + 13).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(cosigner1, burnerPubkey, cosigner2),
+            preSignedSignatures = listOf(null, null, null),
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        assertEquals(3, parsed.numRequiredSignatures)
+        try {
+            SolanaTxSigner.insertSignature(tx, parsed, burnerPubkey, ByteArray(64), allowPartiallySigned = true)
+            fail("Expected unexpected_partial_sign_layout for 3-signer tx")
+        } catch (e: SigningException) {
+            assertEquals("unexpected_partial_sign_layout", e.code)
+        }
+    }
+
+    @Test
+    fun `BAT-582 R-pr367-fix-4 - allowPartiallySigned rejects burner at slot 0`() {
+        // x402 v2 puts the facilitator at slot 0 (server co-signs) and
+        // the burner at slot 1. A tx where the burner is at slot 0
+        // doesn't match the v2 layout and must reject even with the flag.
+        val cosigner = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(burnerPubkey, cosigner),     // burner at slot 0 — wrong!
+            preSignedSignatures = listOf(null, null),
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        try {
+            SolanaTxSigner.insertSignature(tx, parsed, burnerPubkey, ByteArray(64), allowPartiallySigned = true)
+            fail("Expected unexpected_partial_sign_layout when burner is at slot 0")
+        } catch (e: SigningException) {
+            assertEquals("unexpected_partial_sign_layout", e.code)
+        }
+    }
+
+    @Test
+    fun `BAT-582 R-pr367-fix-4 - allowPartiallySigned rejects pre-signed facilitator slot`() {
+        // If slot 0 already has a non-zero signature, something is off:
+        // either we're being asked to re-sign over a message the
+        // facilitator already signed (invalidating their sig), or the tx
+        // came from a non-x402 source. Either way, reject.
+        val facilitator = KeyImporter.derivePubkey(ByteArray(32) { (it + 7).toByte() })
+        val tx = buildLegacyTxMultiSigner(
+            signerPubkeys = listOf(facilitator, burnerPubkey),
+            preSignedSignatures = listOf(ByteArray(64) { 0x42.toByte() }, null),  // slot 0 pre-filled
+            blockhash = ByteArray(32),
+        )
+        val parsed = SolanaTxSigner.parse(tx)
+        try {
+            SolanaTxSigner.insertSignature(tx, parsed, burnerPubkey, ByteArray(64), allowPartiallySigned = true)
+            fail("Expected unexpected_partial_sign_layout when slot 0 is pre-signed")
+        } catch (e: SigningException) {
+            assertEquals("unexpected_partial_sign_layout", e.code)
+        }
+    }
+
+    @Test
     fun `BAT-582 v1_6 Phase 5d - default allowPartiallySigned=false preserves v1 behavior`() {
         // Same multi-signer tx, but without opting in — must reject as
         // before (regression guard against accidentally weakening v1).

--- a/tests/nodejs-project/x402-v2-tx.test.js
+++ b/tests/nodejs-project/x402-v2-tx.test.js
@@ -172,6 +172,55 @@ check('_buildV2PaymentSignatureHeader accepts valid non-empty signedTxBase64', (
     assert.ok(!r.error, 'must not error on valid input');
 });
 
+check('_buildV2PaymentSignatureHeader preserves server-provided extra fields (R-pr367-fix-7)', () => {
+    // Future facilitators may add fields beyond feePayer + memo (e.g.,
+    // signing nonces, fee tiers, expiration hints). Pre-fix dropped them
+    // by rebuilding `extra` as `{ feePayer, memo }`. Now we shallow-clone
+    // so unknown fields round-trip back in the PAYMENT-SIGNATURE proof.
+    const meta = {
+        requirement: {
+            extra: {
+                feePayer: FACILITATOR,
+                signingNonce: 'abc123',
+                feeTier: 'priority',
+                expiresAt: 1234567890,
+            },
+            resource: { url: 'https://x' },
+            payTo: RECIPIENT,
+        },
+        memo: MEMO_FIXED,
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r = _buildV2PaymentSignatureHeader(meta, 'AQABBA==');
+    assert.ok(r.value);
+    const decoded = JSON.parse(Buffer.from(r.value, 'base64').toString('utf8'));
+    assert.strictEqual(decoded.accepted.extra.feePayer, FACILITATOR);
+    assert.strictEqual(decoded.accepted.extra.memo, MEMO_FIXED, 'memo must be the one used in tx (overrides server value)');
+    assert.strictEqual(decoded.accepted.extra.signingNonce, 'abc123', 'extension field must be preserved');
+    assert.strictEqual(decoded.accepted.extra.feeTier, 'priority', 'extension field must be preserved');
+    assert.strictEqual(decoded.accepted.extra.expiresAt, 1234567890, 'extension field must be preserved');
+});
+
+check('_buildV2PaymentSignatureHeader overrides server-provided memo with paymentMeta.memo', () => {
+    // build() may have generated a random nonce if challenge had no
+    // extra.memo; the proof must reflect what's actually IN the signed tx,
+    // not what the server originally sent.
+    const meta = {
+        requirement: {
+            extra: { feePayer: FACILITATOR, memo: 'stale-server-memo' },
+            resource: { url: 'https://x' },
+            payTo: RECIPIENT,
+        },
+        memo: MEMO_FIXED,  // what we actually used in the tx
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r = _buildV2PaymentSignatureHeader(meta, 'AQABBA==');
+    const decoded = JSON.parse(Buffer.from(r.value, 'base64').toString('utf8'));
+    assert.strictEqual(decoded.accepted.extra.memo, MEMO_FIXED);
+});
+
 // ── Full v2 tx structure ────────────────────────────────────────────────
 
 const { txBuffer, paymentMeta } = _buildV2UsdcTransferTx(

--- a/tests/nodejs-project/x402-v2-tx.test.js
+++ b/tests/nodejs-project/x402-v2-tx.test.js
@@ -202,6 +202,44 @@ check('_buildV2PaymentSignatureHeader preserves server-provided extra fields (R-
     assert.strictEqual(decoded.accepted.extra.expiresAt, 1234567890, 'extension field must be preserved');
 });
 
+check('_buildV2PaymentSignatureHeader rejects oversized proofs (R-pr367-fix-8 DoS guard)', () => {
+    // Hostile facilitator inflates server-controlled fields (extra.*,
+    // resource.description, mimeType) to force a huge PAYMENT-SIGNATURE
+    // header. Must fail closed with v2_settle_proof_too_large before any
+    // network call.
+    const meta = {
+        requirement: {
+            extra: { feePayer: FACILITATOR, junk: 'A'.repeat(10_000) },
+            resource: { url: 'https://x' },
+            payTo: RECIPIENT,
+        },
+        memo: MEMO_FIXED,
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r = _buildV2PaymentSignatureHeader(meta, 'AQABBA==');
+    assert.strictEqual(r.error, 'v2_settle_proof_too_large');
+    assert.ok(!r.value);
+});
+
+check('_buildV2PaymentSignatureHeader accepts normal-sized proofs (under 8KB cap)', () => {
+    // Sanity: a reasonable proof (small extra, small description) must
+    // pass — the cap exists to block pathological inputs only.
+    const meta = {
+        requirement: {
+            extra: { feePayer: FACILITATOR, signingNonce: 'abc123' },
+            resource: { url: 'https://x.example.com/resource', description: 'A short description' },
+            payTo: RECIPIENT,
+        },
+        memo: MEMO_FIXED,
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r = _buildV2PaymentSignatureHeader(meta, 'AQABBA==');
+    assert.ok(r.value, 'normal proof must pass the size check');
+    assert.ok(r.value.length <= 8192);
+});
+
 check('_buildV2PaymentSignatureHeader overrides server-provided memo with paymentMeta.memo', () => {
     // build() may have generated a random nonce if challenge had no
     // extra.memo; the proof must reflect what's actually IN the signed tx,

--- a/tests/nodejs-project/x402-v2-tx.test.js
+++ b/tests/nodejs-project/x402-v2-tx.test.js
@@ -31,6 +31,7 @@ const {
     _buildCuPriceData,
     _buildMemoData,
     _generateRandomMemoNonce,
+    _buildV2PaymentSignatureHeader,
     _decodeSolanaPubkey,
     USDC_MINT,
     COMPUTE_BUDGET_PROGRAM_ID,
@@ -96,6 +97,79 @@ check('_generateRandomMemoNonce returns 32 hex chars (16 bytes entropy)', () => 
     // Two calls must differ (cryptographic randomness).
     const n2 = _generateRandomMemoNonce();
     assert.notStrictEqual(n, n2);
+});
+
+// ── Input validation (BAT-582 v1.6 R-pr367-fix-5) ───────────────────────
+
+check('_buildCuLimitData rejects negative limits (no bitwise wrap)', () => {
+    assert.throws(() => _buildCuLimitData(-1), /positive integer in u32 range/);
+});
+
+check('_buildCuLimitData rejects zero', () => {
+    assert.throws(() => _buildCuLimitData(0), /positive integer in u32 range/);
+});
+
+check('_buildCuLimitData rejects non-integer (float)', () => {
+    assert.throws(() => _buildCuLimitData(3.7), /positive integer in u32 range/);
+});
+
+check('_buildCuLimitData rejects NaN and non-numeric', () => {
+    assert.throws(() => _buildCuLimitData(NaN), /positive integer in u32 range/);
+    assert.throws(() => _buildCuLimitData('abc'), /positive integer in u32 range/);
+});
+
+check('_buildCuLimitData rejects values above u32 max', () => {
+    assert.throws(() => _buildCuLimitData(0x100000000), /positive integer in u32 range/);
+});
+
+check('_buildV2UsdcTransferTx rejects negative opts.cuLimit', () => {
+    assert.throws(
+        () => _buildV2UsdcTransferTx(BURNER, RECIPIENT, FACILITATOR, AMOUNT_USDC, BLOCKHASH, MEMO_FIXED, { cuLimit: -1 }),
+        /opts\.cuLimit must be a positive integer/,
+    );
+});
+
+check('_buildV2UsdcTransferTx rejects float opts.cuLimit (no silent truncation)', () => {
+    assert.throws(
+        () => _buildV2UsdcTransferTx(BURNER, RECIPIENT, FACILITATOR, AMOUNT_USDC, BLOCKHASH, MEMO_FIXED, { cuLimit: 3.7 }),
+        /opts\.cuLimit must be a positive integer/,
+    );
+});
+
+check('_buildV2UsdcTransferTx defaults cuLimit when undefined (existing behavior preserved)', () => {
+    const { paymentMeta: m } = _buildV2UsdcTransferTx(
+        BURNER, RECIPIENT, FACILITATOR, AMOUNT_USDC, BLOCKHASH, MEMO_FIXED
+    );
+    assert.strictEqual(m.cuLimit, 50_000);
+});
+
+check('_buildV2PaymentSignatureHeader rejects missing signedTxBase64', () => {
+    const meta = {
+        requirement: { extra: { feePayer: FACILITATOR }, resource: { url: 'https://x' }, payTo: RECIPIENT },
+        memo: MEMO_FIXED,
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r1 = _buildV2PaymentSignatureHeader(meta, undefined);
+    assert.strictEqual(r1.error, 'v2_settle_missing_signed_tx');
+    const r2 = _buildV2PaymentSignatureHeader(meta, '');
+    assert.strictEqual(r2.error, 'v2_settle_missing_signed_tx');
+    const r3 = _buildV2PaymentSignatureHeader(meta, null);
+    assert.strictEqual(r3.error, 'v2_settle_missing_signed_tx');
+    const r4 = _buildV2PaymentSignatureHeader(meta, 42);
+    assert.strictEqual(r4.error, 'v2_settle_missing_signed_tx');
+});
+
+check('_buildV2PaymentSignatureHeader accepts valid non-empty signedTxBase64', () => {
+    const meta = {
+        requirement: { extra: { feePayer: FACILITATOR }, resource: { url: 'https://x' }, payTo: RECIPIENT },
+        memo: MEMO_FIXED,
+        amountAtomic: AMOUNT_USDC,
+        negotiatedNetwork: 'solana',
+    };
+    const r = _buildV2PaymentSignatureHeader(meta, 'AQABBA==');
+    assert.ok(r.value, 'must return a base64 header value');
+    assert.ok(!r.error, 'must not error on valid input');
 });
 
 // ── Full v2 tx structure ────────────────────────────────────────────────

--- a/tests/nodejs-project/x402-v2-tx.test.js
+++ b/tests/nodejs-project/x402-v2-tx.test.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// x402-v2-tx.test.js — BAT-582 v1.6 Phase 5a.
+//
+// Verifies the v0 versioned partially-signed transaction built by
+// `_buildV2UsdcTransferTx` is byte-correct per the Coinbase x402 v2
+// spec (specs/schemes/exact/scheme_exact_svm.md). Tests are
+// fixture-driven against synthetic but spec-compliant inputs.
+//
+// Pre-fix verification: temporarily change any field (wrong account
+// index, wrong instruction order, wrong cuLimit value) and rerun —
+// the appropriate test should fail.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// Stub config.js so x402.js loads without workspace/env state.
+const configPath = require.resolve(path.join(BUNDLE, 'config.js'));
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { BRIDGE_TOKEN: 'test', log: () => {} },
+};
+
+const x402 = require(path.join(BUNDLE, 'payment', 'x402'));
+const {
+    _buildV2UsdcTransferTx,
+    _buildCuLimitData,
+    _buildCuPriceData,
+    _buildMemoData,
+    _generateRandomMemoNonce,
+    _decodeSolanaPubkey,
+    USDC_MINT,
+    COMPUTE_BUDGET_PROGRAM_ID,
+    MEMO_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+} = x402;
+
+// Fixture pubkeys (all valid base58, decoded to 32 bytes — known mainnet keys for tests).
+const BURNER       = '7xKXTg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU';
+const RECIPIENT    = '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ';  // Tripadvisor capture's payTo
+const FACILITATOR  = '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4';  // Tripadvisor capture's extra.feePayer
+const BLOCKHASH    = '2tLBHqeQdeq4Pzioote4ueMkQjrpdnNLBTuDtyKo4ds9';   // arbitrary valid base58, 32 bytes
+const MEMO_FIXED   = 'abcdef0123456789abcdef0123456789';                // 32 hex chars = 16 bytes
+const AMOUNT_USDC  = 10000n;                                            // $0.01 (Tripadvisor pricing)
+
+let failures = 0;
+function check(label, fn) {
+    try { fn(); console.log(`  ✓ ${label}`); }
+    catch (e) { failures++; console.error(`  ✗ ${label}\n    ${e.stack || e.message}`); }
+}
+
+// compact-u16 decode (mirrors x402.js implementation for parsing the
+// tx in the assertions below).
+function readShortvec(buf, offset) {
+    let value = 0, shift = 0, pos = offset;
+    while (pos < buf.length) {
+        const b = buf[pos]; pos++;
+        value |= (b & 0x7F) << shift;
+        if ((b & 0x80) === 0) return { value, length: pos - offset };
+        shift += 7;
+    }
+    throw new Error('compact-u16 unterminated');
+}
+
+console.log('═══ x402 v2 tx builder ═══');
+console.log('');
+
+// ── Instruction data builders ────────────────────────────────────────────
+
+check('_buildCuLimitData encodes [0x02, u32_le(limit)]', () => {
+    const out = _buildCuLimitData(50000);
+    assert.strictEqual(out.length, 5, 'CU-limit data must be 5 bytes');
+    assert.strictEqual(out[0], 0x02, 'discriminator must be 0x02');
+    assert.strictEqual(out.readUInt32LE(1), 50000, 'u32 LE encoding');
+});
+
+check('_buildCuPriceData encodes [0x03, u64_le(microLamports)]', () => {
+    const out = _buildCuPriceData(1000n);
+    assert.strictEqual(out.length, 9, 'CU-price data must be 9 bytes');
+    assert.strictEqual(out[0], 0x03, 'discriminator must be 0x03');
+    assert.strictEqual(out.readBigUInt64LE(1), 1000n, 'u64 LE encoding');
+});
+
+check('_buildMemoData encodes raw UTF-8', () => {
+    const out = _buildMemoData('hello');
+    assert.deepStrictEqual(Array.from(out), [104, 101, 108, 108, 111]);
+});
+
+check('_generateRandomMemoNonce returns 32 hex chars (16 bytes entropy)', () => {
+    const n = _generateRandomMemoNonce();
+    assert.strictEqual(n.length, 32);
+    assert.ok(/^[0-9a-f]{32}$/.test(n), 'must be lowercase hex');
+    // Two calls must differ (cryptographic randomness).
+    const n2 = _generateRandomMemoNonce();
+    assert.notStrictEqual(n, n2);
+});
+
+// ── Full v2 tx structure ────────────────────────────────────────────────
+
+const { txBuffer, paymentMeta } = _buildV2UsdcTransferTx(
+    BURNER, RECIPIENT, FACILITATOR, AMOUNT_USDC, BLOCKHASH, MEMO_FIXED
+);
+
+check('Tx starts with shortvec(2) for two signature slots', () => {
+    const { value, length } = readShortvec(txBuffer, 0);
+    assert.strictEqual(value, 2, 'sigCount must be 2 (facilitator + burner)');
+    assert.strictEqual(length, 1, 'sigCount encodes as single byte for value=2');
+});
+
+check('Both signature slots are 64 zero bytes (empty, pre-sign)', () => {
+    // shortvec is 1 byte; signatures start at offset 1
+    const slot0 = txBuffer.subarray(1, 65);
+    const slot1 = txBuffer.subarray(65, 129);
+    assert.ok(slot0.every(b => b === 0), 'slot 0 (facilitator) must be empty');
+    assert.ok(slot1.every(b => b === 0), 'slot 1 (burner) must be empty until signed');
+});
+
+check('Message version byte is 0x80 (v0 versioned tx)', () => {
+    // After shortvec(1 byte) + 2*64 sigs, message starts at offset 129
+    assert.strictEqual(txBuffer[129], 0x80, 'v0 marker missing');
+});
+
+check('Message header is [2, 1, 4] (numSig, numReadonlySig, numReadonlyUnsigned)', () => {
+    // Right after version byte
+    assert.strictEqual(txBuffer[130], 2, 'numRequiredSignatures');
+    assert.strictEqual(txBuffer[131], 1, 'numReadonlySigned (burner is readonly-signer)');
+    assert.strictEqual(txBuffer[132], 4, 'numReadonlyUnsigned (mint + 3 programs)');
+});
+
+check('Account-keys section: 8 accounts in spec-required order', () => {
+    // Offset 133: shortvec(accountKeys.length) then 32*8 bytes
+    const { value: count, length: cntLen } = readShortvec(txBuffer, 133);
+    assert.strictEqual(count, 8, 'must have 8 account keys');
+    const keysStart = 133 + cntLen;
+    const expectedKeys = [
+        _decodeSolanaPubkey(FACILITATOR),
+        _decodeSolanaPubkey(BURNER),
+        // ATAs are PDAs we'd have to recompute to assert; instead validate
+        // by paymentMeta below.
+        null, null,
+        _decodeSolanaPubkey(USDC_MINT),
+        _decodeSolanaPubkey(COMPUTE_BUDGET_PROGRAM_ID),
+        _decodeSolanaPubkey(TOKEN_PROGRAM_ID),
+        _decodeSolanaPubkey(MEMO_PROGRAM_ID),
+    ];
+    for (let i = 0; i < 8; i++) {
+        const got = txBuffer.subarray(keysStart + i * 32, keysStart + (i + 1) * 32);
+        if (expectedKeys[i] !== null) {
+            assert.ok(got.equals(expectedKeys[i]), `account[${i}] mismatch`);
+        }
+    }
+});
+
+check('paymentMeta carries x402Version=2 and burnerSigSlot=1', () => {
+    assert.strictEqual(paymentMeta.x402Version, 2);
+    assert.strictEqual(paymentMeta.burnerSigSlot, 1, 'burner signs slot 1, not slot 0');
+    assert.strictEqual(paymentMeta.facilitator, FACILITATOR);
+    assert.strictEqual(paymentMeta.amountAtomic, AMOUNT_USDC);
+    assert.strictEqual(paymentMeta.memo, MEMO_FIXED);
+});
+
+check('paymentMeta carries cuLimit + cuPriceMicroLamports defaults', () => {
+    assert.strictEqual(paymentMeta.cuLimit, 50_000);
+    assert.strictEqual(paymentMeta.cuPriceMicroLamports, '1000');
+});
+
+// ── Instruction count + order ───────────────────────────────────────────
+
+check('Tx contains exactly 4 instructions in spec order', () => {
+    // Walk: shortvec(sigCount) + sigs + version + header + shortvec(keysCount)
+    // + 32*keysCount + 32 (blockhash) + shortvec(ixCount)
+    let pos = 0;
+    const sc = readShortvec(txBuffer, pos); pos += sc.length + sc.value * 64;
+    pos += 1; // version
+    pos += 3; // header
+    const kc = readShortvec(txBuffer, pos); pos += kc.length + kc.value * 32;
+    pos += 32; // blockhash
+    const ic = readShortvec(txBuffer, pos);
+    assert.strictEqual(ic.value, 4, 'must have exactly 4 instructions');
+    pos += ic.length;
+    // First two are ComputeBudget (programIdIndex=5)
+    assert.strictEqual(txBuffer[pos], 5, 'ix[0] (cu-limit) programId = ComputeBudget (5)');
+    // Skip ix[0]: programIdIx(1) + shortvec(accounts=0)(1) + shortvec(data=5)(1) + 5
+    pos += 1 + 1 + 1 + 5;
+    assert.strictEqual(txBuffer[pos], 5, 'ix[1] (cu-price) programId = ComputeBudget (5)');
+    // Skip ix[1]: programIdIx(1) + shortvec(0)(1) + shortvec(9)(1) + 9
+    pos += 1 + 1 + 1 + 9;
+    assert.strictEqual(txBuffer[pos], 6, 'ix[2] (transferChecked) programId = Token (6)');
+    // Skip ix[2]: programIdIx(1) + shortvec(4)(1) + 4 + shortvec(10)(1) + 10
+    pos += 1 + 1 + 4 + 1 + 10;
+    assert.strictEqual(txBuffer[pos], 7, 'ix[3] (memo) programId = Memo (7)');
+});
+
+// ── ALT section ─────────────────────────────────────────────────────────
+
+check('Tx ends with empty address-lookup-tables section (compact-u16(0))', () => {
+    assert.strictEqual(txBuffer[txBuffer.length - 1], 0, 'last byte must be ALT count = 0');
+});
+
+console.log('');
+if (failures > 0) {
+    console.log(`✗ ${failures} test(s) failed`);
+    process.exit(1);
+}
+console.log('✓ All x402 v2 tx builder tests passed.');

--- a/tests/nodejs-project/x402.test.js
+++ b/tests/nodejs-project/x402.test.js
@@ -253,6 +253,91 @@ function _safeStringify(v) {
         assert.strictEqual(r.paymentMeta.scheme, 'exact');
     });
 
+    // ── X402Protocol.build — v2 dispatch (BAT-582 Phase 5b) ─────────────────
+    await check('build: v2 challenge produces v2-shape tx (2 sigs, x402Version=2)', async () => {
+        const v2Body = {
+            x402Version: 2,
+            accepts: [{
+                scheme: 'exact',
+                network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                amount: '10000',
+                asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            }],
+        };
+        const r = await proto.build(
+            { status: 402, bodyJson: v2Body },
+            { maxUsdcAtomic: 200000n, burnerPubkey: VALID_BURNER_PUBKEY }
+        );
+        assert.ok(!r.error, `v2 build should not error: ${_safeStringify(r)}`);
+        assert.strictEqual(r.paymentMeta.x402Version, 2, 'paymentMeta.x402Version must be 2');
+        assert.strictEqual(r.paymentMeta.burnerSigSlot, 1, 'burner must sign slot 1 (slot 0 is facilitator)');
+        assert.strictEqual(r.paymentMeta.facilitator, '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4');
+        assert.ok(typeof r.paymentMeta.memo === 'string' && r.paymentMeta.memo.length >= 32, 'memo must be ≥32 chars (16-byte hex nonce default)');
+        // v2 tx is ~497 bytes (2 sigs + 8 account keys + 4 instructions + ALT)
+        const txBytes = Buffer.from(r.txBase64, 'base64');
+        assert.strictEqual(txBytes[0], 0x02, 'sigCount must be 2');
+        assert.strictEqual(txBytes[1 + 64 * 2], 0x80, 'message starts with v0 version byte 0x80');
+    });
+
+    await check('build: v2 with extra.memo uses that memo (not random)', async () => {
+        const FIXED_MEMO = 'pi_test_3abc123def456';
+        const v2Body = {
+            x402Version: 2,
+            accepts: [{
+                scheme: 'exact',
+                network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                amount: '10000',
+                asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4', memo: FIXED_MEMO },
+            }],
+        };
+        const r = await proto.build(
+            { status: 402, bodyJson: v2Body },
+            { maxUsdcAtomic: 200000n, burnerPubkey: VALID_BURNER_PUBKEY }
+        );
+        assert.ok(!r.error);
+        assert.strictEqual(r.paymentMeta.memo, FIXED_MEMO, 'memo must match challenge extra.memo');
+    });
+
+    await check('build: v2 without extra.feePayer → missing_facilitator', async () => {
+        const v2BadBody = {
+            x402Version: 2,
+            accepts: [{
+                scheme: 'exact',
+                network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                amount: '10000',
+                asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                maxTimeoutSeconds: 300,
+                extra: {},                          // no feePayer
+            }],
+        };
+        const r = await proto.build(
+            { status: 402, bodyJson: v2BadBody },
+            { maxUsdcAtomic: 200000n, burnerPubkey: VALID_BURNER_PUBKEY }
+        );
+        assert.strictEqual(r.error, 'missing_facilitator');
+    });
+
+    await check('build: v1 challenge still produces v1-shape tx (backward compat)', async () => {
+        // The original happy-path test above already covers v1 build; this case
+        // adds an EXPLICIT byte-level check that v1 has 1 sig slot (not 2).
+        const { wire } = loadFixture('paysh-sandbox-402');
+        const r = await proto.build(
+            { status: 402, bodyJson: wire.body },
+            { maxUsdcAtomic: 200000n, burnerPubkey: VALID_BURNER_PUBKEY }
+        );
+        assert.ok(!r.error);
+        assert.strictEqual(r.paymentMeta.x402Version, 1);
+        const txBytes = Buffer.from(r.txBase64, 'base64');
+        assert.strictEqual(txBytes[0], 0x01, 'v1 sigCount must be 1');
+    });
+
     // ── X402Protocol.build — boundary rejections ─────────────────────────────
     await check('build: demand > max_usdc → demand_exceeds_max_usdc', async () => {
         const { wire } = loadFixture('paysh-sandbox-402');
@@ -441,20 +526,146 @@ function _safeStringify(v) {
             'AWS metadata-style link-local IP must be rejected');
     });
 
-    // BAT-582 R22: settle() rejects v2 challenges until a real-wire v2
-    // success fixture is committed. Phase 5 of v1.6 will lift this when
-    // the v2 proof-header path is pinned.
-    await check('settle: v2 paymentMeta rejects with v2_settle_not_implemented', async () => {
-        let fetchCalled = false;
-        const fetchFn = async () => { fetchCalled = true; return { status: 200, bodyJson: {} }; };
-        const out = await proto.settle(
-            { parsed: new URL('https://pay.sh/x'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 1000 },
-            'SIGNED',
-            { amountAtomic: 100000n, recipient: VALID_BURNER_PUBKEY, x402Version: 2 },
+    // BAT-582 Phase 5c: settle() now dispatches to v2 PAYMENT-SIGNATURE path
+    // (previously refused with v2_settle_not_implemented). Tests verify
+    // the v2 proof header is emitted with the spec-required shape.
+    await check('settle: v2 paymentMeta emits PAYMENT-SIGNATURE header (not x-payment)', async () => {
+        let capturedHeaders = null;
+        const fetchFn = async (parsed, ip, fam, headers) => {
+            capturedHeaders = headers;
+            return { status: 200, headers: {}, bodyJson: {} };
+        };
+        const v2Meta = {
+            x402Version: 2,
+            amountAtomic: 10000n,
+            recipient: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+            asset: x402Mod.USDC_MINT,
+            memo: 'abcdef0123456789abcdef0123456789',
+            negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact',
+                network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/x', description: 'test', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            },
+        };
+        await proto.settle(
+            { parsed: new URL('https://api.example.com/x'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'V2-SIGNED-TX-FIXTURE',
+            v2Meta,
             { _fetchWithLimits: fetchFn }
         );
-        assert.strictEqual(out.error, 'v2_settle_not_implemented');
-        assert.ok(!fetchCalled, 'settle must NOT touch network when refusing v2');
+        assert.ok(capturedHeaders, 'fetch must have been called');
+        assert.ok(capturedHeaders['payment-signature'], 'PAYMENT-SIGNATURE header must be set');
+        assert.ok(!capturedHeaders['x-payment'], 'v1 x-payment header MUST NOT be set on a v2 call');
+
+        // Decode PAYMENT-SIGNATURE and verify the spec-required shape.
+        const decoded = JSON.parse(Buffer.from(capturedHeaders['payment-signature'], 'base64').toString('utf8'));
+        assert.strictEqual(decoded.x402Version, 2);
+        assert.ok(decoded.resource && typeof decoded.resource === 'object', 'resource must be an object');
+        assert.strictEqual(decoded.resource.url, 'https://api.example.com/x');
+        assert.ok(decoded.accepted && typeof decoded.accepted === 'object', 'accepted (singular) required');
+        assert.strictEqual(decoded.accepted.scheme, 'exact');
+        assert.strictEqual(decoded.accepted.network, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', 'CAIP-2 network in proof');
+        assert.strictEqual(decoded.accepted.amount, '10000', 'amount as decimal string');
+        assert.strictEqual(decoded.accepted.payTo, '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ');
+        assert.strictEqual(decoded.accepted.extra.feePayer, '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4');
+        assert.strictEqual(decoded.accepted.extra.memo, 'abcdef0123456789abcdef0123456789');
+        assert.strictEqual(decoded.payload.transaction, 'V2-SIGNED-TX-FIXTURE');
+    });
+
+    await check('settle: v2 success surfaces signature from PAYMENT-RESPONSE header', async () => {
+        const successPayload = {
+            success: true,
+            transaction: '5xK8...exampleSig',
+            network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            payer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4',
+        };
+        const respHeaderValue = Buffer.from(JSON.stringify(successPayload), 'utf8').toString('base64');
+        const fetchFn = async () => ({
+            status: 200,
+            headers: { 'payment-response': respHeaderValue },
+            bodyJson: { ok: true },
+        });
+        const v2Meta = {
+            x402Version: 2, amountAtomic: 10000n, memo: 'abcdef0123456789abcdef0123456789',
+            asset: x402Mod.USDC_MINT, negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact', network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/x', description: '', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            },
+        };
+        const out = await proto.settle(
+            { parsed: new URL('https://api.example.com/x'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'SIGNED-TX', v2Meta,
+            { _fetchWithLimits: fetchFn }
+        );
+        assert.ok(!out.error, `settle should succeed: ${JSON.stringify(out)}`);
+        assert.strictEqual(out.signature, '5xK8...exampleSig', 'signature surfaced from PAYMENT-RESPONSE.transaction');
+        assert.ok(out.settlementResponse, 'v2 settlementResponse object surfaced');
+        assert.strictEqual(out.settlementResponse.success, true);
+    });
+
+    await check('settle: v2 facilitator failure surfaces as settle_failed', async () => {
+        const failPayload = {
+            success: false,
+            transaction: '',
+            network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            payer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4',
+            errorReason: 'simulated_failure',
+        };
+        const respHeaderValue = Buffer.from(JSON.stringify(failPayload), 'utf8').toString('base64');
+        const fetchFn = async () => ({
+            status: 200,
+            headers: { 'payment-response': respHeaderValue },
+            bodyJson: {},
+        });
+        const v2Meta = {
+            x402Version: 2, amountAtomic: 10000n, memo: 'abcdef0123456789abcdef0123456789',
+            asset: x402Mod.USDC_MINT, negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact', network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/x', description: '', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            },
+        };
+        const out = await proto.settle(
+            { parsed: new URL('https://api.example.com/x'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'SIGNED-TX', v2Meta,
+            { _fetchWithLimits: fetchFn }
+        );
+        assert.strictEqual(out.error, 'settle_failed');
+        assert.ok(out.reason && out.reason.includes('simulated_failure'));
+    });
+
+    await check('settle: v2 paymentMeta without extra.feePayer → v2_settle_missing_facilitator', async () => {
+        let fetchCalled = false;
+        const fetchFn = async () => { fetchCalled = true; return { status: 200, bodyJson: {} }; };
+        const v2Meta = {
+            x402Version: 2, amountAtomic: 10000n, memo: 'abcdef0123456789abcdef0123456789',
+            asset: x402Mod.USDC_MINT, negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact', network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/x', description: '', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: {},                          // no feePayer
+            },
+        };
+        const out = await proto.settle(
+            { parsed: new URL('https://api.example.com/x'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'SIGNED', v2Meta,
+            { _fetchWithLimits: fetchFn }
+        );
+        assert.strictEqual(out.error, 'v2_settle_missing_facilitator');
+        assert.ok(!fetchCalled, 'must not call network when proof construction fails');
     });
 
     await check('settle: missing x402Version rejects with unsupported_settle_version', async () => {

--- a/tests/nodejs-project/x402.test.js
+++ b/tests/nodejs-project/x402.test.js
@@ -681,6 +681,64 @@ function _safeStringify(v) {
         assert.ok(!fetchCalled, 'settle must NOT touch network when version is missing');
     });
 
+    // BAT-582 v1.6 R-pr367-fix-4: end-to-end build→settle against a real
+    // v2 fixture. Pre-fix, build() read `resource` from `accepts[i].resource`
+    // which is always null in real captures — settle then emitted
+    // PAYMENT-SIGNATURE with `resource.url: ''`. The inline-paymentMeta
+    // settle tests above can't catch that propagation bug because they
+    // hand-roll `requirement.resource`. This case pipes a real Tripadvisor
+    // capture through build() and then settle() so the resource has to
+    // flow correctly end-to-end.
+    await check('settle (integration): build→settle from real Tripadvisor v2 fixture propagates resource correctly', async () => {
+        const path = require('path');
+        const fs = require('fs');
+        const capPath = path.resolve(__dirname, '..', 'paysh', 'captures', 'tripadvisor-search-402.json');
+        if (!fs.existsSync(capPath)) {
+            // Capture not committed yet (e.g. running on a branch that
+            // doesn't include tests/paysh/) — skip rather than fail.
+            console.log('    (skipped — Tripadvisor capture not in this branch)');
+            return;
+        }
+        const capture = JSON.parse(fs.readFileSync(capPath, 'utf8'));
+        const response = { status: capture.status, bodyJson: capture.body, headers: capture.headers };
+        // Stub blockhash so build() doesn't hit RPC
+        x402Mod._setBlockhashFetcher(async () => '2tLBHqeQdeq4Pzioote4ueMkQjrpdnNLBTuDtyKo4ds9');
+
+        const built = await proto.build(response, {
+            maxUsdcAtomic: 100_000n,
+            burnerPubkey: VALID_BURNER_PUBKEY,
+        });
+        assert.ok(!built.error, `build should succeed on real v2 fixture: ${_safeStringify(built)}`);
+        // The resource MUST have flowed in from the top-level body.resource,
+        // not the (null) accepts[i].resource. If build() reads from the
+        // wrong place this propagation breaks and settle() fails.
+        assert.ok(built.paymentMeta.requirement.resource, 'paymentMeta.requirement.resource must be set');
+        assert.strictEqual(built.paymentMeta.requirement.resource.url,
+            'https://tripadvisor.x402.paysponge.com/api/v1/location/search',
+            'resource.url must come from top-level body.resource, not accepts[i].resource (which is null)');
+
+        // Now settle the built tx — verify the PAYMENT-SIGNATURE header
+        // contains the resource URL exactly (no empty string fallback).
+        let capturedHeaders = null;
+        const fetchFn = async (parsed, ip, fam, headers) => {
+            capturedHeaders = headers;
+            return { status: 200, headers: {}, bodyJson: {} };
+        };
+        await proto.settle(
+            { parsed: new URL('https://tripadvisor.x402.paysponge.com/api/v1/location/search'),
+              pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'V2-SIGNED-TX-INTEGRATION',
+            built.paymentMeta,
+            { _fetchWithLimits: fetchFn }
+        );
+        assert.ok(capturedHeaders['payment-signature'], 'v2 PAYMENT-SIGNATURE must be emitted');
+        const decoded = JSON.parse(Buffer.from(capturedHeaders['payment-signature'], 'base64').toString('utf8'));
+        assert.strictEqual(decoded.resource.url,
+            'https://tripadvisor.x402.paysponge.com/api/v1/location/search',
+            'PAYMENT-SIGNATURE resource.url must be propagated end-to-end (this is the R-pr367-fix-4 regression guard)');
+        assert.notStrictEqual(decoded.resource.url, '', 'resource.url must not be empty (pre-fix bug)');
+    });
+
     // ── Boundary rejection: response_too_large + timeout via fetch mock ─────
     // These tests target the protocol/handler pair using a controlled mock.
     // Since agent_pay's _handle calls `_fetchWithLimits` via closure (not via

--- a/tests/nodejs-project/x402.test.js
+++ b/tests/nodejs-project/x402.test.js
@@ -693,12 +693,14 @@ function _safeStringify(v) {
         const path = require('path');
         const fs = require('fs');
         const capPath = path.resolve(__dirname, '..', 'paysh', 'captures', 'tripadvisor-search-402.json');
-        if (!fs.existsSync(capPath)) {
-            // Capture not committed yet (e.g. running on a branch that
-            // doesn't include tests/paysh/) — skip rather than fail.
-            console.log('    (skipped — Tripadvisor capture not in this branch)');
-            return;
-        }
+        // BAT-582 v1.6 R-pr367-fix-2: HARD REQUIRE the fixture. Pre-fix
+        // we conditionally skipped if the file was missing, which would
+        // silently drop this regression guard if tests/paysh/captures/
+        // were ever removed or moved. The fixture IS in-repo (committed
+        // alongside Phase 0+1+2 of v1.6 implementation); if this assertion
+        // fires, something has gone wrong with the test setup.
+        assert.ok(fs.existsSync(capPath),
+            `regression guard requires fixture at ${capPath} — must stay committed alongside this test`);
         const capture = JSON.parse(fs.readFileSync(capPath, 'utf8'));
         const response = { status: capture.status, bodyJson: capture.body, headers: capture.headers };
         // Stub blockhash so build() doesn't hit RPC


### PR DESCRIPTION
**Part 2 of 2** of BAT-582 burner wallet. **Targets PR #366's branch** (stacked PR pattern). Diff shows ONLY the v2 settle delta on top of part 1 — ~1,044 lines.

## Read this first

This PR's target is `feature/BAT-582-burner-base` (part 1's source branch), NOT `main` or the integration branch. Once part 1 (#366) merges into the integration branch `feature/BAT-582-burner-wallet`, GitHub will auto-retarget this PR to the integration branch.

```
main
 └── feature/BAT-582-burner-wallet  ← integration (final merge to main happens here)
      ├── PR #366 (part 1): burner + v2 detect/build
      └── this PR (part 2): v2 settle  ← stacked on part 1
```

## What this adds

The send-side of x402 v2. Part 1 (#366) already accepts v2 challenges (detect + build); without this PR, v2 settle would refuse with \`v2_settle_not_implemented\`. After this lands, the agent can actually complete payments against real pay.sh services.

### Phase 5a — v2 tx builder
- \`_buildV2UsdcTransferTx\`: partially-signed v0 versioned Solana tx per Coinbase x402 v2 spec (specs/schemes/exact/scheme_exact_svm.md)
- 4 instructions in required order: ComputeBudget limit + price + SPL TransferChecked + Memo (extra.memo or random 32-hex nonce)
- 8 account keys, 2 signature slots (facilitator slot 0, burner slot 1)

### Phase 5b — build() dispatch
- Branches on negotiated x402Version (1 → existing path, 2 → new builder)
- v2 requires \`extra.feePayer\`; rejects with \`missing_facilitator\` if absent

### Phase 5c — settle() v2 path
- Dispatches v1 (\`x-payment\`) vs v2 (\`PAYMENT-SIGNATURE\`) proof headers
- v2 PaymentPayload per spec: \`x402Version\`, \`resource\`, \`accepted\` (singular), \`payload.transaction\`
- Parses \`PAYMENT-RESPONSE\` on 200; surfaces \`settle_failed\` when \`SettlementResponse.success=false\`

### Phase 5d — Bridge multi-sig
- \`SolanaTxSigner.insertSignature(allowPartiallySigned=true)\` skips v1's "all other slots must be cosigned" check
- KeyVault interface + EncryptedPrefsKeyVault plumb through
- \`/burner/sign-transaction\` accepts optional \`allowPartiallySigned\` JSON field

### Phase 5e — agent_pay wiring
- \`allowPartiallySigned=true\` when \`paymentMeta.x402Version === 2\`
- v1 callers (Jupiter Ultra, v1 x402) keep current behavior

## Tests

- \`tests/nodejs-project/x402-v2-tx.test.js\` (NEW): 13 byte-level assertions on v2 tx wire format using Tripadvisor's real facilitator pubkey from a committed capture
- \`tests/nodejs-project/x402.test.js\` (EXTENDED): 4 new v2 build cases, 4 new v2 settle cases
- \`SolanaTxSignerTest.kt\` (EXTENDED): partial-sign accepted with flag, default rejects (v1 regression)
- All v1 tests still pass

## Test plan

- [x] \`scripts/pre-push-check.sh\` — Node smoke + Kotlin compile both pass
- [x] All v2 tests pass
- [ ] Copilot review (1,044 lines, easily fits 20K limit)
- [ ] After both parts clean: device test the integration branch
- [ ] Real \$0.01 Tripadvisor payment + capture v2 success fixture during device test

## Spec sources

- Coinbase x402 v2: github.com/coinbase/x402
  - specs/transports-v2/http.md
  - specs/schemes/exact/scheme_exact_svm.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)