### PR TITLE
feat(settings): BAT-681 polish — separate Main/Burner Wallet subsections

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -683,13 +683,13 @@ fun SettingsScreen(
         // variants of the same one).
         CollapsibleSection("Solana Wallet", initiallyExpanded = false) {
             CardSurface {
-                // ── Main Wallet ───────────────────────────────────────
-                SectionLabel("Main Wallet")
-                Spacer(modifier = Modifier.height(12.dp))
-                if (walletAddress != null) {
-                    // Connected state — address with copy button
-                    val address = walletAddress!!
-                    WalletAddressRow(address = address, clipboardLabel = "wallet address")
+            // ── Main Wallet ───────────────────────────────────────────
+            SectionLabel("Main Wallet")
+            Spacer(modifier = Modifier.height(12.dp))
+            if (walletAddress != null) {
+                // Connected state — address with copy button
+                val address = walletAddress!!
+                WalletAddressRow(address = address, clipboardLabel = "wallet address")
 
                 val label = ConfigManager.getWalletLabel(context)
                 if (label.isNotBlank()) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -683,219 +683,219 @@ fun SettingsScreen(
         // variants of the same one).
         CollapsibleSection("Solana Wallet", initiallyExpanded = false) {
             CardSurface {
-            // ── Main Wallet ───────────────────────────────────────────
-            SectionLabel("Main Wallet")
-            Spacer(modifier = Modifier.height(12.dp))
-            if (walletAddress != null) {
-                // Connected state — address with copy button
-                val address = walletAddress!!
-                WalletAddressRow(address = address, clipboardLabel = "wallet address")
-
-                val label = ConfigManager.getWalletLabel(context)
-                if (label.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    InfoRow("Wallet", label, isLast = true)
-                }
-
+                // ── Main Wallet ───────────────────────────────────────────
+                SectionLabel("Main Wallet")
                 Spacer(modifier = Modifier.height(12.dp))
-                OutlinedButton(
-                    onClick = {
-                        ConfigManager.clearWalletAddress(context)
-                        walletAddress = null
-                        walletError = null
-                        Analytics.featureUsed("wallet_disconnected")
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = shape,
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = SeekerClawColors.Error,
-                    ),
-                ) {
-                    Text("Disconnect Wallet", fontFamily = RethinkSans, fontSize = 14.sp)
-                }
-            } else {
-                // Not connected — show Connect button
-                if (walletError != null) {
-                    Text(
-                        text = walletError!!,
-                        fontFamily = RethinkSans,
-                        fontSize = 12.sp,
-                        color = SeekerClawColors.Error,
+                if (walletAddress != null) {
+                    // Connected state — address with copy button
+                    val address = walletAddress!!
+                    WalletAddressRow(address = address, clipboardLabel = "wallet address")
+
+                    val label = ConfigManager.getWalletLabel(context)
+                    if (label.isNotBlank()) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        InfoRow("Wallet", label, isLast = true)
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedButton(
+                        onClick = {
+                            ConfigManager.clearWalletAddress(context)
+                            walletAddress = null
+                            walletError = null
+                            Analytics.featureUsed("wallet_disconnected")
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = shape,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = SeekerClawColors.Error,
+                        ),
+                    ) {
+                        Text("Disconnect Wallet", fontFamily = RethinkSans, fontSize = 14.sp)
+                    }
+                } else {
+                    // Not connected — show Connect button
+                    if (walletError != null) {
+                        Text(
+                            text = walletError!!,
+                            fontFamily = RethinkSans,
+                            fontSize = 12.sp,
+                            color = SeekerClawColors.Error,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(SeekerClawColors.Error.copy(alpha = 0.1f), shape)
+                                .padding(12.dp),
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
+
+                    Button(
+                        onClick = {
+                            isConnecting = true
+                            walletError = null
+                            Analytics.featureUsed("wallet_connected")
+                            val requestId = "settings_${System.currentTimeMillis()}"
+                            walletRequestId = requestId
+                            val intent = Intent(context, SolanaAuthActivity::class.java).apply {
+                                putExtra("action", "authorize")
+                                putExtra("requestId", requestId)
+                            }
+                            walletLauncher.launch(intent)
+                        },
+                        enabled = !isConnecting,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(SeekerClawColors.Error.copy(alpha = 0.1f), shape)
-                            .padding(12.dp),
+                            .height(48.dp)
+                            .cornerGlowBorder(),
+                        shape = shape,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = SeekerClawColors.ActionPrimary,
+                            contentColor = androidx.compose.ui.graphics.Color.White,
+                            disabledContainerColor = SeekerClawColors.ActionPrimary.copy(alpha = 0.4f),
+                            disabledContentColor = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.6f),
+                        ),
+                    ) {
+                        if (isConnecting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = androidx.compose.ui.graphics.Color.White,
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(modifier = Modifier.padding(start = 8.dp))
+                            Text("Connecting\u2026", fontFamily = RethinkSans, fontSize = 14.sp)
+                        } else {
+                            Text("Connect Wallet", fontFamily = RethinkSans, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Opens Phantom, Solflare, or Seeker Vault",
+                        fontFamily = RethinkSans,
+                        fontSize = 11.sp,
+                        color = SeekerClawColors.TextDim,
+                        modifier = Modifier.fillMaxWidth(),
                     )
+                }
+
+                // ── Burner Wallet (BAT-582 / BAT-681) ─────────────────────────
+                // Divider + SectionLabel mirror the Main Wallet header above so
+                // Main and Burner read as two distinct wallets sharing the same
+                // collapsible (not two variants of the same wallet). Address
+                // row only renders when KeyVault has a pubkey for the burner.
+                Spacer(modifier = Modifier.height(20.dp))
+                HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
+                Spacer(modifier = Modifier.height(20.dp))
+                SectionLabel("Burner Wallet")
+                Spacer(modifier = Modifier.height(12.dp))
+                burnerPubkey?.let { pk ->
+                    WalletAddressRow(address = pk, clipboardLabel = "burner wallet address")
                     Spacer(modifier = Modifier.height(12.dp))
                 }
-
-                Button(
-                    onClick = {
-                        isConnecting = true
-                        walletError = null
-                        Analytics.featureUsed("wallet_connected")
-                        val requestId = "settings_${System.currentTimeMillis()}"
-                        walletRequestId = requestId
-                        val intent = Intent(context, SolanaAuthActivity::class.java).apply {
-                            putExtra("action", "authorize")
-                            putExtra("requestId", requestId)
-                        }
-                        walletLauncher.launch(intent)
-                    },
-                    enabled = !isConnecting,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp)
-                        .cornerGlowBorder(),
-                    shape = shape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = SeekerClawColors.ActionPrimary,
-                        contentColor = androidx.compose.ui.graphics.Color.White,
-                        disabledContainerColor = SeekerClawColors.ActionPrimary.copy(alpha = 0.4f),
-                        disabledContentColor = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.6f),
-                    ),
-                ) {
-                    if (isConnecting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            color = androidx.compose.ui.graphics.Color.White,
-                            strokeWidth = 2.dp,
+                // Promoted above the API-key fields per BAT-681: this is a
+                // primary capability surface (agent-controlled signer), so it
+                // gets a full-width button parallel to "Connect/Disconnect
+                // Wallet" rather than a small Edit row. State-aware label
+                // matches the iOS Settings two-state pattern:
+                //   - unconfigured → "Set Up Burner Wallet" (filled, primary CTA)
+                //   - configured   → "Manage Burner Wallet" (outlined, neutral)
+                if (burnerConfigured) {
+                    OutlinedButton(
+                        onClick = onNavigateToBurnerWallet,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = shape,
+                        border = BorderStroke(1.dp, SeekerClawColors.BorderSubtle),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = SeekerClawColors.TextPrimary,
+                        ),
+                    ) {
+                        Text(
+                            "Manage Burner Wallet",
+                            fontFamily = RethinkSans,
+                            fontSize = 14.sp,
                         )
-                        Spacer(modifier = Modifier.padding(start = 8.dp))
-                        Text("Connecting\u2026", fontFamily = RethinkSans, fontSize = 14.sp)
-                    } else {
-                        Text("Connect Wallet", fontFamily = RethinkSans, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                    }
+                } else {
+                    Button(
+                        onClick = onNavigateToBurnerWallet,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            // R-pr374-r4-2: match the "Connect Wallet" CTA's
+                            // visual treatment — same glow modifier on the
+                            // primary onboarding button — since the PR
+                            // description claims visual analogy and the user's
+                            // design-system requirement is "consistency."
+                            .cornerGlowBorder(),
+                        shape = shape,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = SeekerClawColors.ActionPrimary,
+                            contentColor = androidx.compose.ui.graphics.Color.White,
+                        ),
+                    ) {
+                        Text(
+                            "Set Up Burner Wallet",
+                            fontFamily = RethinkSans,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Bold,
+                        )
                     }
                 }
-
+                // R-pr374-r6-1: spacer + caption hoisted out of the
+                // if/else (post-R4 both branches had identical copy +
+                // layout). Single source of truth — no copy/layout drift
+                // if future changes only update one branch by mistake.
+                // R-pr374-r4-1 framing ("Agent-controlled signer
+                // (experimental)") preserved verbatim from the pre-PR
+                // ConfigField value text.
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "Opens Phantom, Solflare, or Seeker Vault",
+                    text = "Agent-controlled signer (experimental)",
                     fontFamily = RethinkSans,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,
                     modifier = Modifier.fillMaxWidth(),
                 )
-            }
 
-            // ── Burner Wallet (BAT-582 / BAT-681) ─────────────────────────
-            // Divider + SectionLabel mirror the Main Wallet header above so
-            // Main and Burner read as two distinct wallets sharing the same
-            // collapsible (not two variants of the same wallet). Address
-            // row only renders when KeyVault has a pubkey for the burner.
-            Spacer(modifier = Modifier.height(20.dp))
-            HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
-            Spacer(modifier = Modifier.height(20.dp))
-            SectionLabel("Burner Wallet")
-            Spacer(modifier = Modifier.height(12.dp))
-            burnerPubkey?.let { pk ->
-                WalletAddressRow(address = pk, clipboardLabel = "burner wallet address")
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-            // Promoted above the API-key fields per BAT-681: this is a
-            // primary capability surface (agent-controlled signer), so it
-            // gets a full-width button parallel to "Connect/Disconnect
-            // Wallet" rather than a small Edit row. State-aware label
-            // matches the iOS Settings two-state pattern:
-            //   - unconfigured → "Set Up Burner Wallet" (filled, primary CTA)
-            //   - configured   → "Manage Burner Wallet" (outlined, neutral)
-            if (burnerConfigured) {
-                OutlinedButton(
-                    onClick = onNavigateToBurnerWallet,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = shape,
-                    border = BorderStroke(1.dp, SeekerClawColors.BorderSubtle),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = SeekerClawColors.TextPrimary,
-                    ),
-                ) {
-                    Text(
-                        "Manage Burner Wallet",
-                        fontFamily = RethinkSans,
-                        fontSize = 14.sp,
-                    )
-                }
-            } else {
-                Button(
-                    onClick = onNavigateToBurnerWallet,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp)
-                        // R-pr374-r4-2: match the "Connect Wallet" CTA's
-                        // visual treatment — same glow modifier on the
-                        // primary onboarding button — since the PR
-                        // description claims visual analogy and the user's
-                        // design-system requirement is "consistency."
-                        .cornerGlowBorder(),
-                    shape = shape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = SeekerClawColors.ActionPrimary,
-                        contentColor = androidx.compose.ui.graphics.Color.White,
-                    ),
-                ) {
-                    Text(
-                        "Set Up Burner Wallet",
-                        fontFamily = RethinkSans,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
-            }
-            // R-pr374-r6-1: spacer + caption hoisted out of the
-            // if/else (post-R4 both branches had identical copy +
-            // layout). Single source of truth — no copy/layout drift
-            // if future changes only update one branch by mistake.
-            // R-pr374-r4-1 framing ("Agent-controlled signer
-            // (experimental)") preserved verbatim from the pre-PR
-            // ConfigField value text.
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Agent-controlled signer (experimental)",
-                fontFamily = RethinkSans,
-                fontSize = 11.sp,
-                color = SeekerClawColors.TextDim,
-                modifier = Modifier.fillMaxWidth(),
-            )
+                // ── API keys ─────────────────────────────────────────────────
+                // Divider separates wallet UIs (Main + Burner) from the
+                // chain-data API keys below.
+                Spacer(modifier = Modifier.height(20.dp))
+                HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
+                Spacer(modifier = Modifier.height(20.dp))
+                ConfigField(
+                    label = "Jupiter API Key",
+                    value = config?.jupiterApiKey?.let { key ->
+                        if (key.isBlank()) "Not set — swaps disabled"
+                        else if (key.length > 12) "${key.take(8)}${"*".repeat(8)}${key.takeLast(4)}"
+                        else "*".repeat(key.length)
+                    } ?: "Not set — swaps disabled",
+                    onClick = {
+                        editField = "jupiterApiKey"
+                        editLabel = "Jupiter API Key"
+                        editValue = config?.jupiterApiKey ?: ""
+                    },
+                    showDivider = true,
+                    info = SettingsHelpTexts.JUPITER_API_KEY,
+                )
 
-            // ── API keys ─────────────────────────────────────────────────
-            // Divider separates wallet UIs (Main + Burner) from the
-            // chain-data API keys below.
-            Spacer(modifier = Modifier.height(20.dp))
-            HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
-            Spacer(modifier = Modifier.height(20.dp))
-            ConfigField(
-                label = "Jupiter API Key",
-                value = config?.jupiterApiKey?.let { key ->
-                    if (key.isBlank()) "Not set — swaps disabled"
-                    else if (key.length > 12) "${key.take(8)}${"*".repeat(8)}${key.takeLast(4)}"
-                    else "*".repeat(key.length)
-                } ?: "Not set — swaps disabled",
-                onClick = {
-                    editField = "jupiterApiKey"
-                    editLabel = "Jupiter API Key"
-                    editValue = config?.jupiterApiKey ?: ""
-                },
-                showDivider = true,
-                info = SettingsHelpTexts.JUPITER_API_KEY,
-            )
-
-            // ── Helius API Key (NFT holdings) ─────────────────────────────
-            Spacer(modifier = Modifier.height(20.dp))
-            ConfigField(
-                label = "Helius API Key",
-                value = config?.heliusApiKey?.let { key ->
-                    if (key.isBlank()) "Not set — NFT holdings disabled"
-                    else if (key.length > 12) "${key.take(8)}${"*".repeat(8)}${key.takeLast(4)}"
-                    else "*".repeat(key.length)
-                } ?: "Not set — NFT holdings disabled",
-                onClick = {
-                    editField = "heliusApiKey"
-                    editLabel = "Helius API Key"
-                    editValue = config?.heliusApiKey ?: ""
-                },
-                showDivider = false,
-                info = SettingsHelpTexts.HELIUS_API_KEY,
-            )
+                // ── Helius API Key (NFT holdings) ─────────────────────────────
+                Spacer(modifier = Modifier.height(20.dp))
+                ConfigField(
+                    label = "Helius API Key",
+                    value = config?.heliusApiKey?.let { key ->
+                        if (key.isBlank()) "Not set — NFT holdings disabled"
+                        else if (key.length > 12) "${key.take(8)}${"*".repeat(8)}${key.takeLast(4)}"
+                        else "*".repeat(key.length)
+                    } ?: "Not set — NFT holdings disabled",
+                    onClick = {
+                        editField = "heliusApiKey"
+                        editLabel = "Helius API Key"
+                        editValue = config?.heliusApiKey ?: ""
+                    },
+                    showDivider = false,
+                    info = SettingsHelpTexts.HELIUS_API_KEY,
+                )
             }
         }
 
@@ -1846,6 +1846,7 @@ private fun WalletAddressRow(address: String, clipboardLabel: String) {
             ) {
                 Text(
                     text = "Copy",
+                    fontFamily = RethinkSans,
                     fontSize = 12.sp,
                     color = SeekerClawColors.TextInteractive,
                 )

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -155,7 +156,13 @@ fun SettingsScreen(
     // CancellationException. Matches the rest of SettingsScreen.kt
     // which relies on imports rather than fully-qualified inline refs.
     val burnerKeyVault = remember { EncryptedPrefsKeyVault(context.applicationContext) }
-    var burnerConfigured by remember { mutableStateOf(false) }
+    // Probe result: pubkey when burner is configured AND decryptable;
+    // null otherwise. Drives both the button state (`burnerConfigured`
+    // derived below) AND the optional Address row that mirrors the
+    // Main Wallet's. Single source of truth for the burner-configured
+    // signal.
+    var burnerPubkey by remember { mutableStateOf<String?>(null) }
+    val burnerConfigured: Boolean = burnerPubkey != null
     // Bumped from ON_RESUME below to re-probe after the user returns
     // from BurnerWalletScreen (import / wipe flow). R-pr374-r2-2:
     // primitive IntState matches `mcpServerCount` and other counters
@@ -180,7 +187,7 @@ fun SettingsScreen(
                 null
             }
         }
-        burnerConfigured = pk != null
+        burnerPubkey = pk
     }
 
     var autoStartOnBoot by remember {
@@ -669,48 +676,20 @@ fun SettingsScreen(
 
         Spacer(modifier = Modifier.height(28.dp))
 
-        // Solana Wallet
+        // Solana Wallet (collapsible with three subsections —
+        // Main Wallet, Burner Wallet, API keys — separated by
+        // HorizontalDividers + SectionLabel headers per BAT-681 so
+        // Main and Burner read as distinct wallets rather than two
+        // variants of the same one).
         CollapsibleSection("Solana Wallet", initiallyExpanded = false) {
             CardSurface {
+                // ── Main Wallet ───────────────────────────────────────
+                SectionLabel("Main Wallet")
+                Spacer(modifier = Modifier.height(12.dp))
                 if (walletAddress != null) {
                     // Connected state — address with copy button
                     val address = walletAddress!!
-                    val hapticCopy = LocalHapticFeedback.current
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "Address",
-                            fontFamily = RethinkSans,
-                            fontSize = 13.sp,
-                            color = SeekerClawColors.TextDim,
-                        )
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = "${address.take(6)}\u2026${address.takeLast(4)}",
-                                fontFamily = RethinkSans,
-                                fontSize = 13.sp,
-                                color = SeekerClawColors.TextSecondary,
-                            )
-                            TextButton(
-                                onClick = {
-                                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                    clipboard.setPrimaryClip(ClipData.newPlainText("wallet address", address))
-                                    hapticCopy.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    Toast.makeText(context, "Address copied", Toast.LENGTH_SHORT).show()
-                                },
-                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                            ) {
-                                Text(
-                                    text = "Copy",
-                                    fontSize = 12.sp,
-                                    color = SeekerClawColors.TextInteractive,
-                                )
-                            }
-                        }
-                    }
+                    WalletAddressRow(address = address, clipboardLabel = "wallet address")
 
                 val label = ConfigManager.getWalletLabel(context)
                 if (label.isNotBlank()) {
@@ -800,6 +779,19 @@ fun SettingsScreen(
             }
 
             // ── Burner Wallet (BAT-582 / BAT-681) ─────────────────────────
+            // Divider + SectionLabel mirror the Main Wallet header above so
+            // Main and Burner read as two distinct wallets sharing the same
+            // collapsible (not two variants of the same wallet). Address
+            // row only renders when KeyVault has a pubkey for the burner.
+            Spacer(modifier = Modifier.height(20.dp))
+            HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
+            Spacer(modifier = Modifier.height(20.dp))
+            SectionLabel("Burner Wallet")
+            Spacer(modifier = Modifier.height(12.dp))
+            burnerPubkey?.let { pk ->
+                WalletAddressRow(address = pk, clipboardLabel = "burner wallet address")
+                Spacer(modifier = Modifier.height(12.dp))
+            }
             // Promoted above the API-key fields per BAT-681: this is a
             // primary capability surface (agent-controlled signer), so it
             // gets a full-width button parallel to "Connect/Disconnect
@@ -807,7 +799,6 @@ fun SettingsScreen(
             // matches the iOS Settings two-state pattern:
             //   - unconfigured → "Set Up Burner Wallet" (filled, primary CTA)
             //   - configured   → "Manage Burner Wallet" (outlined, neutral)
-            Spacer(modifier = Modifier.height(20.dp))
             if (burnerConfigured) {
                 OutlinedButton(
                     onClick = onNavigateToBurnerWallet,
@@ -866,7 +857,11 @@ fun SettingsScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            // ── Jupiter API Key (Solana swaps) ────────────────────────────
+            // ── API keys ─────────────────────────────────────────────────
+            // Divider separates wallet UIs (Main + Burner) from the
+            // chain-data API keys below.
+            Spacer(modifier = Modifier.height(20.dp))
+            HorizontalDivider(thickness = 1.dp, color = SeekerClawColors.BorderSubtle)
             Spacer(modifier = Modifier.height(20.dp))
             ConfigField(
                 label = "Jupiter API Key",
@@ -1803,5 +1798,59 @@ private fun maskSensitive(value: String): String {
     if (value.isBlank()) return "Not set"
     if (value.length <= 8) return "*".repeat(value.length)
     return "${value.take(6)}${"*".repeat(8)}${value.takeLast(4)}"
+}
+
+/**
+ * BAT-681: shared "Address" row with a truncated base58 + Copy button,
+ * used by both the Main Wallet and Burner Wallet subsections of the
+ * Settings → Solana Wallet collapsible.
+ *
+ * The two subsections need to look symmetric (parallel hierarchy
+ * helps users see they're two distinct wallets, not two names for the
+ * same one), and the row markup was identical at both sites — extract
+ * once, call twice. Copy haptic + toast match the original Main Wallet
+ * row behavior; `clipboardLabel` lets callers distinguish "wallet
+ * address" vs "burner wallet address" in the system clipboard
+ * description (visible in clipboard-history UIs).
+ */
+@Composable
+private fun WalletAddressRow(address: String, clipboardLabel: String) {
+    val context = LocalContext.current
+    val haptic = LocalHapticFeedback.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Address",
+            fontFamily = RethinkSans,
+            fontSize = 13.sp,
+            color = SeekerClawColors.TextDim,
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "${address.take(6)}…${address.takeLast(4)}",
+                fontFamily = RethinkSans,
+                fontSize = 13.sp,
+                color = SeekerClawColors.TextSecondary,
+            )
+            TextButton(
+                onClick = {
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText(clipboardLabel, address))
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    Toast.makeText(context, "Address copied", Toast.LENGTH_SHORT).show()
+                },
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            ) {
+                Text(
+                    text = "Copy",
+                    fontSize = 12.sp,
+                    color = SeekerClawColors.TextInteractive,
+                )
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary

Post-merge polish on PR #374. Device-testing the squashed integration branch showed the **Disconnect Wallet** + **Manage Burner Wallet** buttons stacked together — they read as two variants of the *same* wallet rather than two *distinct* wallets sharing a Settings collapsible.

This adds the visual differentiation Beka requested ("divider + headers"):

- ` ── Main Wallet ──` SectionLabel above the existing connect/disconnect content
- `HorizontalDivider` (BorderSubtle, 1dp) + 20dp spacers, then
- ` ── Burner Wallet ──` SectionLabel above the existing Set-Up / Manage button
- Burner subsection now ALSO renders an `Address` row with truncated base58 + Copy button when KeyVault has a pubkey (parity with how the Main Wallet shows its connected address)
- Final `HorizontalDivider` between the burner caption and the Jupiter API key (separates wallet UIs from chain-data API keys)

## State refactor

- `burnerConfigured: Boolean` → `burnerPubkey: String?` with derived `val burnerConfigured = burnerPubkey != null`. The pubkey from `EncryptedPrefsKeyVault.getPubkey(BURNER_ID)` is now the single source of truth: it drives **both** the button state AND the optional address row. Pre-fix the probe result was discarded after coercion; now it's preserved for the UI.
- `LaunchedEffect(burnerProbeKey)` path is unchanged — same `Dispatchers.IO` + `CancellationException` rethrow shape, just stores `pk` instead of `pk != null`.

## Refactor

- Extract the inline "Address + Copy" `Row` markup into a private `WalletAddressRow(address, clipboardLabel)` composable at file bottom. The two subsections now use **identical** row markup with **distinct** clipboard descriptions (`"wallet address"` vs `"burner wallet address"`) — the description is visible in Android clipboard-history UIs.

## Design system

- Reuses existing primitives only: `SectionLabel`, `CardSurface`, `HorizontalDivider`, `WalletAddressRow`, `RethinkSans`, `SeekerClawColors.{BorderSubtle, TextDim, TextSecondary, TextInteractive}`.
- No new icons, no new colors, no new typography sizes.
- Spacing follows the established cadence already used elsewhere in Settings: 20dp around dividers, 12dp under section labels, 8dp before captions.

## Verification

```
scripts/pre-push-check.sh
 ✓ Node smoke (18/18 modules)
 ✓ 63 tool input_schemas valid
 ✓ compileDappStoreDebugKotlin BUILD SUCCESSFUL in 14s
```

## Self-Awareness Checklist (BAT-503)

- [x] **N/A** — pure visual restructure of an existing screen. No new tool, no new bridge endpoint, no new error path, no change to `buildSystemBlocks()`, no `DIAGNOSTICS.md` impact.

## Test plan

- [ ] Build dappStoreDebug, install on Seeker
- [ ] Settings → Solana Wallet → expand:
  - [ ] Without main wallet connected: "Main Wallet" header + Connect Wallet CTA visible
  - [ ] With main wallet connected: "Main Wallet" header + Address row (Copy works) + Disconnect Wallet
  - [ ] Divider visible between Main and Burner subsections
  - [ ] Without burner set up: "Burner Wallet" header + "Set Up Burner Wallet" CTA, no Address row
  - [ ] With burner set up: "Burner Wallet" header + Address row (Copy works, distinct toast — same wording, but clipboard label "burner wallet address" appears in clipboard history) + "Manage Burner Wallet" button
  - [ ] Divider visible between burner caption and Jupiter API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)