### PR TITLE
feat(settings): BAT-681 — state-aware Burner Wallet button + section reorder

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -152,14 +152,27 @@ fun SettingsScreen(
     }
     var burnerConfigured by remember { mutableStateOf(false) }
     // Bumped from ON_RESUME below to re-probe after the user returns
-    // from BurnerWalletScreen (import / wipe flow).
-    var burnerProbeKey by remember { mutableStateOf(0) }
+    // from BurnerWalletScreen (import / wipe flow). R-pr374-r2-2:
+    // primitive IntState matches `mcpServerCount` and other counters
+    // in this file — avoids the boxed-Int allocation `mutableStateOf(0)`
+    // would create.
+    var burnerProbeKey by remember { mutableIntStateOf(0) }
     LaunchedEffect(burnerProbeKey) {
         val pk = withContext(Dispatchers.IO) {
             try {
                 burnerKeyVault.getPubkey(
                     com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID,
                 )
+            } catch (ce: kotlinx.coroutines.CancellationException) {
+                // R-pr374-r2-1: CancellationException is how Kotlin
+                // coroutines signal cooperative cancellation. Catching
+                // it under the generic `Exception` branch below would
+                // swallow the cancel and let this LaunchedEffect's
+                // coroutine survive past the composable's disposal
+                // (and delay any structured-concurrency parent that's
+                // waiting on this to finish). Re-throw so cancellation
+                // propagates normally.
+                throw ce
             } catch (_: Exception) {
                 null
             }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -98,6 +98,8 @@ import com.seekerclaw.app.util.Analytics
 import com.seekerclaw.app.util.LogCollector
 import com.seekerclaw.app.util.LogLevel
 import com.seekerclaw.app.BuildConfig
+import com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints
+import com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault
 import com.seekerclaw.app.ui.components.CardSurface
 import com.seekerclaw.app.ui.components.DangerButton
 import com.seekerclaw.app.ui.components.DangerOutlineButton
@@ -110,6 +112,7 @@ import com.seekerclaw.app.ui.components.InfoRow
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 import com.seekerclaw.app.ui.theme.Sizing
 import com.seekerclaw.app.ui.theme.Spacing
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -147,9 +150,11 @@ fun SettingsScreen(
     // R-pr374-r1-2: remember a single keyVault instance; reused for the
     // initial probe AND the ON_RESUME refresh below, no reallocation
     // on each lifecycle event.
-    val burnerKeyVault = remember {
-        com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
-    }
+    // R-pr374-r5-1: use short names via imports (added at the top of
+    // the file) for EncryptedPrefsKeyVault, BurnerBridgeEndpoints, and
+    // CancellationException. Matches the rest of SettingsScreen.kt
+    // which relies on imports rather than fully-qualified inline refs.
+    val burnerKeyVault = remember { EncryptedPrefsKeyVault(context.applicationContext) }
     var burnerConfigured by remember { mutableStateOf(false) }
     // Bumped from ON_RESUME below to re-probe after the user returns
     // from BurnerWalletScreen (import / wipe flow). R-pr374-r2-2:
@@ -160,10 +165,8 @@ fun SettingsScreen(
     LaunchedEffect(burnerProbeKey) {
         val pk = withContext(Dispatchers.IO) {
             try {
-                burnerKeyVault.getPubkey(
-                    com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID,
-                )
-            } catch (ce: kotlinx.coroutines.CancellationException) {
+                burnerKeyVault.getPubkey(BurnerBridgeEndpoints.BURNER_ID)
+            } catch (ce: CancellationException) {
                 // R-pr374-r2-1: CancellationException is how Kotlin
                 // coroutines signal cooperative cancellation. Catching
                 // it under the generic `Exception` branch below would

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -824,14 +824,6 @@ fun SettingsScreen(
                         fontSize = 14.sp,
                     )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Agent-controlled signer (experimental)",
-                    fontFamily = RethinkSans,
-                    fontSize = 11.sp,
-                    color = SeekerClawColors.TextDim,
-                    modifier = Modifier.fillMaxWidth(),
-                )
             } else {
                 Button(
                     onClick = onNavigateToBurnerWallet,
@@ -857,20 +849,22 @@ fun SettingsScreen(
                         fontWeight = FontWeight.Bold,
                     )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                // R-pr374-r4-1: same caption as the configured state so
-                // the user gets consistent framing across both states.
-                // The original ConfigField used "Agent-controlled signer
-                // (experimental)"; preserve that copy in both branches
-                // (no longer-vs-shorter copy drift).
-                Text(
-                    text = "Agent-controlled signer (experimental)",
-                    fontFamily = RethinkSans,
-                    fontSize = 11.sp,
-                    color = SeekerClawColors.TextDim,
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
+            // R-pr374-r6-1: spacer + caption hoisted out of the
+            // if/else (post-R4 both branches had identical copy +
+            // layout). Single source of truth — no copy/layout drift
+            // if future changes only update one branch by mistake.
+            // R-pr374-r4-1 framing ("Agent-controlled signer
+            // (experimental)") preserved verbatim from the pre-PR
+            // ConfigField value text.
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Agent-controlled signer (experimental)",
+                fontFamily = RethinkSans,
+                fontSize = 11.sp,
+                color = SeekerClawColors.TextDim,
+                modifier = Modifier.fillMaxWidth(),
+            )
 
             // ── Jupiter API Key (Solana swaps) ────────────────────────────
             Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -834,7 +834,13 @@ fun SettingsScreen(
                     onClick = onNavigateToBurnerWallet,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(48.dp),
+                        .height(48.dp)
+                        // R-pr374-r4-2: match the "Connect Wallet" CTA's
+                        // visual treatment — same glow modifier on the
+                        // primary onboarding button — since the PR
+                        // description claims visual analogy and the user's
+                        // design-system requirement is "consistency."
+                        .cornerGlowBorder(),
                     shape = shape,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = SeekerClawColors.ActionPrimary,
@@ -849,8 +855,13 @@ fun SettingsScreen(
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
+                // R-pr374-r4-1: same caption as the configured state so
+                // the user gets consistent framing across both states.
+                // The original ConfigField used "Agent-controlled signer
+                // (experimental)"; preserve that copy in both branches
+                // (no longer-vs-shorter copy drift).
                 Text(
-                    text = "Optional agent-controlled signer for autonomous Solana actions (experimental)",
+                    text = "Agent-controlled signer (experimental)",
                     fontFamily = RethinkSans,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -134,14 +134,37 @@ fun SettingsScreen(
     // BAT-681: track whether the burner wallet is configured so the
     // Settings → Solana Wallet section can show "Set Up Burner Wallet"
     // (unconfigured) vs "Manage Burner Wallet" (configured), parallel
-    // to the state-aware iOS Settings pattern. Refreshed on lifecycle
-    // resume below so the label updates after the user navigates back
-    // from the BurnerWalletScreen (import or wipe flow).
-    var burnerConfigured by remember {
-        mutableStateOf(
-            com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
-                .isConfigured(com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID),
-        )
+    // to the state-aware iOS Settings pattern.
+    //
+    // R-pr374-r1-1 (Copilot review): drive the state from a successful
+    // `getPubkey()` probe, NOT `isConfigured()`. The latter only checks
+    // file existence — a key file could exist but be undecryptable
+    // (Keystore wipe, restore-from-backup, etc.) which would make
+    // Settings show "Manage" while BurnerWalletScreen renders empty.
+    // The pubkey probe matches what BurnerWalletScreen itself gates on,
+    // so the two surfaces stay in agreement.
+    //
+    // R-pr374-r1-2: remember a single keyVault instance; reused for the
+    // initial probe AND the ON_RESUME refresh below, no reallocation
+    // on each lifecycle event.
+    val burnerKeyVault = remember {
+        com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
+    }
+    var burnerConfigured by remember { mutableStateOf(false) }
+    // Bumped from ON_RESUME below to re-probe after the user returns
+    // from BurnerWalletScreen (import / wipe flow).
+    var burnerProbeKey by remember { mutableStateOf(0) }
+    LaunchedEffect(burnerProbeKey) {
+        val pk = withContext(Dispatchers.IO) {
+            try {
+                burnerKeyVault.getPubkey(
+                    com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID,
+                )
+            } catch (_: Exception) {
+                null
+            }
+        }
+        burnerConfigured = pk != null
     }
 
     var autoStartOnBoot by remember {
@@ -195,11 +218,12 @@ fun SettingsScreen(
                 hasContactsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED
                 hasSmsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS) == PackageManager.PERMISSION_GRANTED
                 hasCallPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
-                // BAT-681: re-check burner config on resume so the Set Up /
-                // Manage label flips immediately after the user imports a
-                // key or wipes it in the BurnerWalletScreen sub-flow.
-                burnerConfigured = com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
-                    .isConfigured(com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID)
+                // BAT-681: re-probe the burner pubkey on resume so the
+                // Set Up / Manage label flips immediately after the user
+                // imports a key or wipes it in the BurnerWalletScreen
+                // sub-flow. Bumping the key drives the LaunchedEffect
+                // above; the IO-thread probe runs off the main thread.
+                burnerProbeKey++
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -131,6 +131,18 @@ fun SettingsScreen(
     // Observe configVersion so UI refreshes when bridge saves owner ID (auto-detect)
     val configVer by ConfigManager.configVersion
     var config by remember(configVer) { mutableStateOf(ConfigManager.loadConfig(context)) }
+    // BAT-681: track whether the burner wallet is configured so the
+    // Settings → Solana Wallet section can show "Set Up Burner Wallet"
+    // (unconfigured) vs "Manage Burner Wallet" (configured), parallel
+    // to the state-aware iOS Settings pattern. Refreshed on lifecycle
+    // resume below so the label updates after the user navigates back
+    // from the BurnerWalletScreen (import or wipe flow).
+    var burnerConfigured by remember {
+        mutableStateOf(
+            com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
+                .isConfigured(com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID),
+        )
+    }
 
     var autoStartOnBoot by remember {
         mutableStateOf(ConfigManager.getAutoStartOnBoot(context))
@@ -183,6 +195,11 @@ fun SettingsScreen(
                 hasContactsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED
                 hasSmsPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS) == PackageManager.PERMISSION_GRANTED
                 hasCallPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
+                // BAT-681: re-check burner config on resume so the Set Up /
+                // Manage label flips immediately after the user imports a
+                // key or wipes it in the BurnerWalletScreen sub-flow.
+                burnerConfigured = com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault(context.applicationContext)
+                    .isConfigured(com.seekerclaw.app.bridge.burner.BurnerBridgeEndpoints.BURNER_ID)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -742,7 +759,69 @@ fun SettingsScreen(
                 )
             }
 
-            // Jupiter API Key (Solana swaps)
+            // ── Burner Wallet (BAT-582 / BAT-681) ─────────────────────────
+            // Promoted above the API-key fields per BAT-681: this is a
+            // primary capability surface (agent-controlled signer), so it
+            // gets a full-width button parallel to "Connect/Disconnect
+            // Wallet" rather than a small Edit row. State-aware label
+            // matches the iOS Settings two-state pattern:
+            //   - unconfigured → "Set Up Burner Wallet" (filled, primary CTA)
+            //   - configured   → "Manage Burner Wallet" (outlined, neutral)
+            Spacer(modifier = Modifier.height(20.dp))
+            if (burnerConfigured) {
+                OutlinedButton(
+                    onClick = onNavigateToBurnerWallet,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = shape,
+                    border = BorderStroke(1.dp, SeekerClawColors.BorderSubtle),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = SeekerClawColors.TextPrimary,
+                    ),
+                ) {
+                    Text(
+                        "Manage Burner Wallet",
+                        fontFamily = RethinkSans,
+                        fontSize = 14.sp,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Agent-controlled signer (experimental)",
+                    fontFamily = RethinkSans,
+                    fontSize = 11.sp,
+                    color = SeekerClawColors.TextDim,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                Button(
+                    onClick = onNavigateToBurnerWallet,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = shape,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = SeekerClawColors.ActionPrimary,
+                        contentColor = androidx.compose.ui.graphics.Color.White,
+                    ),
+                ) {
+                    Text(
+                        "Set Up Burner Wallet",
+                        fontFamily = RethinkSans,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Optional agent-controlled signer for autonomous Solana actions (experimental)",
+                    fontFamily = RethinkSans,
+                    fontSize = 11.sp,
+                    color = SeekerClawColors.TextDim,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            // ── Jupiter API Key (Solana swaps) ────────────────────────────
             Spacer(modifier = Modifier.height(20.dp))
             ConfigField(
                 label = "Jupiter API Key",
@@ -760,7 +839,7 @@ fun SettingsScreen(
                 info = SettingsHelpTexts.JUPITER_API_KEY,
             )
 
-            // Helius API Key (NFT holdings)
+            // ── Helius API Key (NFT holdings) ─────────────────────────────
             Spacer(modifier = Modifier.height(20.dp))
             ConfigField(
                 label = "Helius API Key",
@@ -774,19 +853,8 @@ fun SettingsScreen(
                     editLabel = "Helius API Key"
                     editValue = config?.heliusApiKey ?: ""
                 },
-                showDivider = true,
-                info = SettingsHelpTexts.HELIUS_API_KEY,
-            )
-
-            // Burner wallet (BAT-582) — agent-controlled signer for
-            // autonomous Solana actions. Shows as a navigation row
-            // because the configuration surface is a full screen
-            // (key import, caps, danger zone).
-            ConfigField(
-                label = "Burner Wallet",
-                value = "Agent-controlled signer (experimental)",
-                onClick = onNavigateToBurnerWallet,
                 showDivider = false,
+                info = SettingsHelpTexts.HELIUS_API_KEY,
             )
             }
         }


### PR DESCRIPTION
## Summary

Closes the **Settings UI** slice of [BAT-681](https://linear.app/batcave/issue/BAT-681) (burner wallet UX polish). Targets the integration branch (not main) — stacked under [PR #372](https://github.com/sepivip/SeekerClaw/pull/372) which carries the BAT-582 + BAT-664 foundation.

Pre-fix the Burner Wallet row sat below Jupiter / Helius API keys with a small "Edit" link, feeling secondary even though autonomous-signing is a primary capability surface. This PR promotes it to a state-aware full-width button.

## What's in here

### 1. Reorder

Burner Wallet moved from the bottom of the Solana Wallet section to immediately under the Connect / Disconnect Wallet block, above Jupiter / Helius API keys.

### 2. State-aware button

Replaces the small `ConfigField` "Edit" link with a full-width button that matches the iOS Settings two-state pattern:

| State | Button | Style | Visual analog |
|-------|--------|-------|---------------|
| Unconfigured | **"Set Up Burner Wallet"** | Filled `Button`, `ActionPrimary`, bold, 48dp | Same as the first-time-onboarding "Connect Wallet" CTA |
| Configured | **"Manage Burner Wallet"** | `OutlinedButton`, `BorderSubtle` + `TextPrimary`, 14sp regular | Same as the existing "Export Memory" outlined button |

Subtext under the button retains the "Agent-controlled signer (experimental)" framing — relocated from the ConfigField `value` slot to an 11sp `TextDim` caption.

### 3. State plumbing — `getPubkey()` probe (NOT `isConfigured()`)

> **Updated after Copilot R1 review (PR description previously said `isConfigured(BURNER_ID)` — that was the initial implementation; switched after R1-1 feedback).**

State is derived from a successful `keyVault.getPubkey(BURNER_ID)` call (`EncryptedPrefsKeyVault.isConfigured()` only checks file existence — file could be present but undecryptable after a Keystore wipe or restore-from-backup, in which case Settings would show "Manage" while BurnerWalletScreen renders empty). The pubkey probe matches what BurnerWalletScreen itself gates on, so the two surfaces stay in agreement.

Implementation:
- A single `EncryptedPrefsKeyVault` instance is `remember`ed (no reallocation on every recomposition or resume).
- A `LaunchedEffect(burnerProbeKey)` runs the `getPubkey()` call on `Dispatchers.IO` (mirrors `BurnerWalletScreen:125`).
- The `burnerProbeKey` counter is bumped from the existing `ON_RESUME` lifecycle observer, so the probe re-runs after the user returns from `BurnerWalletScreen` (import / wipe flow) — label flips without manual reload.
- `getPubkey()` failure (decryption fails, file missing, etc.) → `null pubkey` → `burnerConfigured = false` → "Set Up Burner Wallet" CTA. Defensive: a corrupted-key state cleanly maps to the recovery path.
- `CancellationException` is explicitly rethrown ahead of the generic catch (Compose structured concurrency hygiene — R2-1 fix).

## Design system compliance

Per user's requirement: *"component, spacing and everything here and inside should reflect our design system guidelines, fonts, sizes designs."*

- **Typography:** `RethinkSans` family throughout, 14sp button label / 11sp caption — same as adjacent rows.
- **Colors:** All from `Theme.kt` / `SeekerClawColors` — `ActionPrimary`, `BorderSubtle`, `TextPrimary`, `TextDim`. No ad-hoc hex.
- **Shape:** Reuses the `shape` variable already in scope (consistent with Connect / Disconnect / Export buttons).
- **Spacing:** `Spacer.height(20.dp)` between rows + `8.dp` between button + caption — matches the section's existing rhythm.
- **Primitives:** `OutlinedButton` and `Button` from `ButtonDefaults` — same components the section already uses for Connect / Disconnect / Export.
- **State primitives:** `mutableIntStateOf(0)` for `burnerProbeKey` (matches `mcpServerCount` and other counters in this file — R2-2 fix, no boxed Int).

No new components introduced. No styling additions.

## What's NOT in scope

Items 2-7 of BAT-681 (balance fetch fix, low-balance warning, retry heuristic, step-limit investigation, confirmation prompt polish, `nonRetryable: true` agent loop guard) stay parked. Per user feedback *"Low balance warning is overkill for me tbh,"* explicitly deferred to a future BAT.

## Review iteration

| Round | Findings | Fix |
|-------|----------|-----|
| R1 | 2 blockers: (a) `isConfigured()` necessary-but-not-sufficient — disagrees with BurnerWalletScreen's `getPubkey()` gate; (b) `keyVault` recreated on every resume | Switched to `getPubkey()` probe + `remember`ed keyVault instance |
| R2 | 2 blockers: (a) `catch (_: Exception)` swallows `CancellationException`; (b) boxed Int counter | Explicit `CancellationException` rethrow + `mutableIntStateOf` |
| R3 | 1 nit: PR description out of sync with implementation | (This update) |

## Test plan

- [x] `scripts/pre-push-check.sh` clean across R1, R2, R3 commits (Node smoke + tool-schemas + Kotlin compile `compileDappStoreDebugKotlin` — BUILD SUCCESSFUL each round)
- [ ] Device test: install on Seeker, verify Settings → Solana Wallet section shows the new layout
- [ ] Device test (unconfigured state): wipe burner → see "Set Up Burner Wallet" filled CTA
- [ ] Device test (configured state): import a key → see "Manage Burner Wallet" outlined button
- [ ] Device test (transition): use the button to navigate to BurnerWalletScreen → import a key → back-navigate → label should flip from "Set Up" to "Manage" without manual reload

## Linear

- [BAT-681](https://linear.app/batcave/issue/BAT-681) — Settings UI slice (items 1, 2, 3 from the BAT)

## Self-Awareness Checklist

- [ ] SAB-audited
- [x] N/A — UI-only change, no agent surface (no tool changes, no `buildSystemBlocks()` touch, no new error codes, no DIAGNOSTICS surface)

## Notes

- Targets `feature/BAT-582-burner-wallet` (integration branch), NOT `main`. Per the user's stacked-PR pattern (#366-#371 used the same approach).
- After merge into integration branch + device test, the change flows to main via [PR #372](https://github.com/sepivip/SeekerClaw/pull/372).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
