### PR TITLE
feat(agent_pay): add POST + JSON body support (BAT-664 v2)

### DIFF
--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -586,17 +586,20 @@ grep -i "MCP.*reconcile\|MCP.*Failed to" node_debug.log | tail -20
 
 ## agent_pay (BAT-582 — x402 client)
 
-### `agent_pay: rejected (non-HTTPS / private IP / non-Solana / non-USDC / demand > max_usdc / method or body invalid)`
-**Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_allowed" | "body_required_for_post" | "body_not_json" | "body_too_large"`.
+### `agent_pay: rejected (non-HTTPS / private IP / non-Solana / non-USDC / demand > max_usdc / method or body invalid / URL or DNS errors)`
+**Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_allowed" | "body_required_for_post" | "body_not_json" | "body_too_large" | "invalid_url" | "dns_timeout" | "dns_lookup_failed"`. (List is non-exhaustive — the tool can also surface bridge / settle / response errors documented in their own sections below.)
 **Diagnosis:** Pre-flight or 402-body validation refused the call. Two layers:
 
 **Pre-DNS rejections** (fire BEFORE any DNS lookup — operator typos diagnosed cleanly without touching attacker-supplied hosts):
+- `invalid_url` — URL fails URL parse (e.g., not a string, missing scheme)
 - `non_https` — URL must be `https://`
 - `method_not_allowed` — only GET / POST supported (BAT-664)
 - `body_required_for_post` / `body_not_json` / `body_too_large` — POST body issues (BAT-664)
 
-**Post-DNS, pre-HTTP rejections** (fire AFTER the DNS resolve but BEFORE any HTTP request to the URL):
+**Post-DNS, pre-HTTP rejections** (fire AFTER the DNS resolve attempt but BEFORE any HTTP request to the URL):
 - `private_ip` — DNS resolved to a private IP (SSRF defense — rejection happens immediately after resolve, before any HTTP fetch)
+- `dns_timeout` — DNS lookup exceeded the shared 30 s wall-clock budget
+- `dns_lookup_failed` — DNS resolver returned an error (NXDOMAIN, ENOTFOUND, etc.)
 
 **Post-fetch, pre-payment rejections** (fire AFTER fetching the 402 challenge but BEFORE attempting payment — server response failed v1.6 boundary checks):
 - `non_solana_network` — pay.sh requirement `network` field was not `solana`

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -615,7 +615,7 @@ All errors below:
 - `method_not_allowed` — BAT-664 supports GET and POST only (no PUT/PATCH/DELETE)
 - `body_required_for_post` — `method: "POST"` requires a `body` parameter — BAT-664
 - `body_not_json` — `body` must be a JSON-serializable object/array (or a string that parses as JSON). No `text/plain` — BAT-664
-- `body_too_large` — `body` exceeded 8 KB UTF-8 bytes after compact serialization — BAT-664
+- `body_too_large` — `body` exceeded the 8 KB UTF-8 cap (after compact serialization) OR, for string inputs, the 16 KB pre-parse DoS cap. BOTH caps apply: a multi-MB JSON string with extreme whitespace padding is rejected even if its compact form would fit — BAT-664
 
 **Fix:**
 1. For `demand_exceeds_max_usdc`: re-invoke with a higher `max_usdc` if the user agrees, OR accept the rejection (this is the cap working as designed).

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -591,7 +591,7 @@ grep -i "MCP.*reconcile\|MCP.*Failed to" node_debug.log | tail -20
 **Diagnosis:** Pre-flight or 402-body validation refused the call. Two layers:
 
 **Pre-DNS rejections** (fire BEFORE any DNS lookup — operator typos diagnosed cleanly without touching attacker-supplied hosts):
-- `invalid_url` — URL fails URL parse (e.g., not a string, missing scheme)
+- `invalid_url` — string URL fails `new URL()` parsing (missing scheme, invalid characters, etc.). Note: a non-string `url` argument is rejected earlier as `invalid_input`, not `invalid_url`.
 - `non_https` — URL must be `https://`
 - `method_not_allowed` — only GET / POST supported (BAT-664)
 - `body_required_for_post` / `body_not_json` / `body_too_large` — POST body issues (BAT-664)

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -588,7 +588,20 @@ grep -i "MCP.*reconcile\|MCP.*Failed to" node_debug.log | tail -20
 
 ### `agent_pay: rejected (non-HTTPS / private IP / non-Solana / non-USDC / demand > max_usdc / method or body invalid)`
 **Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_allowed" | "body_required_for_post" | "body_not_json" | "body_too_large"`.
-**Diagnosis:** Pre-flight or 402-body validation refused the call BEFORE any DNS resolve or payment attempt. Each error is a hard V1/V1.5 boundary:
+**Diagnosis:** Pre-flight or 402-body validation refused the call. Two layers:
+
+**Pre-DNS/network rejections** (fire BEFORE any DNS lookup or HTTP fetch — operator typos diagnosed cleanly without touching attacker-supplied hosts):
+- `non_https` — URL must be `https://`
+- `method_not_allowed` — only GET / POST supported (BAT-664)
+- `body_required_for_post` / `body_not_json` / `body_too_large` — POST body issues (BAT-664)
+- `private_ip` — DNS resolved to a private IP (rejection happens immediately after the resolve, before any HTTP request)
+
+**Post-fetch, pre-payment rejections** (fire AFTER fetching the 402 challenge but BEFORE attempting payment — server response failed V1 boundary checks):
+- `non_solana_network` — pay.sh requirement `network` field was not `solana`
+- `non_usdc_asset` — pay.sh requirement `asset` was not USDC (mint `EPjFWdd5...`)
+- `demand_exceeds_max_usdc` — server demanded more than the agent's `max_usdc` cap
+
+All errors below:
 - `non_https` — URL must be `https://` (debug builds also accept `http://localhost`)
 - `private_ip` — DNS resolved to a private/loopback IP (10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, ::1, fc00::/7, fe80::/10) — SSRF defense
 - `non_solana_network` — pay.sh requirement `network` field was not `solana`

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -590,13 +590,15 @@ grep -i "MCP.*reconcile\|MCP.*Failed to" node_debug.log | tail -20
 **Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_allowed" | "body_required_for_post" | "body_not_json" | "body_too_large"`.
 **Diagnosis:** Pre-flight or 402-body validation refused the call. Two layers:
 
-**Pre-DNS/network rejections** (fire BEFORE any DNS lookup or HTTP fetch — operator typos diagnosed cleanly without touching attacker-supplied hosts):
+**Pre-DNS rejections** (fire BEFORE any DNS lookup — operator typos diagnosed cleanly without touching attacker-supplied hosts):
 - `non_https` — URL must be `https://`
 - `method_not_allowed` — only GET / POST supported (BAT-664)
 - `body_required_for_post` / `body_not_json` / `body_too_large` — POST body issues (BAT-664)
-- `private_ip` — DNS resolved to a private IP (rejection happens immediately after the resolve, before any HTTP request)
 
-**Post-fetch, pre-payment rejections** (fire AFTER fetching the 402 challenge but BEFORE attempting payment — server response failed V1 boundary checks):
+**Post-DNS, pre-HTTP rejections** (fire AFTER the DNS resolve but BEFORE any HTTP request to the URL):
+- `private_ip` — DNS resolved to a private IP (SSRF defense — rejection happens immediately after resolve, before any HTTP fetch)
+
+**Post-fetch, pre-payment rejections** (fire AFTER fetching the 402 challenge but BEFORE attempting payment — server response failed v1.6 boundary checks):
 - `non_solana_network` — pay.sh requirement `network` field was not `solana`
 - `non_usdc_asset` — pay.sh requirement `asset` was not USDC (mint `EPjFWdd5...`)
 - `demand_exceeds_max_usdc` — server demanded more than the agent's `max_usdc` cap
@@ -607,7 +609,7 @@ All errors below:
 - `non_solana_network` — pay.sh requirement `network` field was not `solana`
 - `non_usdc_asset` — pay.sh requirement `asset` was not USDC (mint `EPjFWdd5...`)
 - `demand_exceeds_max_usdc` — server demanded more than the agent's `max_usdc` cap
-- `method_not_allowed` — V1.5 supports GET and POST only (no PUT/PATCH/DELETE) — BAT-664
+- `method_not_allowed` — BAT-664 supports GET and POST only (no PUT/PATCH/DELETE)
 - `body_required_for_post` — `method: "POST"` requires a `body` parameter — BAT-664
 - `body_not_json` — `body` must be a JSON-serializable object/array (or a string that parses as JSON). No `text/plain` — BAT-664
 - `body_too_large` — `body` exceeded 8 KB UTF-8 bytes after compact serialization — BAT-664

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -586,20 +586,27 @@ grep -i "MCP.*reconcile\|MCP.*Failed to" node_debug.log | tail -20
 
 ## agent_pay (BAT-582 — x402 client)
 
-### `agent_pay: rejected (non-HTTPS / private IP / non-Solana / non-USDC / demand > max_usdc)`
-**Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_get"`.
-**Diagnosis:** Pre-flight or 402-body validation refused the call before any payment was attempted. Each error is a hard V1 boundary:
+### `agent_pay: rejected (non-HTTPS / private IP / non-Solana / non-USDC / demand > max_usdc / method or body invalid)`
+**Symptoms:** Tool result `error: "non_https" | "private_ip" | "non_solana_network" | "non_usdc_asset" | "demand_exceeds_max_usdc" | "method_not_allowed" | "body_required_for_post" | "body_not_json" | "body_too_large"`.
+**Diagnosis:** Pre-flight or 402-body validation refused the call BEFORE any DNS resolve or payment attempt. Each error is a hard V1/V1.5 boundary:
 - `non_https` — URL must be `https://` (debug builds also accept `http://localhost`)
 - `private_ip` — DNS resolved to a private/loopback IP (10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, ::1, fc00::/7, fe80::/10) — SSRF defense
 - `non_solana_network` — pay.sh requirement `network` field was not `solana`
 - `non_usdc_asset` — pay.sh requirement `asset` was not USDC (mint `EPjFWdd5...`)
 - `demand_exceeds_max_usdc` — server demanded more than the agent's `max_usdc` cap
-- `method_not_get` — V1 only supports GET (no POST/PUT)
+- `method_not_allowed` — V1.5 supports GET and POST only (no PUT/PATCH/DELETE) — BAT-664
+- `body_required_for_post` — `method: "POST"` requires a `body` parameter — BAT-664
+- `body_not_json` — `body` must be a JSON-serializable object/array (or a string that parses as JSON). No `text/plain` — BAT-664
+- `body_too_large` — `body` exceeded 8 KB UTF-8 bytes after compact serialization — BAT-664
 
 **Fix:**
 1. For `demand_exceeds_max_usdc`: re-invoke with a higher `max_usdc` if the user agrees, OR accept the rejection (this is the cap working as designed).
 2. For `non_https` / `private_ip`: this is a security boundary — do not bypass. If the user genuinely wants to call a localhost service from a debug build, ensure NODE_ENV=development is set.
 3. For `non_solana_network` / `non_usdc_asset`: the endpoint isn't compatible with V1. Tell the user "this endpoint requires <network>/<asset>, which agent_pay doesn't support yet (V1 = Solana mainnet USDC only)."
+4. For `method_not_allowed`: only GET and POST are supported. Restructure the call to use one of them, or skip if the endpoint requires e.g. PATCH.
+5. For `body_required_for_post`: pass a `body` arg (JSON-serializable). If the endpoint genuinely has no body, switch to `method: "GET"` if appropriate.
+6. For `body_not_json`: ensure the body is a plain object/array. Functions, symbols, circular refs cause this. If passing a string, it must parse as JSON (no `text/plain`).
+7. For `body_too_large`: trim the body. 8 KB UTF-8 covers nearly every realistic SMS/API call — if you genuinely need more, that's a follow-up BAT to lift the cap.
 
 ### `agent_pay: response too large` / `agent_pay: timeout`
 **Symptoms:** Tool result `error: "response_too_large"` or `error: "timeout"`.

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -701,7 +701,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
             // BAT-582 Phase 6: agent_pay capability — only mentioned when the burner
             // is configured (the tool refuses without one, so no point advertising it
             // when it would just refuse). The user controls max_usdc per call.
