### PR TITLE
chore(deps): MWA 2.0.3 → 2.0.4 security fix (BAT-697 PR 1 of N)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -263,7 +263,16 @@ dependencies {
     implementation("androidx.browser:browser:1.8.0")
 
     // Solana Mobile Wallet Adapter
-    implementation("com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.0.3")
+    // Bumped 2.0.3 → 2.0.4 (BAT-697 commit 1). 2.0.4 ships the security fix
+    // ("Address Security Alerts 58, 63-66" — solana-mobile/mobile-wallet-adapter#791)
+    // without bumping androidx.core transitively past 1.16.x. Going to 2.0.5+
+    // (or 2.1.0) pulls androidx.core:1.17.0 which requires compileSdk 36 — out
+    // of scope for this BAT (we're on compileSdk 35; bumping it cascades to AGP /
+    // target-SDK migration work). Tracked as a follow-up.
+    // Must device-test existing solana_send / solana_swap flows BEFORE adding
+    // any V2 trigger code (per Codex round-2: stage MWA bump as its own commit,
+    // regression-check first).
+    implementation("com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.0.4")
 
     // Solana transaction building (pure Kotlin)
     implementation("org.sol4k:sol4k:0.4.2")


### PR DESCRIPTION
First PR in the **v2.1 wallet-auth wave** (integration branch: \`feature/v2.1\`).

## Summary

Bumps Solana Mobile Wallet Adapter \`clientlib-ktx\` from 2.0.3 to 2.0.4. Picks up the security fix from solana-mobile/mobile-wallet-adapter#791 (\"Address Security Alerts 58, 63-66\").

## Scope adjustment from BAT-697 ticket

BAT-697 originally asked for **2.0.3 → 2.1.0**. Local pre-push compile against 2.1.0 revealed it transitively pulls \`androidx.core:core-ktx:1.17.0\` which requires \`compileSdk = 36\` (we're on 35).

**Trade**: ship the security benefit now via 2.0.4 (no transitive cascade) → defer 2.0.5–2.1.0 + \`compileSdk\` bump to a follow-up BAT (AGP / target-SDK migration scope).

## Why this is its own PR

Per Codex round-2 review of the BAT-697 contract — MWA bump should be its own commit so any regression in existing \`solana_send\` / \`solana_swap\` MWA-signing flows is bounded to the dep bump alone (not entangled with the Jupiter Trigger V2 adapter work that's PR 2). Device-test the existing MWA flows on integration BEFORE BAT-697 PR 2 lands.

## What's NOT in this PR

- Jupiter Trigger V1 → V2 migration (PR 2 — \`feature/BAT-697-trigger-v2\`, depends on this merging first)
- compileSdk bump (deferred follow-up)
- Anything else from the v2.1 wave (BAT-826 Grok OAuth and others land as their own PRs against \`feature/v2.1\`)

## Validation

Pre-push (standalone, no pipe):
- Node smoke (67 files) ✓
- Tool input_schema (63 tools) ✓
- Wallets prompt regression (4 scenarios) ✓
- Kotlin compile \`dappStoreDebug\` ✓ (clean against MWA 2.0.4)

## Test plan

- [ ] Copilot review clean
- [ ] On integration: device-test existing \`solana_send\` + \`solana_swap\` flows (regression check for MWA bump)
- [ ] Then merge → integration branch ready for PR 2 (Trigger V2 adapter)

## Contract reference

Full BAT-697 contract v2 with Codex sign-off: https://linear.app/batcave/issue/BAT-697

🤖 Generated with [Claude Code](https://claude.com/claude-code)