### PR TITLE
BAT-768 fix: stablecrypto body shapes from openapi (post-merge regression fix)

### DIFF
--- a/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
+++ b/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paysh-catalog
 description: "Catalog of pay.sh services payable via agent_pay (x402). OPT-IN ONLY — activate when the user explicitly invokes pay.sh / paysh / x402 / 'pay for'. Stay dormant otherwise; defer to free tools. Full keyword list and policy in SKILL.md body."
-version: "1.6.0"
+version: "1.7.0"
 metadata:
   openclaw:
     emoji: "🛒"

--- a/app/src/main/assets/default-skills/paysh-catalog/services/stablecrypto-market-data.md
+++ b/app/src/main/assets/default-skills/paysh-catalog/services/stablecrypto-market-data.md
@@ -31,19 +31,15 @@ Service URL base: `https://stablecrypto.dev`
 - [`defillama-derivatives-overview`](#defillama-derivatives-overview) — derivatives volume
 - [`defillama-coins-prices-historical`](#defillama-coins-prices-historical) — historical prices by timestamp
 
-## Body construction (universal pattern)
+## Body construction — read this first
 
-All endpoints take a JSON body. The body shape mirrors the underlying CoinGecko/DefiLlama API: pass upstream API query params as JSON object fields. For example, CoinGecko's `/simple/price` API accepts `?ids=bitcoin&vs_currencies=usd`; through stablecrypto's `/api/coingecko/price` you pass:
+All endpoints are POST with a JSON body. **Use the field names + types listed for each endpoint below**, NOT the shapes you'd infer from CoinGecko / DefiLlama public REST docs. The gateway diverges from upstream in three ways that matter:
 
-```json
-{ "ids": "bitcoin", "vs_currencies": "usd" }
-```
+1. **Arrays where upstream uses comma-separated strings.** CoinGecko's public API takes `?ids=bitcoin,ethereum&vs_currencies=usd`. The gateway takes `{"ids":["bitcoin","ethereum"],"vs_currencies":["usd"]}` — arrays, not strings. Sending a string returns HTTP 400 _after_ payment is settled.
+2. **String types where you'd expect numbers.** `days` for `chart`/`ohlc` is a string (`"7"`), not a number (`7`). The gateway rejects numbers.
+3. **Renamed fields.** `pool_address` → `address`, `protocol` → `name`. Use the gateway's name from the table below, not the upstream's.
 
-The gateway forwards these as upstream query params. Refer to:
-- CoinGecko v3 docs: https://docs.coingecko.com/reference/introduction
-- DefiLlama docs: https://defillama.com/docs/api
-
-Per-endpoint notes below cover the minimum + most-useful params. **Empty body `{}` returns 422** after payment for endpoints with required params — always include the upstream-required params.
+Empty body `{}` is fine when the "Required" line says `(none)`. When required params are present, sending `{}` returns 422 after payment.
 
 ## When to use vs free alternatives
 
@@ -57,125 +53,248 @@ Per-endpoint notes below cover the minimum + most-useful params. **Empty body `{
 
 `POST /api/coingecko/price`
 
-Body: `{ "ids": "<coin-id-or-comma-list>", "vs_currencies": "usd" }`
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `ids` | `array<string>` | ✓ | Coin IDs, e.g. `["bitcoin"]` or `["solana","ethereum"]` |
+| `vs_currencies` | `array<string>` | ✓ | Target currencies, e.g. `["usd"]` or `["usd","eur"]` |
+| `include_market_cap` | boolean | | Append market cap per (coin, currency) |
+| `include_24hr_vol` | boolean | | Append 24h volume |
+| `include_24hr_change` | boolean | | Append 24h % change |
+| `include_last_updated_at` | boolean | | Append last-updated unix timestamp |
+| `precision` | string | | Decimal precision, "0".."18" |
 
-Examples:
-- `{ "ids": "bitcoin", "vs_currencies": "usd" }` → BTC in USD
-- `{ "ids": "solana,ethereum,bitcoin", "vs_currencies": "usd,eur" }` → multi-coin multi-currency
-
-Returns: `{ <coin-id>: { <currency>: <price> } }`.
+Example: `{ "ids": ["bitcoin"], "vs_currencies": ["usd"] }` → `{ "bitcoin": { "usd": 67234.12 } }`.
 
 <a id="coingecko-markets"></a>
 ## `coingecko-markets` — top coins by market cap
 
-`POST /api/coingecko/markets` — body params include `vs_currency`, `order`, `per_page`, `page`, `sparkline`.
+`POST /api/coingecko/markets`
 
-Default `{ "vs_currency": "usd", "per_page": 10 }` returns top 10 by market cap. Surface the top N with name + price + market-cap + 24h-change. Don't dump full sparkline arrays.
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `vs_currency` | string | ✓ | Single currency, e.g. `"usd"` |
+| `ids` | `array<string>` | | Filter to specific coin IDs |
+| `category` | string | | CoinGecko category slug |
+| `order` | string | | e.g. `"market_cap_desc"` |
+| `per_page` | number | | Max 250 |
+| `page` | number | | 1-indexed |
+| `sparkline` | boolean | | Include 7d sparkline array |
+| `price_change_percentage` | string | | Comma-separated intervals: `"1h,24h,7d"` |
+
+Example: `{ "vs_currency": "usd", "per_page": 10 }`. Surface top N with name + price + market cap + 24h change. Don't dump sparkline arrays.
 
 <a id="coingecko-chart"></a>
 ## `coingecko-chart` — historical price chart
 
-`POST /api/coingecko/chart` — body: `{ "id": "<coin>", "vs_currency": "usd", "days": <N> }`.
+`POST /api/coingecko/chart`
 
-Returns price points over the requested window. For Telegram replies, summarize: "BTC: opened at $X, closed at $Y, ranged from $low to $high over N days, +/-Z% change."
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | ✓ | Coin ID, e.g. `"bitcoin"` |
+| `vs_currency` | string | ✓ | e.g. `"usd"` |
+| `days` | **string** | ✓ | `"1"`, `"7"`, `"14"`, `"30"`, `"90"`, `"180"`, `"365"`, `"max"` — quoted string, not number |
+| `interval` | string | | e.g. `"daily"` |
+| `precision` | string | | Decimal precision |
+
+Example: `{ "id": "bitcoin", "vs_currency": "usd", "days": "7" }`. Returns price points; summarize for Telegram replies ("opened at $X, closed at $Y, range $low–$high, ±Z%").
 
 <a id="coingecko-ohlc"></a>
 ## `coingecko-ohlc` — OHLC candles
 
-`POST /api/coingecko/ohlc` — body: `{ "id": "<coin>", "vs_currency": "usd", "days": 1|7|14|30|90|180|365 }`. Returns candle data (open/high/low/close arrays). Use only when user asks for candle data specifically.
+`POST /api/coingecko/ohlc`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | ✓ | Coin ID |
+| `vs_currency` | string | ✓ | e.g. `"usd"` |
+| `days` | **string** | ✓ | `"1"`, `"7"`, `"14"`, `"30"`, `"90"`, `"180"`, `"365"` — quoted string |
+| `precision` | string | | Decimal precision |
+
+Example: `{ "id": "bitcoin", "vs_currency": "usd", "days": "7" }`. Use only when user explicitly asks for candle data.
 
 <a id="coingecko-top-movers"></a>
 ## `coingecko-top-movers` — 24h gainers/losers
 
-`POST /api/coingecko/top-movers` — body: `{ "vs_currency": "usd" }`. Returns top gainers + top losers in 24h. Surface as two short lists.
+`POST /api/coingecko/top-movers`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `vs_currency` | string | | Default `"usd"` |
+| `duration` | string | | Window, e.g. `"24h"` |
+| `top_coins` | string | | Filter to top-N coin universe, e.g. `"1000"` |
+
+Empty body `{}` works (all params optional). Returns top gainers + losers — surface as two short lists.
 
 <a id="coingecko-trending"></a>
 ## `coingecko-trending` — top-searched coins
 
-`POST /api/coingecko/trending` — empty body `{}` is fine. Returns top-7 trending coins on CoinGecko (by search volume). Surface as a name + symbol + market-cap-rank list.
+`POST /api/coingecko/trending`
+
+No body params. Send `{}`. Returns top-7 trending coins on CoinGecko by search volume.
 
 <a id="coingecko-categories"></a>
 ## `coingecko-categories` — coin categories
 
-`POST /api/coingecko/categories` — body: `{ "order": "market_cap_desc" }` (default). Returns categories (DeFi, Memes, Layer-1, AI, etc.) with aggregated market cap. Surface top 10.
+`POST /api/coingecko/categories`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `order` | string | | e.g. `"market_cap_desc"` |
+
+Empty body `{}` works. Returns categories (DeFi, Memes, Layer-1, AI, etc.) with aggregated market cap. Surface top 10.
 
 <a id="coingecko-onchain-pool"></a>
 ## `coingecko-onchain-pool` — specific DEX pool
 
-`POST /api/coingecko/onchain/pool` — body: `{ "network": "<chain>", "pool_address": "<addr>" }`.
+`POST /api/coingecko/onchain/pool`
 
-`network` = `solana`, `eth`, `base`, etc. Returns pool TVL, volume, recent trades, reserves. Use when user asks about a specific pool by address.
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `network` | string | ✓ | `"eth"`, `"solana"`, `"base"`, `"arbitrum"`, etc. |
+| `address` | string | ✓ | Pool contract address (note: field is `address`, NOT `pool_address`) |
+| `include` | string | | Additional data, e.g. `"base_token,quote_token,dex"` |
+
+Example: `{ "network": "solana", "address": "<poolAddr>" }`. Returns pool TVL, volume, recent trades, reserves.
 
 <a id="coingecko-onchain-trending"></a>
 ## `coingecko-onchain-trending` — trending on-chain pools
 
-`POST /api/coingecko/onchain/trending` — body: `{ "network": "<chain-or-omit>" }`. Returns trending DEX pools across chains (or filtered to one chain).
+`POST /api/coingecko/onchain/trending`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `include` | string | | e.g. `"base_token,quote_token,dex,network"` |
+| `page` | number | | 1-indexed |
+| `duration` | string | | Trending window, e.g. `"24h"` |
+
+No network filter — returns trending pools across all chains. Empty body `{}` works.
 
 <a id="coingecko-onchain-new-pools"></a>
 ## `coingecko-onchain-new-pools` — newly-created DEX pools
 
-`POST /api/coingecko/onchain/new-pools` — body: `{ "include": "<comma-list-or-omit>", "page": <N-or-omit> }`. Recently-deployed token pairs across DEXes. This endpoint is the legacy "StableCrypto New Pools" intent from BAT-699 — kept for users who learned about it then. Optional `include` examples (refer to CoinGecko `/onchain/networks/new_pools` docs): `base_token`, `quote_token`, `dex`.
+`POST /api/coingecko/onchain/new-pools`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `include` | string | | e.g. `"base_token,quote_token,dex"` |
+| `page` | number | | 1-indexed |
+
+Empty body `{}` works. Recently-deployed token pairs across DEXes. Legacy "StableCrypto New Pools" intent from BAT-699.
 
 ---
 
 <a id="defillama-protocols"></a>
 ## `defillama-protocols` — full protocol list
 
-`POST /api/defillama/protocols` — empty body `{}`. Returns ~2000 DeFi protocols with TVL, 1d/7d change, chains. Surface the top N by TVL or filtered to user's chain interest.
+`POST /api/defillama/protocols`
+
+No body params. Send `{}`. Returns ~2000 DeFi protocols with TVL, 1d/7d change, chains. Surface top N by TVL or filter to the user's chain interest client-side.
 
 <a id="defillama-protocol"></a>
 ## `defillama-protocol` — single protocol detail
 
-`POST /api/defillama/protocol` — body: `{ "protocol": "<slug>" }`.
+`POST /api/defillama/protocol`
 
-Slug examples: `raydium`, `marinade-finance`, `jito-liquid-staking`, `uniswap-v3`. Returns TVL history, chain breakdown, token addresses.
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | ✓ | Protocol slug (note: field is `name`, NOT `protocol`) |
+
+Slug examples: `"raydium"`, `"marinade-finance"`, `"jito-liquid-staking"`, `"uniswap-v3"`, `"aave"`. Returns TVL history, chain breakdown, token addresses.
 
 <a id="defillama-chains"></a>
 ## `defillama-chains` — TVL per chain
 
-`POST /api/defillama/chains` — empty body. Returns TVL for every chain DefiLlama tracks. Surface top 10-15 by TVL or filtered to chain the user named.
+`POST /api/defillama/chains`
+
+No body params. Send `{}`. Returns TVL for every chain DefiLlama tracks. Surface top 10–15 by TVL or filter to the chain the user named.
 
 <a id="defillama-chain-tvl"></a>
 ## `defillama-chain-tvl` — single chain TVL history
 
-`POST /api/defillama/chain-tvl` — body: `{ "chain": "<chain-name>" }`. Common: `Solana`, `Ethereum`, `Base`, `Arbitrum`. Returns daily TVL history. Surface current, change vs N days ago, ATH.
+`POST /api/defillama/chain-tvl`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `chain` | string | ✓ | Chain name, e.g. `"Solana"`, `"Ethereum"`, `"Base"`, `"Arbitrum"` |
+
+Returns daily TVL history. Surface current, change vs N days ago, ATH.
 
 <a id="defillama-yields-pools"></a>
 ## `defillama-yields-pools` — yield-farming pools
 
-`POST /api/defillama/yields/pools` — empty body. Returns ALL yield pools — large response. For better UX the user usually wants top-N filtered (by chain, project, APY range, stablecoin-only, etc.) — describe the filter in your reply since the raw API doesn't support it server-side, so filter client-side after fetching.
+`POST /api/defillama/yields/pools`
+
+No body params. Send `{}`. Returns ALL yield pools — large response. Filter client-side (by chain / project / APY range / stablecoin-only) and surface top-N. Describe the filter in your reply so the user knows what you cut.
 
 <a id="defillama-yields-perps"></a>
 ## `defillama-yields-perps` — perps funding rates
 
-`POST /api/defillama/yields/perps` — empty body. Funding rates across perp protocols. Use for delta-neutral / funding-rate-arbitrage queries.
+`POST /api/defillama/yields/perps`
+
+No body params. Send `{}`. Funding rates across perp protocols. Use for delta-neutral / funding-rate-arbitrage queries.
 
 <a id="defillama-stablecoins"></a>
 ## `defillama-stablecoins` — stablecoin market caps
 
-`POST /api/defillama/stablecoins` — empty body. Returns all stablecoins with circulating supply per chain, peg health, market cap. Surface top 5 by market cap + flag any with > 1% peg deviation.
+`POST /api/defillama/stablecoins`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `includePrices` | boolean | | If true, append live peg price per stablecoin |
+
+Empty body `{}` works. Returns all stablecoins with circulating supply per chain, peg health, market cap. Surface top 5 by market cap + flag any with > 1% peg deviation.
 
 <a id="defillama-dex-overview"></a>
 ## `defillama-dex-overview` — aggregate DEX volume
 
-`POST /api/defillama/dex-overview` — empty body. 24h/7d/30d DEX volume across chains. Surface totals + top chains by volume.
+`POST /api/defillama/dex-overview`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `excludeTotalDataChart` | boolean | | Strip the per-day total time-series array |
+| `excludeTotalDataChartBreakdown` | boolean | | Strip the per-chain breakdown series |
+| `dataType` | string | | `"dailyVolume"` or `"totalVolume"` |
+
+Empty body `{}` works. 24h/7d/30d DEX volume across chains. Pass `excludeTotalDataChart: true` to keep response small when you only need headline totals.
 
 <a id="defillama-fees-overview"></a>
 ## `defillama-fees-overview` — protocol fees / revenue
 
-`POST /api/defillama/fees-overview` — empty body. Daily fees + revenue per protocol. Surface top N by 24h revenue.
+`POST /api/defillama/fees-overview`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `excludeTotalDataChart` | boolean | | Strip per-day total time-series |
+| `excludeTotalDataChartBreakdown` | boolean | | Strip per-protocol breakdown series |
+| `dataType` | string | | `"dailyFees"`, `"dailyRevenue"`, etc. |
+
+Empty body `{}` works. Surface top N protocols by 24h fees or revenue.
 
 <a id="defillama-derivatives-overview"></a>
 ## `defillama-derivatives-overview` — derivatives volume
 
-`POST /api/defillama/derivatives-overview` — empty body. Perp DEX + centralized derivatives volume. Surface aggregate + top venues.
+`POST /api/defillama/derivatives-overview`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `excludeTotalDataChart` | boolean | | Strip per-day total time-series |
+| `excludeTotalDataChartBreakdown` | boolean | | Strip per-venue breakdown series |
+| `dataType` | string | | Derivatives volume slice |
+
+Empty body `{}` works. Perp DEX + centralized derivatives volume. Surface aggregate + top venues.
 
 <a id="defillama-coins-prices-historical"></a>
 ## `defillama-coins-prices-historical` — historical price snapshot
 
-`POST /api/defillama/coins/prices-historical` — body: `{ "coins": "<chain:address-or-coingecko-id>", "timestamp": <unix-seconds> }`.
+`POST /api/defillama/coins/prices-historical`
 
-Examples: `{ "coins": "coingecko:bitcoin", "timestamp": 1640995200 }` (BTC on 2022-01-01). Returns price at exactly that timestamp. Useful for backtesting or "what was X worth on date Y" queries.
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `timestamp` | **number** | ✓ | Unix seconds — number, not string |
+| `coins` | string | ✓ | Comma-separated `<chain>:<address>` or `coingecko:<id>` identifiers |
+| `searchWidth` | string | | Tolerance window for matching the timestamp, e.g. `"4h"` |
+
+Example: `{ "coins": "coingecko:bitcoin", "timestamp": 1640995200 }` (BTC on 2022-01-01). Returns price at that timestamp ± searchWidth. Useful for backtesting or "what was X worth on date Y" queries.
 
 ## Other stablecrypto endpoints on pay.sh (not catalogued)
 


### PR DESCRIPTION
## Why

PR #381 device test 2 (2026-05-18) burned **\$0.02 USDC** across two HTTP 400 retries on \`stablecrypto-coingecko-price\` because the doc body example I wrote in #381 inferred the body shape from CoinGecko's public REST API (\`?ids=bitcoin&vs_currencies=usd\` — strings) instead of from the gateway's actual openapi schema (arrays).

The merit-systems gateway diverges from upstream in three structural ways:

1. **Arrays where upstream uses comma-separated strings** — \`ids\` and \`vs_currencies\` on \`/api/coingecko/price\` are \`array<string>\`, not \`string\`
2. **String types where you'd expect numbers** — \`days\` on \`chart\`/\`ohlc\` is \`string\` (\`\"7\"\`), not \`number\` (\`7\`)
3. **Renamed fields** — \`pool_address\` → \`address\` on \`onchain/pool\`; \`protocol\` → \`name\` on \`defillama/protocol\`

All three classes existed in the #381 doc, in addition to wholly-fabricated params (\`network\` on \`onchain/trending\` — doesn't exist in the schema) and missing optional params.

Inferring from REST docs was wrong; the only safe source of truth is \`<service>/openapi.json\` \`requestBody.content.application/json.schema\`. Now codified as a feedback memory.

## What

Rewrote [stablecrypto-market-data.md](app/src/main/assets/default-skills/paysh-catalog/services/stablecrypto-market-data.md) using openapi-derived schemas live-fetched from \`https://stablecrypto.dev/openapi.json\`. Six blocking shape bugs fixed, six optional-param completions added.

**Blocking shape bugs fixed:**

| Endpoint | Was | Now |
|---|---|---|
| \`coingecko-price\` | \`{\"ids\":\"bitcoin\",\"vs_currencies\":\"usd\"}\` | \`{\"ids\":[\"bitcoin\"],\"vs_currencies\":[\"usd\"]}\` |
| \`coingecko-chart\` | \`\"days\": 7\` (number) | \`\"days\": \"7\"\` (string) |
| \`coingecko-ohlc\` | \`\"days\": 7\` (number) | \`\"days\": \"7\"\` (string) |
| \`coingecko-onchain-pool\` | \`\"pool_address\"\` field | \`\"address\"\` field |
| \`coingecko-onchain-trending\` | \`\"network\"\` param | no network param; \`include\`/\`page\`/\`duration\` only |
| \`defillama-protocol\` | \`\"protocol\"\` field | \`\"name\"\` field |

**Optional params newly documented:** \`coingecko-price\` (5 include_\* flags + precision), \`coingecko-markets\` (sparkline, price_change_percentage, etc.), \`coingecko-top-movers\` (duration, top_coins), \`coingecko-onchain-*\` (include/page/duration), \`defillama-stablecoins\` (includePrices), \`defillama-{dex,fees,derivatives}-overview\` (excludeTotalDataChart etc.), \`defillama-coins-prices-historical\` (searchWidth).

**Doc structure change:** each endpoint section now uses a parameter table (\`Field | Type | Required | Notes\`) instead of inline prose, so the agent can read the gateway field name + type at a glance.

**New explicit warning section:** \"Body construction — read this first\" at the top now tells the agent NOT to infer body shapes from CoinGecko / DefiLlama public REST docs.

**Version bumped:** \`SKILL.md\` 1.6.0 → 1.7.0 so \`ConfigManager.seedSkill()\` will re-seed the workspace doc on next agent start (existing devices will pick up the fix without WIPE).

## What's NOT in this PR

- No code changes — \`agent_pay\`, sanitize.js, validate-*, probe-catalog, catalog.json all untouched
- No new tests — the validators / detectors already pass against the gateway; the bug was purely in human-facing docs
- No fix to the catalog.json \`agent_pay_args.body\` examples — checked, those are NOT the source of agent body construction; the agent reads the markdown doc when the user opts in

## Verification

- Schemas re-fetched live from \`https://stablecrypto.dev/openapi.json\` at 2026-05-18T13:58:06Z
- All 21 endpoint sections now match the openapi \`required\` array + \`properties\` map
- Pre-push: Node smoke (67 files), tool schemas (63), Kotlin compile \`dappStoreDebug\` all PASS

## Test plan

- [ ] Copilot review clean
- [ ] Merge to integration
- [ ] Device test on integration: \"Pay for SOL price via stablecrypto\" — must succeed first try (no HTTP 400 retries)
- [ ] Spot-check 2-3 other endpoints (e.g. \`defillama-protocol\` with \`{\"name\":\"raydium\"}\`, \`coingecko-chart\` with \`\"days\":\"7\"\`)

## Memory

Saved \`feedback_catalog_body_shapes_from_openapi.md\` so this doesn't repeat for future catalog expansions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)