-            lines.push('**Paid APIs (x402)**: Use `agent_pay(url, max_usdc)` to fetch x402-protected endpoints (e.g., pay.sh catalog services). Settles in USDC from the **Burner wallet**. Mainnet only, HTTPS GET only. The user controls `max_usdc` per call; the tool rejects if the 402 demand exceeds it.');
+            lines.push('**Paid APIs (x402)**: Use `agent_pay(url, max_usdc, method?, body?)` to fetch x402-protected endpoints (e.g., pay.sh catalog services). Settles in USDC from the **Burner wallet**. Mainnet only, HTTPS only. Default `method` is GET; pass `method: "POST"` + `body: <JSON-serializable>` for paid POST endpoints (≤ 8 KB body). GET runs silently when under cap. **POST always asks for user confirmation** (side-effect-aware: POST can send SMS, post content, or trigger paid actions). The user controls `max_usdc` per call; the tool rejects if the 402 demand exceeds it.');
         } else {
             lines.push('You have one wallet:');
             lines.push('- **Main** (via MWA) — user\'s wallet. Approval popup required for every action.');

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -104,6 +104,29 @@ function _decimalToAtomic(decimal, decimals) {
     return full;
 }
 
+// BAT-664: confirmation message for agent_pay POST. Shows method + URL +
+// max_usdc + a 200-char body PREVIEW that the UI can render. Per Codex v2
+// note 2: the preview is for HUMAN display only — it must not be persisted
+// to analytics in any form that contains body content. Callers that emit
+// telemetry should record `method`, `host`, `bodyByteLength`, and a
+// `bodyTruncated: true` flag instead. This helper does NOT log or emit;
+// it just returns a string for the confirmation card.
+function _agentPayPostConfirmMessage(args) {
+    const url = typeof args.url === 'string' ? args.url : '<missing url>';
+    const max = typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc);
+    let bodyPreview = '';
+    if (args.body !== undefined && args.body !== null) {
+        let s;
+        try { s = typeof args.body === 'string' ? args.body : JSON.stringify(args.body); }
+        catch (_) { s = '<unserializable body>'; }
+        if (s.length > 200) s = s.slice(0, 200) + '… (truncated)';
+        bodyPreview = `body: ${s}`;
+    } else {
+        bodyPreview = 'body: <empty>';
+    }
+    return `POST ${url}\nmax_usdc: ${max} USDC\n${bodyPreview}`;
+}
+
 function _capDiffMessage(args, walletState) {
     // wallet_set_caps args are decimal strings; current caps in walletState are atomic strings.
     const current = (walletState && walletState.burnerCaps) || {};
@@ -169,6 +192,13 @@ function getConfirmationPolicy(toolName, args, walletState) {
     // Phase 6 does the real demand-vs-max_usdc check inside the tool itself
     // (Node has no way to know the demand pre-fetch). When max_usdc is
     // missing, block at the gate to fail fast.
+    //
+    // BAT-664: POST always requires user confirmation (side-effect-aware).
+    // POST endpoints can send SMS, post content, or trigger paid actions.
+    // The confirmation preview shows method, URL, the first 200 chars of
+    // the body (sanitized — built UI-side; this hook only signals the
+    // policy), and the max_usdc cap. GET keeps its existing under-cap
+    // silent behavior.
     if (toolName === 'agent_pay') {
         if (typeof a.max_usdc !== 'string' && typeof a.max_usdc !== 'number') {
             return {
@@ -177,6 +207,14 @@ function getConfirmationPolicy(toolName, args, walletState) {
                 message: 'agent_pay requires a max_usdc cap (decimal string).',
             };
         }
+        const method = (typeof a.method === 'string' ? a.method : 'GET').toUpperCase();
+        if (method === 'POST') {
+            return {
+                policy: 'confirm',
+                message: _agentPayPostConfirmMessage(a),
+            };
+        }
+        // GET: keep the existing under-cap-silent behavior.
         return 'none';
     }
 

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -190,10 +190,15 @@ function _agentPayPostConfirmMessage(args) {
         let s;
         try { s = typeof args.body === 'string' ? args.body : JSON.stringify(args.body); }
         catch (_) { s = '<unserializable body>'; }
+        // R-pr370-fix-33: literalize BEFORE truncating. Newline → "\n"
+        // is a 2-char expansion; truncating before literalization could
+        // produce a post-literalize string that exceeds _BODY_PREVIEW_MAX.
+        // Now the truncation bound holds on the final user-visible content.
+        s = _literalizeNewlines(s);
         if (s.length > _BODY_PREVIEW_MAX) {
             s = s.slice(0, _BODY_PREVIEW_MAX - _BODY_PREVIEW_SUFFIX.length) + _BODY_PREVIEW_SUFFIX;
         }
-        bodyPreview = `body: ${_literalizeNewlines(s)}`;
+        bodyPreview = `body: ${s}`;
     } else {
         bodyPreview = 'body: <empty>';
     }

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -164,49 +164,33 @@ function _validateAgentPayPostBody(body) {
 const _BODY_PREVIEW_MAX = 200;
 const _BODY_PREVIEW_SUFFIX = '… (truncated)';
 
-// R-pr370-fix-12 (BAT-664 security): the confirmation message is rendered
-// through markdown-it (linkify enabled) by the Telegram/Discord channel.
-// Model-controlled body content could inject:
-//   - backticks → break out into code blocks
-//   - `[text](url)` → render as a fake link
-//   - `**` / `__` → bold/italic spoofing
-//   - newlines / carriage returns → reflow the card to hide context
-//   - HTML angle brackets → with raw HTML enabled, an injection vector
-// Escape the body preview by neutralizing every Markdown metacharacter
-// and normalizing whitespace to a literal `\n` token so the rendered
-// preview is always a single-line opaque blob the user can't be tricked
-// by. URL + max_usdc come from agent args too — sanitize those as well.
-function _escapeMarkdownPreview(s) {
-    return String(s)
-        // Strip / encode newlines first so the regex below works on a single
-        // line; literal "\n" stays visible to the human reader.
-        .replace(/\r\n?/g, '\n')
-        .replace(/\n/g, '\\n')
-        // Escape backslash FIRST so we don't double-escape the markers we
-        // add below.
-        .replace(/\\/g, '\\\\')
-        // Markdown structure chars + HTML angle brackets.
-        .replace(/[`*_~[\](){}#>|!<>]/g, (c) => '\\' + c)
-        // Any leftover non-printable controls → space (defense-in-depth).
-        // eslint-disable-next-line no-control-regex
-        .replace(/[\x00-\x1F\x7F]/g, ' ');
+// R-pr370-fix-13 (BAT-664 security): Markdown escaping happens at the
+// render boundary in tools/index.js::formatConfirmationMessage — EVERY
+// policy-built message gets sanitized there, so individual hooks don't
+// have to remember to escape backticks/links/bold/etc. Newlines are
+// preserved structurally by the format function; only the BODY content
+// here literalizes its own embedded newlines (\n in the JSON value
+// shouldn't break the body line out into a new structural line).
+function _literalizeNewlines(s) {
+    return String(s).replace(/\r\n?/g, '\n').replace(/\n/g, '\\n');
 }
 
 function _agentPayPostConfirmMessage(args) {
-    const url = typeof args.url === 'string' ? _escapeMarkdownPreview(args.url) : '<missing url>';
-    const max = _escapeMarkdownPreview(typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc));
+    const url = typeof args.url === 'string' ? args.url : '<missing url>';
+    const max = typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc);
     let bodyPreview = '';
     if (args.body !== undefined && args.body !== null) {
         let s;
         try { s = typeof args.body === 'string' ? args.body : JSON.stringify(args.body); }
         catch (_) { s = '<unserializable body>'; }
-        // Truncate BEFORE escape so the 200-char limit is on the human-
-        // visible content (post-escape length may be larger due to
-        // backslash insertions, which is fine for safety).
         if (s.length > _BODY_PREVIEW_MAX) {
             s = s.slice(0, _BODY_PREVIEW_MAX - _BODY_PREVIEW_SUFFIX.length) + _BODY_PREVIEW_SUFFIX;
         }
-        bodyPreview = `body: ${_escapeMarkdownPreview(s)}`;
+        // Literalize newlines inside the body content so a model-supplied
+        // JSON containing real newlines can't reflow the card across
+        // structural lines. Markdown char escaping happens at the render
+        // boundary (formatConfirmationMessage).
+        bodyPreview = `body: ${_literalizeNewlines(s)}`;
     } else {
         bodyPreview = 'body: <empty>';
     }

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -163,18 +163,50 @@ function _validateAgentPayPostBody(body) {
 // 200-char contract from BAT-664 v2.
 const _BODY_PREVIEW_MAX = 200;
 const _BODY_PREVIEW_SUFFIX = '… (truncated)';
+
+// R-pr370-fix-12 (BAT-664 security): the confirmation message is rendered
+// through markdown-it (linkify enabled) by the Telegram/Discord channel.
+// Model-controlled body content could inject:
+//   - backticks → break out into code blocks
+//   - `[text](url)` → render as a fake link
+//   - `**` / `__` → bold/italic spoofing
+//   - newlines / carriage returns → reflow the card to hide context
+//   - HTML angle brackets → with raw HTML enabled, an injection vector
+// Escape the body preview by neutralizing every Markdown metacharacter
+// and normalizing whitespace to a literal `\n` token so the rendered
+// preview is always a single-line opaque blob the user can't be tricked
+// by. URL + max_usdc come from agent args too — sanitize those as well.
+function _escapeMarkdownPreview(s) {
+    return String(s)
+        // Strip / encode newlines first so the regex below works on a single
+        // line; literal "\n" stays visible to the human reader.
+        .replace(/\r\n?/g, '\n')
+        .replace(/\n/g, '\\n')
+        // Escape backslash FIRST so we don't double-escape the markers we
+        // add below.
+        .replace(/\\/g, '\\\\')
+        // Markdown structure chars + HTML angle brackets.
+        .replace(/[`*_~[\](){}#>|!<>]/g, (c) => '\\' + c)
+        // Any leftover non-printable controls → space (defense-in-depth).
+        // eslint-disable-next-line no-control-regex
+        .replace(/[\x00-\x1F\x7F]/g, ' ');
+}
+
 function _agentPayPostConfirmMessage(args) {
-    const url = typeof args.url === 'string' ? args.url : '<missing url>';
-    const max = typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc);
+    const url = typeof args.url === 'string' ? _escapeMarkdownPreview(args.url) : '<missing url>';
+    const max = _escapeMarkdownPreview(typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc));
     let bodyPreview = '';
     if (args.body !== undefined && args.body !== null) {
         let s;
         try { s = typeof args.body === 'string' ? args.body : JSON.stringify(args.body); }
         catch (_) { s = '<unserializable body>'; }
+        // Truncate BEFORE escape so the 200-char limit is on the human-
+        // visible content (post-escape length may be larger due to
+        // backslash insertions, which is fine for safety).
         if (s.length > _BODY_PREVIEW_MAX) {
             s = s.slice(0, _BODY_PREVIEW_MAX - _BODY_PREVIEW_SUFFIX.length) + _BODY_PREVIEW_SUFFIX;
         }
-        bodyPreview = `body: ${s}`;
+        bodyPreview = `body: ${_escapeMarkdownPreview(s)}`;
     } else {
         bodyPreview = 'body: <empty>';
     }

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -176,8 +176,15 @@ function _literalizeNewlines(s) {
 }
 
 function _agentPayPostConfirmMessage(args) {
-    const url = typeof args.url === 'string' ? args.url : '<missing url>';
-    const max = typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc);
+    // R-pr370-fix-16: literalize newlines in EVERY interpolated field so
+    // a model-controlled url or max_usdc with embedded \n can't inject
+    // extra structural lines into the confirmation card. Pre-fix only the
+    // body had newline literalization — url/max_usdc were passed through
+    // verbatim and formatConfirmationMessage's escape preserves real
+    // newlines for structure, which is the exact lever an attacker would
+    // use to misrepresent the action being confirmed.
+    const url = typeof args.url === 'string' ? _literalizeNewlines(args.url) : '<missing url>';
+    const max = _literalizeNewlines(typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc));
     let bodyPreview = '';
     if (args.body !== undefined && args.body !== null) {
         let s;
@@ -186,10 +193,6 @@ function _agentPayPostConfirmMessage(args) {
         if (s.length > _BODY_PREVIEW_MAX) {
             s = s.slice(0, _BODY_PREVIEW_MAX - _BODY_PREVIEW_SUFFIX.length) + _BODY_PREVIEW_SUFFIX;
         }
-        // Literalize newlines inside the body content so a model-supplied
-        // JSON containing real newlines can't reflow the card across
-        // structural lines. Markdown char escaping happens at the render
-        // boundary (formatConfirmationMessage).
         bodyPreview = `body: ${_literalizeNewlines(s)}`;
     } else {
         bodyPreview = 'body: <empty>';

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -118,6 +118,16 @@ function _validateAgentPayPostBody(body) {
     }
     let parsed = body;
     if (typeof body === 'string') {
+        // R-pr370-fix-5: bound raw string length BEFORE JSON.parse to
+        // avoid resource exhaustion in the confirmation path. Same 2×
+        // cap as agent_pay's validator — final compact-serialized size
+        // is still checked against the strict 8 KB cap below.
+        if (Buffer.byteLength(body, 'utf8') > _POLICY_MAX_POST_BODY_BYTES * 2) {
+            return {
+                error: 'body_too_large',
+                reason: `raw POST body string exceeds ${_POLICY_MAX_POST_BODY_BYTES * 2} bytes pre-parse`,
+            };
+        }
         try { parsed = JSON.parse(body); }
         catch (_) {
             return { error: 'body_not_json', reason: 'string body must be valid JSON' };
@@ -147,6 +157,12 @@ function _validateAgentPayPostBody(body) {
 // telemetry should record `method`, `host`, `bodyByteLength`, and a
 // `bodyTruncated: true` flag instead. This helper does NOT log or emit;
 // it just returns a string for the confirmation card.
+// R-pr370-fix-3.2: budget the body preview at 200 chars TOTAL (including
+// the truncation suffix), not 200 chars + suffix. Pre-fix produced strings
+// like "<200 chars>… (truncated)" which were 213 chars long — broke the
+// 200-char contract from BAT-664 v2.
+const _BODY_PREVIEW_MAX = 200;
+const _BODY_PREVIEW_SUFFIX = '… (truncated)';
 function _agentPayPostConfirmMessage(args) {
     const url = typeof args.url === 'string' ? args.url : '<missing url>';
     const max = typeof args.max_usdc === 'string' ? args.max_usdc : String(args.max_usdc);
@@ -155,7 +171,9 @@ function _agentPayPostConfirmMessage(args) {
         let s;
         try { s = typeof args.body === 'string' ? args.body : JSON.stringify(args.body); }
         catch (_) { s = '<unserializable body>'; }
-        if (s.length > 200) s = s.slice(0, 200) + '… (truncated)';
+        if (s.length > _BODY_PREVIEW_MAX) {
+            s = s.slice(0, _BODY_PREVIEW_MAX - _BODY_PREVIEW_SUFFIX.length) + _BODY_PREVIEW_SUFFIX;
+        }
         bodyPreview = `body: ${s}`;
     } else {
         bodyPreview = 'body: <empty>';

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -312,9 +312,12 @@ function getConfirmationPolicy(toolName, args, walletState) {
             };
         }
         if (method === 'POST') {
-            // R-pr370-fix-39: validate url here too — if missing/non-string,
-            // the tool deterministically rejects with invalid_input. Don't
-            // prompt the user to confirm an action that can't succeed.
+            // R-pr370-fix-39/43: validate url here — if missing/non-string,
+            // unparseable, or non-HTTPS, the tool deterministically rejects
+            // downstream. Don't prompt the user to confirm an action that
+            // can't succeed. We don't replicate the FULL preflight here
+            // (private IP / debug-localhost) since those need DNS — just
+            // the cheap pre-DNS checks.
             if (typeof a.url !== 'string' || a.url.length === 0) {
                 return {
                     policy: 'block',
@@ -322,6 +325,27 @@ function getConfirmationPolicy(toolName, args, walletState) {
                     message: 'agent_pay POST requires a non-empty url string.',
                 };
             }
+            let parsedUrl;
+            try { parsedUrl = new URL(a.url); }
+            catch (_) {
+                return {
+                    policy: 'block',
+                    reason: 'invalid_url',
+                    message: 'agent_pay POST: url failed to parse as a URL.',
+                };
+            }
+            if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+                return {
+                    policy: 'block',
+                    reason: 'non_https',
+                    message: `agent_pay POST: url scheme must be https (got ${parsedUrl.protocol}).`,
+                };
+            }
+            // http:// only allowed for localhost in debug builds; the
+            // handler enforces the localhost+debug rule via the
+            // shared preflightUrlSync, so we approximate at the gate
+            // with the scheme-only check (cheap pre-DNS). The handler
+            // will block again for http://attacker.com in production.
             // R-pr370-fix-20: fail-fast at gate when no burner. POST
             // deterministically rejects with burner_not_configured at the
             // handler — prompting the user to confirm an action that

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -312,6 +312,16 @@ function getConfirmationPolicy(toolName, args, walletState) {
             };
         }
         if (method === 'POST') {
+            // R-pr370-fix-39: validate url here too — if missing/non-string,
+            // the tool deterministically rejects with invalid_input. Don't
+            // prompt the user to confirm an action that can't succeed.
+            if (typeof a.url !== 'string' || a.url.length === 0) {
+                return {
+                    policy: 'block',
+                    reason: 'invalid_input',
+                    message: 'agent_pay POST requires a non-empty url string.',
+                };
+            }
             // R-pr370-fix-20: fail-fast at gate when no burner. POST
             // deterministically rejects with burner_not_configured at the
             // handler — prompting the user to confirm an action that

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -262,7 +262,31 @@ function getConfirmationPolicy(toolName, args, walletState) {
                 message: 'agent_pay requires a max_usdc cap (decimal string).',
             };
         }
-        const method = (typeof a.method === 'string' ? a.method : 'GET').toUpperCase();
+        // R-pr370-fix-9: gate-level method validation. Pre-fix any method
+        // other than POST silently fell through to GET behavior (return
+        // 'none'), so an invalid method only failed at the handler. Now
+        // block unsupported methods at the policy so the agent gets a
+        // clear, immediate reason without going through the confirmation
+        // or dispatch path.
+        let method;
+        if (a.method === undefined || a.method === null) {
+            method = 'GET';
+        } else if (typeof a.method !== 'string') {
+            return {
+                policy: 'block',
+                reason: 'method_not_allowed',
+                message: `agent_pay: method must be a string (got ${typeof a.method})`,
+            };
+        } else {
+            method = a.method.toUpperCase();
+        }
+        if (method !== 'GET' && method !== 'POST') {
+            return {
+                policy: 'block',
+                reason: 'method_not_allowed',
+                message: `agent_pay: method must be GET or POST (got ${method})`,
+            };
+        }
         if (method === 'POST') {
             // R-pr370-fix-4: validate the body here BEFORE asking the user
             // to confirm. Pre-fix the user could confirm a POST that the

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -307,6 +307,18 @@ function getConfirmationPolicy(toolName, args, walletState) {
             };
         }
         if (method === 'POST') {
+            // R-pr370-fix-20: fail-fast at gate when no burner. POST
+            // deterministically rejects with burner_not_configured at the
+            // handler — prompting the user to confirm an action that
+            // can't succeed is bad UX. Block early so the agent gets the
+            // signal without involving the user.
+            if (!burnerConfigured) {
+                return {
+                    policy: 'block',
+                    reason: 'burner_not_configured',
+                    message: 'agent_pay POST requires a burner wallet. Configure one in Settings → Burner Wallet.',
+                };
+            }
             // R-pr370-fix-4: validate the body here BEFORE asking the user
             // to confirm. Pre-fix the user could confirm a POST that the
             // tool then deterministically rejects with body_required_for_post

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -334,6 +334,12 @@ function getConfirmationPolicy(toolName, args, walletState) {
                     message: 'agent_pay POST: url failed to parse as a URL.',
                 };
             }
+            // R-pr370-fix-44: mirror tools/agent_pay.js::preflightUrlSync.
+            // https:// always OK. http:// only OK for localhost AND debug
+            // build — otherwise non_https. Any other scheme → non_https.
+            // Pre-fix the gate only blocked non-http(s); plain `http://x`
+            // would reach 'confirm' even though the tool deterministically
+            // rejects it as non_https.
             if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
                 return {
                     policy: 'block',
@@ -341,11 +347,18 @@ function getConfirmationPolicy(toolName, args, walletState) {
                     message: `agent_pay POST: url scheme must be https (got ${parsedUrl.protocol}).`,
                 };
             }
-            // http:// only allowed for localhost in debug builds; the
-            // handler enforces the localhost+debug rule via the
-            // shared preflightUrlSync, so we approximate at the gate
-            // with the scheme-only check (cheap pre-DNS). The handler
-            // will block again for http://attacker.com in production.
+            if (parsedUrl.protocol === 'http:') {
+                const host = (parsedUrl.hostname || '').toLowerCase();
+                const isLocal = host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+                const isDebug = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+                if (!isLocal || !isDebug) {
+                    return {
+                        policy: 'block',
+                        reason: 'non_https',
+                        message: 'agent_pay POST: http:// only allowed for localhost in debug builds.',
+                    };
+                }
+            }
             // R-pr370-fix-20: fail-fast at gate when no burner. POST
             // deterministically rejects with burner_not_configured at the
             // handler — prompting the user to confirm an action that

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -104,6 +104,42 @@ function _decimalToAtomic(decimal, decimals) {
     return full;
 }
 
+// BAT-664 (R-pr370-fix-4): early body validation in the policy hook so
+// invalid POST calls fail fast WITHOUT prompting the user to confirm an
+// action that would deterministically reject downstream. Mirrors the
+// rules in tools/agent_pay.js::validateAndSerializeBody — duplicated
+// here rather than imported to avoid a confirmation→tools require cycle.
+// The two MUST stay in sync (regression test in agent-pay-post.test.js
+// pins the rules cross-check).
+const _POLICY_MAX_POST_BODY_BYTES = 8 * 1024;
+function _validateAgentPayPostBody(body) {
+    if (body === undefined || body === null) {
+        return { error: 'body_required_for_post', reason: 'POST requires a JSON body' };
+    }
+    let parsed = body;
+    if (typeof body === 'string') {
+        try { parsed = JSON.parse(body); }
+        catch (_) {
+            return { error: 'body_not_json', reason: 'string body must be valid JSON' };
+        }
+    }
+    if (parsed === null || typeof parsed !== 'object') {
+        return { error: 'body_not_json', reason: `body must be a JSON object or array (got ${parsed === null ? 'null' : typeof parsed})` };
+    }
+    let s;
+    try { s = JSON.stringify(parsed); }
+    catch (e) {
+        return { error: 'body_not_json', reason: `body could not be serialized: ${e.message}` };
+    }
+    if (typeof s !== 'string') {
+        return { error: 'body_not_json', reason: 'body did not produce a JSON value' };
+    }
+    if (Buffer.byteLength(s, 'utf8') > _POLICY_MAX_POST_BODY_BYTES) {
+        return { error: 'body_too_large', reason: `POST body exceeds ${_POLICY_MAX_POST_BODY_BYTES} UTF-8 bytes` };
+    }
+    return { ok: true };
+}
+
 // BAT-664: confirmation message for agent_pay POST. Shows method + URL +
 // max_usdc + a 200-char body PREVIEW that the UI can render. Per Codex v2
 // note 2: the preview is for HUMAN display only — it must not be persisted
@@ -210,6 +246,20 @@ function getConfirmationPolicy(toolName, args, walletState) {
         }
         const method = (typeof a.method === 'string' ? a.method : 'GET').toUpperCase();
         if (method === 'POST') {
+            // R-pr370-fix-4: validate the body here BEFORE asking the user
+            // to confirm. Pre-fix the user could confirm a POST that the
+            // tool then deterministically rejects with body_required_for_post
+            // / body_not_json / body_too_large — wasted UX. Block at the
+            // policy gate with a clear reason so the agent fixes the call
+            // without involving the user.
+            const v = _validateAgentPayPostBody(a.body);
+            if (v.error) {
+                return {
+                    policy: 'block',
+                    reason: v.error,
+                    message: `agent_pay POST rejected: ${v.reason}`,
+                };
+            }
             return {
                 policy: 'confirm',
                 message: _agentPayPostConfirmMessage(a),

--- a/app/src/main/assets/nodejs-project/confirmation/policy.js
+++ b/app/src/main/assets/nodejs-project/confirmation/policy.js
@@ -195,10 +195,11 @@ function getConfirmationPolicy(toolName, args, walletState) {
     //
     // BAT-664: POST always requires user confirmation (side-effect-aware).
     // POST endpoints can send SMS, post content, or trigger paid actions.
-    // The confirmation preview shows method, URL, the first 200 chars of
-    // the body (sanitized — built UI-side; this hook only signals the
-    // policy), and the max_usdc cap. GET keeps its existing under-cap
-    // silent behavior.
+    // _agentPayPostConfirmMessage() below builds the preview text that the
+    // confirmation UI will render verbatim (method + URL + 200-char body
+    // preview + max_usdc). The UI shows this string in the card; this
+    // hook is the source of truth for the preview content. GET keeps its
+    // existing under-cap silent behavior.
     if (toolName === 'agent_pay') {
         if (typeof a.max_usdc !== 'string' && typeof a.max_usdc !== 'number') {
             return {

--- a/app/src/main/assets/nodejs-project/payment/x402.js
+++ b/app/src/main/assets/nodejs-project/payment/x402.js
@@ -1318,7 +1318,15 @@ class X402Protocol extends PaymentProtocol {
         if (typeof fetchFn !== 'function') {
             return { error: 'missing_fetch_helper', reason: 'settle() requires helpers._fetchWithLimits' };
         }
-        const { parsed, pinnedIp, pinnedFamily, timeoutLeftMs } = originalRequest || {};
+        const {
+            parsed, pinnedIp, pinnedFamily, timeoutLeftMs,
+            // BAT-664: probe and settle MUST send the SAME method + body
+            // + Idempotency-Key (the SAME bytes). agent_pay caches the
+            // serialized body once at request-validation time and threads
+            // both halves through originalRequest. Defaults preserve v1
+            // GET-only behavior for callers that don't pass them.
+            method, bodyJsonStr, idempotencyKey,
+        } = originalRequest || {};
         if (!parsed) return { error: 'missing_request_context', reason: 'originalRequest.parsed missing' };
 
         // BAT-582 v1.6 Phase 5c: settle() dispatches v1 vs v2 proof-header
@@ -1357,7 +1365,19 @@ class X402Protocol extends PaymentProtocol {
             proofHeaders = { 'x-payment': xPaymentHeader };
         }
 
-        const resp = await fetchFn(parsed, pinnedIp, pinnedFamily, proofHeaders, timeoutLeftMs || 30000);
+        // BAT-664: settle replay sends the SAME method + body + idempotency
+        // key as the probe. Adding the proof header to the existing probe
+        // headers gives strict facilitators (paysponge) a byte-identical
+        // body to validate against.
+        const settleHeaders = idempotencyKey
+            ? { 'idempotency-key': idempotencyKey, ...proofHeaders }
+            : proofHeaders;
+        const resp = await fetchFn(
+            parsed, pinnedIp, pinnedFamily,
+            settleHeaders,
+            timeoutLeftMs || 30000,
+            { method, bodyJsonStr },
+        );
 
         if (resp.error) return { error: resp.error, reason: resp.reason };
         if (resp.status === 402) {

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -218,7 +218,19 @@ function preflightUrlSync(url, method) {
     try { parsed = new URL(url); }
     catch (_) { return { error: 'invalid_url', reason: 'URL parse failed' }; }
 
-    const m = (method || 'GET').toUpperCase();
+    // R-pr370-fix-6: defensive type check. Tool inputs aren't schema-validated
+    // at runtime, so a malformed call could pass `method: 123` / `method: {}`.
+    // `(non-string).toUpperCase()` would throw an uninformative TypeError;
+    // we treat any non-string as "missing" → default GET, but reject other
+    // truthy non-strings as method_not_allowed so the operator gets a clear
+    // signal that the type was wrong.
+    let m;
+    if (method === undefined || method === null) m = 'GET';
+    else if (typeof method !== 'string') {
+        return { error: 'method_not_allowed', reason: `method must be a string (got ${typeof method})` };
+    } else {
+        m = method.toUpperCase();
+    }
     if (!ALLOWED_METHODS.has(m)) {
         return { error: 'method_not_allowed', reason: `method must be GET or POST (got ${m})` };
     }
@@ -242,11 +254,13 @@ function preflightUrlSync(url, method) {
 // Returns { bodyJsonStr } on success, or { error, reason } on rejection.
 //
 // Rules (per contract v2):
-//   - method === 'POST' ⇒ body required (else body_required_for_post)
+//   - method === 'POST' ⇒ body required; `undefined` or `null` rejected as
+//     body_required_for_post (treated as "no body supplied")
 //   - body string ⇒ MUST parse as JSON (else body_not_json)
 //   - body object/array ⇒ pass through
-//   - other types (null, boolean, number) ⇒ accepted only if JSON.stringify
-//     produces a value (matches JSON.stringify semantics)
+//   - body of other types (boolean, number) ⇒ accepted only if
+//     JSON.stringify produces a string (matches JSON.stringify semantics);
+//     functions / symbols-only / circular refs return body_not_json
 //   - Final compact-serialized form ≤ 8192 UTF-8 bytes (body_too_large)
 //
 // The returned bodyJsonStr is REUSED byte-identically for probe and settle
@@ -324,8 +338,9 @@ async function preflightUrl(url, method, deadlineMs) {
 
 // ── Fetch with timeout + size cap, using pinned IP ───────────────────────────
 
-// Returns { status, headers, bodyBuffer, bodyJson?, request: {url, method, headers} } or { error, reason }.
-// `parsed` is a URL instance; `pinnedIp` is the resolved IPv4/IPv6 string (or null for localhost).
+// Returns { status, headers, bodyBuffer, bodyJson? } or { error, reason }.
+// `parsed` is a URL instance; `pinnedIp` is the resolved IPv4/IPv6 string
+// (or null for localhost).
 //
 // BAT-664: `opts.method` ('GET'|'POST') and `opts.bodyJsonStr` (cached
 // pre-serialized compact JSON, or null) thread through here so the SAME

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -59,7 +59,14 @@ const { wouldReserve } = require('../caps/preflight');
 
 const USDC_DECIMALS = 6;
 const MAX_BODY_BYTES = 1024 * 1024;        // 1 MB response cap
-const MAX_POST_BODY_BYTES = 8 * 1024;      // 8 KB request-body cap (BAT-664, per v1.6 contract)
+const MAX_POST_BODY_BYTES = 8 * 1024;      // 8 KB compact-serialized body cap (BAT-664, per v1.6 contract)
+// R-pr370-fix-35: separate DoS guard on raw string input BEFORE
+// JSON.parse. Without this, a model-supplied multi-MB JSON string
+// would burn CPU/memory in the parser even though the post-serialize
+// 8 KB cap would eventually reject it. 2× MAX_POST_BODY_BYTES gives
+// callers slack for whitespace/formatting in their JSON string while
+// keeping the worst-case parse cost bounded.
+const MAX_RAW_STRING_BYTES = MAX_POST_BODY_BYTES * 2;
 const TOTAL_TIMEOUT_MS = 30 * 1000;        // 30 s
 const RESERVE_TTL_MS = 60 * 1000;          // 60 s (matches dispatch.js)
 const ALLOWED_METHODS = new Set(['GET', 'POST']);
@@ -297,13 +304,16 @@ function validateAndSerializeBody(method, body) {
         // R-pr370-fix-4: bound raw string length BEFORE JSON.parse. A
         // model-controlled multi-MB string would burn CPU/memory in the
         // parser before being rejected by the post-serialize 8 KB cap.
-        // Cap raw input at 2× the compact-serialized cap (room for
-        // whitespace + minor formatting); strictly checked again after
-        // parse via the existing size check below.
-        if (Buffer.byteLength(body, 'utf8') > MAX_POST_BODY_BYTES * 2) {
+        // 2× MAX_POST_BODY_BYTES is documented as a pre-parse DoS guard
+        // (see MAX_RAW_STRING_BYTES); a JSON string with extreme
+        // whitespace padding could exceed this even if its
+        // post-compact-serialize form would fit. That's the documented
+        // contract: BOTH caps apply (pre-parse + post-serialize).
+        const rawLen = Buffer.byteLength(body, 'utf8');
+        if (rawLen > MAX_RAW_STRING_BYTES) {
             return {
                 error: 'body_too_large',
-                reason: `raw POST body string is ${Buffer.byteLength(body, 'utf8')} bytes (max ${MAX_POST_BODY_BYTES * 2} pre-parse)`,
+                reason: `raw POST body string is ${rawLen} bytes (pre-parse cap ${MAX_RAW_STRING_BYTES} = 2× compact-serialize cap, DoS guard)`,
             };
         }
         try { parsed = JSON.parse(body); }
@@ -533,7 +543,7 @@ const tools = [
                     // full surface. Bare primitives rejected at validate
                     // time (see validateAndSerializeBody).
                     type: ['object', 'array', 'string'],
-                    description: 'Request body for POST. JSON object or array (or a JSON string that parses to an object/array). Bare primitives (numbers, booleans, plain strings) are rejected. Max 8 KB UTF-8 compact-serialized. Required when method=POST.',
+                    description: 'Request body for POST. JSON object or array (or a JSON string that parses to an object/array). Bare primitives (numbers, booleans, plain strings) are rejected. Max 8 KB UTF-8 after compact serialization. String inputs are ALSO capped at 16 KB UTF-8 pre-parse (DoS guard against multi-MB strings that would compact down). Required when method=POST.',
                 },
             },
             required: ['url', 'max_usdc'],

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -517,6 +517,13 @@ const tools = [
                     description: 'HTTP method. Defaults to "GET". POST always requires user confirmation regardless of cap.',
                 },
                 body: {
+                    // R-pr370-fix-25: validator accepts both an object/array
+                    // directly AND a JSON-string that PARSES to an object/array.
+                    // Express that as a union type in the schema so model
+                    // guidance + downstream schema-driven validators see the
+                    // full surface. Bare primitives rejected at validate
+                    // time (see validateAndSerializeBody).
+                    type: ['object', 'array', 'string'],
                     description: 'Request body for POST. JSON object or array (or a JSON string that parses to an object/array). Bare primitives (numbers, booleans, plain strings) are rejected. Max 8 KB UTF-8 compact-serialized. Required when method=POST.',
                 },
             },

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -389,7 +389,12 @@ function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, sig
         return _fetchOverride(parsed, pinnedIp, pinnedFamily, extraHeaders, signalTimeoutLeftMs, opts);
     }
     return new Promise((resolve) => {
-        const method = (opts.method || 'GET').toUpperCase();
+        // R-pr370-fix-29: defensive method type check. settle() now passes
+        // method via originalRequest; a future caller / test override that
+        // sets opts.method to a non-string would crash here with an
+        // uninformative TypeError. Treat non-strings as missing → GET.
+        let method = 'GET';
+        if (typeof opts.method === 'string') method = opts.method.toUpperCase();
         const bodyJsonStr = (method === 'POST' && typeof opts.bodyJsonStr === 'string')
             ? opts.bodyJsonStr
             : null;
@@ -402,7 +407,11 @@ function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, sig
         }, extraHeaders);
         if (bodyJsonStr !== null) {
             headers['content-type'] = 'application/json';
-            headers['content-length'] = Buffer.byteLength(bodyJsonStr, 'utf8');
+            // R-pr370-fix-28: Content-Length MUST be a string. Node's HTTP
+            // client throws ERR_HTTP_INVALID_HEADER_VALUE for numeric
+            // header values in strict modes; even when it works, normalized
+            // header transport (HTTP/2) expects strings.
+            headers['content-length'] = String(Buffer.byteLength(bodyJsonStr, 'utf8'));
         }
 
         const reqOptions = {

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -1,30 +1,41 @@
 // SeekerClaw — tools/agent_pay.js
-// BAT-582 Phase 6 — agent_pay tool: pay an x402-protected HTTP endpoint
-// and fetch its response.
+// BAT-582 Phase 6 + BAT-664 — agent_pay tool: pay an x402-protected HTTP
+// endpoint and fetch its response.
 //
 // FLOW
 // ----
-//   1. Pre-flight rejections: HTTPS-only (debug-localhost exception), GET-only,
-//      private-IP rejection, DNS rebinding defense (resolve once, pin IP).
+//   1. Pre-flight rejections: HTTPS-only (debug-localhost exception),
+//      GET/POST only, private-IP rejection, DNS rebinding defense
+//      (resolve once, pin IP), POST body validation (JSON-only, ≤ 8 KB).
 //   2. Burner-configured check via /burner/status — if no burner, refuse
 //      WITHOUT issuing any HTTP request to the URL.
-//   3. Issue HTTPS GET with size + timeout limits.
+//   3. Issue HTTPS GET or POST (same byte-identical body if POST) with
+//      size + timeout limits + per-invocation Idempotency-Key (POST only).
 //   4. If response is NOT 402, return resource directly (URL might not be
 //      x402-protected; treat as a regular successful fetch).
 //   5. If 402: detect protocol via payment/index.js → build unsigned tx via
 //      protocol.build(response, ctx) → reserve cap → sign via burner →
-//      protocol.settle() with proof header.
+//      protocol.settle() with proof header (replay sends same method +
+//      same byte-identical body + same idempotency key for POST).
 //   6. Commit on success / release on error. Return resource response.
 //
 // The dynamic confirmation hook in confirmation/policy.js authorizes
-// agent_pay only when args.max_usdc is provided (Phase 4); the demand-vs-
-// max_usdc check happens INSIDE this tool because Node only learns the
-// real demand after fetching the 402 challenge.
+// agent_pay GET silently when under cap (existing behavior). POST always
+// returns `confirm` (side-effect-aware, BAT-664). The demand-vs-max_usdc
+// check happens INSIDE this tool because Node only learns the real demand
+// after fetching the 402 challenge.
 //
-// HARD RULES (per BAT-582 contract v1.4)
-// --------------------------------------
+// HARD RULES (per BAT-582 contract v1.4 + BAT-664 contract v2)
+// ------------------------------------------------------------
 //   - HTTPS only (with localhost exception gated by NODE_ENV=development)
-//   - Method is always GET (V1 boundary; POST/PUT not supported)
+//   - Method must be GET or POST (BAT-664); other methods rejected with
+//     `method_not_allowed`
+//   - POST body: JSON-serializable, ≤ 8 KB UTF-8 bytes compact-serialized,
+//     validated BEFORE any DNS or network call
+//   - POST sends byte-identical compact JSON body on both probe and settle
+//     replay; same Content-Length and Idempotency-Key headers
+//   - Idempotency-Key: one `crypto.randomUUID()` per agent_pay invocation,
+//     attached only when method === 'POST', reused for probe + settle
 //   - Single retry only after payment (no retry chains)
 //   - Response body capped at 1 MB; total timeout 30 s
 //   - DNS rebinding defense: resolve once, pin IP for the request
@@ -34,6 +45,7 @@
 'use strict';
 
 const { URL } = require('url');
+const crypto = require('crypto');
 const dns = require('dns');
 const https = require('https');
 const http = require('http');
@@ -45,9 +57,11 @@ const { detectProtocol } = require('../payment');
 const { wouldReserve } = require('../caps/preflight');
 
 const USDC_DECIMALS = 6;
-const MAX_BODY_BYTES = 1024 * 1024;        // 1 MB
+const MAX_BODY_BYTES = 1024 * 1024;        // 1 MB response cap
+const MAX_POST_BODY_BYTES = 8 * 1024;      // 8 KB request-body cap (BAT-664, per v1.6 contract)
 const TOTAL_TIMEOUT_MS = 30 * 1000;        // 30 s
 const RESERVE_TTL_MS = 60 * 1000;          // 60 s (matches dispatch.js)
+const ALLOWED_METHODS = new Set(['GET', 'POST']);
 
 // ── Decimal → atomic helper (USDC, 6 decimals) ───────────────────────────────
 
@@ -196,13 +210,17 @@ function _isLocalhostHostname(h) {
 
 // Validate URL + scheme + method (cheap, synchronous). Returns null on
 // success or {error, reason} on rejection. NEVER opens a network connection.
+//
+// BAT-664: `method` can be 'GET' or 'POST'. Anything else rejected with
+// `method_not_allowed` (stable code matching v1.6 contract).
 function preflightUrlSync(url, method) {
     let parsed;
     try { parsed = new URL(url); }
     catch (_) { return { error: 'invalid_url', reason: 'URL parse failed' }; }
 
-    if ((method || 'GET').toUpperCase() !== 'GET') {
-        return { error: 'method_not_get', reason: 'agent_pay only supports GET (V1)' };
+    const m = (method || 'GET').toUpperCase();
+    if (!ALLOWED_METHODS.has(m)) {
+        return { error: 'method_not_allowed', reason: `method must be GET or POST (got ${m})` };
     }
 
     const hostname = parsed.hostname;
@@ -217,7 +235,54 @@ function preflightUrlSync(url, method) {
         return { error: 'non_https', reason: 'http:// only allowed for localhost in debug builds' };
     }
 
-    return { ok: true, parsed, isLocal };
+    return { ok: true, parsed, isLocal, method: m };
+}
+
+// BAT-664: validate + serialize a POST body BEFORE DNS / network / payment.
+// Returns { bodyJsonStr } on success, or { error, reason } on rejection.
+//
+// Rules (per contract v2):
+//   - method === 'POST' ⇒ body required (else body_required_for_post)
+//   - body string ⇒ MUST parse as JSON (else body_not_json)
+//   - body object/array ⇒ pass through
+//   - other types (null, boolean, number) ⇒ accepted only if JSON.stringify
+//     produces a value (matches JSON.stringify semantics)
+//   - Final compact-serialized form ≤ 8192 UTF-8 bytes (body_too_large)
+//
+// The returned bodyJsonStr is REUSED byte-identically for probe and settle
+// replay — never re-serialized. Drift between probe and settle would cause
+// strict facilitators to reject the proof.
+function validateAndSerializeBody(method, body) {
+    if (method !== 'POST') {
+        return { bodyJsonStr: null };  // GET path: no body
+    }
+    if (body === undefined || body === null) {
+        return { error: 'body_required_for_post', reason: 'POST requires a JSON body' };
+    }
+    let parsed = body;
+    if (typeof body === 'string') {
+        try { parsed = JSON.parse(body); }
+        catch (_) {
+            return { error: 'body_not_json', reason: 'string body must be valid JSON' };
+        }
+    }
+    let bodyJsonStr;
+    try { bodyJsonStr = JSON.stringify(parsed); }
+    catch (e) {
+        return { error: 'body_not_json', reason: `body could not be serialized: ${e.message}` };
+    }
+    if (typeof bodyJsonStr !== 'string') {
+        // JSON.stringify can return undefined (functions, symbols)
+        return { error: 'body_not_json', reason: 'body did not produce a JSON value (functions/symbols not allowed)' };
+    }
+    const byteLen = Buffer.byteLength(bodyJsonStr, 'utf8');
+    if (byteLen > MAX_POST_BODY_BYTES) {
+        return {
+            error: 'body_too_large',
+            reason: `POST body is ${byteLen} bytes (max ${MAX_POST_BODY_BYTES} UTF-8 bytes per v1.6 contract)`,
+        };
+    }
+    return { bodyJsonStr };
 }
 
 // DNS resolve (and pin) to detect private-IP rebinding. Skip resolution for
@@ -261,8 +326,18 @@ async function preflightUrl(url, method, deadlineMs) {
 
 // Returns { status, headers, bodyBuffer, bodyJson?, request: {url, method, headers} } or { error, reason }.
 // `parsed` is a URL instance; `pinnedIp` is the resolved IPv4/IPv6 string (or null for localhost).
-function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, signalTimeoutLeftMs = TOTAL_TIMEOUT_MS) {
+//
+// BAT-664: `opts.method` ('GET'|'POST') and `opts.bodyJsonStr` (cached
+// pre-serialized compact JSON, or null) thread through here so the SAME
+// byte-identical body is sent on probe and settle replay. The caller is
+// responsible for sourcing both from one cached pair (no per-call
+// re-serialization).
+function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, signalTimeoutLeftMs = TOTAL_TIMEOUT_MS, opts = {}) {
     return new Promise((resolve) => {
+        const method = (opts.method || 'GET').toUpperCase();
+        const bodyJsonStr = (method === 'POST' && typeof opts.bodyJsonStr === 'string')
+            ? opts.bodyJsonStr
+            : null;
         const isHttps = parsed.protocol === 'https:';
         const lib = isHttps ? https : http;
         const headers = Object.assign({
@@ -270,9 +345,13 @@ function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, sig
             'user-agent': 'SeekerClaw-agent_pay/1.0',
             accept: 'application/json,*/*;q=0.5',
         }, extraHeaders);
+        if (bodyJsonStr !== null) {
+            headers['content-type'] = 'application/json';
+            headers['content-length'] = Buffer.byteLength(bodyJsonStr, 'utf8');
+        }
 
         const reqOptions = {
-            method: 'GET',
+            method,
             // IP-pin: connect to the resolved address but send the original Host header
             // so TLS SNI and HTTP routing still work. For localhost we let Node resolve.
             host: pinnedIp || parsed.hostname,
@@ -347,6 +426,12 @@ function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, sig
             clearTimeout(overall);
             settle({ error: 'timeout', reason: 'socket idle timeout' });
         });
+        // BAT-664: write the cached pre-serialized body for POST. We pass
+        // it as a Node Buffer so http.request doesn't re-encode it — the
+        // bytes on the wire are exactly `Buffer.from(bodyJsonStr, 'utf8')`.
+        if (bodyJsonStr !== null) {
+            req.write(Buffer.from(bodyJsonStr, 'utf8'));
+        }
         req.end();
     });
 }
@@ -357,17 +442,28 @@ const tools = [
     {
         name: 'agent_pay',
         description:
-            'Pay an x402-protected HTTP endpoint and fetch its response. Used for paid APIs ' +
+            'Pay an x402-protected HTTPS endpoint (GET or POST) and fetch its response. Used for paid APIs ' +
             '(pay.sh catalog, x402-enabled endpoints). Solana mainnet, USDC only. ' +
-            'Args: `url` (HTTPS GET only) + `max_usdc` (max amount willing to spend, decimal string, e.g. "0.10"). ' +
+            'Args: `url` (HTTPS) + `max_usdc` (max amount willing to spend, decimal string, e.g. "0.10") ' +
+            '+ optional `method` ("GET" default, or "POST") + optional `body` (JSON-serializable object, required for POST, ≤ 8 KB). ' +
             'The burner wallet signs autonomously when the 402 demand is ≤ max_usdc; the call is rejected ' +
             'if the demand exceeds max_usdc, the network is not Solana, or the asset is not USDC. ' +
+            'GET runs silently when under cap. POST always asks for user confirmation (side-effect-aware: ' +
+            'POST can send SMS, post content, or trigger other paid actions). ' +
             'Refuses if no burner is configured (Settings → Burner Wallet to set up).',
         input_schema: {
             type: 'object',
             properties: {
-                url: { type: 'string', description: 'Target URL (HTTPS GET only).' },
+                url: { type: 'string', description: 'Target URL (HTTPS).' },
                 max_usdc: { type: 'string', description: 'Maximum USDC willing to spend, decimal string (e.g. "0.10").' },
+                method: {
+                    type: 'string',
+                    enum: ['GET', 'POST'],
+                    description: 'HTTP method. Defaults to "GET". POST always requires user confirmation regardless of cap.',
+                },
+                body: {
+                    description: 'Request body for POST. JSON-serializable object/array. Max 8 KB UTF-8 compact-serialized. Required when method=POST.',
+                },
             },
             required: ['url', 'max_usdc'],
         },
@@ -380,6 +476,8 @@ async function _handle(input /* , chatId */) {
     const a = input || {};
     const url = a.url;
     const maxUsdcStr = a.max_usdc;
+    const methodRaw = a.method;
+    const bodyRaw = a.body;
 
     if (typeof url !== 'string' || !url) {
         return { error: 'invalid_input', reason: 'url is required' };
@@ -408,12 +506,29 @@ async function _handle(input /* , chatId */) {
     // 1a. Cheap pre-flight (URL parse + scheme + method). Synchronous — no
     // bridge calls, no DNS. Fails fast on the dumbest input mistakes before
     // we bother the bridge at all.
-    const sync = preflightUrlSync(url, 'GET');
+    const sync = preflightUrlSync(url, methodRaw);
     if (sync.error) {
         log(`[agent_pay] rejected: ${sync.error} — ${sync.reason}`, 'WARN');
         return { error: sync.error, reason: sync.reason };
     }
-    const { parsed, isLocal } = sync;
+    const { parsed, isLocal, method } = sync;
+
+    // 1a.5. BAT-664: validate + compact-serialize the POST body BEFORE any
+    // DNS resolve or network call. Pre-network validation is an explicit
+    // acceptance gate — operator typos must not trigger DNS lookups on
+    // attacker-supplied hosts.
+    const bodyCheck = validateAndSerializeBody(method, bodyRaw);
+    if (bodyCheck.error) {
+        log(`[agent_pay] rejected: ${bodyCheck.error} — ${bodyCheck.reason}`, 'WARN');
+        return { error: bodyCheck.error, reason: bodyCheck.reason };
+    }
+    const bodyJsonStr = bodyCheck.bodyJsonStr;  // string for POST, null for GET
+
+    // BAT-664: per-invocation idempotency key for POST. Generated ONCE here
+    // and reused for both the 402 probe and the settle replay so the
+    // facilitator + upstream see the same key on the retried request.
+    // Distinct agent_pay calls get distinct keys.
+    const idempotencyKey = method === 'POST' ? crypto.randomUUID() : null;
 
     // 1b. Burner-configured check BEFORE DNS resolution. Per BAT-582 contract
     // "agent_pay refuses cleanly when no burner is configured AND makes no
@@ -440,10 +555,18 @@ async function _handle(input /* , chatId */) {
     }
     const { pinnedIp, pinnedFamily } = dnsRes;
 
-    // 3. Initial fetch — bounded by the SHARED remaining budget so DNS +
-    // fetch can't together exceed TOTAL_TIMEOUT_MS.
+    // 3. Initial fetch (probe) — bounded by the SHARED remaining budget
+    // so DNS + fetch can't together exceed TOTAL_TIMEOUT_MS. For POST,
+    // sends the cached body + Idempotency-Key — the SAME pair will be
+    // reused on the settle replay.
     const fetchTimeoutMs = Math.max(1, deadlineMs - Date.now());
-    const firstResp = await _fetchWithLimits(parsed, pinnedIp, pinnedFamily, {}, fetchTimeoutMs);
+    const probeHeaders = idempotencyKey ? { 'idempotency-key': idempotencyKey } : {};
+    const firstResp = await _fetchWithLimits(
+        parsed, pinnedIp, pinnedFamily,
+        probeHeaders,
+        fetchTimeoutMs,
+        { method, bodyJsonStr },
+    );
     if (firstResp.error) {
         log(`[agent_pay] initial fetch failed: ${firstResp.error}`, 'WARN');
         return { error: firstResp.error, reason: firstResp.reason };
@@ -548,12 +671,24 @@ async function _handle(input /* , chatId */) {
         return { error: 'sign_failed', reason: e.message };
     }
 
-    // 10. Settle: replay GET with proof header(s). Single retry only — no
-    //     retry chains (per contract). BAT-582 R5: settle inherits the
-    //     SAME shared deadline so total wall-clock is bounded by
-    //     TOTAL_TIMEOUT_MS regardless of how DNS / fetch / sign spent it.
+    // 10. Settle: replay the same request (same method, same body for POST,
+    //     same Idempotency-Key for POST) with proof header(s) added. Single
+    //     retry only — no retry chains (per contract). BAT-582 R5: settle
+    //     inherits the SAME shared deadline so total wall-clock is bounded
+    //     by TOTAL_TIMEOUT_MS regardless of how DNS / fetch / sign spent it.
+    //
+    //     BAT-664: `originalRequest` carries `method`, `bodyJsonStr`, and
+    //     `idempotencyKey`. settle() reads those and forwards through the
+    //     fetch helper so probe + settle send byte-identical request shapes
+    //     (modulo the additional PAYMENT-SIGNATURE / x-payment proof header).
     const remaining = Math.max(1000, deadlineMs - Date.now());
-    const originalRequest = { parsed, pinnedIp, pinnedFamily, timeoutLeftMs: remaining };
+    const originalRequest = {
+        parsed, pinnedIp, pinnedFamily,
+        timeoutLeftMs: remaining,
+        method,
+        bodyJsonStr,
+        idempotencyKey,
+    };
     const settled = await protocol.settle(originalRequest, signedTxBase64, paymentMeta, { _fetchWithLimits });
     if (!settled || settled.error) {
         await _release(reservationId, settled && settled.error ? settled.error : 'settle_failed');
@@ -643,6 +778,8 @@ module.exports = {
     preflightUrl,
     preflightUrlSync,
     preflightDns,
+    validateAndSerializeBody,   // BAT-664
+    MAX_POST_BODY_BYTES,        // BAT-664
     _setDnsLookup,
     _fetchWithLimits,
 };

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -218,8 +218,9 @@ function _isLocalhostHostname(h) {
     return s === 'localhost' || s === '127.0.0.1' || s === '::1';
 }
 
-// Validate URL + scheme + method (cheap, synchronous). Returns null on
-// success or {error, reason} on rejection. NEVER opens a network connection.
+// Validate URL + scheme + method (cheap, synchronous).
+// Returns `{ ok: true, parsed, isLocal, method }` on success or
+// `{ error, reason }` on rejection. NEVER opens a network connection.
 //
 // BAT-664: `method` can be 'GET' or 'POST'. Anything else rejected with
 // `method_not_allowed` (stable code matching v1.6 contract).

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -283,6 +283,18 @@ function validateAndSerializeBody(method, body) {
     }
     let parsed = body;
     if (typeof body === 'string') {
+        // R-pr370-fix-4: bound raw string length BEFORE JSON.parse. A
+        // model-controlled multi-MB string would burn CPU/memory in the
+        // parser before being rejected by the post-serialize 8 KB cap.
+        // Cap raw input at 2× the compact-serialized cap (room for
+        // whitespace + minor formatting); strictly checked again after
+        // parse via the existing size check below.
+        if (Buffer.byteLength(body, 'utf8') > MAX_POST_BODY_BYTES * 2) {
+            return {
+                error: 'body_too_large',
+                reason: `raw POST body string is ${Buffer.byteLength(body, 'utf8')} bytes (max ${MAX_POST_BODY_BYTES * 2} pre-parse)`,
+            };
+        }
         try { parsed = JSON.parse(body); }
         catch (_) {
             return { error: 'body_not_json', reason: 'string body must be valid JSON' };

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -1,6 +1,7 @@
 // SeekerClaw — tools/agent_pay.js
-// BAT-582 Phase 6 + BAT-664 — agent_pay tool: pay an x402-protected HTTP
-// endpoint and fetch its response.
+// BAT-582 Phase 6 + BAT-664 — agent_pay tool: pay an x402-protected HTTPS
+// endpoint and fetch its response. HTTPS-only by contract (debug builds
+// also accept http://localhost for sandbox testing).
 //
 // FLOW
 // ----

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -219,11 +219,14 @@ function preflightUrlSync(url, method) {
     catch (_) { return { error: 'invalid_url', reason: 'URL parse failed' }; }
 
     // R-pr370-fix-6: defensive type check. Tool inputs aren't schema-validated
-    // at runtime, so a malformed call could pass `method: 123` / `method: {}`.
-    // `(non-string).toUpperCase()` would throw an uninformative TypeError;
-    // we treat any non-string as "missing" → default GET, but reject other
-    // truthy non-strings as method_not_allowed so the operator gets a clear
-    // signal that the type was wrong.
+    // at runtime, so a malformed call could pass `method: 123` / `method: {}` /
+    // method: []`. `(non-string).toUpperCase()` would throw an uninformative
+    // TypeError. Behavior:
+    //   - undefined / null → default to GET (treat as "method omitted")
+    //   - any other non-string (number, boolean, object, array) → reject
+    //     with method_not_allowed and the type name so the operator gets a
+    //     clear signal
+    //   - string → uppercase + check against ALLOWED_METHODS
     let m;
     if (method === undefined || method === null) m = 'GET';
     else if (typeof method !== 'string') {
@@ -253,14 +256,19 @@ function preflightUrlSync(url, method) {
 // BAT-664: validate + serialize a POST body BEFORE DNS / network / payment.
 // Returns { bodyJsonStr } on success, or { error, reason } on rejection.
 //
-// Rules (per contract v2):
+// Rules (per contract v2 + R-pr370-fix-2):
 //   - method === 'POST' ⇒ body required; `undefined` or `null` rejected as
 //     body_required_for_post (treated as "no body supplied")
-//   - body string ⇒ MUST parse as JSON (else body_not_json)
-//   - body object/array ⇒ pass through
-//   - body of other types (boolean, number) ⇒ accepted only if
-//     JSON.stringify produces a string (matches JSON.stringify semantics);
-//     functions / symbols-only / circular refs return body_not_json
+//   - body string ⇒ MUST parse as JSON via JSON.parse and the parsed value
+//     MUST be a non-null object or array (else body_not_json)
+//   - body non-null object or array ⇒ pass through
+//   - body primitives (number, boolean, plain string-after-parse) ⇒
+//     rejected as body_not_json — the input_schema describes body as a
+//     JSON object/array, and paid POST endpoints expect structured payloads
+//     (textbelt: {phone, message}; coingecko-like: query objects). A bare
+//     primitive would deterministically confuse upstream services.
+//   - body that JSON.stringify can't represent (functions, symbols-only,
+//     circular refs) ⇒ body_not_json
 //   - Final compact-serialized form ≤ 8192 UTF-8 bytes (body_too_large)
 //
 // The returned bodyJsonStr is REUSED byte-identically for probe and settle
@@ -279,6 +287,12 @@ function validateAndSerializeBody(method, body) {
         catch (_) {
             return { error: 'body_not_json', reason: 'string body must be valid JSON' };
         }
+    }
+    // R-pr370-fix-2: require parsed body to be a non-null object or array.
+    // Bare primitives are rejected — the input_schema describes body as a
+    // structured payload; paid POST endpoints expect objects.
+    if (parsed === null || typeof parsed !== 'object') {
+        return { error: 'body_not_json', reason: `body must be a JSON object or array (got ${parsed === null ? 'null' : typeof parsed})` };
     }
     let bodyJsonStr;
     try { bodyJsonStr = JSON.stringify(parsed); }

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -158,6 +158,15 @@ function isPrivateIp(ip) {
 let _dnsLookupOverride = null;
 function _setDnsLookup(fn) { _dnsLookupOverride = fn; }
 
+// R-pr370-fix-7 (BAT-664): test hook to intercept the internal
+// `_fetchWithLimits` call. Production code calls the function by its
+// closure-captured reference, NOT via module.exports — so replacing the
+// export doesn't affect runtime behavior. This hook gives tests a way to
+// capture the probe + settle requests and assert byte-identity of
+// Idempotency-Key, body, etc.
+let _fetchOverride = null;
+function _setFetchOverride(fn) { _fetchOverride = fn; }
+
 const DNS_DEFAULT_TIMEOUT_MS = TOTAL_TIMEOUT_MS;
 
 function _lookupHost(hostname, deadlineMs) {
@@ -374,6 +383,9 @@ async function preflightUrl(url, method, deadlineMs) {
 // responsible for sourcing both from one cached pair (no per-call
 // re-serialization).
 function _fetchWithLimits(parsed, pinnedIp, pinnedFamily, extraHeaders = {}, signalTimeoutLeftMs = TOTAL_TIMEOUT_MS, opts = {}) {
+    if (_fetchOverride) {
+        return _fetchOverride(parsed, pinnedIp, pinnedFamily, extraHeaders, signalTimeoutLeftMs, opts);
+    }
     return new Promise((resolve) => {
         const method = (opts.method || 'GET').toUpperCase();
         const bodyJsonStr = (method === 'POST' && typeof opts.bodyJsonStr === 'string')
@@ -822,5 +834,6 @@ module.exports = {
     validateAndSerializeBody,   // BAT-664
     MAX_POST_BODY_BYTES,        // BAT-664
     _setDnsLookup,
+    _setFetchOverride,          // BAT-664 (R-pr370-fix-7)
     _fetchWithLimits,
 };

--- a/app/src/main/assets/nodejs-project/tools/agent_pay.js
+++ b/app/src/main/assets/nodejs-project/tools/agent_pay.js
@@ -515,7 +515,7 @@ const tools = [
                     description: 'HTTP method. Defaults to "GET". POST always requires user confirmation regardless of cap.',
                 },
                 body: {
-                    description: 'Request body for POST. JSON-serializable object/array. Max 8 KB UTF-8 compact-serialized. Required when method=POST.',
+                    description: 'Request body for POST. JSON object or array (or a JSON string that parses to an object/array). Bare primitives (numbers, booleans, plain strings) are rejected. Max 8 KB UTF-8 compact-serialized. Required when method=POST.',
                 },
             },
             required: ['url', 'max_usdc'],

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -232,10 +232,20 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // structural separator for multi-line cards and must survive).
         // eslint-disable-next-line no-control-regex
         v = v.replace(/[\x00-\x09\x0B-\x1F\x7F]/g, ' ');
-        // R-pr370-fix-15: cap AFTER escaping so the rendered message is
-        // actually bounded. Escaping can roughly double the byte count
-        // (every `*` becomes `\*`), so a pre-escape cap of 1024 could
-        // produce a ~2 KB rendered card. Cap the final escaped output.
+        // R-pr370-fix-18 (security): markdown-it's `linkify: true` auto-
+        // detects raw URLs (http:// / https:// / ftp:// etc.) and renders
+        // them as clickable links — even after Markdown char escaping.
+        // An attacker-controlled body preview containing a URL would
+        // render as a clickable phishing link in the confirmation card.
+        // Insert a zero-width space (U+200B) between the scheme and `//`
+        // to break linkify's detection. URLs remain visually readable
+        // (the ZWSP renders as nothing) but copy/paste users get a tiny
+        // anomaly they can clean up — preferable to a one-click phish.
+        v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, '$1:​//');
+        // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered
+        // message is actually bounded. Escaping can roughly double the
+        // byte count (every `*` becomes `\*`); de-linkify adds ~1 char
+        // per URL. Cap the final output, not the input.
         if (v.length > 1024) v = v.slice(0, 1021) + '...';
         return v;
     };

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -250,19 +250,22 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // Break schemed URLs (http://, https://, ftp://, ws://, wss://,
         // file://, data://).
         v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
-        // R-pr370-fix-32/34: break BARE DOMAINS (no scheme). markdown-it
+        // R-pr370-fix-32/34/38: break BARE DOMAINS (no scheme). markdown-it
         // linkify defaults to `fuzzyLink: true`, which auto-detects
         // patterns like "attacker.evil.com" or "www.example.org" and
         // renders them as clickable links without any explicit scheme.
-        // Match every `.` that's preceded by an alpha-led label and
-        // followed by 2+ alphabetic chars — via lookbehind + lookahead
-        // so consecutive dots in `api.example.com` ALL get broken
-        // (regex backtracking under /g advances past the match group,
-        // missing the second dot if it's part of an alpha-led label
-        // pattern). Numeric values like "0.10" are not mangled because
-        // the lookbehind requires the previous label to start with a
-        // letter.
-        v = v.replace(/(?<=[a-z][a-z0-9-]*)\.(?=[a-z]{2,})/gi, `${ZWSP}.`);
+        //
+        // Match an alpha-led label as a capture group + `.` + lookahead
+        // for 2+ alphabetic chars, then re-insert the captured label
+        // before the ZWSP. The capture-group approach avoids a
+        // variable-length lookbehind (which some JS engines don't
+        // support — V8 does, but explicit capture is portable). For
+        // consecutive dots in `api.example.com`, /g advances past each
+        // match (past the consumed label + dot), then the next
+        // iteration starts on `example` and matches its trailing dot
+        // too — both dots get a ZWSP. Numeric values like "0.10" are
+        // not mangled because the capture group requires alpha-led.
+        v = v.replace(/([a-z][a-z0-9-]*)\.(?=[a-z]{2,})/gi, `$1${ZWSP}.`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered
         // message is actually bounded. Escaping can roughly double the
         // byte count (every `*` becomes `\*`); de-linkify adds ~1 char

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -235,6 +235,15 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // structural separator for multi-line cards and must survive).
         // eslint-disable-next-line no-control-regex
         v = v.replace(/[\x00-\x09\x0B-\x1F\x7F]/g, ' ');
+        // R-pr370-fix-40: neutralize Markdown list markers at start of line.
+        // markdown-it auto-renders `- foo`, `+ foo`, `1. foo` (and `2. ` etc)
+        // at the beginning of any line into list items. Because we
+        // intentionally preserve newlines for multi-line cards, a model-
+        // controlled value containing `\n- malicious-item` would render
+        // as a fake bullet list. Escape the list marker so the line
+        // shows literally as `- foo` text instead.
+        v = v.replace(/(^|\n)([-+])(\s)/g, '$1\\$2$3');
+        v = v.replace(/(^|\n)(\d+)(\.)(\s)/g, '$1$2\\$3$4');
         // R-pr370-fix-18 (security): markdown-it's `linkify: true` auto-
         // detects raw URLs (http:// / https:// / ftp:// etc.) and renders
         // them as clickable links — even after Markdown char escaping.

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -212,9 +212,27 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
     // body previews aren't decapitated. 1024 chars covers a long URL +
     // a 200-char body preview + framing comfortably; still bounded so
     // a buggy hook can't blow up the confirmation card.
+    //
+    // R-pr370-fix-13 (security): the policyMessage can include
+    // model-controlled args (e.g. wallet_set_caps decimals, agent_pay
+    // URL/body). markdown-it on the channel side renders backticks as
+    // code, [text](url) as links, ** as bold, etc. Escape Markdown
+    // metacharacters here at the render boundary so EVERY policy hook
+    // is safe by default — individual hooks don't have to remember to
+    // sanitize. Newlines are PRESERVED so multi-line cards still
+    // render as separate visual lines (hooks that want a single-line
+    // preview must literalize their own newlines first).
     const escPolicy = (s) => {
         let v = String(s ?? '');
         if (v.length > 1024) v = v.slice(0, 1021) + '...';
+        // Escape backslash first (so we don't double-escape markers below).
+        v = v.replace(/\\/g, '\\\\');
+        // Markdown structure characters + HTML angle brackets.
+        v = v.replace(/[`*_~[\](){}#>|!<>]/g, (c) => '\\' + c);
+        // Strip control chars OTHER than newlines (newlines are the
+        // structural separator for multi-line cards and must survive).
+        // eslint-disable-next-line no-control-regex
+        v = v.replace(/[\x00-\x09\x0B-\x1F\x7F]/g, ' ');
         return v;
     };
     let details;

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -224,7 +224,6 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
     // preview must literalize their own newlines first).
     const escPolicy = (s) => {
         let v = String(s ?? '');
-        if (v.length > 1024) v = v.slice(0, 1021) + '...';
         // Escape backslash first (so we don't double-escape markers below).
         v = v.replace(/\\/g, '\\\\');
         // Markdown structure characters + HTML angle brackets.
@@ -233,6 +232,11 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // structural separator for multi-line cards and must survive).
         // eslint-disable-next-line no-control-regex
         v = v.replace(/[\x00-\x09\x0B-\x1F\x7F]/g, ' ');
+        // R-pr370-fix-15: cap AFTER escaping so the rendered message is
+        // actually bounded. Escaping can roughly double the byte count
+        // (every `*` becomes `\*`), so a pre-escape cap of 1024 could
+        // produce a ~2 KB rendered card. Cap the final escaped output.
+        if (v.length > 1024) v = v.slice(0, 1021) + '...';
         return v;
     };
     let details;

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -244,10 +244,10 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // to break linkify's detection. URLs remain visually readable
         // (the ZWSP renders as nothing) but copy/paste users get a tiny
         // anomaly they can clean up — preferable to a one-click phish.
-        // R-pr370-fix-19/23: declare the ZWSP via the explicit ​
-        // escape so it's visible in source/diffs. A literal U+200B in
-        // source code is invisible to most editors and can be silently
-        // removed by formatters or copy-paste.
+        // R-pr370-fix-19/23/26: declare ZWSP via the explicit ​ escape
+        // so the character is VISIBLE in source/diffs/reviews. Pre-fix the
+        // const value was a literal U+200B — invisible in most editors and
+        // silently removed by formatters / copy-paste / unicode normalization.
         const ZWSP = '​';
         v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -226,8 +226,11 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         let v = String(s ?? '');
         // Escape backslash first (so we don't double-escape markers below).
         v = v.replace(/\\/g, '\\\\');
-        // Markdown structure characters + HTML angle brackets.
-        v = v.replace(/[`*_~[\](){}#>|!<>]/g, (c) => '\\' + c);
+        // Markdown structure characters + HTML angle brackets. Use explicit
+        // \[ and \] inside the character class so the regex is unambiguous
+        // to future readers (the parser handles `[\]]` correctly but mixed
+        // escaping inside a class is a recurring source of confusion).
+        v = v.replace(/[`*_~\[\](){}#>|!<>]/g, (c) => '\\' + c);
         // Strip control chars OTHER than newlines (newlines are the
         // structural separator for multi-line cards and must survive).
         // eslint-disable-next-line no-control-regex
@@ -241,10 +244,10 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // to break linkify's detection. URLs remain visually readable
         // (the ZWSP renders as nothing) but copy/paste users get a tiny
         // anomaly they can clean up — preferable to a one-click phish.
-        // R-pr370-fix-19: use the explicit `​` escape so the
-        // zero-width-space is visible in diffs/reviews; a literal
-        // invisible character would silently change behavior under a
-        // copy-paste or unicode-aware editor.
+        // R-pr370-fix-19/23: declare the ZWSP via the explicit ​
+        // escape so it's visible in source/diffs. A literal U+200B in
+        // source code is invisible to most editors and can be silently
+        // removed by formatters or copy-paste.
         const ZWSP = '​';
         v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -245,14 +245,24 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // (the ZWSP renders as nothing) but copy/paste users get a tiny
         // anomaly they can clean up — preferable to a one-click phish.
         // R-pr370-fix-19/23/26/28: declare ZWSP via String.fromCharCode so
-        // the literal U+200B character never appears in source. A literal
-        // would be invisible to most editors / diffs / reviews and
-        // silently removable by formatters / copy-paste / Unicode
-        // normalization. String.fromCharCode(0x200B) makes the intent
-        // unambiguous in source while producing the identical runtime
-        // character.
+        // the literal U+200B character never appears in source.
         const ZWSP = String.fromCharCode(0x200B);
+        // Break schemed URLs (http://, https://, ftp://, ws://, wss://,
+        // file://, data://).
         v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
+        // R-pr370-fix-32/34: break BARE DOMAINS (no scheme). markdown-it
+        // linkify defaults to `fuzzyLink: true`, which auto-detects
+        // patterns like "attacker.evil.com" or "www.example.org" and
+        // renders them as clickable links without any explicit scheme.
+        // Match every `.` that's preceded by an alpha-led label and
+        // followed by 2+ alphabetic chars — via lookbehind + lookahead
+        // so consecutive dots in `api.example.com` ALL get broken
+        // (regex backtracking under /g advances past the match group,
+        // missing the second dot if it's part of an alpha-led label
+        // pattern). Numeric values like "0.10" are not mangled because
+        // the lookbehind requires the previous label to start with a
+        // letter.
+        v = v.replace(/(?<=[a-z][a-z0-9-]*)\.(?=[a-z]{2,})/gi, `${ZWSP}.`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered
         // message is actually bounded. Escaping can roughly double the
         // byte count (every `*` becomes `\*`); de-linkify adds ~1 char

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -241,7 +241,12 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // to break linkify's detection. URLs remain visually readable
         // (the ZWSP renders as nothing) but copy/paste users get a tiny
         // anomaly they can clean up — preferable to a one-click phish.
-        v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, '$1:​//');
+        // R-pr370-fix-19: use the explicit `​` escape so the
+        // zero-width-space is visible in diffs/reviews; a literal
+        // invisible character would silently change behavior under a
+        // copy-paste or unicode-aware editor.
+        const ZWSP = '​';
+        v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered
         // message is actually bounded. Escaping can roughly double the
         // byte count (every `*` becomes `\*`); de-linkify adds ~1 char

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -204,9 +204,22 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         if (v.length > 200) v = v.slice(0, 197) + '...';
         return v;
     };
+    // R-pr370-fix-3 (BAT-664): policy hooks construct their own preview
+    // strings (agent_pay POST: method + URL + max_usdc + 200-char body
+    // preview; wallet_set_caps: old→new cap diffs). These messages are
+    // intentionally multi-line and can exceed the 200-char per-field cap.
+    // Use a more generous limit for explicit policyMessage so URLs +
+    // body previews aren't decapitated. 1024 chars covers a long URL +
+    // a 200-char body preview + framing comfortably; still bounded so
+    // a buggy hook can't blow up the confirmation card.
+    const escPolicy = (s) => {
+        let v = String(s ?? '');
+        if (v.length > 1024) v = v.slice(0, 1021) + '...';
+        return v;
+    };
     let details;
     if (typeof policyMessage === 'string' && policyMessage.length > 0) {
-        details = `**${esc(toolName)}** — ${esc(policyMessage)}`;
+        details = `**${esc(toolName)}** — ${escPolicy(policyMessage)}`;
     } else {
         switch (toolName) {
             case 'android_sms':

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -244,11 +244,14 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // to break linkify's detection. URLs remain visually readable
         // (the ZWSP renders as nothing) but copy/paste users get a tiny
         // anomaly they can clean up — preferable to a one-click phish.
-        // R-pr370-fix-19/23/26: declare ZWSP via the explicit ​ escape
-        // so the character is VISIBLE in source/diffs/reviews. Pre-fix the
-        // const value was a literal U+200B — invisible in most editors and
-        // silently removed by formatters / copy-paste / unicode normalization.
-        const ZWSP = '​';
+        // R-pr370-fix-19/23/26/28: declare ZWSP via String.fromCharCode so
+        // the literal U+200B character never appears in source. A literal
+        // would be invisible to most editors / diffs / reviews and
+        // silently removable by formatters / copy-paste / Unicode
+        // normalization. String.fromCharCode(0x200B) makes the intent
+        // unambiguous in source while producing the identical runtime
+        // character.
+        const ZWSP = String.fromCharCode(0x200B);
         v = v.replace(/(https?|ftp|ws|wss|file|data):\/\//gi, `$1:${ZWSP}//`);
         // R-pr370-fix-15: cap AFTER escaping + de-linkify so the rendered
         // message is actually bounded. Escaping can roughly double the

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -235,15 +235,23 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
         // structural separator for multi-line cards and must survive).
         // eslint-disable-next-line no-control-regex
         v = v.replace(/[\x00-\x09\x0B-\x1F\x7F]/g, ' ');
-        // R-pr370-fix-40: neutralize Markdown list markers at start of line.
-        // markdown-it auto-renders `- foo`, `+ foo`, `1. foo` (and `2. ` etc)
-        // at the beginning of any line into list items. Because we
-        // intentionally preserve newlines for multi-line cards, a model-
-        // controlled value containing `\n- malicious-item` would render
-        // as a fake bullet list. Escape the list marker so the line
-        // shows literally as `- foo` text instead.
+        // R-pr370-fix-40/42: neutralize Markdown line-start structures.
+        // markdown-it auto-renders:
+        //   `- foo` / `+ foo` / `1. foo` → list items
+        //   `--- ` → horizontal rule (or setext H2 underline)
+        //   `=== ` → setext H1 underline
+        // (`***` and `___` HR patterns are already neutralized by the
+        // per-character escape pass above — every `*` and `_` becomes
+        // `\*` / `\_` which breaks the contiguous-marker requirement
+        // markdown-it uses to detect HRs.)
+        //
+        // Because we intentionally preserve newlines for multi-line cards,
+        // a model-controlled value containing `\n--- ` could inject a
+        // visual divider or restructure the card. Escape the line-leading
+        // marker so each renders as literal text.
         v = v.replace(/(^|\n)([-+])(\s)/g, '$1\\$2$3');
         v = v.replace(/(^|\n)(\d+)(\.)(\s)/g, '$1$2\\$3$4');
+        v = v.replace(/(^|\n)(-{3,}|={3,})/g, (m, lead, run) => `${lead}\\${run[0]}${run.slice(1)}`);
         // R-pr370-fix-18 (security): markdown-it's `linkify: true` auto-
         // detects raw URLs (http:// / https:// / ftp:// etc.) and renders
         // them as clickable links — even after Markdown char escaping.

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -29,15 +29,22 @@ require.cache[configPath] = {
 };
 
 // Stub bridge.js so the handler-level tests don't need a live bridge.
+// Use a mutable handler reference so tests can swap behavior between
+// "no burner" (default) and "configured burner" — the agent_pay module
+// captures `androidBridgeCall` at require time, so we need the wrapper
+// to delegate through a mutable function ref.
 const bridgeCalls = [];
+let _bridgeHandler = async (endpoint /* , body */) => {
+    if (endpoint === '/burner/status') return { configured: false };
+    return {};
+};
 const bridgePath = require.resolve(path.join(BUNDLE, 'bridge.js'));
 require.cache[bridgePath] = {
     id: bridgePath, filename: bridgePath, loaded: true,
     exports: {
         androidBridgeCall: async (endpoint, body) => {
             bridgeCalls.push({ endpoint, body });
-            if (endpoint === '/burner/status') return { configured: false };
-            return {};
+            return _bridgeHandler(endpoint, body);
         },
     },
 };
@@ -160,12 +167,28 @@ async function check(label, fn) {
         assert.strictEqual(r.error, 'body_not_json');
     });
 
-    await check('validateAndSerializeBody: POST + 8 KB body accepted', () => {
-        // 8192 bytes UTF-8 exactly. Build a key:value pair whose JSON length lands at 8192.
-        const filler = 'A'.repeat(8192 - 14);  // 14 = '{"k":"' + '"}' + a few padding bytes
+    await check('validateAndSerializeBody: POST + body sized at exactly MAX_POST_BODY_BYTES is accepted', () => {
+        // R-pr370-fix-8: compute filler from actual JSON overhead so the
+        // resulting serialized size is exactly MAX_POST_BODY_BYTES, not
+        // "approximately 8 KB". The overhead for {"k":"…"} is 8 bytes
+        // (`{"k":""}`) in ASCII; filler needs to fill the remaining
+        // MAX_POST_BODY_BYTES - 8 bytes.
+        const JSON_OVERHEAD = JSON.stringify({ k: '' }).length;  // 8
+        const filler = 'A'.repeat(MAX_POST_BODY_BYTES - JSON_OVERHEAD);
         const r = validateAndSerializeBody('POST', { k: filler });
         assert.ok(r.bodyJsonStr, `expected accept, got ${JSON.stringify(r)}`);
-        assert.ok(Buffer.byteLength(r.bodyJsonStr, 'utf8') <= MAX_POST_BODY_BYTES);
+        // Tight boundary: exactly equal to the cap, not "≤".
+        assert.strictEqual(Buffer.byteLength(r.bodyJsonStr, 'utf8'), MAX_POST_BODY_BYTES,
+            `serialized body should be exactly MAX_POST_BODY_BYTES (${MAX_POST_BODY_BYTES}) bytes`);
+    });
+
+    await check('validateAndSerializeBody: POST + body 1 byte over the cap is rejected', () => {
+        // Pair with the exact-cap test above — together they pin the
+        // boundary at MAX_POST_BODY_BYTES inclusive.
+        const JSON_OVERHEAD = JSON.stringify({ k: '' }).length;
+        const filler = 'A'.repeat(MAX_POST_BODY_BYTES - JSON_OVERHEAD + 1);  // 1 byte over
+        const r = validateAndSerializeBody('POST', { k: filler });
+        assert.strictEqual(r.error, 'body_too_large');
     });
 
     await check('validateAndSerializeBody: POST + >8 KB body → body_too_large', () => {
@@ -383,6 +406,113 @@ async function check(label, fn) {
         const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
         assert.ok(uuidRe.test(a));
         assert.ok(uuidRe.test(b));
+    });
+
+    // ── Deep integration: handler-level Idempotency-Key generation ──────────
+    // R-pr370-fix-7 (BAT-664): proves the FULL contract — agent_pay
+    // generates a UUID at the handler level, attaches it to the probe
+    // request, and reuses the same value on settle replay. Two distinct
+    // tool invocations get distinct keys. Pre-fix the suite only checked
+    // settle forwarding from a hand-set key; this exercises generation.
+
+    await check('handler: agent_pay POST attaches Idempotency-Key to probe; distinct invocations get distinct keys', async () => {
+        // Swap the no-burner bridge stub for a configured-burner one,
+        // and inject DNS + fetch overrides that bypass the network.
+        // Returning a synthetic 200 from the probe means agent_pay
+        // returns after probe without going through settle — we cover
+        // settle byte-identity in the X402Protocol.settle test above.
+        const oldHandler = _bridgeHandler;
+        _bridgeHandler = async (endpoint) => {
+            if (endpoint === '/burner/status') return { configured: true, pubkey: '7xKXTg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU' };
+            return {};
+        };
+        // Restore a passing DNS so the probe is reached (the suite-level
+        // override throws to enforce zero-network on pre-flight rejections).
+        agentPay._setDnsLookup(async () => ({ address: '1.2.3.4', family: 4 }));
+
+        const probeCalls = [];
+        agentPay._setFetchOverride(async (parsed, ip, fam, headers, timeout, opts) => {
+            probeCalls.push({ url: parsed.toString(), headers: { ...headers }, opts: { ...opts } });
+            // Return non-402 so the handler returns after probe.
+            return { status: 200, headers: {}, bodyJson: { ok: true } };
+        });
+
+        try {
+            const r1 = await handlers.agent_pay({
+                url: 'https://api.example.com/text',
+                max_usdc: '0.10',
+                method: 'POST',
+                body: { phone: '+15555550000', message: 'hi' },
+            });
+            const r2 = await handlers.agent_pay({
+                url: 'https://api.example.com/text',
+                max_usdc: '0.10',
+                method: 'POST',
+                body: { phone: '+15555550000', message: 'hi' },
+            });
+            assert.ok(!r1.error, `r1 should succeed (non-402 path): ${JSON.stringify(r1)}`);
+            assert.ok(!r2.error, `r2 should succeed: ${JSON.stringify(r2)}`);
+            assert.strictEqual(probeCalls.length, 2, 'should have probed twice');
+
+            // (a) Each probe has an Idempotency-Key header.
+            const key1 = probeCalls[0].headers['idempotency-key'];
+            const key2 = probeCalls[1].headers['idempotency-key'];
+            assert.ok(typeof key1 === 'string' && key1.length > 0, 'probe 1 must attach Idempotency-Key');
+            assert.ok(typeof key2 === 'string' && key2.length > 0, 'probe 2 must attach Idempotency-Key');
+
+            // (b) Distinct invocations get DISTINCT keys.
+            assert.notStrictEqual(key1, key2, 'distinct agent_pay invocations must have distinct Idempotency-Keys');
+
+            // (c) Each key is RFC 4122 UUID-shaped.
+            const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+            assert.ok(uuidRe.test(key1));
+            assert.ok(uuidRe.test(key2));
+
+            // (d) POST method propagates to the fetch opts; same byte body.
+            assert.strictEqual(probeCalls[0].opts.method, 'POST');
+            assert.strictEqual(probeCalls[0].opts.bodyJsonStr, JSON.stringify({ phone: '+15555550000', message: 'hi' }));
+        } finally {
+            agentPay._setFetchOverride(null);
+            // Re-arm the throwing DNS override so subsequent pre-flight tests
+            // still enforce zero-network.
+            agentPay._setDnsLookup(async () => {
+                dnsLookupCalled++;
+                throw new Error('dns lookup should not have been called');
+            });
+            _bridgeHandler = oldHandler;
+        }
+    });
+
+    await check('handler: agent_pay GET does NOT attach Idempotency-Key (regression)', async () => {
+        const oldHandler = _bridgeHandler;
+        _bridgeHandler = async (endpoint) => {
+            if (endpoint === '/burner/status') return { configured: true, pubkey: '7xKXTg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU' };
+            return {};
+        };
+        agentPay._setDnsLookup(async () => ({ address: '1.2.3.4', family: 4 }));
+        const probeCalls = [];
+        agentPay._setFetchOverride(async (parsed, ip, fam, headers, timeout, opts) => {
+            probeCalls.push({ headers: { ...headers }, opts: { ...opts } });
+            return { status: 200, headers: {}, bodyJson: { ok: true } };
+        });
+        try {
+            await handlers.agent_pay({
+                url: 'https://api.example.com/x',
+                max_usdc: '0.10',
+                // No method (defaults to GET), no body
+            });
+            assert.strictEqual(probeCalls.length, 1);
+            assert.ok(!probeCalls[0].headers['idempotency-key'],
+                'GET probe must NOT have Idempotency-Key header');
+            assert.ok(!probeCalls[0].opts.bodyJsonStr, 'GET probe must not have a serialized body');
+        } finally {
+            agentPay._setFetchOverride(null);
+            agentPay._setDnsLookup(async () => {
+                dnsLookupCalled++;
+                throw new Error('dns lookup should not have been called');
+            });
+            _bridgeHandler = oldHandler;
+        }
     });
 
     // ── GET regression: pre-existing behavior preserved ─────────────────────

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -603,6 +603,26 @@ async function check(label, fn) {
         assert.strictEqual(r, 'none');
     });
 
+    await check('policy: PUT/PATCH/DELETE blocked at gate with method_not_allowed (R-pr370-fix-9)', () => {
+        for (const m of ['PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']) {
+            const r = getConfirmationPolicy('agent_pay', {
+                url: 'https://api.example.com/x', max_usdc: '0.10', method: m,
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'block', `${m}: expected block, got ${JSON.stringify(r)}`);
+            assert.strictEqual(r.reason, 'method_not_allowed');
+        }
+    });
+
+    await check('policy: non-string method blocked with method_not_allowed', () => {
+        for (const m of [42, true, {}, []]) {
+            const r = getConfirmationPolicy('agent_pay', {
+                url: 'https://api.example.com/x', max_usdc: '0.10', method: m,
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'block', `${typeof m}: expected block, got ${JSON.stringify(r)}`);
+            assert.strictEqual(r.reason, 'method_not_allowed');
+        }
+    });
+
     // Cross-check: policy duplicates the body rules from agent_pay's
     // validateAndSerializeBody. Same inputs must produce same outcomes so
     // a future refactor that moves the validation can't drift.

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -411,6 +411,97 @@ async function check(label, fn) {
         assert.strictEqual(dnsLookupCalled, 0);
     });
 
+    // ── Policy-hook body validation (R-pr370-fix-4) ─────────────────────────
+    // The confirmation policy now validates the body BEFORE returning
+    // `confirm`. Invalid POST bodies return `block` with a stable reason
+    // so the agent doesn't ask the user to confirm a call that would
+    // deterministically reject downstream.
+
+    const { getConfirmationPolicy } = require(path.join(BUNDLE, 'confirmation', 'policy'));
+
+    await check('policy: POST + valid body → confirm', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: { phone: '+15555550000', message: 'hi' },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'confirm');
+        assert.ok(typeof r.message === 'string' && r.message.includes('POST'));
+        assert.ok(r.message.includes('https://api.example.com/x'));
+        assert.ok(r.message.includes('0.10'));
+    });
+
+    await check('policy: POST + no body → block (body_required_for_post)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', // no body
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'body_required_for_post');
+    });
+
+    await check('policy: POST + invalid JSON string → block (body_not_json)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: 'not actually json',
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'body_not_json');
+    });
+
+    await check('policy: POST + primitive body → block (body_not_json — object/array required)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: 42,
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'body_not_json');
+    });
+
+    await check('policy: POST + oversized body → block (body_too_large)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: { k: 'A'.repeat(10_000) },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'body_too_large');
+    });
+
+    await check('policy: GET unchanged (no body validation needed)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+        }, { burnerConfigured: true });
+        assert.strictEqual(r, 'none');
+    });
+
+    // Cross-check: policy duplicates the body rules from agent_pay's
+    // validateAndSerializeBody. Same inputs must produce same outcomes so
+    // a future refactor that moves the validation can't drift.
+    await check('policy + agent_pay body rules stay in lock-step (R-pr370-fix-4 cross-check)', () => {
+        const cases = [
+            [undefined,                     'body_required_for_post'],
+            [null,                          'body_required_for_post'],
+            ['not-json',                    'body_not_json'],
+            [42,                            'body_not_json'],
+            [true,                          'body_not_json'],
+            ['"a-json-string"',             'body_not_json'],
+            [{ a: 1 },                      'ok'],
+            [['a', 'b'],                    'ok'],
+            [{ k: 'X'.repeat(10_000) },     'body_too_large'],
+        ];
+        for (const [body, expectedError] of cases) {
+            const fromValidator = validateAndSerializeBody('POST', body);
+            const validatorErr = fromValidator.error || 'ok';
+            const fromPolicy = getConfirmationPolicy('agent_pay', {
+                url: 'https://example.com', max_usdc: '0.10', method: 'POST', body,
+            }, { burnerConfigured: true });
+            const policyErr = (fromPolicy && fromPolicy.policy === 'block') ? fromPolicy.reason : 'ok';
+            assert.strictEqual(validatorErr, expectedError,
+                `validator: body=${JSON.stringify(body)} expected ${expectedError}, got ${validatorErr}`);
+            assert.strictEqual(policyErr, expectedError,
+                `policy: body=${JSON.stringify(body)} expected ${expectedError}, got ${policyErr}`);
+        }
+    });
+
     if (failures === 0) {
         console.log('\n✓ All agent-pay-post.test.js cases passed');
         process.exit(0);

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -827,6 +827,38 @@ async function check(label, fn) {
         }
     });
 
+    await check('policy: POST + http://non-localhost → block (non_https, R-pr370-fix-44)', () => {
+        // http:// is only allowed for localhost in debug builds; mirror
+        // agent_pay's preflightUrlSync at the policy gate.
+        const oldEnv = process.env.NODE_ENV;
+        delete process.env.NODE_ENV;
+        try {
+            const r = getConfirmationPolicy('agent_pay', {
+                url: 'http://attacker.com/x', max_usdc: '0.10',
+                method: 'POST', body: { ok: true },
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'block');
+            assert.strictEqual(r.reason, 'non_https');
+        } finally {
+            if (oldEnv) process.env.NODE_ENV = oldEnv;
+        }
+    });
+
+    await check('policy: POST + http://localhost in debug → confirm (R-pr370-fix-44)', () => {
+        const oldEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'development';
+        try {
+            const r = getConfirmationPolicy('agent_pay', {
+                url: 'http://localhost:3000/x', max_usdc: '0.10',
+                method: 'POST', body: { ok: true },
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'confirm');
+        } finally {
+            if (oldEnv !== undefined) process.env.NODE_ENV = oldEnv;
+            else delete process.env.NODE_ENV;
+        }
+    });
+
     await check('policy: POST + no burner → block (burner_not_configured, R-pr370-fix-20)', () => {
         // Fail-fast at gate when no burner. POST without a burner deterministically
         // rejects at the handler; the policy gate should block early instead of

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -261,25 +261,128 @@ async function check(label, fn) {
         assert.strictEqual(statusCalls.length, 1);
     });
 
-    // ── Idempotency-Key generation contract ─────────────────────────────────
+    // ── Idempotency-Key contract — integration test via stubbed fetch ──────
 
-    await check('crypto.randomUUID() produces distinct UUIDs across calls', () => {
-        // Pin the underlying expectation rather than wiring through the
-        // private idempotency generation: validate that distinct calls in
-        // tight succession produce distinct UUIDs. The handler generates one
-        // per agent_pay invocation using crypto.randomUUID(), so distinct
-        // invocations get distinct keys.
+    // R-pr370-fix-5: validate the REAL contract — probe + settle send the
+    // SAME `Idempotency-Key` header for one agent_pay invocation, and two
+    // separate invocations get DISTINCT keys. Pre-fix this test only asserted
+    // crypto.randomUUID() distinctness; it would have passed even if
+    // agent_pay forgot to attach the header at all. Now stubs the protocol
+    // settle path so we can capture both fetch calls.
+
+    await check('POST integration: probe + settle send the SAME Idempotency-Key, byte-identical body', async () => {
+        // Build the originalRequest the handler would construct and call
+        // X402Protocol.settle() directly with a fetch helper that captures
+        // headers + body bytes. This exercises the EXACT settle dispatch
+        // logic in payment/x402.js that BAT-664 extended.
+        const x402 = require(path.join(BUNDLE, 'payment', 'x402'));
+        const { X402Protocol } = x402;
+        const proto = new X402Protocol();
+
+        // Build a synthetic v2 paymentMeta good enough for settle dispatch.
+        const idempotencyKey = crypto.randomUUID();
+        const bodyJsonStr = JSON.stringify({ phone: '+15555550000', message: 'hi' });
+        const paymentMeta = {
+            x402Version: 2,
+            amountAtomic: 10000n,
+            recipient: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+            asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            memo: 'abcd0123abcd0123abcd0123abcd0123',
+            negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact',
+                network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/text', description: 't', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            },
+        };
+
+        let settleCallArgs = null;
+        const fetchFn = async (parsed, ip, fam, headers, timeout, opts) => {
+            settleCallArgs = { parsed, headers, timeout, opts };
+            return { status: 200, headers: { 'payment-response': '' }, bodyJson: { ok: true } };
+        };
+
+        await proto.settle(
+            {
+                parsed: new URL('https://api.example.com/text'),
+                pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000,
+                method: 'POST',
+                bodyJsonStr,
+                idempotencyKey,
+            },
+            'SIGNED-TX',
+            paymentMeta,
+            { _fetchWithLimits: fetchFn },
+        );
+
+        assert.ok(settleCallArgs, 'fetch must have been called by settle');
+        // BAT-664: settle must forward the SAME Idempotency-Key the probe used.
+        assert.strictEqual(settleCallArgs.headers['idempotency-key'], idempotencyKey,
+            'settle replay must reuse the probe idempotency key');
+        // BAT-664: method + bodyJsonStr forwarded byte-identically to fetch.
+        assert.strictEqual(settleCallArgs.opts.method, 'POST');
+        assert.strictEqual(settleCallArgs.opts.bodyJsonStr, bodyJsonStr,
+            'settle replay must reuse the same serialized body the probe used');
+        // PAYMENT-SIGNATURE proof header must coexist with idempotency-key.
+        assert.ok(settleCallArgs.headers['payment-signature'],
+            'v2 settle still attaches PAYMENT-SIGNATURE alongside the idempotency key');
+    });
+
+    await check('POST integration: GET path does NOT add idempotency-key header (regression)', async () => {
+        // R-pr370-fix-5 complement: the GET path must not add an
+        // Idempotency-Key header — only POST does, per contract.
+        const x402 = require(path.join(BUNDLE, 'payment', 'x402'));
+        const { X402Protocol } = x402;
+        const proto = new X402Protocol();
+
+        const paymentMeta = {
+            x402Version: 2, amountAtomic: 10000n,
+            recipient: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+            asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            memo: 'abcd0123abcd0123abcd0123abcd0123',
+            negotiatedNetwork: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            requirement: {
+                scheme: 'exact', network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                payTo: '9hw9Py9uMGtXRNpABZjifcK1t3suwzjyri9L9QYKg6zZ',
+                resource: { url: 'https://api.example.com/r', description: '', mimeType: 'application/json' },
+                maxTimeoutSeconds: 300,
+                extra: { feePayer: '2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4' },
+            },
+        };
+
+        let captured = null;
+        const fetchFn = async (parsed, ip, fam, headers, timeout, opts) => {
+            captured = { headers, opts };
+            return { status: 200, headers: {}, bodyJson: {} };
+        };
+        await proto.settle(
+            // No method/body/idempotencyKey — GET path.
+            { parsed: new URL('https://api.example.com/r'), pinnedIp: '1.2.3.4', pinnedFamily: 4, timeoutLeftMs: 30000 },
+            'SIGNED-TX', paymentMeta,
+            { _fetchWithLimits: fetchFn },
+        );
+        assert.ok(captured, 'fetch must have been called');
+        assert.ok(!captured.headers['idempotency-key'],
+            'idempotency-key MUST NOT be attached on the GET path');
+        // method/bodyJsonStr arrive as undefined → _fetchWithLimits defaults to GET, no body.
+        assert.ok(captured.opts.method === undefined || captured.opts.method === 'GET');
+        assert.ok(!captured.opts.bodyJsonStr,
+            'GET path must not have a serialized body');
+    });
+
+    await check('crypto.randomUUID() produces distinct UUIDs (handler generates one per invocation)', () => {
+        // Format + distinctness sanity check. Kept as a small unit on top
+        // of the integration test above so a future refactor that changes
+        // the UUID source still trips a clear assertion.
         const a = crypto.randomUUID();
         const b = crypto.randomUUID();
-        const c = crypto.randomUUID();
         assert.notStrictEqual(a, b);
-        assert.notStrictEqual(b, c);
-        assert.notStrictEqual(a, c);
-        // RFC 4122 format check.
         const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        for (const u of [a, b, c]) {
-            assert.ok(uuidRe.test(u), `UUID format invalid: ${u}`);
-        }
+        assert.ok(uuidRe.test(a));
+        assert.ok(uuidRe.test(b));
     });
 
     // ── GET regression: pre-existing behavior preserved ─────────────────────

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -562,6 +562,24 @@ async function check(label, fn) {
         assert.ok(r.message.includes('0.10'));
     });
 
+    await check('policy: POST confirm hook literalizes newlines in url/max_usdc too (R-pr370-fix-16)', () => {
+        // Newlines in url or max_usdc would inject extra structural lines
+        // into the multi-line confirmation card and could be used to
+        // misrepresent what's being confirmed.
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x\n[FAKE PHISH LINE]',
+            max_usdc: '0.10\nIGNORE PREVIOUS LINE',
+            method: 'POST', body: { ok: true },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'confirm');
+        const lines = r.message.split('\n');
+        // EXACTLY 3 structural lines (POST line, max_usdc line, body line).
+        assert.strictEqual(lines.length, 3, `expected exactly 3 structural lines, got ${lines.length}: ${JSON.stringify(lines)}`);
+        // The injected newlines in url and max_usdc must appear as literal "\\n".
+        assert.ok(lines[0].includes('\\n[FAKE PHISH LINE]'), 'url newline must be literalized');
+        assert.ok(lines[1].includes('\\nIGNORE PREVIOUS LINE'), 'max_usdc newline must be literalized');
+    });
+
     await check('policy: POST confirm hook literalizes body newlines (no structural breakout)', () => {
         // Body content with real \n must NOT break out into a new
         // structural line of the confirmation card. The hook is responsible

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -639,10 +639,10 @@ async function check(label, fn) {
             body: { phish: 'http://attacker.evil.com/take-money' },
         }, { burnerConfigured: true });
         const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
-        // R-pr370-fix-19/24/26: ZWSP via the explicit ​ escape —
-        // a literal U+200B in test source is invisible and silently
-        // removable by formatters / copy-paste / unicode normalization.
-        const ZWSP = '​';
+        // R-pr370-fix-19/24/26/28: ZWSP via String.fromCharCode so the
+        // literal U+200B never appears in source (matches the production
+        // impl in tools/index.js).
+        const ZWSP = String.fromCharCode(0x200B);
         // Raw `http://...` would be linkified. After the fix, the scheme
         // has a zero-width space inserted before //.
         assert.ok(!new RegExp(`(?<!:${ZWSP})http:\\/\\/`).test(rendered),

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -625,6 +625,54 @@ async function check(label, fn) {
         assert.ok(lines.length >= 3, `expected ≥3 structural lines, got ${lines.length}`);
     });
 
+    await check('render: formatConfirmationMessage de-linkifies BARE DOMAINS (R-pr370-fix-32/34, fuzzyLink defense)', () => {
+        // markdown-it linkify with fuzzyLink: true (default) auto-detects
+        // patterns like "attacker.evil.com" without any scheme. We use a
+        // lookbehind/lookahead regex to insert ZWSP before EVERY dot in a
+        // multi-label domain (api.example.com → api[ZWSP].example[ZWSP].com).
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policy = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST',
+            // Body contains a bare-domain phishing target.
+            body: { phish: 'visit attacker.evil.com today' },
+        }, { burnerConfigured: true });
+        const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
+        const ZWSP = String.fromCharCode(0x200B);
+        // EVERY dot in a multi-label domain gets a ZWSP. The bare-domain
+        // "attacker.evil.com" → "attacker[ZWSP].evil[ZWSP].com".
+        assert.ok(rendered.includes(`attacker${ZWSP}.evil${ZWSP}.com`),
+            `bare domain should be fully de-linkified (got: ${JSON.stringify(rendered)})`);
+        // Numeric "0.10" (USDC amount) MUST NOT be mangled — the lookbehind
+        // requires alpha-led label.
+        assert.ok(rendered.includes('0.10'),
+            'numeric decimals like 0.10 must not have ZWSP injected');
+    });
+
+    await check('policy: body preview truncation respects post-literalize length (R-pr370-fix-33)', () => {
+        // Literalizing newlines is a 2-char expansion (\\n). Truncating
+        // BEFORE literalization could produce a string longer than the
+        // 200-char budget after literalization. The fix truncates AFTER
+        // literalize so the bound holds on the rendered content.
+        const manyNewlines = 'a\n'.repeat(150);  // 300 chars, 150 newlines
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: manyNewlines,
+        }, { burnerConfigured: true });
+        // The body might block (string body must JSON.parse), so verify
+        // through the policy + render with a valid body that has newlines.
+        const r2 = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: { k: 'long\n'.repeat(100) },  // many real \n inside JSON
+        }, { burnerConfigured: true });
+        assert.strictEqual(r2.policy, 'confirm');
+        const bodyLine = r2.message.split('\n').find(l => l.startsWith('body:')) || '';
+        // The body LINE (post-literalize) is bounded at body: + 200 chars.
+        // The "body: " prefix is 6 chars; the rest is the preview, max 200.
+        assert.ok(bodyLine.length <= 6 + 200,
+            `body line length ${bodyLine.length} exceeds 6+200 cap (truncation order bug)`);
+    });
+
     await check('render: formatConfirmationMessage de-linkifies URLs in policyMessage (R-pr370-fix-18)', () => {
         // markdown-it linkify auto-converts raw URLs to clickable links.
         // Even after metachar escaping, a body preview with a URL would
@@ -650,9 +698,13 @@ async function check(label, fn) {
         assert.ok(rendered.includes(`http:${ZWSP}//`),
             'URL should have zero-width-space inserted between scheme and //');
         // The agent_pay URL (also in the rendered message) gets the same
-        // treatment — it's part of the policyMessage too.
-        assert.ok(rendered.includes(`https:${ZWSP}//api.example.com`),
-            'agent_pay URL should also be de-linkified');
+        // treatment — it's part of the policyMessage too. With the
+        // bare-domain ZWSP fix, the domain part also has ZWSPs in every
+        // dot, so the assertion checks both layers of defense.
+        assert.ok(rendered.includes(`https:${ZWSP}//`),
+            'agent_pay URL should have schemed-URL de-linkify applied');
+        assert.ok(rendered.includes(`api${ZWSP}.example${ZWSP}.com`),
+            'agent_pay URL domain should also have bare-domain de-linkify applied');
     });
 
     await check('render: formatConfirmationMessage escapes wallet_set_caps diff content (defense-in-depth)', () => {

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -639,9 +639,9 @@ async function check(label, fn) {
             body: { phish: 'http://attacker.evil.com/take-money' },
         }, { burnerConfigured: true });
         const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
-        // R-pr370-fix-19: use ​ explicit escape so the test is
-        // readable in diffs (a literal invisible char would silently
-        // alter behavior under copy/paste or editor configs).
+        // R-pr370-fix-19/24: ZWSP as the explicit ​ escape — a
+        // literal U+200B in the test source would be invisible and
+        // could silently break under copy/paste or formatter passes.
         const ZWSP = '​';
         // Raw `http://...` would be linkified. After the fix, the scheme
         // has a zero-width space inserted before //.

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -625,6 +625,32 @@ async function check(label, fn) {
         assert.ok(lines.length >= 3, `expected ≥3 structural lines, got ${lines.length}`);
     });
 
+    await check('render: formatConfirmationMessage de-linkifies URLs in policyMessage (R-pr370-fix-18)', () => {
+        // markdown-it linkify auto-converts raw URLs to clickable links.
+        // Even after metachar escaping, a body preview with a URL would
+        // render as a one-click phishing link. The render boundary
+        // inserts a zero-width space between scheme and "//" to break
+        // linkify detection.
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policy = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x',
+            max_usdc: '0.10',
+            method: 'POST',
+            body: { phish: 'http://attacker.evil.com/take-money' },
+        }, { burnerConfigured: true });
+        const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
+        // Raw `http://...` would be linkified. After the fix, the scheme
+        // has a zero-width space (​) inserted before //.
+        assert.ok(!/(?<![:​])http:\/\//.test(rendered),
+            `attacker URL should be de-linkified (no raw http:// substring left); rendered: ${JSON.stringify(rendered)}`);
+        assert.ok(rendered.includes('http:​//'),
+            'URL should have zero-width-space inserted between scheme and //');
+        // The agent_pay URL (also in the rendered message) gets the same
+        // treatment — it's part of the policyMessage too.
+        assert.ok(rendered.includes('https:​//api.example.com'),
+            'agent_pay URL should also be de-linkified');
+    });
+
     await check('render: formatConfirmationMessage escapes wallet_set_caps diff content (defense-in-depth)', () => {
         // Even other policy hooks benefit from the render-boundary escape.
         // wallet_set_caps's diff message embeds raw arg values; a malicious

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -639,9 +639,9 @@ async function check(label, fn) {
             body: { phish: 'http://attacker.evil.com/take-money' },
         }, { burnerConfigured: true });
         const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
-        // R-pr370-fix-19/24: ZWSP as the explicit ​ escape — a
-        // literal U+200B in the test source would be invisible and
-        // could silently break under copy/paste or formatter passes.
+        // R-pr370-fix-19/24/26: ZWSP via the explicit ​ escape —
+        // a literal U+200B in test source is invisible and silently
+        // removable by formatters / copy-paste / unicode normalization.
         const ZWSP = '​';
         // Raw `http://...` would be linkified. After the fix, the scheme
         // has a zero-width space inserted before //.

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -21,11 +21,13 @@ const crypto = require('crypto');
 
 const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
 
-// Stub config.js for transitive requires (matches other test files).
+// Stub config.js for transitive requires. tools/index.js → security.js
+// destructures `config` and iterates its keys at module load, so the
+// stub must include `config: {}` (empty object) to avoid the load crash.
 const configPath = require.resolve(path.join(BUNDLE, 'config.js'));
 require.cache[configPath] = {
     id: configPath, filename: configPath, loaded: true,
-    exports: { BRIDGE_TOKEN: 't', log: () => {} },
+    exports: { BRIDGE_TOKEN: 't', log: () => {}, config: {}, workDir: '/tmp' },
 };
 
 // Stub bridge.js so the handler-level tests don't need a live bridge.
@@ -560,47 +562,65 @@ async function check(label, fn) {
         assert.ok(r.message.includes('0.10'));
     });
 
-    await check('policy: POST confirm message escapes Markdown metacharacters in body (R-pr370-fix-12)', () => {
-        // Model-controlled body content could inject backticks, links, bold,
-        // newlines, HTML — all of which markdown-it renders. The escape
-        // function must neutralize each.
+    await check('policy: POST confirm hook literalizes body newlines (no structural breakout)', () => {
+        // Body content with real \n must NOT break out into a new
+        // structural line of the confirmation card. The hook is responsible
+        // for collapsing body newlines to literal "\\n" — Markdown escaping
+        // itself happens at the render boundary (formatConfirmationMessage).
         const r = getConfirmationPolicy('agent_pay', {
             url: 'https://api.example.com/x', max_usdc: '0.10',
-            method: 'POST', body: { evil: '`code` [click](http://bad) **bold** <script>alert(1)</script>\nnewline' },
+            method: 'POST', body: { evil: 'line1\nline2\rline3' },
         }, { burnerConfigured: true });
         assert.strictEqual(r.policy, 'confirm');
-        const msg = r.message;
-        // Each Markdown metacharacter present in input should be backslash-escaped.
-        assert.ok(!/[^\\]`/.test(msg.replace(/^.+max_usdc.+\n/, '')),
-            'unescaped backtick must not appear in the body line');
-        assert.ok(msg.includes('\\['), 'left bracket must be escaped');
-        assert.ok(msg.includes('\\]'), 'right bracket must be escaped');
-        assert.ok(msg.includes('\\('), 'left paren must be escaped');
-        assert.ok(msg.includes('\\)'), 'right paren must be escaped');
-        assert.ok(msg.includes('\\*'), 'asterisk must be escaped');
-        assert.ok(msg.includes('\\<'), 'less-than must be escaped');
-        assert.ok(msg.includes('\\>'), 'greater-than must be escaped');
-        // Newlines inside the body preview become literal "\\n" so they
-        // don't reflow the card. The card's own structure newlines (between
-        // POST line / max_usdc line / body line) remain.
-        const bodyLine = msg.split('\n').find(l => l.startsWith('body:')) || '';
-        assert.ok(!bodyLine.includes('\n'), 'body line must be a single line');
-        assert.ok(bodyLine.includes('\\n'), 'embedded newline must be literalized as \\\\n');
+        const bodyLine = r.message.split('\n').find(l => l.startsWith('body:')) || '';
+        assert.ok(!bodyLine.includes('\n'), 'body line must be a single structural line');
+        assert.ok(bodyLine.includes('\\n'), 'embedded newline must be literalized');
     });
 
-    await check('policy: POST confirm message escapes Markdown in URL too', () => {
-        // Even though URLs shouldn't contain markdown metachars, an attacker
-        // could craft a URL with backticks/etc. — sanitize defensively.
-        const r = getConfirmationPolicy('agent_pay', {
-            url: 'https://api.example.com/`evil`?q=*test*',
+    await check('render: formatConfirmationMessage escapes Markdown in policyMessage (R-pr370-fix-13)', () => {
+        // Security: the WHOLE policyMessage gets Markdown-escaped at the
+        // render boundary so EVERY policy hook is safe by default — agent_pay
+        // POST, wallet_set_caps diff, any future hook. Test by routing a
+        // policy hook with model-controlled content through format() and
+        // asserting the rendered message has all metachars escaped.
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policy = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/`evil`',
             max_usdc: '0.10',
-            method: 'POST', body: { ok: true },
+            method: 'POST',
+            body: { evil: '`code` [click](http://bad) **bold** <script>alert(1)</script>' },
         }, { burnerConfigured: true });
-        assert.strictEqual(r.policy, 'confirm');
-        // The URL backticks must be escaped, not preserved literally.
-        const urlLine = r.message.split('\n')[0];
-        assert.ok(urlLine.includes('\\`'), 'URL backticks must be escaped');
-        assert.ok(urlLine.includes('\\*'), 'URL asterisks must be escaped');
+        assert.strictEqual(policy.policy, 'confirm');
+        const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
+        // Every Markdown metacharacter from the input must be backslash-escaped.
+        assert.ok(rendered.includes('\\`'), 'backtick must be escaped');
+        assert.ok(rendered.includes('\\['), 'left bracket must be escaped');
+        assert.ok(rendered.includes('\\]'), 'right bracket must be escaped');
+        assert.ok(rendered.includes('\\('), 'left paren must be escaped');
+        assert.ok(rendered.includes('\\)'), 'right paren must be escaped');
+        assert.ok(rendered.includes('\\*'), 'asterisk must be escaped');
+        assert.ok(rendered.includes('\\<'), 'less-than must be escaped');
+        assert.ok(rendered.includes('\\>'), 'greater-than must be escaped');
+        // Structural newlines (between POST line / max_usdc line / body line)
+        // MUST be preserved so the card renders multi-line.
+        const lines = rendered.split('\n');
+        assert.ok(lines.length >= 3, `expected ≥3 structural lines, got ${lines.length}`);
+    });
+
+    await check('render: formatConfirmationMessage escapes wallet_set_caps diff content (defense-in-depth)', () => {
+        // Even other policy hooks benefit from the render-boundary escape.
+        // wallet_set_caps's diff message embeds raw arg values; a malicious
+        // value with backticks would inject without the format-level escape.
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policy = getConfirmationPolicy('wallet_set_caps', {
+            per_tx_sol: '0.05`evil`',  // crafted to look like a normal decimal
+        }, {
+            burnerConfigured: true,
+            burnerCaps: { capPerTxSol: '50000000' },
+        });
+        const rendered = formatConfirmationMessage('wallet_set_caps', {}, policy.message);
+        // The crafted backticks in the arg must be escaped, not rendered.
+        assert.ok(rendered.includes('\\`'), 'wallet_set_caps args must be escaped at render');
     });
 
     await check('policy: POST + no body → block (body_required_for_post)', () => {

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -707,6 +707,26 @@ async function check(label, fn) {
             'agent_pay URL domain should also have bare-domain de-linkify applied');
     });
 
+    await check('render: formatConfirmationMessage escapes line-start list markers (R-pr370-fix-40)', () => {
+        // markdown-it renders `- foo`, `+ foo`, `1. foo` at start of line
+        // as list items. Body preview newlines are intentionally preserved
+        // for structural lines, so a model-controlled value containing
+        // `\n- malicious-item` would render as a fake bullet list.
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policyMessage = 'POST /endpoint\n- bullet item\n+ plus item\n1. numbered item\n2. another\nbody: ok';
+        const rendered = formatConfirmationMessage('agent_pay', {}, policyMessage);
+        // Each list marker at start of line must be backslash-escaped.
+        // Note: '- ' becomes '\\- ', '1. ' becomes '1\\. '.
+        assert.ok(rendered.includes('\\- bullet'),
+            `dash list marker should be escaped (got: ${JSON.stringify(rendered)})`);
+        assert.ok(rendered.includes('\\+ plus'),
+            'plus list marker should be escaped');
+        assert.ok(rendered.includes('1\\. numbered'),
+            'numbered list marker should be escaped (1.)');
+        assert.ok(rendered.includes('2\\. another'),
+            'numbered list marker should be escaped (2.)');
+    });
+
     await check('render: formatConfirmationMessage escapes wallet_set_caps diff content (defense-in-depth)', () => {
         // Even other policy hooks benefit from the render-boundary escape.
         // wallet_set_caps's diff message embeds raw arg values; a malicious
@@ -757,6 +777,20 @@ async function check(label, fn) {
         }, { burnerConfigured: true });
         assert.strictEqual(r.policy, 'block');
         assert.strictEqual(r.reason, 'body_too_large');
+    });
+
+    await check('policy: POST + missing/invalid url → block (invalid_input, R-pr370-fix-39)', () => {
+        // Tool inputs aren't runtime schema-validated, so a malformed call
+        // could pass an empty/missing/non-string url. Block at the gate
+        // so the agent doesn't prompt the user to confirm an action that
+        // will deterministically fail.
+        for (const url of [undefined, null, '', 42, {}, []]) {
+            const r = getConfirmationPolicy('agent_pay', {
+                url, max_usdc: '0.10', method: 'POST', body: { ok: true },
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'block', `${typeof url}: expected block, got ${JSON.stringify(r)}`);
+            assert.strictEqual(r.reason, 'invalid_input');
+        }
     });
 
     await check('policy: POST + no burner → block (burner_not_configured, R-pr370-fix-20)', () => {

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -727,6 +727,21 @@ async function check(label, fn) {
             'numbered list marker should be escaped (2.)');
     });
 
+    await check('render: formatConfirmationMessage escapes horizontal-rule patterns (R-pr370-fix-42)', () => {
+        // markdown-it renders `---` / `===` at line start as horizontal
+        // rules or setext heading underlines. Escape the first char so
+        // they render as literal text.
+        const { formatConfirmationMessage } = require(path.join(BUNDLE, 'tools', 'index'));
+        const policyMessage = 'POST /endpoint\n---\nfake heading\n===\nbody: ok';
+        const rendered = formatConfirmationMessage('agent_pay', {}, policyMessage);
+        // `---` becomes `\---` (first dash escaped).
+        assert.ok(rendered.includes('\\---'),
+            `horizontal-rule dashes should be escaped (got: ${JSON.stringify(rendered)})`);
+        // `===` becomes `\===`.
+        assert.ok(rendered.includes('\\==='),
+            'setext H1 equals should be escaped');
+    });
+
     await check('render: formatConfirmationMessage escapes wallet_set_caps diff content (defense-in-depth)', () => {
         // Even other policy hooks benefit from the render-boundary escape.
         // wallet_set_caps's diff message embeds raw arg values; a malicious
@@ -790,6 +805,25 @@ async function check(label, fn) {
             }, { burnerConfigured: true });
             assert.strictEqual(r.policy, 'block', `${typeof url}: expected block, got ${JSON.stringify(r)}`);
             assert.strictEqual(r.reason, 'invalid_input');
+        }
+    });
+
+    await check('policy: POST + unparseable url → block (invalid_url, R-pr370-fix-43)', () => {
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'not a url at all', max_usdc: '0.10',
+            method: 'POST', body: { ok: true },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'invalid_url');
+    });
+
+    await check('policy: POST + non-http(s) scheme → block (non_https, R-pr370-fix-43)', () => {
+        for (const url of ['ftp://example.com/file', 'data:text/plain,foo', 'javascript:alert(1)']) {
+            const r = getConfirmationPolicy('agent_pay', {
+                url, max_usdc: '0.10', method: 'POST', body: { ok: true },
+            }, { burnerConfigured: true });
+            assert.strictEqual(r.policy, 'block', `${url}: expected block, got ${JSON.stringify(r)}`);
+            assert.strictEqual(r.reason, 'non_https');
         }
     });
 

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -639,15 +639,19 @@ async function check(label, fn) {
             body: { phish: 'http://attacker.evil.com/take-money' },
         }, { burnerConfigured: true });
         const rendered = formatConfirmationMessage('agent_pay', {}, policy.message);
+        // R-pr370-fix-19: use ​ explicit escape so the test is
+        // readable in diffs (a literal invisible char would silently
+        // alter behavior under copy/paste or editor configs).
+        const ZWSP = '​';
         // Raw `http://...` would be linkified. After the fix, the scheme
-        // has a zero-width space (​) inserted before //.
-        assert.ok(!/(?<![:​])http:\/\//.test(rendered),
+        // has a zero-width space inserted before //.
+        assert.ok(!new RegExp(`(?<!:${ZWSP})http:\\/\\/`).test(rendered),
             `attacker URL should be de-linkified (no raw http:// substring left); rendered: ${JSON.stringify(rendered)}`);
-        assert.ok(rendered.includes('http:​//'),
+        assert.ok(rendered.includes(`http:${ZWSP}//`),
             'URL should have zero-width-space inserted between scheme and //');
         // The agent_pay URL (also in the rendered message) gets the same
         // treatment — it's part of the policyMessage too.
-        assert.ok(rendered.includes('https:​//api.example.com'),
+        assert.ok(rendered.includes(`https:${ZWSP}//api.example.com`),
             'agent_pay URL should also be de-linkified');
     });
 
@@ -701,6 +705,18 @@ async function check(label, fn) {
         }, { burnerConfigured: true });
         assert.strictEqual(r.policy, 'block');
         assert.strictEqual(r.reason, 'body_too_large');
+    });
+
+    await check('policy: POST + no burner → block (burner_not_configured, R-pr370-fix-20)', () => {
+        // Fail-fast at gate when no burner. POST without a burner deterministically
+        // rejects at the handler; the policy gate should block early instead of
+        // prompting the user to confirm an action that can't succeed.
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: { ok: true },
+        }, { burnerConfigured: false });
+        assert.strictEqual(r.policy, 'block');
+        assert.strictEqual(r.reason, 'burner_not_configured');
     });
 
     await check('policy: GET unchanged (no body validation needed)', () => {

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -560,6 +560,49 @@ async function check(label, fn) {
         assert.ok(r.message.includes('0.10'));
     });
 
+    await check('policy: POST confirm message escapes Markdown metacharacters in body (R-pr370-fix-12)', () => {
+        // Model-controlled body content could inject backticks, links, bold,
+        // newlines, HTML — all of which markdown-it renders. The escape
+        // function must neutralize each.
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/x', max_usdc: '0.10',
+            method: 'POST', body: { evil: '`code` [click](http://bad) **bold** <script>alert(1)</script>\nnewline' },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'confirm');
+        const msg = r.message;
+        // Each Markdown metacharacter present in input should be backslash-escaped.
+        assert.ok(!/[^\\]`/.test(msg.replace(/^.+max_usdc.+\n/, '')),
+            'unescaped backtick must not appear in the body line');
+        assert.ok(msg.includes('\\['), 'left bracket must be escaped');
+        assert.ok(msg.includes('\\]'), 'right bracket must be escaped');
+        assert.ok(msg.includes('\\('), 'left paren must be escaped');
+        assert.ok(msg.includes('\\)'), 'right paren must be escaped');
+        assert.ok(msg.includes('\\*'), 'asterisk must be escaped');
+        assert.ok(msg.includes('\\<'), 'less-than must be escaped');
+        assert.ok(msg.includes('\\>'), 'greater-than must be escaped');
+        // Newlines inside the body preview become literal "\\n" so they
+        // don't reflow the card. The card's own structure newlines (between
+        // POST line / max_usdc line / body line) remain.
+        const bodyLine = msg.split('\n').find(l => l.startsWith('body:')) || '';
+        assert.ok(!bodyLine.includes('\n'), 'body line must be a single line');
+        assert.ok(bodyLine.includes('\\n'), 'embedded newline must be literalized as \\\\n');
+    });
+
+    await check('policy: POST confirm message escapes Markdown in URL too', () => {
+        // Even though URLs shouldn't contain markdown metachars, an attacker
+        // could craft a URL with backticks/etc. — sanitize defensively.
+        const r = getConfirmationPolicy('agent_pay', {
+            url: 'https://api.example.com/`evil`?q=*test*',
+            max_usdc: '0.10',
+            method: 'POST', body: { ok: true },
+        }, { burnerConfigured: true });
+        assert.strictEqual(r.policy, 'confirm');
+        // The URL backticks must be escaped, not preserved literally.
+        const urlLine = r.message.split('\n')[0];
+        assert.ok(urlLine.includes('\\`'), 'URL backticks must be escaped');
+        assert.ok(urlLine.includes('\\*'), 'URL asterisks must be escaped');
+    });
+
     await check('policy: POST + no body → block (body_required_for_post)', () => {
         const r = getConfirmationPolicy('agent_pay', {
             url: 'https://api.example.com/x', max_usdc: '0.10',

--- a/tests/nodejs-project/agent-pay-post.test.js
+++ b/tests/nodejs-project/agent-pay-post.test.js
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// agent-pay-post.test.js — BAT-664.
+//
+// Verifies agent_pay POST support added in BAT-664 v2:
+//   - method_not_allowed for PUT / PATCH / DELETE (before any DNS/network)
+//   - body_required_for_post when method=POST without body (before network)
+//   - body_not_json when string body is not valid JSON (before network)
+//   - body_too_large when serialized body > 8 KB UTF-8 (before network)
+//   - validateAndSerializeBody compact-serializes once for byte-identical
+//     probe + settle replay
+//   - Idempotency-Key generated per agent_pay invocation; distinct calls
+//     get distinct UUIDs
+//   - GET regression: existing under-cap-silent behavior preserved
+//   - Zero-network guarantee: every rejection above fires BEFORE DNS resolves
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const crypto = require('crypto');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// Stub config.js for transitive requires (matches other test files).
+const configPath = require.resolve(path.join(BUNDLE, 'config.js'));
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { BRIDGE_TOKEN: 't', log: () => {} },
+};
+
+// Stub bridge.js so the handler-level tests don't need a live bridge.
+const bridgeCalls = [];
+const bridgePath = require.resolve(path.join(BUNDLE, 'bridge.js'));
+require.cache[bridgePath] = {
+    id: bridgePath, filename: bridgePath, loaded: true,
+    exports: {
+        androidBridgeCall: async (endpoint, body) => {
+            bridgeCalls.push({ endpoint, body });
+            if (endpoint === '/burner/status') return { configured: false };
+            return {};
+        },
+    },
+};
+
+// Stub solana.js (matches agent-pay-no-burner test).
+const solanaPath = require.resolve(path.join(BUNDLE, 'solana.js'));
+require.cache[solanaPath] = {
+    id: solanaPath, filename: solanaPath, loaded: true,
+    exports: {
+        getConnectedWalletAddress: () => { throw new Error('not connected'); },
+        solanaRpc: async () => ({ error: 'mocked' }),
+    },
+};
+
+const agentPay = require(path.join(BUNDLE, 'tools', 'agent_pay'));
+const { validateAndSerializeBody, MAX_POST_BODY_BYTES, preflightUrlSync, handlers } = agentPay;
+
+// Track DNS lookups to assert zero-network guarantee.
+let dnsLookupCalled = 0;
+agentPay._setDnsLookup(async () => {
+    dnsLookupCalled++;
+    throw new Error('dns lookup should not have been called');
+});
+
+let failures = 0;
+async function check(label, fn) {
+    try { await fn(); console.log(`  ✓ ${label}`); }
+    catch (e) { failures++; console.error(`  ✗ ${label}\n    ${e.stack || e.message}`); }
+}
+
+(async () => {
+    // ── Unit tests on the validation helpers ────────────────────────────────
+
+    await check('preflightUrlSync allows GET', () => {
+        const r = preflightUrlSync('https://example.com/x', 'GET');
+        assert.strictEqual(r.method, 'GET');
+        assert.ok(r.ok);
+    });
+
+    await check('preflightUrlSync allows POST', () => {
+        const r = preflightUrlSync('https://example.com/x', 'POST');
+        assert.strictEqual(r.method, 'POST');
+        assert.ok(r.ok);
+    });
+
+    await check('preflightUrlSync defaults to GET when method missing', () => {
+        const r = preflightUrlSync('https://example.com/x', undefined);
+        assert.strictEqual(r.method, 'GET');
+    });
+
+    await check('preflightUrlSync rejects PUT with method_not_allowed', () => {
+        const r = preflightUrlSync('https://example.com/x', 'PUT');
+        assert.strictEqual(r.error, 'method_not_allowed');
+    });
+
+    await check('preflightUrlSync rejects PATCH with method_not_allowed', () => {
+        const r = preflightUrlSync('https://example.com/x', 'PATCH');
+        assert.strictEqual(r.error, 'method_not_allowed');
+    });
+
+    await check('preflightUrlSync rejects DELETE with method_not_allowed', () => {
+        const r = preflightUrlSync('https://example.com/x', 'DELETE');
+        assert.strictEqual(r.error, 'method_not_allowed');
+    });
+
+    await check('validateAndSerializeBody: GET returns bodyJsonStr=null', () => {
+        const r = validateAndSerializeBody('GET', undefined);
+        assert.deepStrictEqual(r, { bodyJsonStr: null });
+    });
+
+    await check('validateAndSerializeBody: GET ignores body if provided', () => {
+        // GET path: the body parameter is silently dropped (request never sends a body for GET).
+        const r = validateAndSerializeBody('GET', { phone: '+1234567890' });
+        assert.strictEqual(r.bodyJsonStr, null);
+    });
+
+    await check('validateAndSerializeBody: POST + no body → body_required_for_post', () => {
+        const r = validateAndSerializeBody('POST', undefined);
+        assert.strictEqual(r.error, 'body_required_for_post');
+    });
+
+    await check('validateAndSerializeBody: POST + null body → body_required_for_post', () => {
+        const r = validateAndSerializeBody('POST', null);
+        assert.strictEqual(r.error, 'body_required_for_post');
+    });
+
+    await check('validateAndSerializeBody: POST + object body → compact JSON', () => {
+        const r = validateAndSerializeBody('POST', { phone: '+15555550000', message: 'hi' });
+        assert.ok(r.bodyJsonStr);
+        // Compact serialization — no spaces.
+        assert.ok(!r.bodyJsonStr.includes(' '));
+        const parsed = JSON.parse(r.bodyJsonStr);
+        assert.strictEqual(parsed.phone, '+15555550000');
+        assert.strictEqual(parsed.message, 'hi');
+    });
+
+    await check('validateAndSerializeBody: POST + valid JSON string → re-serialized', () => {
+        const r = validateAndSerializeBody('POST', '{"phone":"+15555550000","message":"hi"}');
+        assert.ok(r.bodyJsonStr);
+        const parsed = JSON.parse(r.bodyJsonStr);
+        assert.strictEqual(parsed.phone, '+15555550000');
+    });
+
+    await check('validateAndSerializeBody: POST + invalid JSON string → body_not_json', () => {
+        const r = validateAndSerializeBody('POST', 'this is not json');
+        assert.strictEqual(r.error, 'body_not_json');
+    });
+
+    await check('validateAndSerializeBody: POST + function value → body_not_json', () => {
+        // JSON.stringify({fn: ()=>1}) drops the fn → {} (still valid, accepted).
+        // JSON.stringify(()=>1) returns undefined → body_not_json.
+        const r = validateAndSerializeBody('POST', () => 1);
+        assert.strictEqual(r.error, 'body_not_json');
+    });
+
+    await check('validateAndSerializeBody: POST + circular → body_not_json', () => {
+        const obj = {};
+        obj.self = obj;
+        const r = validateAndSerializeBody('POST', obj);
+        assert.strictEqual(r.error, 'body_not_json');
+    });
+
+    await check('validateAndSerializeBody: POST + 8 KB body accepted', () => {
+        // 8192 bytes UTF-8 exactly. Build a key:value pair whose JSON length lands at 8192.
+        const filler = 'A'.repeat(8192 - 14);  // 14 = '{"k":"' + '"}' + a few padding bytes
+        const r = validateAndSerializeBody('POST', { k: filler });
+        assert.ok(r.bodyJsonStr, `expected accept, got ${JSON.stringify(r)}`);
+        assert.ok(Buffer.byteLength(r.bodyJsonStr, 'utf8') <= MAX_POST_BODY_BYTES);
+    });
+
+    await check('validateAndSerializeBody: POST + >8 KB body → body_too_large', () => {
+        const huge = 'B'.repeat(10_000);
+        const r = validateAndSerializeBody('POST', { k: huge });
+        assert.strictEqual(r.error, 'body_too_large');
+        // Message mentions the cap.
+        assert.ok(r.reason.includes('8192'));
+    });
+
+    await check('validateAndSerializeBody: POST cap is computed on UTF-8 bytes (multi-byte chars)', () => {
+        // 4097 emoji × 4 bytes each = 16388 bytes (well over 8 KB) wrapped in {"k":"..."}
+        // confirms the cap is on UTF-8 byte length, not character count.
+        const r = validateAndSerializeBody('POST', { k: '😀'.repeat(2200) });
+        assert.strictEqual(r.error, 'body_too_large');
+    });
+
+    // ── Handler-level tests: zero-network guarantee on rejection ────────────
+
+    await check('handler: POST + PUT method rejected before DNS', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'PUT',
+            body: { x: 1 },
+        });
+        assert.strictEqual(r.error, 'method_not_allowed');
+        assert.strictEqual(dnsLookupCalled, 0, 'DNS must not be called for method rejection');
+        assert.strictEqual(bridgeCalls.length, 0, 'bridge must not be called for method rejection');
+    });
+
+    await check('handler: POST without body rejected before DNS', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'POST',
+            // no body
+        });
+        assert.strictEqual(r.error, 'body_required_for_post');
+        assert.strictEqual(dnsLookupCalled, 0);
+        assert.strictEqual(bridgeCalls.length, 0);
+    });
+
+    await check('handler: POST + invalid JSON string body rejected before DNS', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'POST',
+            body: 'definitely not json',
+        });
+        assert.strictEqual(r.error, 'body_not_json');
+        assert.strictEqual(dnsLookupCalled, 0);
+        assert.strictEqual(bridgeCalls.length, 0);
+    });
+
+    await check('handler: POST + oversized body rejected before DNS', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'POST',
+            body: { k: 'X'.repeat(10_000) },
+        });
+        assert.strictEqual(r.error, 'body_too_large');
+        assert.strictEqual(dnsLookupCalled, 0);
+        assert.strictEqual(bridgeCalls.length, 0);
+    });
+
+    await check('handler: POST + no burner + valid body → burner_not_configured (body check passes first, then bridge check)', async () => {
+        // With a valid POST body, validation passes; bridge says no burner.
+        // We end up with burner_not_configured. CRITICALLY: DNS is still not
+        // called (per BAT-582: refuse before any URL fetch).
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'POST',
+            body: { phone: '+15555550000', message: 'hi' },
+        });
+        assert.strictEqual(r.error, 'burner_not_configured');
+        assert.strictEqual(dnsLookupCalled, 0,
+            'DNS must not be called when burner unconfigured (true even for POST)');
+        // /burner/status was called; nothing else.
+        const statusCalls = bridgeCalls.filter(c => c.endpoint === '/burner/status');
+        assert.strictEqual(statusCalls.length, 1);
+    });
+
+    // ── Idempotency-Key generation contract ─────────────────────────────────
+
+    await check('crypto.randomUUID() produces distinct UUIDs across calls', () => {
+        // Pin the underlying expectation rather than wiring through the
+        // private idempotency generation: validate that distinct calls in
+        // tight succession produce distinct UUIDs. The handler generates one
+        // per agent_pay invocation using crypto.randomUUID(), so distinct
+        // invocations get distinct keys.
+        const a = crypto.randomUUID();
+        const b = crypto.randomUUID();
+        const c = crypto.randomUUID();
+        assert.notStrictEqual(a, b);
+        assert.notStrictEqual(b, c);
+        assert.notStrictEqual(a, c);
+        // RFC 4122 format check.
+        const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        for (const u of [a, b, c]) {
+            assert.ok(uuidRe.test(u), `UUID format invalid: ${u}`);
+        }
+    });
+
+    // ── GET regression: pre-existing behavior preserved ─────────────────────
+
+    await check('GET regression: handler still works for GET (method defaults to GET when omitted)', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            // No method, no body — pure GET path
+        });
+        assert.strictEqual(r.error, 'burner_not_configured');  // same as before — no behavior change
+        assert.strictEqual(dnsLookupCalled, 0);
+    });
+
+    await check('GET regression: explicit method:"GET" + no body works', async () => {
+        bridgeCalls.length = 0;
+        dnsLookupCalled = 0;
+        const r = await handlers.agent_pay({
+            url: 'https://pay.sh/sandbox/echo',
+            max_usdc: '0.10',
+            method: 'GET',
+        });
+        assert.strictEqual(r.error, 'burner_not_configured');
+        assert.strictEqual(dnsLookupCalled, 0);
+    });
+
+    if (failures === 0) {
+        console.log('\n✓ All agent-pay-post.test.js cases passed');
+        process.exit(0);
+    } else {
+        console.error(`\n✗ ${failures} case(s) failed`);
+        process.exit(1);
+    }
+})();


### PR DESCRIPTION
**Targets the integration branch** \`feature/BAT-582-burner-wallet\`.

Implements [BAT-664](https://linear.app/batcave/issue/BAT-664) — lifts the GET-only gate from BAT-582 v1.4 so \`agent_pay\` can hit paid POST endpoints (textbelt-text SMS, post-style x402 services).

## Codex sign-off

BAT-664 v2 contract approved by Codex PM (2026-05-11). v1 review had 7 required edits; v2 added 2 polish notes (analytics body, typo). All incorporated into this implementation.

## Tool surface

\`agent_pay(url, max_usdc, method?, body?)\`

- \`method\`: \`"GET"\` (default) or \`"POST"\`
- \`body\`: JSON-serializable, ≤ 8 KB UTF-8 compact-serialized (POST only, required)
- GET: under-cap silent (existing behavior preserved)
- **POST always asks for user confirmation** — side-effect-aware (can send SMS, post content, trigger paid actions)

## Implementation highlights

- **Body validated BEFORE DNS or any network call** (5 stable error codes: \`method_not_allowed\`, \`body_required_for_post\`, \`body_not_json\`, \`body_too_large\`)
- **Body cached once** at validation time as compact JSON string; reused byte-identically for probe + settle replay (no per-call re-serialization)
- **\`Idempotency-Key\` = \`crypto.randomUUID()\`** per agent_pay invocation, attached to both probe and settle replay
- **\`payment/x402.js::settle()\`** extended to thread \`method\`, \`bodyJsonStr\`, \`idempotencyKey\` via \`originalRequest\` (per Codex's v1 edit 3 — settle isn't fully method-agnostic for replay)
- **Confirmation message** shows method + URL + 200-char body preview + max_usdc. Per Codex v2 note 2: preview is for human display only — analytics should record only non-content metadata (\`method\`, \`host\`, \`bodyByteLength\`, \`bodyTruncated\`)

## Test coverage

New \`tests/nodejs-project/agent-pay-post.test.js\` — **26 cases**:

| Section | Cases |
|---|---|
| \`preflightUrlSync\` (method gates) | 6 |
| \`validateAndSerializeBody\` (no-body, null, object, JSON string, invalid string, function, circular, 8 KB cap, multi-byte UTF-8) | 12 |
| Handler-level **zero-network** rejections (DNS lookup not called) | 5 |
| Idempotency-Key uniqueness | 1 |
| GET regression (no behavior change) | 2 |

Full nodejs rollup: **44/44 pass** (including new file).
\`tests/paysh/validate-detect.js\`: 8/8 ✓
\`tests/paysh/validate-settle.js\`: 6/6 ✓
\`scripts/pre-push-check.sh\`: Node smoke + Kotlin compile clean ✓

## Hard gates from Codex v2

- [x] New POST tests green (26/26)
- [x] Old GET / x402 v1 / v2 tests green (44/44 total)
- [x] Confirmation snapshot proves GET unchanged (existing snapshot test passes — POST returns confirm via the explicit POST branch in policy.js)
- [ ] SAB updated and green — will run sab-audit after Copilot review converges
- [ ] One device/live note showing POST confirmation + replay — will run \`tests/paysh/live-pay-curated.js --live\` post-merge to swap from the test-side POST implementation to production agent_pay

## Out of scope

- PUT / PATCH / DELETE (rejected with \`method_not_allowed\`)
- Non-JSON content types
- Streaming bodies
- MPP session payments

## Test plan after merge

- Re-run \`tests/paysh/live-pay-curated.js --live --include-side-effecting --phone <test-num>\` using production agent_pay POST path (currently the test file has its own POST implementation; after this PR lands the test framework can drop it and use \`agent_pay\` directly). Spend ≤ \$0.05 USDC.
- Device test on Seeker: POST against safe sandbox endpoint, verify the confirmation card shows method + URL + body preview + max_usdc, and full body never appears in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)