### PR TITLE
feat(jupiter): Trigger V2 adapter (BAT-697 PR B) — flag-gated

### DIFF
--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -490,6 +490,13 @@ if (config.exaApiKey) config.exaApiKey = normalizeSecret(config.exaApiKey);
 if (config.tavilyApiKey) config.tavilyApiKey = normalizeSecret(config.tavilyApiKey);
 if (config.firecrawlApiKey) config.firecrawlApiKey = normalizeSecret(config.firecrawlApiKey);
 
+// BAT-697 PR B: Jupiter Trigger V2 adapter feature flag. Default false —
+// V1 remains the shipping path until the staged-rollout commits (live smoke
+// → default flip → V1 removal) land in subsequent PRs. Normalize to a real
+// boolean so handlers can branch on `config.useTriggerV2 === true` without
+// truthy-coercing a string "false".
+config.useTriggerV2 = config.useTriggerV2 === true;
+
 // MCP server configs (remote tool servers) — normalize first, then filter invalid
 const MCP_SERVERS = (config.mcpServers || [])
     .map((server) => {

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -495,7 +495,17 @@ if (config.firecrawlApiKey) config.firecrawlApiKey = normalizeSecret(config.fire
 // → default flip → V1 removal) land in subsequent PRs. Normalize to a real
 // boolean so handlers can branch on `config.useTriggerV2 === true` without
 // truthy-coercing a string "false".
-config.useTriggerV2 = config.useTriggerV2 === true;
+//
+// PR #388 R7: Kotlin's writeConfigJson() does not yet emit a `useTriggerV2`
+// field (that arrives with PR C's Settings toggle), so the JSON-load path
+// always normalizes to false in the live runtime. To make PR B actually
+// enable-able for the PR C live-smoke phase WITHOUT shipping the UI early,
+// also accept SEEKERCLAW_USE_TRIGGER_V2=true via the env-var bridge (Settings
+// → Env Vars), which is already plumbed Kotlin → Node and merged into
+// process.env at line ~142 above. PR C migrates this to a proper Config
+// field + Settings toggle and can drop the env-var path.
+config.useTriggerV2 = config.useTriggerV2 === true
+    || process.env.SEEKERCLAW_USE_TRIGGER_V2 === 'true';
 
 // MCP server configs (remote tool servers) — normalize first, then filter invalid
 const MCP_SERVERS = (config.mcpServers || [])

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -547,24 +547,47 @@ async function ensureVault(pubkey, token) {
     const cached = _vaultCache.get(pubkey);
     if (cached && cached.vaultPubkey) return { ok: true, vaultPubkey: cached.vaultPubkey };
 
-    // Try the existing vault first; register (idempotent GET) if absent.
-    let res = await _get('/trigger/v2/vault', token);
-    if (res.status === 401) {
+    // 1) Try the existing vault.
+    const getRes = await _get('/trigger/v2/vault', token);
+    if (getRes.status === 401) {
         invalidateJwt(pubkey);
         return { ok: false, error: 'auth_expired', reason: 'JWT rejected by /vault' };
     }
-    if (!(res.status === 200 && res.data && res.data.vaultPubkey)) {
-        res = await _get('/trigger/v2/vault/register', token);
-        if (res.status === 401) {
-            invalidateJwt(pubkey);
-            return { ok: false, error: 'auth_expired', reason: 'JWT rejected by /vault/register' };
-        }
+    if (getRes.status === 200 && getRes.data && getRes.data.vaultPubkey) {
+        _vaultCache.set(pubkey, { vaultPubkey: getRes.data.vaultPubkey });
+        return { ok: true, vaultPubkey: getRes.data.vaultPubkey };
     }
-    if (res.status >= 200 && res.status < 300 && res.data && res.data.vaultPubkey) {
-        _vaultCache.set(pubkey, { vaultPubkey: res.data.vaultPubkey });
-        return { ok: true, vaultPubkey: res.data.vaultPubkey };
+
+    // 2) PR #388 R3: only register on the DOCUMENTED "no vault yet" signal
+    // (HTTP 404). Any other non-2xx — 429, 5xx, malformed JSON, etc. — must
+    // surface the original failure unchanged. Pre-fix, any non-success fell
+    // through to /vault/register, which (a) hid transient errors behind a
+    // confusing register attempt, and (b) on a 429 could trigger a second
+    // rate-limited call instead of letting the caller back off.
+    if (getRes.status !== 404) {
+        return {
+            ok: false,
+            error: 'vault_unavailable',
+            reason: `GET /vault returned HTTP ${getRes.status} (expected 200 with vaultPubkey, or 404 "Vault not found"). Not registering — failing closed.`,
+        };
     }
-    return { ok: false, error: 'vault_unavailable', reason: `vault GET/register failed (HTTP ${res.status})` };
+
+    // 3) 404 confirmed → register (idempotent GET). Privy creates the vault
+    // server-side; no on-chain action, no funds.
+    const regRes = await _get('/trigger/v2/vault/register', token);
+    if (regRes.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by /vault/register' };
+    }
+    if (regRes.status >= 200 && regRes.status < 300 && regRes.data && regRes.data.vaultPubkey) {
+        _vaultCache.set(pubkey, { vaultPubkey: regRes.data.vaultPubkey });
+        return { ok: true, vaultPubkey: regRes.data.vaultPubkey };
+    }
+    return {
+        ok: false,
+        error: 'vault_unavailable',
+        reason: `GET /vault/register returned HTTP ${regRes.status} without a vaultPubkey`,
+    };
 }
 
 // ── V2 semantic validation (contract v2 §6) ─────────────────────────────────

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -95,12 +95,6 @@ async function _post(path, body, token) {
     return _parseResponse(res);
 }
 
-async function _patch(path, body, token) {
-    const headers = { ..._authHeaders(token), 'Content-Type': 'application/json' };
-    const res = await httpRequest({ hostname: JUPITER_HOST, path, method: 'PATCH', headers }, body);
-    return _parseResponse(res);
-}
-
 async function _get(path, token) {
     const res = await httpRequest({ hostname: JUPITER_HOST, path, method: 'GET', headers: _authHeaders(token) });
     return _parseResponse(res);
@@ -655,8 +649,17 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
         return { ok: false, error: 'invalid_input', reason: 'depositSignedTx required' };
     }
 
+    // BAT-697 LIVE-SMOKE MUST-VERIFY: the orderType/orderSubType pair on the
+    // create POST is unconfirmed against the live API. deposit/craft uses
+    // { orderType:'price', orderSubType:'single' }; we mirror that family here
+    // for internal consistency rather than the bare orderType:'single' the
+    // first draft sent. Commit-3 live smoke MUST confirm the exact wire shape
+    // Jupiter expects (it may want only orderType, only orderSubType, or
+    // neither since the path already says /orders/price). Adjust here once
+    // verified — this is the single most likely create-rejection cause.
     const createBody = {
-        orderType: 'single',
+        orderType: 'price',
+        orderSubType: 'single',
         depositRequestId: recoveryContext.depositRequestId,
         depositSignedTx,
         userPubkey: recoveryContext.walletPubkey,
@@ -705,29 +708,64 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
  *
  * Sequence:
  *   1. Wait 5s for any in-flight settle on Jupiter's side.
- *   2. Query /orders/history filtered by walletPubkey; look for the most
- *      recent active or pending_deposit order matching our inputMint +
- *      inputAmount (recorded in `ctx`).
- *   3. If found → success, with `recovered: true` flag.
- *   4. If not found → return orphan-deposit advisory with the
+ *   2. Query /orders/history filtered by walletPubkey.
+ *   3. Match PRIMARILY on depositRequestId (unique to this attempt) when the
+ *      history row carries it — the only definitive correlation. Fall back to
+ *      a heuristic (inputMint + inputAmount + non-terminal status + tight
+ *      time window) ONLY when no row exposes depositRequestId.
+ *   4. If found → success, with `recovered: true` flag.
+ *   5. If not found → return orphan-deposit advisory with the
  *      depositRequestId so the user can check Jupiter UI manually.
  *
  * NEVER auto-retries the create POST — non-idempotent + funds-moving.
  */
+// States that mean the order is live (deposit landed / order working). An
+// order in any OTHER state — including a terminal failure that still carries
+// vaultState:'pending_deposit' — must NOT be reported as a recovered success,
+// or we'd commit the burner cap for a dead order and tell the user it worked.
+const _RECOVERY_LIVE_STATUSES = new Set(['active', 'pending_deposit', 'open']);
+const _RECOVERY_TERMINAL_FAIL = new Set(['failed', 'cancelled', 'canceled', 'expired', 'rejected', 'closed']);
+
 async function _recoverFromAmbiguousCreate(ctx, token) {
     log(`[trigger-v2] recovery: waiting 5s before /orders/history query for depositRequestId=${ctx.depositRequestId}`, 'INFO');
     await new Promise(r => setTimeout(r, 5000));
 
     const histRes = await _get(`/trigger/v2/orders/history?walletPubkey=${encodeURIComponent(ctx.walletPubkey)}&limit=20`, token);
     if (histRes.status === 200 && histRes.data && Array.isArray(histRes.data.orders)) {
-        const matchTime = ctx.timestamp - 60_000; // accept anything from 1min before our attempt
-        const match = histRes.data.orders.find(o =>
-            o
-            && (o.status === 'active' || o.status === 'pending_deposit' || o.vaultState === 'pending_deposit')
-            && o.inputMint === ctx.inputMint
-            && String(o.inputAmount) === String(ctx.inputAmount)
-            && (!o.createdAt || new Date(o.createdAt).getTime() >= matchTime)
+        const orders = histRes.data.orders.filter(Boolean);
+
+        const isLive = (o) =>
+            !_RECOVERY_TERMINAL_FAIL.has(o.status)
+            && (_RECOVERY_LIVE_STATUSES.has(o.status) || o.vaultState === 'pending_deposit');
+
+        // PRIMARY: depositRequestId correlation. Unique per attempt, so it can
+        // never alias a pre-existing same-amount order. Accept whichever field
+        // name Jupiter exposes (depositRequestId / requestId).
+        let match = orders.find(o =>
+            isLive(o)
+            && (o.depositRequestId === ctx.depositRequestId || o.requestId === ctx.depositRequestId)
         );
+
+        // FALLBACK (only if no row carried a deposit-request id at all): the
+        // mint + amount + tight-time-window heuristic. Bounded on BOTH sides
+        // around the attempt so a stale identical order from minutes earlier
+        // can't false-match. ctx.timestamp is recorded at deposit/craft (just
+        // before the create POST), so our order's createdAt is ≈ctx.timestamp
+        // and never earlier; allow a small clock skew either way.
+        const anyRowHasReqId = orders.some(o => o.depositRequestId != null || o.requestId != null);
+        if (!match && !anyRowHasReqId) {
+            const lo = ctx.timestamp - 15_000;   // 15s skew tolerance before the attempt
+            const hi = ctx.timestamp + 180_000;  // 3min ceiling after the attempt
+            match = orders.find(o => {
+                if (!isLive(o)) return false;
+                if (o.inputMint !== ctx.inputMint) return false;
+                if (String(o.inputAmount) !== String(ctx.inputAmount)) return false;
+                if (!o.createdAt) return false; // require a timestamp to bound the heuristic
+                const created = new Date(o.createdAt).getTime();
+                return Number.isFinite(created) && created >= lo && created <= hi;
+            });
+        }
+
         if (match && match.id) {
             log(`[trigger-v2] recovery: matched order id=${match.id} in history`, 'INFO');
             return {
@@ -831,30 +869,12 @@ async function listOrders({ pubkey, token, status, page, limit }) {
     return { ok: true, orders };
 }
 
-// ── Update order (PATCH) ────────────────────────────────────────────────────
-
-/**
- * Update an existing V2 price order's triggerPriceUsd or slippageBps.
- * V1 had no equivalent; exposed here for completeness but not wired into
- * a tool handler in PR B (no V1 tool to migrate). Future BAT can add a
- * `jupiter_trigger_update` tool against this helper.
- */
-async function updateOrder({ orderId, token, pubkey, triggerPriceUsd, slippageBps }) {
-    if (!orderId) return { ok: false, error: 'invalid_input', reason: 'orderId required' };
-    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
-    const body = { orderType: 'single' };
-    if (triggerPriceUsd != null) body.triggerPriceUsd = triggerPriceUsd;
-    if (slippageBps != null) body.slippageBps = slippageBps;
-    const res = await _patch(`/trigger/v2/orders/price/${encodeURIComponent(orderId)}`, body, token);
-    if (res.status === 401) {
-        invalidateJwt(pubkey);
-        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by update' };
-    }
-    if (res.status !== 200) {
-        return { ok: false, error: 'update_failed', reason: `HTTP ${res.status}` };
-    }
-    return { ok: true, id: (res.data && res.data.id) || orderId };
-}
+// NOTE: a PATCH /orders/price/{orderId} "update order" primitive (and its
+// _patch HTTP helper) were considered but deliberately NOT shipped in PR B —
+// there is no V1 tool to migrate and no handler would call it, so it would be
+// dead, untested, funds-adjacent code. Add both in a dedicated follow-up BAT
+// alongside a `jupiter_trigger_update` tool + tests when the product needs
+// edit-in-place.
 
 // ── Test-only ───────────────────────────────────────────────────────────────
 
@@ -869,7 +889,6 @@ module.exports = {
     invalidateJwt,
     ensureVault,
     listOrders,
-    updateOrder,
     validateOrderArgs,
     // Low-level (caller drives signing between primitives so reservation
     // lifecycles can wrap the deposit/cancel sign step).
@@ -880,6 +899,8 @@ module.exports = {
     // Exported for tests + cross-module use of the guards.
     _validateChallengePayload,
     _validateAuthTransaction,
+    _readCompactU16,
+    _base58Encode,
     _resetCachesForTests,
     _redactPubkey,
     // Constants useful to callers/tests.

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -255,9 +255,14 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
     }
     messageOffset = instrCount.offset;
     if (instrCount.value === 0) {
-        return { ok: false, error: 'auth_tx_invalid', reason: 'auth tx must contain at least one Memo instruction' };
+        return { ok: false, error: 'auth_tx_invalid', reason: 'auth tx must contain at least one instruction' };
     }
 
+    // Count Memo instructions as we walk — auth challenges MUST carry the
+    // actual challenge payload in a Memo. A ComputeBudget-only tx is in the
+    // program allowlist but contains no challenge text to commit to, so
+    // signing it would be signing nothing meaningful (PR #388 R2 finding).
+    let memoCount = 0;
     for (let i = 0; i < instrCount.value; i++) {
         if (messageOffset + 1 > txBuf.length) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} truncated at program id index` };
@@ -274,6 +279,7 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
                 reason: `instruction ${i} references disallowed program ${programId} — auth tx may only use Memo or ComputeBudget`,
             };
         }
+        if (programId === MEMO_PROGRAM_V1 || programId === MEMO_PROGRAM_V2) memoCount += 1;
         // Skip accounts compact-u16 + bytes
         const acctIdx = _readCompactU16(txBuf, messageOffset);
         if (!acctIdx) {
@@ -289,6 +295,14 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
         if (messageOffset > txBuf.length) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} data truncated` };
         }
+    }
+
+    if (memoCount === 0) {
+        return {
+            ok: false,
+            error: 'auth_tx_invalid',
+            reason: 'auth tx must contain at least one Memo (v1 or v2) instruction — a ComputeBudget-only tx carries no challenge payload to commit to',
+        };
     }
 
     return { ok: true };
@@ -667,6 +681,7 @@ async function depositCraft({ pubkey, token, inputMint, outputMint, inputAmount 
         walletPubkey: pubkey,
         depositRequestId: craftRes.data.requestId,
         inputMint,
+        outputMint, // PR #388 R2: needed for the recovery heuristic to discriminate two same-mint+amount orders.
         inputAmount,
         timestamp: Date.now(),
     };
@@ -833,6 +848,10 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
         const match = orders.find((o) => {
             if (!isLive(o)) return false;
             if (o.inputMint !== ctx.inputMint) return false;
+            // PR #388 R2: discriminate two same-mint+amount orders by also
+            // requiring outputMint to match. A wallet running multiple limit
+            // orders on the same input token could otherwise false-match.
+            if (ctx.outputMint && o.outputMint !== ctx.outputMint) return false;
             if (String(o.initialInputAmount) !== String(ctx.inputAmount)) return false;
             if (!o.createdAt) return false;
             const created = new Date(o.createdAt).getTime();
@@ -854,7 +873,7 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
                 txSignature: depositSig,
                 depositRequestId: ctx.depositRequestId,
                 recovered: true,
-                recoveryNote: 'Order matched in /orders/history (mint + initialInputAmount + tight time window) after lost create response.',
+                recoveryNote: 'Order matched in /orders/history (inputMint + outputMint + initialInputAmount + tight time window) after lost create response.',
             };
         }
     }

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -262,7 +262,11 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
     // actual challenge payload in a Memo. A ComputeBudget-only tx is in the
     // program allowlist but contains no challenge text to commit to, so
     // signing it would be signing nothing meaningful (PR #388 R2 finding).
+    // PR #388 R7: also track whether ANY Memo instruction carries non-empty
+    // data — an empty Memo (data length 0) commits to no payload, defeating
+    // the purpose of the blind-sign guard the same way a missing Memo does.
     let memoCount = 0;
+    let memoWithDataCount = 0;
     for (let i = 0; i < instrCount.value; i++) {
         if (messageOffset + 1 > txBuf.length) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} truncated at program id index` };
@@ -279,7 +283,8 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
                 reason: `instruction ${i} references disallowed program ${programId} — auth tx may only use Memo or ComputeBudget`,
             };
         }
-        if (programId === MEMO_PROGRAM_V1 || programId === MEMO_PROGRAM_V2) memoCount += 1;
+        const isMemo = programId === MEMO_PROGRAM_V1 || programId === MEMO_PROGRAM_V2;
+        if (isMemo) memoCount += 1;
         // Skip accounts compact-u16 + bytes
         const acctIdx = _readCompactU16(txBuf, messageOffset);
         if (!acctIdx) {
@@ -291,6 +296,7 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
         if (!dataLen) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} malformed data length` };
         }
+        if (isMemo && dataLen.value > 0) memoWithDataCount += 1;
         messageOffset = dataLen.offset + dataLen.value;
         if (messageOffset > txBuf.length) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} data truncated` };
@@ -302,6 +308,13 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
             ok: false,
             error: 'auth_tx_invalid',
             reason: 'auth tx must contain at least one Memo (v1 or v2) instruction — a ComputeBudget-only tx carries no challenge payload to commit to',
+        };
+    }
+    if (memoWithDataCount === 0) {
+        return {
+            ok: false,
+            error: 'auth_tx_invalid',
+            reason: 'auth tx contains Memo instruction(s) but all are empty (zero-byte data) — Memo must carry the challenge payload bytes for the blind-sign guard to be meaningful',
         };
     }
 

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -835,19 +835,33 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
     log(`[trigger-v2] recovery: waiting 5s before /orders/history query for depositRequestId=${ctx.depositRequestId}`, 'INFO');
     await new Promise(r => setTimeout(r, 5000));
 
-    const histRes = await _get(`/trigger/v2/orders/history?walletPubkey=${encodeURIComponent(ctx.walletPubkey)}&limit=20`, token);
-    // Auth expired DURING recovery — invalidate the cached JWT so the caller's
-    // retry path forces a re-auth, instead of silently falling through to
-    // "no recovery" and leaving a stale token live for hours.
+    // PR #388 R4: recovery is the LAST chance to surface "the deposit may
+    // have landed" — every failure mode here MUST stay in the ambiguous
+    // bucket so the upstream broadcast callback commits the burner cap
+    // conservatively (over-count is safer than under-count). Pre-fix:
+    //   - A transport throw bubbled up to routeAndSign, which treated it
+    //     as broadcast failure and RELEASED the reservation.
+    //   - The 401 branch returned `auth_expired`, which the broadcast
+    //     callback returned as `{error: ...}` → also release.
+    // Both cases freed the cap while funds may have been sitting in the
+    // Privy vault. We now wrap the history call in try/catch and route
+    // ALL failure modes (transport throw, 401, 5xx, malformed JSON)
+    // through the same `create_ambiguous_no_recovery` exit so the cap
+    // commits and the user gets a manual-recovery advisory.
+    let histRes;
+    try {
+        histRes = await _get(`/trigger/v2/orders/history?walletPubkey=${encodeURIComponent(ctx.walletPubkey)}&limit=20`, token);
+    } catch (e) {
+        log(`[trigger-v2] recovery: /orders/history threw: ${e.message} — ambiguous bucket`, 'WARN');
+        return _ambiguousNoRecovery(ctx, `history lookup threw during recovery (${e.message})`);
+    }
     if (histRes.status === 401) {
+        // Still invalidate the cached JWT so a follow-up call re-auths
+        // cleanly, but route this through the ambiguous bucket rather than
+        // auth_expired — the deposit may have landed and we lost our only
+        // way to confirm it.
         invalidateJwt(ctx.walletPubkey);
-        return {
-            ok: false,
-            error: 'auth_expired',
-            reason: 'JWT rejected by /orders/history during recovery — re-auth and retry. Check Jupiter UI for ' +
-                    `depositRequestId=${ctx.depositRequestId} to confirm whether the deposit landed.`,
-            recovery: ctx,
-        };
+        return _ambiguousNoRecovery(ctx, 'JWT rejected by /orders/history during recovery (cached JWT invalidated; re-auth and retry the original create from scratch if you want to verify)');
     }
     if (histRes.status === 200 && histRes.data && Array.isArray(histRes.data.orders)) {
         const orders = histRes.data.orders.filter(Boolean);
@@ -901,11 +915,22 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
         }
     }
 
+    return _ambiguousNoRecovery(ctx, 'history query returned no matching order');
+}
+
+// PR #388 R4: single exit shape for "deposit was signed + sent but we
+// couldn't confirm the order id." All recovery failure modes (transport
+// throw, 401, 5xx, malformed response, history-miss) MUST route through
+// here so the upstream broadcast callback in _jupiterTriggerCreateV2 sees
+// `create_ambiguous_no_recovery` and commits the burner cap conservatively.
+// Releasing the cap on any of these failure modes would risk under-counting
+// spend if the deposit actually landed in the Privy vault.
+function _ambiguousNoRecovery(ctx, detail) {
     return {
         ok: false,
         error: 'create_ambiguous_no_recovery',
         reason:
-            'Create POST response was lost AND /orders/history showed no matching order. ' +
+            `Create POST response was lost AND recovery could not confirm the order (${detail}). ` +
             `Deposit may still be in flight or stuck. Check Jupiter UI for depositRequestId=${ctx.depositRequestId}. ` +
             'Funds will appear in the Jupiter vault if the deposit landed; cancel or use Jupiter UI to recover.',
         recovery: ctx,

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -762,12 +762,14 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
  *
  * NEVER auto-retries the create POST — non-idempotent + funds-moving.
  */
-// States that mean the order is live (deposit landed / order working). An
-// order in any OTHER state — including a terminal failure that still carries
-// vaultState:'pending_deposit' — must NOT be reported as a recovered success,
-// or we'd commit the burner cap for a dead order and tell the user it worked.
-const _RECOVERY_LIVE_STATUSES = new Set(['active', 'pending_deposit', 'open']);
-const _RECOVERY_TERMINAL_FAIL = new Set(['failed', 'cancelled', 'canceled', 'expired', 'rejected', 'closed']);
+// Terminal states for /orders/history rows — orders in any of these are DEAD
+// and MUST NOT be reported as a recovered success. Verified live 2026-05-30:
+// history rows use `orderState` (NOT `status`); a cancelled order surfaces
+// as `orderState:"cancelled"`. The deny-list shape is safer than an allow-list
+// of live states because Jupiter may add new in-flight states we'd miss.
+const _RECOVERY_TERMINAL_STATES = new Set([
+    'cancelled', 'canceled', 'expired', 'filled', 'failed', 'rejected', 'closed',
+]);
 
 async function _recoverFromAmbiguousCreate(ctx, token) {
     log(`[trigger-v2] recovery: waiting 5s before /orders/history query for depositRequestId=${ctx.depositRequestId}`, 'INFO');
@@ -777,47 +779,47 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
     if (histRes.status === 200 && histRes.data && Array.isArray(histRes.data.orders)) {
         const orders = histRes.data.orders.filter(Boolean);
 
-        const isLive = (o) =>
-            !_RECOVERY_TERMINAL_FAIL.has(o.status)
-            && (_RECOVERY_LIVE_STATUSES.has(o.status) || o.vaultState === 'pending_deposit');
-
-        // PRIMARY: depositRequestId correlation. Unique per attempt, so it can
-        // never alias a pre-existing same-amount order. Accept whichever field
-        // name Jupiter exposes (depositRequestId / requestId).
-        let match = orders.find(o =>
-            isLive(o)
-            && (o.depositRequestId === ctx.depositRequestId || o.requestId === ctx.depositRequestId)
-        );
-
-        // FALLBACK (only if no row carried a deposit-request id at all): the
-        // mint + amount + tight-time-window heuristic. Bounded on BOTH sides
-        // around the attempt so a stale identical order from minutes earlier
-        // can't false-match. ctx.timestamp is recorded at deposit/craft (just
-        // before the create POST), so our order's createdAt is ≈ctx.timestamp
-        // and never earlier; allow a small clock skew either way.
-        const anyRowHasReqId = orders.some(o => o.depositRequestId != null || o.requestId != null);
-        if (!match && !anyRowHasReqId) {
-            const lo = ctx.timestamp - 15_000;   // 15s skew tolerance before the attempt
-            const hi = ctx.timestamp + 180_000;  // 3min ceiling after the attempt
-            match = orders.find(o => {
-                if (!isLive(o)) return false;
-                if (o.inputMint !== ctx.inputMint) return false;
-                if (String(o.inputAmount) !== String(ctx.inputAmount)) return false;
-                if (!o.createdAt) return false; // require a timestamp to bound the heuristic
-                const created = new Date(o.createdAt).getTime();
-                return Number.isFinite(created) && created >= lo && created <= hi;
-            });
-        }
+        // Real-API field-name correction (verified live 2026-05-30 via
+        // tests/jupiter-ultra/v2-contract-probe.js --verify-onchain):
+        //   row keys: id, orderState, rawState, initialInputAmount,
+        //             remainingInputAmount, inputMint, outputMint, createdAt,
+        //             events, ...  — NO depositRequestId / requestId on rows.
+        // Implication: correlation MUST be heuristic (mint + initial amount +
+        // tight time window around the attempt). The depositRequestId-primary
+        // correlation the first draft used is IMPOSSIBLE — that field does
+        // not exist on the history surface. The tight bounded window keeps
+        // false-match risk small even without a unique correlator.
+        //
+        // initialInputAmount = deposit at creation; remainingInputAmount shrinks
+        // as the order fills. We match on initial to find OUR create attempt.
+        const lo = ctx.timestamp - 15_000;   // 15s skew tolerance before the attempt
+        const hi = ctx.timestamp + 180_000;  // 3min ceiling after the attempt
+        const isLive = (o) => !_RECOVERY_TERMINAL_STATES.has(o.orderState);
+        const match = orders.find((o) => {
+            if (!isLive(o)) return false;
+            if (o.inputMint !== ctx.inputMint) return false;
+            if (String(o.initialInputAmount) !== String(ctx.inputAmount)) return false;
+            if (!o.createdAt) return false;
+            const created = new Date(o.createdAt).getTime();
+            return Number.isFinite(created) && created >= lo && created <= hi;
+        });
 
         if (match && match.id) {
-            log(`[trigger-v2] recovery: matched order id=${match.id} in history`, 'INFO');
+            // events[] carries per-event txSignatures; surface the deposit
+            // signature if present so the caller can stamp the broadcast.
+            let depositSig = null;
+            if (Array.isArray(match.events)) {
+                const dep = match.events.find((e) => e && e.type === 'deposit' && e.txSignature);
+                if (dep) depositSig = dep.txSignature;
+            }
+            log(`[trigger-v2] recovery: matched order id=${match.id} in history (orderState=${match.orderState})`, 'INFO');
             return {
                 ok: true,
                 id: match.id,
-                txSignature: match.txSignature || null,
+                txSignature: depositSig,
                 depositRequestId: ctx.depositRequestId,
                 recovered: true,
-                recoveryNote: 'Order found in /orders/history after lost create response.',
+                recoveryNote: 'Order matched in /orders/history (mint + initialInputAmount + tight time window) after lost create response.',
             };
         }
     }

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -171,13 +171,59 @@ const MEMO_PROGRAM_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo';
 // safe: the value-moving programs we actually defend against (SystemProgram
 // Transfer, SPL-Token transfer/approve/closeAccount, swap/DEX programs) are
 // still rejected by the allowlist below.
-// RESIDUAL (low): a malicious challenge could set an absurd SetComputeUnitPrice
-// to grief the payer on priority fees. Bounded by CU-limit × price and the
-// wallet's SOL; a future hardening could decode + cap the priority fee. Out of
-// scope for PR B (the counterparty is Jupiter over TLS).
+// PR #388 R10: previously this comment noted a RESIDUAL fee-grief risk —
+// "a malicious challenge could set an absurd SetComputeUnitPrice to grief
+// the payer on priority fees". That risk is now closed: ComputeBudget
+// instructions are decoded and capped (see _validateComputeBudgetInstr
+// below). The burner path silently zero-cap-signs auth challenges, so a
+// SOL-draining priority fee in an unbounded auth tx WAS a real attack
+// surface even with TLS to Jupiter (compromised endpoint, MITM, etc.).
 const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
 // Programs an auth challenge may reference. Everything else → reject.
 const _AUTH_ALLOWED_PROGRAMS = new Set([MEMO_PROGRAM_V1, MEMO_PROGRAM_V2, COMPUTE_BUDGET_PROGRAM]);
+
+// PR #388 R10: ComputeBudget caps for auth challenges. Auth txs only need
+// to commit to a Memo payload + maybe set a modest CU price — they should
+// never need anything close to mainnet ceilings. Tight caps mean a
+// compromised or MITM'd Jupiter endpoint can't sneak a high-fee draining
+// tx past the blind-sign guard.
+//   - Max CU limit: 200_000 (memo + budget ix fit comfortably under this;
+//     Solana default per-tx limit is 200K)
+//   - Max CU price: 10_000 micro_lamports/CU (combined with the 200K CU
+//     ceiling → worst-case fee ≈ 2_000_000 lamports = 0.002 SOL,
+//     trivial vs the unbounded pre-fix exposure where an attacker could
+//     have set u64::MAX micro_lamports/CU and drained the burner)
+const _AUTH_MAX_CU_LIMIT = 200_000;
+const _AUTH_MAX_CU_PRICE_MICROLAMPORTS = 10_000n; // BigInt — instr field is u64
+
+// Decode + validate a single ComputeBudget instruction's data bytes.
+// Returns { ok: true } or { ok: false, reason }. Unknown tags (heap frame,
+// loaded-accounts-data-size, deprecated RequestUnits) don't drain SOL on
+// their own, so accept silently — only the two fee-affecting variants are
+// capped.
+function _validateComputeBudgetInstr(data) {
+    if (data.length === 0) return { ok: true };
+    const tag = data[0];
+    // 0x02 = SetComputeUnitLimit (u32 LE units)
+    if (tag === 0x02) {
+        if (data.length < 5) return { ok: false, reason: 'ComputeBudget SetComputeUnitLimit data truncated' };
+        const limit = data.readUInt32LE(1);
+        if (limit > _AUTH_MAX_CU_LIMIT) {
+            return { ok: false, reason: `ComputeBudget SetComputeUnitLimit=${limit} exceeds auth-tx cap ${_AUTH_MAX_CU_LIMIT}` };
+        }
+    }
+    // 0x03 = SetComputeUnitPrice (u64 LE micro_lamports/CU)
+    else if (tag === 0x03) {
+        if (data.length < 9) return { ok: false, reason: 'ComputeBudget SetComputeUnitPrice data truncated' };
+        const priceLo = BigInt(data.readUInt32LE(1));
+        const priceHi = BigInt(data.readUInt32LE(5));
+        const price = (priceHi << 32n) | priceLo;
+        if (price > _AUTH_MAX_CU_PRICE_MICROLAMPORTS) {
+            return { ok: false, reason: `ComputeBudget SetComputeUnitPrice=${price.toString()} exceeds auth-tx cap ${_AUTH_MAX_CU_PRICE_MICROLAMPORTS.toString()} micro_lamports/CU` };
+        }
+    }
+    return { ok: true };
+}
 
 function _validateAuthTransaction(txBase64, expectedPubkey) {
     if (typeof txBase64 !== 'string' || txBase64.length === 0) {
@@ -284,6 +330,7 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
             };
         }
         const isMemo = programId === MEMO_PROGRAM_V1 || programId === MEMO_PROGRAM_V2;
+        const isComputeBudget = programId === COMPUTE_BUDGET_PROGRAM;
         if (isMemo) memoCount += 1;
         // Skip accounts compact-u16 + bytes
         const acctIdx = _readCompactU16(txBuf, messageOffset);
@@ -291,16 +338,30 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} malformed accounts count` };
         }
         messageOffset = acctIdx.offset + acctIdx.value;
-        // Skip data compact-u16 + bytes
+        // Read data compact-u16 + bytes
         const dataLen = _readCompactU16(txBuf, messageOffset);
         if (!dataLen) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} malformed data length` };
         }
         if (isMemo && dataLen.value > 0) memoWithDataCount += 1;
-        messageOffset = dataLen.offset + dataLen.value;
-        if (messageOffset > txBuf.length) {
+        const dataStart = dataLen.offset;
+        const dataEnd = dataStart + dataLen.value;
+        if (dataEnd > txBuf.length) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} data truncated` };
         }
+        // PR #388 R10: decode + cap ComputeBudget payloads. Without this,
+        // a hostile or compromised challenge endpoint could set absurd
+        // CU price / CU limit values and drain the fee payer's SOL when
+        // the signed auth tx is later broadcast — the blind-sign guard
+        // would have happily approved the empty value-transfer surface
+        // but missed the fee-grief vector.
+        if (isComputeBudget) {
+            const cbCheck = _validateComputeBudgetInstr(txBuf.slice(dataStart, dataEnd));
+            if (!cbCheck.ok) {
+                return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} ${cbCheck.reason}` };
+            }
+        }
+        messageOffset = dataEnd;
     }
 
     if (memoCount === 0) {
@@ -1067,6 +1128,7 @@ module.exports = {
     // Exported for tests + cross-module use of the guards.
     _validateChallengePayload,
     _validateAuthTransaction,
+    _validateComputeBudgetInstr,
     _readCompactU16,
     _base58Encode,
     _resetCachesForTests,
@@ -1076,4 +1138,6 @@ module.exports = {
     DEFAULT_SLIPPAGE_BPS,
     MEMO_PROGRAM_V1,
     MEMO_PROGRAM_V2,
+    _AUTH_MAX_CU_LIMIT,
+    _AUTH_MAX_CU_PRICE_MICROLAMPORTS,
 };

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -152,14 +152,32 @@ function _validateChallengePayload(payload, expectedPubkey) {
  * Constraints checked:
  *   1. Buffer decodes to a plausible Solana tx (signatures + message).
  *   2. Fee payer (first account) equals expectedPubkey.
- *   3. EVERY instruction's program id is the Memo program. No other
- *      programs (no SystemProgram::Transfer, no Token program, no swap,
- *      no closeAccount — nothing that can move value or state).
+ *   3. EVERY instruction's program id is in the auth allowlist — Memo
+ *      (v1/v2) or ComputeBudget. No other programs (no SystemProgram::
+ *      Transfer, no Token program, no swap, no closeAccount — nothing that
+ *      can move value or state). ComputeBudget is allowed because Jupiter's
+ *      real challenge bundles it and it cannot move value; see the constant
+ *      block below for the full rationale + residual fee-grief note.
  *
  * Returns { ok: true } or { ok: false, error, reason }.
  */
 const MEMO_PROGRAM_V2 = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 const MEMO_PROGRAM_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo';
+// ComputeBudget — sets CU limit / priority fee. Moves NO value (cannot
+// transfer SOL or tokens to any party; only affects the fee the payer pays
+// to validators). Jupiter's REAL auth challenge (verified against the live
+// API on 2026-05-29) bundles a ComputeBudget instruction alongside the Memo,
+// so a Memo-only guard rejects the legitimate challenge. Whitelisting it is
+// safe: the value-moving programs we actually defend against (SystemProgram
+// Transfer, SPL-Token transfer/approve/closeAccount, swap/DEX programs) are
+// still rejected by the allowlist below.
+// RESIDUAL (low): a malicious challenge could set an absurd SetComputeUnitPrice
+// to grief the payer on priority fees. Bounded by CU-limit × price and the
+// wallet's SOL; a future hardening could decode + cap the priority fee. Out of
+// scope for PR B (the counterparty is Jupiter over TLS).
+const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
+// Programs an auth challenge may reference. Everything else → reject.
+const _AUTH_ALLOWED_PROGRAMS = new Set([MEMO_PROGRAM_V1, MEMO_PROGRAM_V2, COMPUTE_BUDGET_PROGRAM]);
 
 function _validateAuthTransaction(txBase64, expectedPubkey) {
     if (typeof txBase64 !== 'string' || txBase64.length === 0) {
@@ -249,11 +267,11 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
             return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} program index ${programIdx} out of range` };
         }
         const programId = accountKeys[programIdx];
-        if (programId !== MEMO_PROGRAM_V2 && programId !== MEMO_PROGRAM_V1) {
+        if (!_AUTH_ALLOWED_PROGRAMS.has(programId)) {
             return {
                 ok: false,
                 error: 'auth_tx_invalid',
-                reason: `instruction ${i} references non-Memo program ${programId} — auth tx must be Memo-only`,
+                reason: `instruction ${i} references disallowed program ${programId} — auth tx may only use Memo or ComputeBudget`,
             };
         }
         // Skip accounts compact-u16 + bytes
@@ -489,30 +507,41 @@ function _redactPubkey(pubkey) {
 // ── Vault registration (lazy per Codex round-2 #4) ──────────────────────────
 
 /**
- * Ensure the wallet has a Jupiter/Privy vault. GETs vault address; if not
- * registered, POSTs /vault/register. Cached in-memory per pubkey for the
- * Node lifetime — vault registration is one-shot per wallet.
+ * Ensure the wallet has a Jupiter/Privy vault.
+ *
+ * BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29):
+ * The original two-step "GET /vault → POST /vault/register" design is WRONG.
+ * Confirmed against the live API with the test wallet:
+ *   • GET /trigger/v2/vault?walletPubkey=… is a REAL route — for an
+ *     unregistered wallet it returns 404 {"error":"Vault not found"}.
+ *   • POST /trigger/v2/vault/register does NOT exist (generic 404) — and
+ *     neither do /vault, /vault/create, /vault/craft, /register.
+ *   • deposit/craft hard-requires a registered vault first (403
+ *     {"error":"No vault registered for this user"}).
+ * So a vault IS a prerequisite, but its registration mechanism is still
+ * unknown (likely a Privy-managed or on-chain init flow not in the paths we
+ * probed). This function therefore CANNOT yet establish a vault. It reports a
+ * clear `vault_registration_unsupported` state so the create flow fails
+ * loudly instead of POSTing a 404. Resolve the real mechanism from Jupiter V2
+ * docs/openapi, then implement. Tracked on PR #388.
  */
 async function ensureVault(pubkey, token) {
     const cached = _vaultCache.get(pubkey);
     if (cached && cached.registered) return { ok: true, vaultAddress: cached.vaultAddress };
 
     const getRes = await _get(`/trigger/v2/vault?walletPubkey=${encodeURIComponent(pubkey)}`, token);
-    if (getRes.status === 200 && getRes.data && getRes.data.registered === true && getRes.data.vaultAddress) {
+    if (getRes.status === 200 && getRes.data && getRes.data.vaultAddress) {
         _vaultCache.set(pubkey, { vaultAddress: getRes.data.vaultAddress, registered: true });
         return { ok: true, vaultAddress: getRes.data.vaultAddress };
     }
 
-    // Not registered (or vault endpoint returns 404 for unregistered) — POST register.
-    const regRes = await _post('/trigger/v2/vault/register', { walletPubkey: pubkey }, token);
-    if (regRes.status !== 200 && regRes.status !== 201) {
-        return { ok: false, error: 'vault_register_failed', reason: `HTTP ${regRes.status}` };
-    }
-    if (!regRes.data || !regRes.data.vaultAddress) {
-        return { ok: false, error: 'vault_register_failed', reason: 'no vaultAddress in response' };
-    }
-    _vaultCache.set(pubkey, { vaultAddress: regRes.data.vaultAddress, registered: true });
-    return { ok: true, vaultAddress: regRes.data.vaultAddress };
+    // Vault not found and no known registration endpoint. Fail loudly rather
+    // than POST a route that returns 404 (the old behavior).
+    return {
+        ok: false,
+        error: 'vault_registration_unsupported',
+        reason: 'No vault for this wallet and the V2 vault-registration mechanism is not yet implemented (the /vault/register route does not exist). Needs Jupiter V2 docs — see PR #388.',
+    };
 }
 
 // ── V2 semantic validation (contract v2 §6) ─────────────────────────────────
@@ -593,6 +622,17 @@ function validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippa
  * recoveryContext is opaque to the caller — it carries the metadata
  * needed to find the order in /orders/history if the create POST is lost
  * after deposit signing. Caller must NOT persist or log it.
+ *
+ * BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29): the request
+ * body below uses the WRONG field names. The live deposit/craft validation
+ * proved the real contract is:
+ *   { userAddress, inputMint, outputMint (REQUIRED), amount (numeric string,
+ *     NOT inputAmount), orderType:'price' (REQUIRED), orderSubType:'single' }
+ * i.e. `walletPubkey`→`userAddress`, `inputAmount`→`amount`, and `outputMint`
+ * must be threaded in (depositCraft currently has no outputMint param). With
+ * the corrected body, craft returns 403 until the wallet has a vault (see
+ * ensureVault). Do the rewrite once the vault flow is confirmed so the whole
+ * deposit→create path lands in one coherent, testable change.
  */
 async function depositCraft({ pubkey, token, inputMint, inputAmount }) {
     if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
@@ -649,14 +689,19 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
         return { ok: false, error: 'invalid_input', reason: 'depositSignedTx required' };
     }
 
-    // BAT-697 LIVE-SMOKE MUST-VERIFY: the orderType/orderSubType pair on the
-    // create POST is unconfirmed against the live API. deposit/craft uses
-    // { orderType:'price', orderSubType:'single' }; we mirror that family here
-    // for internal consistency rather than the bare orderType:'single' the
-    // first draft sent. Commit-3 live smoke MUST confirm the exact wire shape
-    // Jupiter expects (it may want only orderType, only orderSubType, or
-    // neither since the path already says /orders/price). Adjust here once
-    // verified — this is the single most likely create-rejection cause.
+    // BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29):
+    // This create body is NOT yet reconciled with the real Jupiter V2 API and
+    // is known-incomplete. The deposit/craft probe proved Jupiter uses a
+    // DIFFERENT field convention than this adapter was first drafted with:
+    //   • userAddress   (NOT walletPubkey / userPubkey)
+    //   • amount        (NOT inputAmount)
+    //   • outputMint    REQUIRED
+    //   • orderType:'price' REQUIRED ('single' alone → 400 "Invalid input")
+    // /orders/price itself could NOT be reached in the probe (it requires a
+    // registered vault, and the vault-registration mechanism is still unknown —
+    // /trigger/v2/vault/register returns 404, i.e. that route does not exist).
+    // Do the coherent body rewrite once the vault flow + the /orders/price
+    // schema are confirmed from Jupiter V2 docs/openapi. See PR #388 thread.
     const createBody = {
         orderType: 'price',
         orderSubType: 'single',

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -295,15 +295,22 @@ function _validateAuthTransaction(txBase64, expectedPubkey) {
 }
 
 // Compact-u16 reader. Returns { value, offset } or null if malformed.
+// Strict 2-byte cap (max value 16383). Solana spec technically allows a
+// 3-byte short_vec (up to 0xFFFF, with byte 3 contributing only 2 bits),
+// but auth-challenge txs in our context never need more than a 2-byte count
+// (Memo + ComputeBudget — small instruction/account counts). The stricter
+// cap also avoids the byte-3 u16-overflow ambiguity that the earlier reader
+// allowed (byte 3 high bits left unmasked silently producing values > 65535).
+// The gate is at the TOP of the loop so a 3rd byte is never read.
 function _readCompactU16(buf, offset) {
     if (offset >= buf.length) return null;
     let v = 0, shift = 0, i = offset;
     while (i < buf.length) {
+        if (shift > 7) return null;
         const b = buf[i]; i += 1;
         v |= (b & 0x7f) << shift;
         if ((b & 0x80) === 0) return { value: v, offset: i };
         shift += 7;
-        if (shift > 14) return null;
     }
     return null;
 }
@@ -729,21 +736,36 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
         return { ok: false, error: 'auth_expired', reason: 'JWT rejected by orders/price', recovery: recoveryContext };
     }
 
-    if (createRes.status >= 500 || !createRes.data || (createRes.status === 200 && !createRes.data.id)) {
-        log(`[trigger-v2] ambiguous create response (status=${createRes.status}, hasId=${!!(createRes.data && createRes.data.id)}) — entering recovery`, 'WARN');
+    // Ambiguous: 5xx OR no body at all. Deposit may or may not have landed —
+    // recover via /orders/history.
+    if (createRes.status >= 500 || !createRes.data) {
+        log(`[trigger-v2] ambiguous create response (status=${createRes.status}, hasData=${!!createRes.data}) — entering recovery`, 'WARN');
         return await _recoverFromAmbiguousCreate(recoveryContext, token);
     }
 
-    if (createRes.status !== 200) {
-        return { ok: false, error: 'create_failed', reason: `HTTP ${createRes.status}` };
+    // Accept ANY 2xx with id as success. The original `status === 200` gate
+    // dropped a 201/202 + id into the create_failed branch — silent
+    // funds-on-chain-but-error-to-user inconsistency. Jupiter is consistent
+    // with 200 today, but defending against legitimate alternate 2xx codes
+    // is the safe shape.
+    if (createRes.status >= 200 && createRes.status < 300) {
+        if (createRes.data.id) {
+            return {
+                ok: true,
+                id: createRes.data.id,
+                txSignature: createRes.data.txSignature || null,
+                depositRequestId: recoveryContext.depositRequestId,
+            };
+        }
+        // 2xx but no id — ambiguous (Jupiter accepted-but-pending?). Recover.
+        log(`[trigger-v2] 2xx without id (status=${createRes.status}) — entering recovery`, 'WARN');
+        return await _recoverFromAmbiguousCreate(recoveryContext, token);
     }
 
-    return {
-        ok: true,
-        id: createRes.data.id,
-        txSignature: createRes.data.txSignature || null,
-        depositRequestId: recoveryContext.depositRequestId,
-    };
+    // Non-2xx, non-5xx (3xx redirect, 4xx hard error) — fail outright. The
+    // deposit signature went to Jupiter but the server rejected the order
+    // params or auth — there's nothing useful to recover.
+    return { ok: false, error: 'create_failed', reason: `HTTP ${createRes.status}` };
 }
 
 /**
@@ -776,6 +798,19 @@ async function _recoverFromAmbiguousCreate(ctx, token) {
     await new Promise(r => setTimeout(r, 5000));
 
     const histRes = await _get(`/trigger/v2/orders/history?walletPubkey=${encodeURIComponent(ctx.walletPubkey)}&limit=20`, token);
+    // Auth expired DURING recovery — invalidate the cached JWT so the caller's
+    // retry path forces a re-auth, instead of silently falling through to
+    // "no recovery" and leaving a stale token live for hours.
+    if (histRes.status === 401) {
+        invalidateJwt(ctx.walletPubkey);
+        return {
+            ok: false,
+            error: 'auth_expired',
+            reason: 'JWT rejected by /orders/history during recovery — re-auth and retry. Check Jupiter UI for ' +
+                    `depositRequestId=${ctx.depositRequestId} to confirm whether the deposit landed.`,
+            recovery: ctx,
+        };
+    }
     if (histRes.status === 200 && histRes.data && Array.isArray(histRes.data.orders)) {
         const orders = histRes.data.orders.filter(Boolean);
 

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -190,22 +190,48 @@ const _AUTH_ALLOWED_PROGRAMS = new Set([MEMO_PROGRAM_V1, MEMO_PROGRAM_V2, COMPUT
 //   - Max CU limit: 200_000 (memo + budget ix fit comfortably under this;
 //     Solana default per-tx limit is 200K)
 //   - Max CU price: 10_000 micro_lamports/CU (combined with the 200K CU
-//     ceiling → worst-case fee ≈ 2_000_000 lamports = 0.002 SOL,
-//     trivial vs the unbounded pre-fix exposure where an attacker could
-//     have set u64::MAX micro_lamports/CU and drained the burner)
+//     ceiling → priority fee worst case = 200_000 * 10_000 / 1_000_000
+//     = 2_000 lamports ≈ 0.000002 SOL — trivial vs the unbounded pre-fix
+//     exposure where an attacker could have set u64::MAX micro_lamports/CU
+//     and drained the burner)
+//   - Max additional_fee (deprecated tag 0x00): 5_000 lamports ≈ 0.000005
+//     SOL — same trivial ceiling, accommodates any real-world priority bump
 const _AUTH_MAX_CU_LIMIT = 200_000;
 const _AUTH_MAX_CU_PRICE_MICROLAMPORTS = 10_000n; // BigInt — instr field is u64
+const _AUTH_MAX_ADDITIONAL_FEE_LAMPORTS = 5_000;
 
 // Decode + validate a single ComputeBudget instruction's data bytes.
-// Returns { ok: true } or { ok: false, reason }. Unknown tags (heap frame,
-// loaded-accounts-data-size, deprecated RequestUnits) don't drain SOL on
-// their own, so accept silently — only the two fee-affecting variants are
-// capped.
+// Returns { ok: true } or { ok: false, reason }.
+//
+// Fee-affecting tags (capped):
+//   0x00 RequestUnitsDeprecated (u32 units, u32 additional_fee LAMPORTS)
+//   0x02 SetComputeUnitLimit    (u32 units)
+//   0x03 SetComputeUnitPrice    (u64 micro_lamports/CU)
+// Non-fee-affecting tags (accepted silently):
+//   0x01 RequestHeapFrame                (u32 bytes — only changes heap, no fee)
+//   0x04 SetLoadedAccountsDataSizeLimit  (u32 bytes — limit, no direct fee)
+//
+// PR #388 R11: tag 0x00's `additional_fee` field was previously treated as
+// "unknown safe" and accepted unconditionally — that left a fee-drain path
+// the same magnitude as the unbounded SetComputeUnitPrice path. Now decoded
+// and capped.
 function _validateComputeBudgetInstr(data) {
     if (data.length === 0) return { ok: true };
     const tag = data[0];
+    // 0x00 = RequestUnitsDeprecated (u32 LE units, u32 LE additional_fee LAMPORTS)
+    if (tag === 0x00) {
+        if (data.length < 9) return { ok: false, reason: 'ComputeBudget RequestUnitsDeprecated data truncated' };
+        const units = data.readUInt32LE(1);
+        const additionalFee = data.readUInt32LE(5);
+        if (units > _AUTH_MAX_CU_LIMIT) {
+            return { ok: false, reason: `ComputeBudget RequestUnitsDeprecated units=${units} exceeds auth-tx cap ${_AUTH_MAX_CU_LIMIT}` };
+        }
+        if (additionalFee > _AUTH_MAX_ADDITIONAL_FEE_LAMPORTS) {
+            return { ok: false, reason: `ComputeBudget RequestUnitsDeprecated additional_fee=${additionalFee} lamports exceeds auth-tx cap ${_AUTH_MAX_ADDITIONAL_FEE_LAMPORTS}` };
+        }
+    }
     // 0x02 = SetComputeUnitLimit (u32 LE units)
-    if (tag === 0x02) {
+    else if (tag === 0x02) {
         if (data.length < 5) return { ok: false, reason: 'ComputeBudget SetComputeUnitLimit data truncated' };
         const limit = data.readUInt32LE(1);
         if (limit > _AUTH_MAX_CU_LIMIT) {
@@ -222,6 +248,9 @@ function _validateComputeBudgetInstr(data) {
             return { ok: false, reason: `ComputeBudget SetComputeUnitPrice=${price.toString()} exceeds auth-tx cap ${_AUTH_MAX_CU_PRICE_MICROLAMPORTS.toString()} micro_lamports/CU` };
         }
     }
+    // 0x01 RequestHeapFrame, 0x04 SetLoadedAccountsDataSizeLimit → no direct
+    // SOL drain (heap frame doesn't add fee; loaded-accounts cap just limits
+    // what can be loaded). CU spent on those is bounded by 0x02 above.
     return { ok: true };
 }
 
@@ -1140,4 +1169,5 @@ module.exports = {
     MEMO_PROGRAM_V2,
     _AUTH_MAX_CU_LIMIT,
     _AUTH_MAX_CU_PRICE_MICROLAMPORTS,
+    _AUTH_MAX_ADDITIONAL_FEE_LAMPORTS,
 };

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -708,7 +708,12 @@ async function depositCraft({ pubkey, token, inputMint, outputMint, inputAmount 
         inputAmount,
         timestamp: Date.now(),
     };
-    log(`[trigger-v2] deposit/craft wallet=${_redactPubkey(pubkey)} input=${inputMint} amount=${inputAmount} depositRequestId=${recoveryContext.depositRequestId}`, 'INFO');
+    // PR #388 R5: depositRequestId is the ambiguous-create correlation token
+    // — keeping it OUT of persistent logs limits how an attacker who reads
+    // node_debug.log could correlate a wallet's deposit attempts. The token
+    // is still surfaced in the returned recoveryContext + the user-facing
+    // ambiguous-recovery advisory, which is where consumers actually need it.
+    log(`[trigger-v2] deposit/craft wallet=${_redactPubkey(pubkey)} input=${inputMint} amount=${inputAmount}`, 'INFO');
     return {
         ok: true,
         transaction: craftRes.data.transaction,
@@ -832,7 +837,10 @@ const _RECOVERY_TERMINAL_STATES = new Set([
 ]);
 
 async function _recoverFromAmbiguousCreate(ctx, token) {
-    log(`[trigger-v2] recovery: waiting 5s before /orders/history query for depositRequestId=${ctx.depositRequestId}`, 'INFO');
+    // PR #388 R5: don't persist the depositRequestId correlation token to
+    // node_debug.log (see depositCraft logging note above). The token is
+    // still in `ctx` and the returned recoveryNote/reason for callers.
+    log(`[trigger-v2] recovery: waiting 5s before /orders/history query for wallet=${_redactPubkey(ctx.walletPubkey)}`, 'INFO');
     await new Promise(r => setTimeout(r, 5000));
 
     // PR #388 R4: recovery is the LAST chance to surface "the deposit may

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -507,41 +507,43 @@ function _redactPubkey(pubkey) {
 // ── Vault registration (lazy per Codex round-2 #4) ──────────────────────────
 
 /**
- * Ensure the wallet has a Jupiter/Privy vault.
+ * Ensure the wallet has a Jupiter/Privy vault, returning its vaultPubkey.
  *
- * BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29):
- * The original two-step "GET /vault → POST /vault/register" design is WRONG.
- * Confirmed against the live API with the test wallet:
- *   • GET /trigger/v2/vault?walletPubkey=… is a REAL route — for an
- *     unregistered wallet it returns 404 {"error":"Vault not found"}.
- *   • POST /trigger/v2/vault/register does NOT exist (generic 404) — and
- *     neither do /vault, /vault/create, /vault/craft, /register.
- *   • deposit/craft hard-requires a registered vault first (403
- *     {"error":"No vault registered for this user"}).
- * So a vault IS a prerequisite, but its registration mechanism is still
- * unknown (likely a Privy-managed or on-chain init flow not in the paths we
- * probed). This function therefore CANNOT yet establish a vault. It reports a
- * clear `vault_registration_unsupported` state so the create flow fails
- * loudly instead of POSTing a 404. Resolve the real mechanism from Jupiter V2
- * docs/openapi, then implement. Tracked on PR #388.
+ * Contract (Jupiter V2 openapi, verified live 2026-05-29):
+ *   • GET /trigger/v2/vault          → 200 {userPubkey, vaultPubkey, privyVaultId, privyUserId?}
+ *                                       (JWT identifies the wallet; 404 when no vault yet)
+ *   • GET /trigger/v2/vault/register → 200/201 {userPubkey, vaultPubkey, privyVaultId}
+ *                                       IDEMPOTENT — registration is a GET; the Privy
+ *                                       custodial vault is created server-side (no funds,
+ *                                       no on-chain action). Subsequent calls return the
+ *                                       existing vault.
+ * (Both are GET + JWT-only — there is NO POST register endpoint; the first
+ * draft's POST /vault/register 404'd in the live probe.)
+ *
+ * Cached in-memory per pubkey for the Node lifetime — vault is one-shot.
  */
 async function ensureVault(pubkey, token) {
     const cached = _vaultCache.get(pubkey);
-    if (cached && cached.registered) return { ok: true, vaultAddress: cached.vaultAddress };
+    if (cached && cached.vaultPubkey) return { ok: true, vaultPubkey: cached.vaultPubkey };
 
-    const getRes = await _get(`/trigger/v2/vault?walletPubkey=${encodeURIComponent(pubkey)}`, token);
-    if (getRes.status === 200 && getRes.data && getRes.data.vaultAddress) {
-        _vaultCache.set(pubkey, { vaultAddress: getRes.data.vaultAddress, registered: true });
-        return { ok: true, vaultAddress: getRes.data.vaultAddress };
+    // Try the existing vault first; register (idempotent GET) if absent.
+    let res = await _get('/trigger/v2/vault', token);
+    if (res.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by /vault' };
     }
-
-    // Vault not found and no known registration endpoint. Fail loudly rather
-    // than POST a route that returns 404 (the old behavior).
-    return {
-        ok: false,
-        error: 'vault_registration_unsupported',
-        reason: 'No vault for this wallet and the V2 vault-registration mechanism is not yet implemented (the /vault/register route does not exist). Needs Jupiter V2 docs — see PR #388.',
-    };
+    if (!(res.status === 200 && res.data && res.data.vaultPubkey)) {
+        res = await _get('/trigger/v2/vault/register', token);
+        if (res.status === 401) {
+            invalidateJwt(pubkey);
+            return { ok: false, error: 'auth_expired', reason: 'JWT rejected by /vault/register' };
+        }
+    }
+    if (res.status >= 200 && res.status < 300 && res.data && res.data.vaultPubkey) {
+        _vaultCache.set(pubkey, { vaultPubkey: res.data.vaultPubkey });
+        return { ok: true, vaultPubkey: res.data.vaultPubkey };
+    }
+    return { ok: false, error: 'vault_unavailable', reason: `vault GET/register failed (HTTP ${res.status})` };
 }
 
 // ── V2 semantic validation (contract v2 §6) ─────────────────────────────────
@@ -623,25 +625,26 @@ function validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippa
  * needed to find the order in /orders/history if the create POST is lost
  * after deposit signing. Caller must NOT persist or log it.
  *
- * BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29): the request
- * body below uses the WRONG field names. The live deposit/craft validation
- * proved the real contract is:
- *   { userAddress, inputMint, outputMint (REQUIRED), amount (numeric string,
- *     NOT inputAmount), orderType:'price' (REQUIRED), orderSubType:'single' }
- * i.e. `walletPubkey`→`userAddress`, `inputAmount`→`amount`, and `outputMint`
- * must be threaded in (depositCraft currently has no outputMint param). With
- * the corrected body, craft returns 403 until the wallet has a vault (see
- * ensureVault). Do the rewrite once the vault flow is confirmed so the whole
- * deposit→create path lands in one coherent, testable change.
+ * Contract (Jupiter V2 openapi, verified live 2026-05-29):
+ *   POST /trigger/v2/deposit/craft
+ *   body: { inputMint, outputMint, userAddress, amount (smallest-unit string),
+ *           orderType:'price', orderSubType:'single' }
+ *   resp: { transaction (base64 unsigned), requestId, receiverAddress, mint,
+ *           amount, tokenDecimals, ... }
+ * Note the cross-endpoint naming quirk: craft uses `userAddress`/`amount`,
+ * while /orders/price (submitCreateOrder) uses `userPubkey`/`inputAmount`.
+ * The craft response's `requestId` becomes /orders/price's `depositRequestId`.
  */
-async function depositCraft({ pubkey, token, inputMint, inputAmount }) {
+async function depositCraft({ pubkey, token, inputMint, outputMint, inputAmount }) {
     if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    if (!outputMint) return { ok: false, error: 'invalid_input', reason: 'outputMint required for deposit/craft' };
     const craftRes = await _post('/trigger/v2/deposit/craft', {
-        walletPubkey: pubkey,
+        inputMint,
+        outputMint,
+        userAddress: pubkey,
+        amount: inputAmount,
         orderType: 'price',
         orderSubType: 'single',
-        inputMint,
-        inputAmount,
     }, token);
     if (craftRes.status === 401) {
         invalidateJwt(pubkey);
@@ -650,12 +653,12 @@ async function depositCraft({ pubkey, token, inputMint, inputAmount }) {
     if (craftRes.status !== 200) {
         return { ok: false, error: 'deposit_craft_failed', reason: `HTTP ${craftRes.status}` };
     }
-    if (!craftRes.data || typeof craftRes.data.transaction !== 'string' || !craftRes.data.depositRequestId) {
-        return { ok: false, error: 'deposit_craft_failed', reason: 'response missing transaction or depositRequestId' };
+    if (!craftRes.data || typeof craftRes.data.transaction !== 'string' || !craftRes.data.requestId) {
+        return { ok: false, error: 'deposit_craft_failed', reason: 'response missing transaction or requestId' };
     }
     const recoveryContext = {
         walletPubkey: pubkey,
-        depositRequestId: craftRes.data.depositRequestId,
+        depositRequestId: craftRes.data.requestId,
         inputMint,
         inputAmount,
         timestamp: Date.now(),
@@ -664,7 +667,7 @@ async function depositCraft({ pubkey, token, inputMint, inputAmount }) {
     return {
         ok: true,
         transaction: craftRes.data.transaction,
-        depositRequestId: craftRes.data.depositRequestId,
+        depositRequestId: craftRes.data.requestId,
         recoveryContext,
     };
 }
@@ -689,22 +692,17 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
         return { ok: false, error: 'invalid_input', reason: 'depositSignedTx required' };
     }
 
-    // BAT-697 CONTRACT-REWRITE PENDING (live-API probe 2026-05-29):
-    // This create body is NOT yet reconciled with the real Jupiter V2 API and
-    // is known-incomplete. The deposit/craft probe proved Jupiter uses a
-    // DIFFERENT field convention than this adapter was first drafted with:
-    //   • userAddress   (NOT walletPubkey / userPubkey)
-    //   • amount        (NOT inputAmount)
-    //   • outputMint    REQUIRED
-    //   • orderType:'price' REQUIRED ('single' alone → 400 "Invalid input")
-    // /orders/price itself could NOT be reached in the probe (it requires a
-    // registered vault, and the vault-registration mechanism is still unknown —
-    // /trigger/v2/vault/register returns 404, i.e. that route does not exist).
-    // Do the coherent body rewrite once the vault flow + the /orders/price
-    // schema are confirmed from Jupiter V2 docs/openapi. See PR #388 thread.
+    // Contract (Jupiter V2 openapi, verified live 2026-05-29):
+    //   POST /trigger/v2/orders/price
+    //   { orderType:'single', depositRequestId, depositSignedTx, userPubkey,
+    //     inputMint, inputAmount, outputMint, triggerMint, triggerCondition,
+    //     triggerPriceUsd, slippageBps?, expiresAt }
+    // For a single price order, orderType IS 'single' (the sub-type value) —
+    // distinct from deposit/craft which uses orderType:'price'+orderSubType.
+    // expiresAt is MILLISECONDS (not seconds). userPubkey/inputAmount here
+    // (vs userAddress/amount on craft).
     const createBody = {
-        orderType: 'price',
-        orderSubType: 'single',
+        orderType: 'single',
         depositRequestId: recoveryContext.depositRequestId,
         depositSignedTx,
         userPubkey: recoveryContext.walletPubkey,
@@ -712,9 +710,9 @@ async function submitCreateOrder({ token, recoveryContext, depositSignedTx, orde
         inputAmount: order.inputAmount,
         outputMint: order.outputMint,
         triggerMint: order.triggerMint || order.outputMint,
-        expiresAt: Math.floor(order.expiresAtMs / 1000),
         triggerCondition: order.triggerCondition || 'below',
         triggerPriceUsd: order.triggerPriceUsd,
+        expiresAt: order.expiresAtMs,
     };
     if (order.slippageBps != null) createBody.slippageBps = order.slippageBps;
 

--- a/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
+++ b/app/src/main/assets/nodejs-project/jupiter/trigger-v2.js
@@ -1,0 +1,890 @@
+// SeekerClaw — jupiter/trigger-v2.js
+// BAT-697 PR B: Jupiter Trigger API V2 adapter.
+//
+// Pure module — tool handlers pass in signer callbacks. No direct wallet
+// or dispatch coupling. This makes the auth/vault/deposit/create/cancel/
+// recovery flows testable without spinning the bridge.
+//
+// SCOPE OF THIS FILE
+// ------------------
+// 1. Auth challenge → verify → 24h JWT (in-memory per-pubkey cache).
+// 2. Blind-sign guards (parse memo-only auth tx, reject value-moving instrs).
+// 3. Vault register (lazy — only on first trigger create per wallet).
+// 4. Deposit craft → wallet signs → orders/price create.
+// 5. Two-step cancel: cancel/{id} → wallet signs → confirm-cancel/{id}.
+// 6. Ambiguous-create recovery via /orders/history.
+// 7. Order history list (GET).
+// 8. V2 semantic validation (min $10, required expiresAt, USD trigger,
+//    explicit slippage).
+//
+// AUTH CHALLENGE TYPE — TRANSACTION ONLY IN PR B
+// ----------------------------------------------
+// V2 contract specifies message-first with transaction fallback "on a
+// clearly unsupported-method/capability error" (per Codex round-2 #3).
+// PR B has no `/burner/sign-message` or `/solana/sign-message` bridge
+// endpoint, so both wallets fall directly to transaction-challenge —
+// the spec-allowed path. The adapter still accepts `signers.signMessage`
+// as an optional callback; a follow-up BAT can add the bridge endpoints
+// and pass a non-null signMessage, and the adapter will prefer the
+// message path automatically.
+//
+// JWT CACHE
+// ---------
+// In-memory only, per-pubkey, NOT persisted across Node restart. 24h JWT
+// TTL minus a 60s skew. Refresh-on-401: any V2 call that returns 401
+// invalidates the cache for that pubkey and the caller can retry once.
+// The retry is the caller's responsibility (the adapter exposes
+// `invalidateJwt(pubkey)`).
+//
+// NEVER LOG: signatures, JWTs, raw challenge text. All log lines redact
+// signature/token-shaped fields. Caller-side logs in tools/solana.js also
+// route through the existing redactSecrets pattern.
+
+'use strict';
+
+const { httpRequest } = require('../http');
+const { log, config } = require('../config');
+
+// ── Module-level state ──────────────────────────────────────────────────────
+
+// JWT cache: pubkey → { token, expiresAt }. Token is opaque (Jupiter Bearer).
+// expiresAt is a JS millisecond timestamp; we refresh anything within 60s.
+const _jwtCache = new Map();
+
+// Vault cache: pubkey → { vaultAddress, registered: true }. Lazy — populated
+// at first trigger_create per wallet.
+const _vaultCache = new Map();
+
+// 60s skew before JWT expiry to avoid a refresh race on the wire.
+const JWT_SKEW_MS = 60_000;
+// Jupiter docs: 24h JWT TTL. We don't trust the server-returned expiry
+// (Jupiter only returns the token, not an expires-at), so we anchor on
+// our own clock.
+const JWT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const JUPITER_HOST = 'api.jup.ag';
+
+// V2 semantic validation bounds (per contract v2 §6).
+const MIN_ORDER_USD = 10;
+const MIN_EXPIRY_SKEW_MS = 60_000; // expiresAt must be ≥ now+1min
+const DEFAULT_SLIPPAGE_BPS = 100;  // 1% — matches solana_swap default
+const MIN_SLIPPAGE_BPS = 1;
+const MAX_SLIPPAGE_BPS = 10_000;
+
+// ── HTTP helpers ────────────────────────────────────────────────────────────
+
+function _ensureApiKey() {
+    if (!config.jupiterApiKey) {
+        return {
+            error: 'jupiter_api_key_required',
+            reason: 'Get a free key at portal.jup.ag and add it in Settings > Configuration > Jupiter API Key',
+        };
+    }
+    return null;
+}
+
+function _authHeaders(token) {
+    const h = { 'x-api-key': config.jupiterApiKey, 'Accept': 'application/json' };
+    if (token) h['Authorization'] = `Bearer ${token}`;
+    return h;
+}
+
+async function _post(path, body, token) {
+    const headers = { ..._authHeaders(token), 'Content-Type': 'application/json' };
+    const res = await httpRequest({ hostname: JUPITER_HOST, path, method: 'POST', headers }, body);
+    return _parseResponse(res);
+}
+
+async function _patch(path, body, token) {
+    const headers = { ..._authHeaders(token), 'Content-Type': 'application/json' };
+    const res = await httpRequest({ hostname: JUPITER_HOST, path, method: 'PATCH', headers }, body);
+    return _parseResponse(res);
+}
+
+async function _get(path, token) {
+    const res = await httpRequest({ hostname: JUPITER_HOST, path, method: 'GET', headers: _authHeaders(token) });
+    return _parseResponse(res);
+}
+
+function _parseResponse(res) {
+    const data = typeof res.data === 'string' ? _safeJsonParse(res.data) : res.data;
+    return { status: res.status, data, raw: res };
+}
+
+function _safeJsonParse(s) {
+    try { return JSON.parse(s); } catch (_) { return s; }
+}
+
+// ── Blind-sign guards (contract v2 §4) ──────────────────────────────────────
+
+/**
+ * Validate a JSON auth challenge payload before passing it to the signer.
+ * Refuses anything that isn't shaped like a Jupiter Trigger V2 auth challenge
+ * for the requested wallet.
+ *
+ * Returns { ok: true } or { ok: false, error, reason }.
+ */
+function _validateChallengePayload(payload, expectedPubkey) {
+    if (!payload || typeof payload !== 'object') {
+        return { ok: false, error: 'auth_challenge_invalid', reason: 'challenge payload is not an object' };
+    }
+    if (payload.type !== 'message' && payload.type !== 'transaction') {
+        return { ok: false, error: 'auth_challenge_invalid', reason: `challenge type must be "message" or "transaction" (got ${payload.type})` };
+    }
+    if (payload.type === 'message') {
+        if (typeof payload.challenge !== 'string' || payload.challenge.length === 0) {
+            return { ok: false, error: 'auth_challenge_invalid', reason: 'message challenge body is empty' };
+        }
+    } else {
+        if (typeof payload.transaction !== 'string' || payload.transaction.length === 0) {
+            return { ok: false, error: 'auth_challenge_invalid', reason: 'transaction challenge body is empty' };
+        }
+    }
+    // Pubkey echo check — Jupiter may include `walletPubkey` in the response.
+    // If present, it MUST match the one we asked for. If absent, we can't
+    // verify here but the verify endpoint will reject any mismatch downstream.
+    if (payload.walletPubkey && payload.walletPubkey !== expectedPubkey) {
+        return { ok: false, error: 'auth_challenge_invalid', reason: 'walletPubkey echoed by Jupiter does not match the active wallet' };
+    }
+    return { ok: true };
+}
+
+/**
+ * Parse a transaction-challenge tx (base64) and validate that it's a
+ * memo-only Jupiter auth transaction (no Transfer, swap, closeAccount, or
+ * any value-moving instruction). Memo program ID is the well-known SPL
+ * Memo v2: `MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`.
+ *
+ * Constraints checked:
+ *   1. Buffer decodes to a plausible Solana tx (signatures + message).
+ *   2. Fee payer (first account) equals expectedPubkey.
+ *   3. EVERY instruction's program id is the Memo program. No other
+ *      programs (no SystemProgram::Transfer, no Token program, no swap,
+ *      no closeAccount — nothing that can move value or state).
+ *
+ * Returns { ok: true } or { ok: false, error, reason }.
+ */
+const MEMO_PROGRAM_V2 = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+const MEMO_PROGRAM_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo';
+
+function _validateAuthTransaction(txBase64, expectedPubkey) {
+    if (typeof txBase64 !== 'string' || txBase64.length === 0) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'empty transaction payload' };
+    }
+    let txBuf;
+    try {
+        txBuf = Buffer.from(txBase64, 'base64');
+    } catch (_) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'transaction is not valid base64' };
+    }
+    if (txBuf.length < 64) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'transaction shorter than one signature slot' };
+    }
+
+    let offset = 0;
+    const sigCount = _readCompactU16(txBuf, offset);
+    if (!sigCount) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'malformed signature count' };
+    }
+    offset = sigCount.offset + sigCount.value * 64;
+    if (offset >= txBuf.length) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'transaction truncated before message header' };
+    }
+
+    // v0 prefix (0x80) means versioned message; otherwise legacy. We accept
+    // both — auth memos are typically legacy.
+    let messageOffset = offset;
+    const versionByte = txBuf[messageOffset];
+    if (versionByte === 0x80) {
+        messageOffset += 1; // skip v0 byte
+    }
+
+    // Message header: 3 bytes
+    if (messageOffset + 3 > txBuf.length) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'message header truncated' };
+    }
+    messageOffset += 3; // numRequired, numReadonlySigned, numReadonlyUnsigned
+
+    const acctCount = _readCompactU16(txBuf, messageOffset);
+    if (!acctCount) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'malformed account count' };
+    }
+    messageOffset = acctCount.offset;
+    const accountKeys = [];
+    for (let i = 0; i < acctCount.value; i++) {
+        if (messageOffset + 32 > txBuf.length) {
+            return { ok: false, error: 'auth_tx_invalid', reason: 'account key array truncated' };
+        }
+        accountKeys.push(_base58Encode(txBuf.slice(messageOffset, messageOffset + 32)));
+        messageOffset += 32;
+    }
+    if (accountKeys.length === 0) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'no account keys' };
+    }
+
+    // First account is the fee payer.
+    if (accountKeys[0] !== expectedPubkey) {
+        return {
+            ok: false,
+            error: 'auth_tx_invalid',
+            reason: `fee payer mismatch: tx pays from ${accountKeys[0]}, expected ${expectedPubkey}`,
+        };
+    }
+
+    // Skip recent blockhash (32 bytes).
+    messageOffset += 32;
+    if (messageOffset > txBuf.length) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'message truncated before instructions' };
+    }
+
+    const instrCount = _readCompactU16(txBuf, messageOffset);
+    if (!instrCount) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'malformed instruction count' };
+    }
+    messageOffset = instrCount.offset;
+    if (instrCount.value === 0) {
+        return { ok: false, error: 'auth_tx_invalid', reason: 'auth tx must contain at least one Memo instruction' };
+    }
+
+    for (let i = 0; i < instrCount.value; i++) {
+        if (messageOffset + 1 > txBuf.length) {
+            return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} truncated at program id index` };
+        }
+        const programIdx = txBuf[messageOffset]; messageOffset += 1;
+        if (programIdx >= accountKeys.length) {
+            return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} program index ${programIdx} out of range` };
+        }
+        const programId = accountKeys[programIdx];
+        if (programId !== MEMO_PROGRAM_V2 && programId !== MEMO_PROGRAM_V1) {
+            return {
+                ok: false,
+                error: 'auth_tx_invalid',
+                reason: `instruction ${i} references non-Memo program ${programId} — auth tx must be Memo-only`,
+            };
+        }
+        // Skip accounts compact-u16 + bytes
+        const acctIdx = _readCompactU16(txBuf, messageOffset);
+        if (!acctIdx) {
+            return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} malformed accounts count` };
+        }
+        messageOffset = acctIdx.offset + acctIdx.value;
+        // Skip data compact-u16 + bytes
+        const dataLen = _readCompactU16(txBuf, messageOffset);
+        if (!dataLen) {
+            return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} malformed data length` };
+        }
+        messageOffset = dataLen.offset + dataLen.value;
+        if (messageOffset > txBuf.length) {
+            return { ok: false, error: 'auth_tx_invalid', reason: `instruction ${i} data truncated` };
+        }
+    }
+
+    return { ok: true };
+}
+
+// Compact-u16 reader. Returns { value, offset } or null if malformed.
+function _readCompactU16(buf, offset) {
+    if (offset >= buf.length) return null;
+    let v = 0, shift = 0, i = offset;
+    while (i < buf.length) {
+        const b = buf[i]; i += 1;
+        v |= (b & 0x7f) << shift;
+        if ((b & 0x80) === 0) return { value: v, offset: i };
+        shift += 7;
+        if (shift > 14) return null;
+    }
+    return null;
+}
+
+// Minimal base58 encoder for account keys. Mirrors solana.js::base58Encode
+// (avoids requiring it to keep this module dependency-free / testable).
+const _BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+function _base58Encode(buf) {
+    if (!buf || buf.length === 0) return '';
+    let zeros = 0;
+    while (zeros < buf.length && buf[zeros] === 0) zeros += 1;
+    const digits = [0];
+    for (let i = zeros; i < buf.length; i++) {
+        let carry = buf[i];
+        for (let j = 0; j < digits.length; j++) {
+            carry += digits[j] << 8;
+            digits[j] = carry % 58;
+            carry = (carry / 58) | 0;
+        }
+        while (carry) {
+            digits.push(carry % 58);
+            carry = (carry / 58) | 0;
+        }
+    }
+    let str = '1'.repeat(zeros);
+    for (let i = digits.length - 1; i >= 0; i--) str += _BASE58_ALPHABET[digits[i]];
+    return str;
+}
+
+// ── Auth ────────────────────────────────────────────────────────────────────
+
+/**
+ * Cached JWT lookup. Returns { token } or null when miss/expired.
+ */
+function _getCachedJwt(pubkey) {
+    const entry = _jwtCache.get(pubkey);
+    if (!entry) return null;
+    if (Date.now() + JWT_SKEW_MS >= entry.expiresAt) {
+        _jwtCache.delete(pubkey);
+        return null;
+    }
+    return { token: entry.token };
+}
+
+function invalidateJwt(pubkey) {
+    _jwtCache.delete(pubkey);
+}
+
+/**
+ * Authenticate a wallet and return a Bearer token. Cached for 24h - 60s.
+ *
+ * @param {string} pubkey  - base58 wallet pubkey to authenticate
+ * @param {object} signers - { signTransaction(b64) → b64signed, signMessage?(bytes) → b58sig }
+ *                           signMessage is OPTIONAL. When null/undefined, transaction-challenge is used.
+ * @returns {Promise<{ok: true, token, cached?: boolean} | {ok: false, error, reason}>}
+ */
+async function authenticate(pubkey, signers) {
+    if (typeof pubkey !== 'string' || pubkey.length === 0) {
+        return { ok: false, error: 'invalid_input', reason: 'pubkey required' };
+    }
+    if (!signers || typeof signers.signTransaction !== 'function') {
+        return { ok: false, error: 'invalid_input', reason: 'signers.signTransaction required' };
+    }
+    const keyErr = _ensureApiKey();
+    if (keyErr) return { ok: false, ...keyErr };
+
+    // Cache hit?
+    const cached = _getCachedJwt(pubkey);
+    if (cached) {
+        return { ok: true, token: cached.token, cached: true };
+    }
+
+    // Prefer message challenge when the wallet supports it. Per Codex round-2
+    // #3: fallback to transaction ONLY on an unsupported-capability error,
+    // never on user rejection. The adapter encodes this as: if signMessage
+    // is provided, try it; if it returns `{ error: 'unsupported_capability' }`
+    // (or any error shape with `unsupported: true`), fall back. Any OTHER
+    // error (user_rejected, timeout, etc.) is surfaced WITHOUT fallback so
+    // a denial can't be parlayed into a second consent prompt.
+    if (typeof signers.signMessage === 'function') {
+        const msgResult = await _authenticateMessage(pubkey, signers);
+        if (msgResult.ok) {
+            _cacheJwt(pubkey, msgResult.token);
+            return { ok: true, token: msgResult.token };
+        }
+        const isUnsupported = msgResult.unsupported === true
+            || msgResult.error === 'unsupported_capability';
+        if (!isUnsupported) {
+            // Surface message-path failure WITHOUT falling back. A user
+            // rejection or timeout must not be silently re-prompted as a
+            // tx-challenge — that would convert a no into a second yes/no.
+            return { ok: false, error: msgResult.error || 'auth_failed', reason: msgResult.reason };
+        }
+        log(`[trigger-v2] message-challenge unsupported, falling back to transaction-challenge for ${_redactPubkey(pubkey)}`, 'INFO');
+    }
+
+    const txResult = await _authenticateTransaction(pubkey, signers);
+    if (!txResult.ok) return txResult;
+    _cacheJwt(pubkey, txResult.token);
+    return { ok: true, token: txResult.token };
+}
+
+async function _authenticateMessage(pubkey, signers) {
+    const challengeRes = await _post(
+        '/trigger/v2/auth/challenge',
+        { walletPubkey: pubkey, type: 'message' },
+    );
+    if (challengeRes.status !== 200) {
+        return { ok: false, error: 'auth_challenge_failed', reason: `HTTP ${challengeRes.status}` };
+    }
+    const validation = _validateChallengePayload(challengeRes.data, pubkey);
+    if (!validation.ok) return { ok: false, error: validation.error, reason: validation.reason };
+    if (challengeRes.data.type !== 'message') {
+        return { ok: false, error: 'auth_challenge_invalid', reason: `expected message challenge, got ${challengeRes.data.type}` };
+    }
+
+    const signature = await signers.signMessage(Buffer.from(challengeRes.data.challenge, 'utf8'));
+    if (!signature || typeof signature !== 'object' && typeof signature !== 'string') {
+        return { ok: false, error: 'auth_sign_failed', reason: 'signMessage returned no result' };
+    }
+    if (typeof signature === 'object' && signature.error) {
+        return {
+            ok: false,
+            error: signature.error,
+            reason: signature.reason,
+            unsupported: signature.unsupported === true || signature.error === 'unsupported_capability',
+        };
+    }
+    const sigB58 = typeof signature === 'string' ? signature : signature.signatureBase58;
+    if (!sigB58) {
+        return { ok: false, error: 'auth_sign_failed', reason: 'signMessage returned no signatureBase58' };
+    }
+
+    const verifyRes = await _post(
+        '/trigger/v2/auth/verify',
+        { type: 'message', walletPubkey: pubkey, signature: sigB58 },
+    );
+    if (verifyRes.status !== 200) {
+        return { ok: false, error: 'auth_verify_failed', reason: `HTTP ${verifyRes.status}` };
+    }
+    if (!verifyRes.data || typeof verifyRes.data.token !== 'string') {
+        return { ok: false, error: 'auth_verify_failed', reason: 'no token in verify response' };
+    }
+    return { ok: true, token: verifyRes.data.token };
+}
+
+async function _authenticateTransaction(pubkey, signers) {
+    const challengeRes = await _post(
+        '/trigger/v2/auth/challenge',
+        { walletPubkey: pubkey, type: 'transaction' },
+    );
+    if (challengeRes.status !== 200) {
+        return { ok: false, error: 'auth_challenge_failed', reason: `HTTP ${challengeRes.status}` };
+    }
+    const validation = _validateChallengePayload(challengeRes.data, pubkey);
+    if (!validation.ok) return { ok: false, error: validation.error, reason: validation.reason };
+    if (challengeRes.data.type !== 'transaction') {
+        return { ok: false, error: 'auth_challenge_invalid', reason: `expected transaction challenge, got ${challengeRes.data.type}` };
+    }
+    const txValidation = _validateAuthTransaction(challengeRes.data.transaction, pubkey);
+    if (!txValidation.ok) {
+        log(`[trigger-v2] BLIND-SIGN GUARD blocked auth tx for ${_redactPubkey(pubkey)}: ${txValidation.reason}`, 'WARN');
+        return { ok: false, error: txValidation.error, reason: txValidation.reason };
+    }
+
+    const signed = await signers.signTransaction(challengeRes.data.transaction);
+    if (!signed || (typeof signed === 'object' && signed.error)) {
+        return {
+            ok: false,
+            error: (signed && signed.error) || 'auth_sign_failed',
+            reason: (signed && signed.reason) || 'signTransaction returned no result',
+        };
+    }
+    const signedB64 = typeof signed === 'string' ? signed : (signed.signedTxBase64 || signed.signedTransaction);
+    if (!signedB64) {
+        return { ok: false, error: 'auth_sign_failed', reason: 'signTransaction returned no signedTxBase64' };
+    }
+
+    const verifyRes = await _post(
+        '/trigger/v2/auth/verify',
+        { type: 'transaction', walletPubkey: pubkey, signedTransaction: signedB64 },
+    );
+    if (verifyRes.status !== 200) {
+        return { ok: false, error: 'auth_verify_failed', reason: `HTTP ${verifyRes.status}` };
+    }
+    if (!verifyRes.data || typeof verifyRes.data.token !== 'string') {
+        return { ok: false, error: 'auth_verify_failed', reason: 'no token in verify response' };
+    }
+    return { ok: true, token: verifyRes.data.token };
+}
+
+function _cacheJwt(pubkey, token) {
+    _jwtCache.set(pubkey, { token, expiresAt: Date.now() + JWT_TTL_MS });
+}
+
+function _redactPubkey(pubkey) {
+    if (typeof pubkey !== 'string' || pubkey.length < 8) return '<pubkey>';
+    return `${pubkey.slice(0, 4)}…${pubkey.slice(-4)}`;
+}
+
+// ── Vault registration (lazy per Codex round-2 #4) ──────────────────────────
+
+/**
+ * Ensure the wallet has a Jupiter/Privy vault. GETs vault address; if not
+ * registered, POSTs /vault/register. Cached in-memory per pubkey for the
+ * Node lifetime — vault registration is one-shot per wallet.
+ */
+async function ensureVault(pubkey, token) {
+    const cached = _vaultCache.get(pubkey);
+    if (cached && cached.registered) return { ok: true, vaultAddress: cached.vaultAddress };
+
+    const getRes = await _get(`/trigger/v2/vault?walletPubkey=${encodeURIComponent(pubkey)}`, token);
+    if (getRes.status === 200 && getRes.data && getRes.data.registered === true && getRes.data.vaultAddress) {
+        _vaultCache.set(pubkey, { vaultAddress: getRes.data.vaultAddress, registered: true });
+        return { ok: true, vaultAddress: getRes.data.vaultAddress };
+    }
+
+    // Not registered (or vault endpoint returns 404 for unregistered) — POST register.
+    const regRes = await _post('/trigger/v2/vault/register', { walletPubkey: pubkey }, token);
+    if (regRes.status !== 200 && regRes.status !== 201) {
+        return { ok: false, error: 'vault_register_failed', reason: `HTTP ${regRes.status}` };
+    }
+    if (!regRes.data || !regRes.data.vaultAddress) {
+        return { ok: false, error: 'vault_register_failed', reason: 'no vaultAddress in response' };
+    }
+    _vaultCache.set(pubkey, { vaultAddress: regRes.data.vaultAddress, registered: true });
+    return { ok: true, vaultAddress: regRes.data.vaultAddress };
+}
+
+// ── V2 semantic validation (contract v2 §6) ─────────────────────────────────
+
+/**
+ * Validate the user-supplied order args BEFORE any auth/deposit work. Pure —
+ * no I/O — so the agent gets an immediate, deterministic rejection on bad
+ * input rather than burning a deposit signing on a doomed order.
+ *
+ * inputUsdValue is the caller-computed USD value of `inputAmount`. The
+ * adapter doesn't fetch prices itself to keep the module pure and testable;
+ * the tool handler resolves the price via the existing `jupiterPrice()` call
+ * and passes the result in.
+ */
+function validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippageBps }) {
+    if (!Number.isFinite(inputUsdValue) || inputUsdValue <= 0) {
+        return { ok: false, error: 'input_usd_value_invalid', reason: 'caller must supply inputUsdValue as a positive number' };
+    }
+    if (inputUsdValue < MIN_ORDER_USD) {
+        return {
+            ok: false,
+            error: 'min_order_size_below_10_usd',
+            reason: `Order size $${inputUsdValue.toFixed(2)} is below Jupiter Trigger V2's $${MIN_ORDER_USD} minimum.`,
+        };
+    }
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs < Date.now() + MIN_EXPIRY_SKEW_MS) {
+        return {
+            ok: false,
+            error: 'expires_at_too_soon',
+            reason: 'expiresAt must be at least 1 minute in the future.',
+        };
+    }
+    if (!Number.isFinite(triggerPriceUsd) || triggerPriceUsd <= 0) {
+        return {
+            ok: false,
+            error: 'trigger_price_required',
+            reason: 'triggerPriceUsd is required and must be a positive number (USD, e.g., 80.50 for $80.50).',
+        };
+    }
+    if (slippageBps != null) {
+        if (!Number.isInteger(slippageBps) || slippageBps < MIN_SLIPPAGE_BPS || slippageBps > MAX_SLIPPAGE_BPS) {
+            return {
+                ok: false,
+                error: 'slippage_out_of_range',
+                reason: `slippageBps must be an integer between ${MIN_SLIPPAGE_BPS} and ${MAX_SLIPPAGE_BPS} (0.01% to 100%).`,
+            };
+        }
+    }
+    return { ok: true };
+}
+
+// ── Low-level create primitives ─────────────────────────────────────────────
+//
+// The tool handler composes these with the existing wallet/dispatch helpers
+// (routeAndSign) so the burner reservation lifecycle (reserve → sign-with-
+// reservation → commit/release) wraps the deposit signing step.
+//
+// Sequence:
+//   1. tool handler calls depositCraft(...) → { transaction, depositRequestId, recoveryContext }
+//   2. tool handler calls routeAndSign(unsignedTx=transaction, broadcast: async signedDepositTx => {
+//          return submitCreateOrder({ recoveryContext, depositSignedTx: signedDepositTx, order, ... });
+//      })
+//   3. routeAndSign handles burner reserve/sign/commit-or-release (or main MWA sign-only)
+//   4. submitCreateOrder runs ambiguous-recovery on lost responses
+//
+// Why two primitives instead of one high-level fn: routeAndSign's reservation
+// spans sign + broadcast (= POST to /orders/price), and commit/release fires
+// based on the broadcast result. To get that lifecycle right, the tool handler
+// has to drive both halves explicitly.
+
+/**
+ * POST /trigger/v2/deposit/craft. Returns the unsigned deposit tx + the
+ * depositRequestId that must accompany the eventual /orders/price POST.
+ *
+ * Caller is responsible for signing the returned transaction and passing
+ * both the signed tx AND the recoveryContext to submitCreateOrder.
+ *
+ * recoveryContext is opaque to the caller — it carries the metadata
+ * needed to find the order in /orders/history if the create POST is lost
+ * after deposit signing. Caller must NOT persist or log it.
+ */
+async function depositCraft({ pubkey, token, inputMint, inputAmount }) {
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    const craftRes = await _post('/trigger/v2/deposit/craft', {
+        walletPubkey: pubkey,
+        orderType: 'price',
+        orderSubType: 'single',
+        inputMint,
+        inputAmount,
+    }, token);
+    if (craftRes.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by deposit/craft' };
+    }
+    if (craftRes.status !== 200) {
+        return { ok: false, error: 'deposit_craft_failed', reason: `HTTP ${craftRes.status}` };
+    }
+    if (!craftRes.data || typeof craftRes.data.transaction !== 'string' || !craftRes.data.depositRequestId) {
+        return { ok: false, error: 'deposit_craft_failed', reason: 'response missing transaction or depositRequestId' };
+    }
+    const recoveryContext = {
+        walletPubkey: pubkey,
+        depositRequestId: craftRes.data.depositRequestId,
+        inputMint,
+        inputAmount,
+        timestamp: Date.now(),
+    };
+    log(`[trigger-v2] deposit/craft wallet=${_redactPubkey(pubkey)} input=${inputMint} amount=${inputAmount} depositRequestId=${recoveryContext.depositRequestId}`, 'INFO');
+    return {
+        ok: true,
+        transaction: craftRes.data.transaction,
+        depositRequestId: craftRes.data.depositRequestId,
+        recoveryContext,
+    };
+}
+
+/**
+ * POST /trigger/v2/orders/price. Runs ambiguous-create recovery on lost or
+ * incomplete responses (status >= 500, status 200 but missing id, network
+ * exceptions). Never auto-retries a non-idempotent create POST.
+ *
+ * @param {object} params
+ * @param {string} params.token
+ * @param {object} params.recoveryContext - from depositCraft()
+ * @param {string} params.depositSignedTx - caller-signed deposit tx
+ * @param {object} params.order - { inputMint, inputAmount, outputMint, triggerMint?, triggerPriceUsd, triggerCondition?, slippageBps?, expiresAtMs }
+ */
+async function submitCreateOrder({ token, recoveryContext, depositSignedTx, order }) {
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    if (!recoveryContext || !recoveryContext.walletPubkey || !recoveryContext.depositRequestId) {
+        return { ok: false, error: 'invalid_input', reason: 'recoveryContext required (from depositCraft)' };
+    }
+    if (typeof depositSignedTx !== 'string' || depositSignedTx.length === 0) {
+        return { ok: false, error: 'invalid_input', reason: 'depositSignedTx required' };
+    }
+
+    const createBody = {
+        orderType: 'single',
+        depositRequestId: recoveryContext.depositRequestId,
+        depositSignedTx,
+        userPubkey: recoveryContext.walletPubkey,
+        inputMint: order.inputMint,
+        inputAmount: order.inputAmount,
+        outputMint: order.outputMint,
+        triggerMint: order.triggerMint || order.outputMint,
+        expiresAt: Math.floor(order.expiresAtMs / 1000),
+        triggerCondition: order.triggerCondition || 'below',
+        triggerPriceUsd: order.triggerPriceUsd,
+    };
+    if (order.slippageBps != null) createBody.slippageBps = order.slippageBps;
+
+    let createRes;
+    try {
+        createRes = await _post('/trigger/v2/orders/price', createBody, token);
+    } catch (e) {
+        log(`[trigger-v2] create POST threw after signed deposit: ${e.message} — entering recovery`, 'WARN');
+        return await _recoverFromAmbiguousCreate(recoveryContext, token);
+    }
+
+    if (createRes.status === 401) {
+        invalidateJwt(recoveryContext.walletPubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by orders/price', recovery: recoveryContext };
+    }
+
+    if (createRes.status >= 500 || !createRes.data || (createRes.status === 200 && !createRes.data.id)) {
+        log(`[trigger-v2] ambiguous create response (status=${createRes.status}, hasId=${!!(createRes.data && createRes.data.id)}) — entering recovery`, 'WARN');
+        return await _recoverFromAmbiguousCreate(recoveryContext, token);
+    }
+
+    if (createRes.status !== 200) {
+        return { ok: false, error: 'create_failed', reason: `HTTP ${createRes.status}` };
+    }
+
+    return {
+        ok: true,
+        id: createRes.data.id,
+        txSignature: createRes.data.txSignature || null,
+        depositRequestId: recoveryContext.depositRequestId,
+    };
+}
+
+/**
+ * Ambiguous-create recovery (contract v2 §5).
+ *
+ * Sequence:
+ *   1. Wait 5s for any in-flight settle on Jupiter's side.
+ *   2. Query /orders/history filtered by walletPubkey; look for the most
+ *      recent active or pending_deposit order matching our inputMint +
+ *      inputAmount (recorded in `ctx`).
+ *   3. If found → success, with `recovered: true` flag.
+ *   4. If not found → return orphan-deposit advisory with the
+ *      depositRequestId so the user can check Jupiter UI manually.
+ *
+ * NEVER auto-retries the create POST — non-idempotent + funds-moving.
+ */
+async function _recoverFromAmbiguousCreate(ctx, token) {
+    log(`[trigger-v2] recovery: waiting 5s before /orders/history query for depositRequestId=${ctx.depositRequestId}`, 'INFO');
+    await new Promise(r => setTimeout(r, 5000));
+
+    const histRes = await _get(`/trigger/v2/orders/history?walletPubkey=${encodeURIComponent(ctx.walletPubkey)}&limit=20`, token);
+    if (histRes.status === 200 && histRes.data && Array.isArray(histRes.data.orders)) {
+        const matchTime = ctx.timestamp - 60_000; // accept anything from 1min before our attempt
+        const match = histRes.data.orders.find(o =>
+            o
+            && (o.status === 'active' || o.status === 'pending_deposit' || o.vaultState === 'pending_deposit')
+            && o.inputMint === ctx.inputMint
+            && String(o.inputAmount) === String(ctx.inputAmount)
+            && (!o.createdAt || new Date(o.createdAt).getTime() >= matchTime)
+        );
+        if (match && match.id) {
+            log(`[trigger-v2] recovery: matched order id=${match.id} in history`, 'INFO');
+            return {
+                ok: true,
+                id: match.id,
+                txSignature: match.txSignature || null,
+                depositRequestId: ctx.depositRequestId,
+                recovered: true,
+                recoveryNote: 'Order found in /orders/history after lost create response.',
+            };
+        }
+    }
+
+    return {
+        ok: false,
+        error: 'create_ambiguous_no_recovery',
+        reason:
+            'Create POST response was lost AND /orders/history showed no matching order. ' +
+            `Deposit may still be in flight or stuck. Check Jupiter UI for depositRequestId=${ctx.depositRequestId}. ` +
+            'Funds will appear in the Jupiter vault if the deposit landed; cancel or use Jupiter UI to recover.',
+        recovery: ctx,
+    };
+}
+
+// ── Two-step cancel primitives ──────────────────────────────────────────────
+//
+// Same composability rationale as create: tool handler drives the signing
+// step explicitly so burner-owned cancels can flow through signCancelViaBurner
+// (zero-cap reservation, ownership-gated) and main-owned cancels through
+// /solana/sign-only.
+
+/**
+ * POST /trigger/v2/orders/price/cancel/{id}. Returns unsigned cancel tx +
+ * the cancelRequestId that must accompany confirmCancel.
+ */
+async function cancelStep1({ orderId, pubkey, token }) {
+    if (!orderId) return { ok: false, error: 'invalid_input', reason: 'orderId required' };
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    const res = await _post(`/trigger/v2/orders/price/cancel/${encodeURIComponent(orderId)}`, {}, token);
+    if (res.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by cancel step 1' };
+    }
+    if (res.status !== 200) {
+        return { ok: false, error: 'cancel_step1_failed', reason: `HTTP ${res.status}` };
+    }
+    if (!res.data || typeof res.data.transaction !== 'string' || !res.data.requestId) {
+        return { ok: false, error: 'cancel_step1_failed', reason: 'response missing transaction or requestId' };
+    }
+    return { ok: true, transaction: res.data.transaction, cancelRequestId: res.data.requestId };
+}
+
+/**
+ * POST /trigger/v2/orders/price/confirm-cancel/{id}. Takes the signed cancel
+ * tx + the cancelRequestId from cancelStep1. Returns the executed signature
+ * on success.
+ */
+async function confirmCancel({ orderId, pubkey, token, signedTransaction, cancelRequestId }) {
+    if (!orderId) return { ok: false, error: 'invalid_input', reason: 'orderId required' };
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    if (typeof signedTransaction !== 'string' || !signedTransaction) {
+        return { ok: false, error: 'invalid_input', reason: 'signedTransaction required' };
+    }
+    if (!cancelRequestId) return { ok: false, error: 'invalid_input', reason: 'cancelRequestId required (from cancelStep1)' };
+    const res = await _post(
+        `/trigger/v2/orders/price/confirm-cancel/${encodeURIComponent(orderId)}`,
+        { signedTransaction, cancelRequestId },
+        token,
+    );
+    if (res.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by confirm-cancel' };
+    }
+    if (res.status !== 200) {
+        return { ok: false, error: 'confirm_cancel_failed', reason: `HTTP ${res.status}` };
+    }
+    return { ok: true, id: orderId, txSignature: (res.data && res.data.txSignature) || null };
+}
+
+// ── List orders ─────────────────────────────────────────────────────────────
+
+/**
+ * List orders from /orders/history. Optional status filter ("active" / "history"
+ * mirrors V1 UX; V2 history endpoint covers both via filter).
+ */
+async function listOrders({ pubkey, token, status, page, limit }) {
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    const params = new URLSearchParams({ walletPubkey: pubkey });
+    if (status) params.set('status', status);
+    if (page != null) params.set('page', String(page));
+    if (limit != null) params.set('limit', String(limit));
+    const res = await _get(`/trigger/v2/orders/history?${params.toString()}`, token);
+    if (res.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by orders/history' };
+    }
+    if (res.status !== 200) {
+        return { ok: false, error: 'list_failed', reason: `HTTP ${res.status}` };
+    }
+    const orders = (res.data && Array.isArray(res.data.orders)) ? res.data.orders : [];
+    return { ok: true, orders };
+}
+
+// ── Update order (PATCH) ────────────────────────────────────────────────────
+
+/**
+ * Update an existing V2 price order's triggerPriceUsd or slippageBps.
+ * V1 had no equivalent; exposed here for completeness but not wired into
+ * a tool handler in PR B (no V1 tool to migrate). Future BAT can add a
+ * `jupiter_trigger_update` tool against this helper.
+ */
+async function updateOrder({ orderId, token, pubkey, triggerPriceUsd, slippageBps }) {
+    if (!orderId) return { ok: false, error: 'invalid_input', reason: 'orderId required' };
+    if (!token) return { ok: false, error: 'auth_required', reason: 'no JWT supplied — call authenticate() first' };
+    const body = { orderType: 'single' };
+    if (triggerPriceUsd != null) body.triggerPriceUsd = triggerPriceUsd;
+    if (slippageBps != null) body.slippageBps = slippageBps;
+    const res = await _patch(`/trigger/v2/orders/price/${encodeURIComponent(orderId)}`, body, token);
+    if (res.status === 401) {
+        invalidateJwt(pubkey);
+        return { ok: false, error: 'auth_expired', reason: 'JWT rejected by update' };
+    }
+    if (res.status !== 200) {
+        return { ok: false, error: 'update_failed', reason: `HTTP ${res.status}` };
+    }
+    return { ok: true, id: (res.data && res.data.id) || orderId };
+}
+
+// ── Test-only ───────────────────────────────────────────────────────────────
+
+function _resetCachesForTests() {
+    _jwtCache.clear();
+    _vaultCache.clear();
+}
+
+module.exports = {
+    // High-level (single-shot, no signing-step composition needed).
+    authenticate,
+    invalidateJwt,
+    ensureVault,
+    listOrders,
+    updateOrder,
+    validateOrderArgs,
+    // Low-level (caller drives signing between primitives so reservation
+    // lifecycles can wrap the deposit/cancel sign step).
+    depositCraft,
+    submitCreateOrder,
+    cancelStep1,
+    confirmCancel,
+    // Exported for tests + cross-module use of the guards.
+    _validateChallengePayload,
+    _validateAuthTransaction,
+    _resetCachesForTests,
+    _redactPubkey,
+    // Constants useful to callers/tests.
+    MIN_ORDER_USD,
+    DEFAULT_SLIPPAGE_BPS,
+    MEMO_PROGRAM_V1,
+    MEMO_PROGRAM_V2,
+};

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -1,7 +1,7 @@
 // tools/index.js — Tool registry + executeTool() dispatcher (BAT-470)
 // Merges all domain modules, builds handler dispatch map, routes tool calls.
 
-const { log, CHANNEL } = require('../config');
+const { log, CHANNEL, config: _runtimeConfig } = require('../config');
 const channel = require('../channel');
 // BAT-582 R1: BigInt-safe decimal math for monetary values (e.g. DCA total
 // deposit display). Avoids JS Number coercion on user-supplied strings.
@@ -313,7 +313,16 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
                 // rendered `Trigger price: undefined` for V2 main-wallet
                 // creates — the user would be asked to approve a card that
                 // didn't describe the price they were authorizing.
-                const priceLine = input.triggerPriceUsd != null
+                //
+                // PR #388 R10: branch on the ACTIVE flag (config.useTriggerV2),
+                // NOT on which field happens to be present. Tool inputs are
+                // not runtime-stripped to the schema — a flag-off V1 call
+                // could include a stray `triggerPriceUsd` and pre-fix would
+                // display the USD card while the handler created a V1 ratio
+                // order. The card MUST match the transaction semantics that
+                // will actually be authorized.
+                const useV2 = _runtimeConfig && _runtimeConfig.useTriggerV2 === true;
+                const priceLine = useV2
                     ? `Trigger price: $${esc(input.triggerPriceUsd)} USD`
                     : `Trigger price: ${esc(input.triggerPrice)} (${esc(input.outputToken)} per ${esc(input.inputToken)})`;
                 details = `📊 **Create Trigger Order**\n  Sell: ${esc(input.inputAmount)} ${esc(input.inputToken)}\n  For: ${esc(input.outputToken)}\n  ${priceLine}`;

--- a/app/src/main/assets/nodejs-project/tools/index.js
+++ b/app/src/main/assets/nodejs-project/tools/index.js
@@ -307,9 +307,18 @@ function formatConfirmationMessage(toolName, input, policyMessage) {
             case 'solana_swap':
                 details = `🔄 **Swap Tokens**\n  Sell: ${esc(input.amount)} ${esc(input.inputToken)}\n  Buy: ${esc(input.outputToken)}`;
                 break;
-            case 'jupiter_trigger_create':
-                details = `📊 **Create Trigger Order**\n  Sell: ${esc(input.inputAmount)} ${esc(input.inputToken)}\n  For: ${esc(input.outputToken)}\n  Trigger price: ${esc(input.triggerPrice)}`;
+            case 'jupiter_trigger_create': {
+                // PR #388 R6: V2 callers pass `triggerPriceUsd` (USD) instead
+                // of the V1 `triggerPrice` (token ratio). Pre-fix this line
+                // rendered `Trigger price: undefined` for V2 main-wallet
+                // creates — the user would be asked to approve a card that
+                // didn't describe the price they were authorizing.
+                const priceLine = input.triggerPriceUsd != null
+                    ? `Trigger price: $${esc(input.triggerPriceUsd)} USD`
+                    : `Trigger price: ${esc(input.triggerPrice)} (${esc(input.outputToken)} per ${esc(input.inputToken)})`;
+                details = `📊 **Create Trigger Order**\n  Sell: ${esc(input.inputAmount)} ${esc(input.inputToken)}\n  For: ${esc(input.outputToken)}\n  ${priceLine}`;
                 break;
+            }
             case 'jupiter_dca_create': {
                 // BAT-582 R1: total deposit was previously computed via
                 // `input.amountPerCycle * (input.totalCycles || 30)` — JS

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -496,12 +496,40 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
             return { error: 'price_lookup_failed', reason: e.message };
         }
 
-        // 7. Resolve V2-specific args (with V1-compat fallbacks).
-        const triggerPriceUsd = Number(input.triggerPriceUsd ?? input.triggerPrice);
+        // 7. Resolve V2-specific args. PR #388 R4 hardened the contract:
+        // V2 REQUIRES explicit triggerPriceUsd and explicit expiry. No silent
+        // fallbacks — they were causing two real failure modes:
+        //   (a) Falling back to the V1 `triggerPrice` field silently reused a
+        //       ratio value (V1 semantic) as if it were a USD price (V2
+        //       semantic). For most pairs the order would fire at the wrong
+        //       price; for a stablecoin-to-asset buy where the ratio
+        //       coincidentally lands near $X, the user would never notice.
+        //   (b) Defaulting expiresAt to "30 days from now" silently locked
+        //       funds into a much longer order than the caller intended.
+        // Both fail loudly now; consumers MUST migrate to V2 field names.
+        if (input.triggerPriceUsd == null) {
+            return {
+                error: 'trigger_price_usd_required',
+                reason: 'V2 requires explicit `triggerPriceUsd` (USD price; e.g. 80.5). The V1 `triggerPrice` field was a token ratio with a different meaning and is not accepted by the V2 path — see PR #388.',
+            };
+        }
+        const triggerPriceUsd = Number(input.triggerPriceUsd);
         const slippageBps = input.slippageBps != null ? Number(input.slippageBps) : triggerV2.DEFAULT_SLIPPAGE_BPS;
-        const expiresAtMs = input.expiresAt != null
-            ? Number(input.expiresAt) * (Number(input.expiresAt) < 10_000_000_000 ? 1000 : 1) // accept s or ms
-            : (input.expiryTime != null ? Number(input.expiryTime) * 1000 : Date.now() + 30 * 24 * 60 * 60 * 1000);
+        // expiresAt MUST be provided (in seconds OR ms — heuristic still
+        // accepts either unit) OR expiryTime (legacy V1 alias, Unix seconds).
+        // No silent default — fail loud if neither is set.
+        let expiresAtMs;
+        if (input.expiresAt != null) {
+            const n = Number(input.expiresAt);
+            expiresAtMs = n * (n < 10_000_000_000 ? 1000 : 1);
+        } else if (input.expiryTime != null) {
+            expiresAtMs = Number(input.expiryTime) * 1000; // legacy V1 alias (seconds)
+        } else {
+            return {
+                error: 'expires_at_required',
+                reason: 'V2 requires explicit `expiresAt` (Unix seconds OR ms) or legacy `expiryTime` (Unix seconds). No silent default — pass an explicit expiration timestamp. See PR #388.',
+            };
+        }
         const triggerCondition = _inferTriggerCondition(inputToken.address, outputToken.address, input.triggerCondition);
         if (!triggerCondition) {
             return {

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -426,6 +426,11 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         const routingHint = await _routeForTriggerV2('jupiter_trigger_create', input);
 
         // 4. Resolve wallet address — burner pubkey if routing=burner, MWA pubkey otherwise.
+        // If burner routing was chosen but the burner pubkey is unavailable
+        // (bridge unreachable, not configured, etc.), we MUST also flip the
+        // routing decision to 'main' before proceeding. Otherwise routeAndSign
+        // would re-evaluate routing as 'burner' and attempt to sign a tx
+        // whose fee payer is the MWA wallet — cap state and signer mismatch.
         let walletAddress;
         if (routingHint.routingDecision === 'burner') {
             try {
@@ -434,6 +439,10 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
                     walletAddress = burnerStatus.pubkey;
                 }
             } catch (_) { /* fall through */ }
+            if (!walletAddress) {
+                log('[Jupiter Trigger V2] burner routing chosen but pubkey unavailable — falling back to main wallet', 'WARN');
+                routingHint.routingDecision = 'main';
+            }
         }
         if (!walletAddress) {
             try { walletAddress = getConnectedWalletAddress(); }
@@ -663,17 +672,23 @@ async function _jupiterTriggerListV2(input, _chatId) {
             count: listResult.orders.length,
             wallet: walletAddress,
             note: 'V2 list shows main-wallet orders only. Burner-routed orders need separate auth (follow-up).',
+            // Field names verified live 2026-05-30: real rows use orderState,
+            // rawState, initialInputAmount, remainingInputAmount, fillPercent.
+            // The first-draft status/vaultState/inputAmount fields don't exist
+            // on the API — mapping them would return three `undefined`s per row.
             orders: listResult.orders.map(order => ({
                 orderId: order.id || order.orderId,
                 orderType: order.orderType,
                 inputMint: order.inputMint,
                 outputMint: order.outputMint,
-                inputAmount: order.inputAmount,
+                initialInputAmount: order.initialInputAmount,
+                remainingInputAmount: order.remainingInputAmount,
                 triggerPriceUsd: order.triggerPriceUsd,
                 triggerCondition: order.triggerCondition,
                 slippageBps: order.slippageBps,
-                status: order.status,
-                vaultState: order.vaultState,
+                orderState: order.orderState,
+                rawState: order.rawState,
+                fillPercent: order.fillPercent,
                 expiresAt: order.expiresAt,
                 createdAt: order.createdAt,
             })),
@@ -765,8 +780,8 @@ async function _jupiterTriggerCancelV2(input, _chatId) {
             try { await ensureWalletAuthorized(); }
             catch (e) { return { error: 'wallet_not_authorized', reason: e.message }; }
             const signRes = await androidBridgeCall('/solana/sign-only', { transaction: step1.transaction }, 120000);
-            if (signRes.error) return { error: signRes.error };
-            if (!signRes.signedTransaction) return { error: 'No signed transaction returned from wallet' };
+            if (signRes.error) return { error: signRes.error, reason: signRes.reason };
+            if (!signRes.signedTransaction) return { error: 'sign_failed', reason: 'No signed transaction returned from wallet' };
             signedCancelB64 = signRes.signedTransaction;
             signWallet = 'main';
         }

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -368,6 +368,31 @@ function _inferTriggerCondition(inputMint, outputMint, explicit) {
     return null;
 }
 
+/**
+ * Resolve which mint Jupiter should watch the USD price of (the
+ * `triggerMint` body field). The non-stable side of the pair — that's
+ * the asset whose USD price actually moves around the trigger value:
+ *   - Buying a non-stable with a stable (USDC → SOL, "below $80"):
+ *     trigger reads SOL's price → triggerMint = outputMint.
+ *   - Selling a non-stable for a stable (SOL → USDC, "above $90"):
+ *     trigger reads SOL's price → triggerMint = inputMint.
+ *   - Non-stable ↔ non-stable (rare, e.g. SOL ↔ JUP): no clean
+ *     inference; caller must pass explicit `input.triggerMint`. We
+ *     default to outputMint so the caller's explicit override is the
+ *     only correct path (the default will not fire usefully).
+ *
+ * The pre-fix shipped `triggerMint = outputMint` unconditionally, which
+ * for a sell-into-stable (e.g. SOL → USDC) made Jupiter watch USDC at
+ * ~$1 — the documented "SOL ≥ $90" limit-sell would never trigger
+ * (PR #388 R2 finding).
+ */
+function _inferTriggerMint(inputMint, outputMint, explicit) {
+    if (typeof explicit === 'string' && explicit.length > 0) return explicit;
+    if (_STABLE_MINTS.has(inputMint) && !_STABLE_MINTS.has(outputMint)) return outputMint;
+    if (_STABLE_MINTS.has(outputMint) && !_STABLE_MINTS.has(inputMint)) return inputMint;
+    return outputMint; // both-stable or both-non-stable: degenerate; caller should override.
+}
+
 async function _jupiterTriggerCreateV2(input, _chatId) {
     if (!config.jupiterApiKey) {
         return {
@@ -532,11 +557,16 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         }
 
         // 13. routeAndSign for the deposit signing + orders/price POST.
+        // PR #388 R2: derive triggerMint from the non-stable side of the
+        // pair (the asset whose USD price the trigger watches). Pre-fix
+        // unconditionally used outputMint, which broke sell-into-stable
+        // orders (SOL → USDC "above $90" would watch USDC's ~$1 price).
+        const triggerMint = _inferTriggerMint(inputToken.address, outputToken.address, input.triggerMint);
         const orderArgs = {
             inputMint: inputToken.address,
             inputAmount: String(inputAmountAtomic),
             outputMint: outputToken.address,
-            triggerMint: outputToken.address,
+            triggerMint,
             triggerPriceUsd,
             triggerCondition,
             slippageBps,

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -543,12 +543,17 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
             expiresAtMs,
         };
         let submitWarning = null;
+        // PR #388 R2: if our local burner-fallback fired above (we couldn't
+        // reach burner pubkey so flipped routingHint to 'main'), pass that
+        // override into routeAndSign so it does NOT re-route to burner and
+        // try to sign with a burner the deposit tx isn't paying from.
         const dispatchResult = await routeAndSign({
             toolName: 'jupiter_trigger_create',
             toolArgs: input,
             unsignedTxBase64: unsignedDepositTx,
             broadcastVia: 'jupiter',
             flowName: 'jupiter_trigger_create_v2',
+            forceRouting: routingHint,
             broadcast: async (txOrUnsigned, _signer, ctx) => {
                 let signedDeposit;
                 if (ctx && ctx.signed) {
@@ -610,10 +615,15 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         if (outputToken.warning) warnings.push(`⚠️ ${outputToken.symbol}: ${outputToken.warning}`);
         if (submitWarning) warnings.push(submitWarning);
 
+        // PR #388 R2: keep V1's `signature` field as an alias of `txSignature`
+        // so consumers (tool-result prompts, downstream parsers) that parse
+        // the V1 shape don't break when the flag is flipped.
+        const _sig = orderResult.txSignature || dispatchResult.signature || null;
         return {
             success: true,
             orderId,
-            txSignature: orderResult.txSignature || dispatchResult.signature || null,
+            txSignature: _sig,
+            signature: _sig,
             depositRequestId,
             inputToken: `${inputToken.symbol} (${inputToken.address})`,
             outputToken: `${outputToken.symbol} (${outputToken.address})`,
@@ -681,6 +691,14 @@ async function _jupiterTriggerListV2(input, _chatId) {
                 orderType: order.orderType,
                 inputMint: order.inputMint,
                 outputMint: order.outputMint,
+                // PR #388 R2: V1 listed orders under `inputToken`/`outputToken`
+                // aliases of the mint addresses. Kept here so consumers parsing
+                // the V1 shape don't see undefined when the flag is flipped.
+                // (V1 sometimes resolved these to symbols; we leave them as
+                // mints because the V2 API doesn't surface symbol metadata on
+                // history rows. Consumers needing symbols can resolveToken().)
+                inputToken: order.inputMint,
+                outputToken: order.outputMint,
                 initialInputAmount: order.initialInputAmount,
                 remainingInputAmount: order.remainingInputAmount,
                 triggerPriceUsd: order.triggerPriceUsd,
@@ -800,6 +818,9 @@ async function _jupiterTriggerCancelV2(input, _chatId) {
             success: true,
             orderId: confirmRes.id,
             txSignature: confirmRes.txSignature,
+            // PR #388 R2: V1's `signature` alias kept so downstream parsers
+            // don't break when the flag flips.
+            signature: confirmRes.txSignature,
             status: 'cancelled',
             wallet: signWallet,
             creatorRole,

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -34,8 +34,15 @@ const {
 const {
     routeAndSign,
     signCancelViaBurner,
+    signZeroCapTxViaBurner,
     recordJupiterOwnership,
 } = require('../wallet/dispatch');
+
+// BAT-697 PR B: Jupiter Trigger V2 adapter. Activated when
+// `config.useTriggerV2 === true` (default false). V1 paths in
+// jupiter_trigger_* handlers remain the shipping default until the staged
+// rollout (live smoke → default flip → V1 deletion) lands in subsequent PRs.
+const triggerV2 = require('../jupiter/trigger-v2');
 
 // BAT-255: Safe number-to-decimal-string conversion (imported from index.js shared state)
 let numberToDecimalString;
@@ -250,6 +257,543 @@ const tools = [
         }
     },
 ];
+
+// ============================================================================
+// JUPITER TRIGGER V2 HELPERS (BAT-697 PR B)
+// ============================================================================
+//
+// V2 endpoints are gated behind `config.useTriggerV2`. The V1 handlers below
+// branch at the top: if the flag is true, delegate to the helper below;
+// otherwise continue the existing V1 path unchanged.
+//
+// V2 flow (create):
+//   1. authenticate(walletPubkey, signers)        → JWT (cached 24h-60s)
+//   2. ensureVault(walletPubkey, token)           → lazy register on first use
+//   3. depositCraft(...)                          → unsigned deposit tx + depositRequestId
+//   4. routeAndSign with broadcast callback that:
+//        - signs deposit (main MWA or burner-with-reservation, both via routeAndSign)
+//        - POSTs signed deposit to /trigger/v2/orders/price via submitCreateOrder
+//        - returns { signature } on create success, { error } on hard failure
+//      routeAndSign handles burner reserve/sign/commit-or-release atomically.
+//   5. recordJupiterOwnership(id, wallet) — fire-and-forget bookkeeping
+//
+// V2 flow (cancel):
+//   1. ownership lookup (same as V1) → creatorRole
+//   2. authenticate that wallet                    → JWT
+//   3. cancelStep1(orderId, pubkey, token)         → unsigned cancel tx + cancelRequestId
+//   4. sign:
+//        - burner-owned → signCancelViaBurner (zero-cap reservation, ownership-gated)
+//        - main/unknown → /solana/sign-only via MWA
+//   5. confirmCancel(orderId, pubkey, token, signedTx, cancelRequestId)
+//
+// V2 flow (list):
+//   1. main wallet only (scope cut — burner-routed orders need separate auth)
+//   2. authenticate main → JWT
+//   3. listOrders(pubkey, token, status, page)
+//
+// AMBIGUOUS-CREATE RECOVERY (Codex round-2 §5)
+// --------------------------------------------
+// The adapter's submitCreateOrder() runs recovery on 5xx / network drop /
+// missing-id-after-200. Recovery queries /orders/history; if a matching
+// order is found, returns success with `recovered: true`. If not found,
+// returns `create_ambiguous_no_recovery` — the deposit MAY have moved
+// funds into the Jupiter vault. We treat this as broadcast success
+// (commits the burner cap conservatively) and surface a warning to the
+// user with the depositRequestId for manual recovery via Jupiter UI.
+// Rationale: cap over-count > under-count for user safety.
+//
+// MESSAGE-CHALLENGE DEFERRED
+// --------------------------
+// PR B uses transaction-challenge for both wallets — there is no
+// `/burner/sign-message` or `/solana/sign-message` bridge endpoint yet.
+// The adapter's signers.signMessage parameter is `null` for both wallets;
+// the adapter falls through to transaction-challenge per Codex round-2 #3
+// ("unsupported-method/capability error"). A follow-up BAT can add the
+// bridge endpoints and pass a non-null signMessage to take the cheaper
+// message-only path.
+
+/**
+ * Build signers object for trigger-v2.authenticate() based on wallet role.
+ * signMessage is null in PR B (see "MESSAGE-CHALLENGE DEFERRED" above).
+ */
+function _buildAuthSigners(walletRole) {
+    if (walletRole === 'burner') {
+        return {
+            signTransaction: async (txB64) => {
+                const r = await signZeroCapTxViaBurner({
+                    unsignedTxBase64: txB64,
+                    flowName: 'trigger-v2-auth',
+                });
+                if (!r.ok) return { error: r.error, reason: r.reason };
+                return r.signedTxBase64;
+            },
+            signMessage: null,
+        };
+    }
+    return {
+        signTransaction: async (txB64) => {
+            try { await ensureWalletAuthorized(); }
+            catch (e) { return { error: 'wallet_not_authorized', reason: e.message }; }
+            const r = await androidBridgeCall('/solana/sign-only', { transaction: txB64 }, 120000);
+            if (r.error) return { error: 'sign_failed', reason: r.error };
+            if (!r.signedTransaction) return { error: 'sign_failed', reason: 'no signed tx returned from wallet' };
+            return r.signedTransaction;
+        },
+        signMessage: null,
+    };
+}
+
+/**
+ * Resolve `triggerCondition` for V2 from explicit input or from the
+ * input/output token relationship. Returns 'above' | 'below' | null
+ * (null only when both are unstable, e.g., a custom altcoin pair without
+ * an obvious stable side).
+ *
+ * Rules:
+ *   - Explicit input wins.
+ *   - input is a stablecoin (USDC/USDT) → buying outputToken → 'below'
+ *     (trigger when output price drops to triggerPriceUsd or lower)
+ *   - output is a stablecoin → selling inputToken → 'above'
+ *     (trigger when input price rises to triggerPriceUsd or higher)
+ *   - neither obvious → null; caller must pass explicit triggerCondition
+ */
+const _STABLE_MINTS = new Set([
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', // USDT
+]);
+function _inferTriggerCondition(inputMint, outputMint, explicit) {
+    if (explicit === 'above' || explicit === 'below') return explicit;
+    if (_STABLE_MINTS.has(inputMint) && !_STABLE_MINTS.has(outputMint)) return 'below';
+    if (_STABLE_MINTS.has(outputMint) && !_STABLE_MINTS.has(inputMint)) return 'above';
+    return null;
+}
+
+async function _jupiterTriggerCreateV2(input, _chatId) {
+    if (!config.jupiterApiKey) {
+        return {
+            error: 'Jupiter API key required',
+            guide: 'Get a free API key at portal.jup.ag, then add it in SeekerClaw Settings > Configuration > Jupiter API Key',
+        };
+    }
+    try {
+        // 1. Resolve tokens (mirrors V1).
+        const inputToken = await resolveToken(input.inputToken);
+        const outputToken = await resolveToken(input.outputToken);
+        if (!inputToken || inputToken.ambiguous) {
+            return { error: 'Could not resolve input token', details: inputToken?.ambiguous
+                ? `Multiple tokens match "${input.inputToken}". Use the full mint address.`
+                : `Token "${input.inputToken}" not found.` };
+        }
+        if (inputToken.warning && inputToken.decimals == null) {
+            return { error: 'Unverified input token with missing metadata', details: inputToken.warning };
+        }
+        if (!outputToken || outputToken.ambiguous) {
+            return { error: 'Could not resolve output token', details: outputToken?.ambiguous
+                ? `Multiple tokens match "${input.outputToken}". Use the full mint address.`
+                : `Token "${input.outputToken}" not found.` };
+        }
+        if (outputToken.warning && outputToken.decimals == null) {
+            return { error: 'Unverified output token with missing metadata', details: outputToken.warning };
+        }
+
+        // 2. Token-2022 shield check (Trigger V2 also rejects Token-2022).
+        try {
+            const mints = [inputToken.address, outputToken.address].join(',');
+            const shieldRes = await jupiterRequest({
+                hostname: 'api.jup.ag',
+                path: `/ultra/v1/shield?mints=${encodeURIComponent(mints)}`,
+                method: 'GET',
+                headers: { 'x-api-key': config.jupiterApiKey },
+            });
+            if (shieldRes.status === 200) {
+                const shieldData = typeof shieldRes.data === 'string' ? JSON.parse(shieldRes.data) : shieldRes.data;
+                for (const [mint, info] of Object.entries(shieldData || {})) {
+                    if (info && (info.tokenType === 'token-2022' || info.isToken2022)) {
+                        const sym = mint === inputToken.address ? inputToken.symbol : outputToken.symbol;
+                        return {
+                            error: 'Token-2022 not supported for limit orders',
+                            details: `${sym} (${mint}) is a Token-2022 token. Use a regular swap instead.`,
+                        };
+                    }
+                }
+            }
+        } catch (shieldErr) {
+            log(`[Jupiter Trigger V2] Token-2022 check skipped: ${shieldErr.message}`, 'DEBUG');
+        }
+
+        // 3. Routing decision (V1 parity — same caps/preflight call).
+        const { routeFor: _routeForTriggerV2 } = require('../caps/preflight');
+        const routingHint = await _routeForTriggerV2('jupiter_trigger_create', input);
+
+        // 4. Resolve wallet address — burner pubkey if routing=burner, MWA pubkey otherwise.
+        let walletAddress;
+        if (routingHint.routingDecision === 'burner') {
+            try {
+                const burnerStatus = await androidBridgeCall('/burner/status', {}, 5000);
+                if (burnerStatus && !burnerStatus.error && burnerStatus.configured && burnerStatus.pubkey) {
+                    walletAddress = burnerStatus.pubkey;
+                }
+            } catch (_) { /* fall through */ }
+        }
+        if (!walletAddress) {
+            try { walletAddress = getConnectedWalletAddress(); }
+            catch (e) { return { error: e.message }; }
+        }
+
+        // 5. Parse inputAmount → raw atomic units (BigInt-safe).
+        let inputAmountAtomic;
+        try {
+            inputAmountAtomic = parseInputAmountToLamports(numberToDecimalString(input.inputAmount), inputToken.decimals);
+        } catch (e) {
+            return { error: 'Invalid input amount', details: e.message };
+        }
+
+        // 6. Compute USD value of inputAmount via jupiterPrice for the $10 min check.
+        let inputUsdValue;
+        try {
+            const priceData = await jupiterPrice([inputToken.address]);
+            const priceEntry = priceData && (priceData[inputToken.address] || priceData.data?.[inputToken.address]);
+            const usdPrice = priceEntry && (priceEntry.usdPrice ?? priceEntry.price);
+            if (!Number.isFinite(Number(usdPrice)) || Number(usdPrice) <= 0) {
+                return { error: 'price_unavailable', reason: `Could not fetch USD price for ${inputToken.symbol} — required for $10 minimum check.` };
+            }
+            inputUsdValue = Number(input.inputAmount) * Number(usdPrice);
+        } catch (e) {
+            return { error: 'price_lookup_failed', reason: e.message };
+        }
+
+        // 7. Resolve V2-specific args (with V1-compat fallbacks).
+        const triggerPriceUsd = Number(input.triggerPriceUsd ?? input.triggerPrice);
+        const slippageBps = input.slippageBps != null ? Number(input.slippageBps) : triggerV2.DEFAULT_SLIPPAGE_BPS;
+        const expiresAtMs = input.expiresAt != null
+            ? Number(input.expiresAt) * (Number(input.expiresAt) < 10_000_000_000 ? 1000 : 1) // accept s or ms
+            : (input.expiryTime != null ? Number(input.expiryTime) * 1000 : Date.now() + 30 * 24 * 60 * 60 * 1000);
+        const triggerCondition = _inferTriggerCondition(inputToken.address, outputToken.address, input.triggerCondition);
+        if (!triggerCondition) {
+            return {
+                error: 'trigger_condition_required',
+                reason: 'Could not infer triggerCondition from token pair. Pass triggerCondition: "above" or "below" explicitly.',
+            };
+        }
+
+        // 8. Semantic validation (pure — fail fast before any network work).
+        const validation = triggerV2.validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippageBps });
+        if (!validation.ok) {
+            return { error: validation.error, reason: validation.reason };
+        }
+
+        // 9. Authenticate (cached 24h-60s per pubkey).
+        const walletRole = routingHint.routingDecision === 'burner' ? 'burner' : 'main';
+        const authSigners = _buildAuthSigners(walletRole);
+        const authResult = await triggerV2.authenticate(walletAddress, authSigners);
+        if (!authResult.ok) {
+            return { error: authResult.error, reason: authResult.reason };
+        }
+        const token = authResult.token;
+
+        // 10. Ensure vault (lazy — only on first create per wallet).
+        const vaultResult = await triggerV2.ensureVault(walletAddress, token);
+        if (!vaultResult.ok) {
+            return { error: vaultResult.error, reason: vaultResult.reason };
+        }
+        const vaultAddress = vaultResult.vaultAddress;
+
+        // 11. Craft deposit.
+        const craftResult = await triggerV2.depositCraft({
+            pubkey: walletAddress,
+            token,
+            inputMint: inputToken.address,
+            inputAmount: String(inputAmountAtomic),
+        });
+        if (!craftResult.ok) {
+            return { error: craftResult.error, reason: craftResult.reason };
+        }
+        const { transaction: unsignedDepositTx, depositRequestId, recoveryContext } = craftResult;
+
+        // 12. Verify deposit tx fee payer matches active wallet — guard against
+        // a malicious craft response that would route funds from the wrong wallet.
+        try {
+            const verification = verifySwapTransaction(unsignedDepositTx, walletAddress);
+            if (!verification.valid) {
+                return { error: `Deposit tx rejected: ${verification.error}` };
+            }
+        } catch (verifyErr) {
+            return { error: `Could not verify deposit tx: ${verifyErr.message}` };
+        }
+
+        // 13. routeAndSign for the deposit signing + orders/price POST.
+        const orderArgs = {
+            inputMint: inputToken.address,
+            inputAmount: String(inputAmountAtomic),
+            outputMint: outputToken.address,
+            triggerMint: outputToken.address,
+            triggerPriceUsd,
+            triggerCondition,
+            slippageBps,
+            expiresAtMs,
+        };
+        let submitWarning = null;
+        const dispatchResult = await routeAndSign({
+            toolName: 'jupiter_trigger_create',
+            toolArgs: input,
+            unsignedTxBase64: unsignedDepositTx,
+            broadcastVia: 'jupiter',
+            flowName: 'jupiter_trigger_create_v2',
+            broadcast: async (txOrUnsigned, _signer, ctx) => {
+                let signedDeposit;
+                if (ctx && ctx.signed) {
+                    signedDeposit = txOrUnsigned;
+                } else {
+                    try { await ensureWalletAuthorized(); }
+                    catch (e) { return { error: 'wallet_not_authorized', reason: e.message }; }
+                    const signRes = await androidBridgeCall('/solana/sign-only', { transaction: txOrUnsigned }, 120000);
+                    if (signRes.error) return { error: 'sign_failed', reason: signRes.error };
+                    if (!signRes.signedTransaction) return { error: 'sign_failed', reason: 'no signed tx returned from wallet' };
+                    signedDeposit = signRes.signedTransaction;
+                }
+                const submitRes = await triggerV2.submitCreateOrder({
+                    token,
+                    recoveryContext,
+                    depositSignedTx: signedDeposit,
+                    order: orderArgs,
+                });
+                if (submitRes.ok) {
+                    if (submitRes.recovered) {
+                        submitWarning = submitRes.recoveryNote || 'Order recovered from /orders/history after lost create response.';
+                    }
+                    return { signature: submitRes.txSignature, trigger: submitRes };
+                }
+                // Ambiguous-no-recovery: deposit MAY have moved funds. Conservative —
+                // treat as broadcast success so the burner cap is committed
+                // (over-count is safer than under-count). Surface a clear warning
+                // including the depositRequestId so the user can reconcile via
+                // Jupiter UI.
+                if (submitRes.error === 'create_ambiguous_no_recovery') {
+                    submitWarning =
+                        `Trigger V2 create response was lost AND /orders/history showed no matching order. ` +
+                        `Deposit may still be in flight in Jupiter's vault. Check Jupiter UI for ` +
+                        `depositRequestId=${depositRequestId}. ` +
+                        `Your wallet's burner cap has been committed conservatively — if the deposit ` +
+                        `did NOT land on-chain, the cap will regenerate at the next daily window.`;
+                    return { signature: null, trigger: submitRes };
+                }
+                return { error: submitRes.error, reason: submitRes.reason };
+            },
+        });
+
+        if (!dispatchResult.ok) {
+            return { error: dispatchResult.error, reason: dispatchResult.reason };
+        }
+
+        const orderResult = (dispatchResult.broadcastResult && dispatchResult.broadcastResult.trigger) || {};
+        const orderId = orderResult.id || null;
+
+        // 14. Record ownership (fire-and-forget; failure logs only, doesn't unwind).
+        if (orderId) {
+            await recordJupiterOwnership(orderId, dispatchResult.wallet, 'jupiter_trigger_create_v2');
+        } else {
+            log('[Jupiter Trigger V2] No orderId from create — ownership not recorded', 'WARN');
+        }
+
+        const warnings = [];
+        if (inputToken.warning) warnings.push(`⚠️ ${inputToken.symbol}: ${inputToken.warning}`);
+        if (outputToken.warning) warnings.push(`⚠️ ${outputToken.symbol}: ${outputToken.warning}`);
+        if (submitWarning) warnings.push(submitWarning);
+
+        return {
+            success: true,
+            orderId,
+            txSignature: orderResult.txSignature || dispatchResult.signature || null,
+            depositRequestId,
+            inputToken: `${inputToken.symbol} (${inputToken.address})`,
+            outputToken: `${outputToken.symbol} (${outputToken.address})`,
+            inputAmount: input.inputAmount,
+            triggerPriceUsd,
+            triggerCondition,
+            slippageBps,
+            expiresAt: Math.floor(expiresAtMs / 1000),
+            wallet: dispatchResult.wallet,
+            vaultAddress,
+            recovered: orderResult.recovered === true || undefined,
+            warnings: warnings.length > 0 ? warnings : undefined,
+        };
+    } catch (e) {
+        return { error: e.message };
+    }
+}
+
+async function _jupiterTriggerListV2(input, _chatId) {
+    if (!config.jupiterApiKey) {
+        return {
+            error: 'Jupiter API key required',
+            guide: 'Get a free API key at portal.jup.ag, then add it in SeekerClaw Settings > Configuration > Jupiter API Key',
+        };
+    }
+    try {
+        let walletAddress;
+        try { walletAddress = getConnectedWalletAddress(); }
+        catch (e) { return { error: e.message }; }
+
+        if (input.status && !['active', 'history'].includes(input.status)) {
+            return { error: 'Invalid status value', details: 'status must be either "active" or "history"' };
+        }
+        if (input.page != null && (!Number.isInteger(Number(input.page)) || Number(input.page) <= 0)) {
+            return { error: 'Invalid page value', details: 'page must be a positive integer' };
+        }
+
+        // Scope cut for PR B: V2 list authenticates the MAIN wallet only.
+        // Listing burner-routed orders requires authenticating the burner
+        // pubkey separately — deferred to a follow-up BAT to avoid surfacing
+        // a "sign to view your orders" prompt for users with no burner orders.
+        const authSigners = _buildAuthSigners('main');
+        const authResult = await triggerV2.authenticate(walletAddress, authSigners);
+        if (!authResult.ok) return { error: authResult.error, reason: authResult.reason };
+
+        const listResult = await triggerV2.listOrders({
+            pubkey: walletAddress,
+            token: authResult.token,
+            status: input.status,
+            page: input.page != null ? Number(input.page) : undefined,
+        });
+        if (!listResult.ok) return { error: listResult.error, reason: listResult.reason };
+
+        return {
+            success: true,
+            count: listResult.orders.length,
+            wallet: walletAddress,
+            note: 'V2 list shows main-wallet orders only. Burner-routed orders need separate auth (follow-up).',
+            orders: listResult.orders.map(order => ({
+                orderId: order.id || order.orderId,
+                orderType: order.orderType,
+                inputMint: order.inputMint,
+                outputMint: order.outputMint,
+                inputAmount: order.inputAmount,
+                triggerPriceUsd: order.triggerPriceUsd,
+                triggerCondition: order.triggerCondition,
+                slippageBps: order.slippageBps,
+                status: order.status,
+                vaultState: order.vaultState,
+                expiresAt: order.expiresAt,
+                createdAt: order.createdAt,
+            })),
+        };
+    } catch (e) {
+        return { error: e.message };
+    }
+}
+
+async function _jupiterTriggerCancelV2(input, _chatId) {
+    if (!config.jupiterApiKey) {
+        return {
+            error: 'Jupiter API key required',
+            guide: 'Get a free API key at portal.jup.ag, then add it in SeekerClaw Settings > Configuration > Jupiter API Key',
+        };
+    }
+    try {
+        if (!input.orderId || String(input.orderId).trim() === '') {
+            return { error: 'orderId is required' };
+        }
+        const orderId = String(input.orderId).trim();
+
+        // 1. Ownership lookup (same as V1).
+        let creatorRole = 'unknown';
+        try {
+            const lookup = await androidBridgeCall(
+                '/jupiter/order-owner/get',
+                { orderId },
+                5000,
+            );
+            if (lookup && !lookup.error && (lookup.creatorWalletRole === 'burner' || lookup.creatorWalletRole === 'main')) {
+                creatorRole = lookup.creatorWalletRole;
+            }
+        } catch (_) { /* fall through to MWA path */ }
+
+        // 2. Resolve wallet address per creator role.
+        let walletAddress;
+        if (creatorRole === 'burner') {
+            try {
+                const burnerStatus = await androidBridgeCall('/burner/status', {}, 5000);
+                if (burnerStatus && !burnerStatus.error && burnerStatus.configured && burnerStatus.pubkey) {
+                    walletAddress = burnerStatus.pubkey;
+                }
+            } catch (_) { /* fall through */ }
+            if (!walletAddress) {
+                log('[Jupiter Trigger V2] burner-owned cancel but burner pubkey unavailable — falling back to MWA', 'WARN');
+                creatorRole = 'main';
+            }
+        }
+        if (!walletAddress) {
+            try { walletAddress = getConnectedWalletAddress(); }
+            catch (e) { return { error: e.message }; }
+        }
+
+        // 3. Authenticate the relevant wallet (cached per-pubkey).
+        const walletRole = creatorRole === 'burner' ? 'burner' : 'main';
+        const authSigners = _buildAuthSigners(walletRole);
+        const authResult = await triggerV2.authenticate(walletAddress, authSigners);
+        if (!authResult.ok) return { error: authResult.error, reason: authResult.reason };
+        const token = authResult.token;
+
+        // 4. Cancel step 1 — get unsigned cancel tx.
+        const step1 = await triggerV2.cancelStep1({ orderId, pubkey: walletAddress, token });
+        if (!step1.ok) return { error: step1.error, reason: step1.reason };
+
+        // 5. Verify cancel tx fee payer.
+        try {
+            const verification = verifySwapTransaction(step1.transaction, walletAddress);
+            if (!verification.valid) return { error: `Cancel tx rejected: ${verification.error}` };
+        } catch (e) {
+            return { error: `Could not verify cancel tx: ${e.message}` };
+        }
+
+        // 6. Sign + confirm-cancel — routed to burner or main path.
+        let signedCancelB64;
+        let signWallet;
+        if (creatorRole === 'burner') {
+            // Use signZeroCapTxViaBurner (cancel doesn't consume cap principal,
+            // and signCancelViaBurner is broadcast-coupled). We POST confirm-cancel
+            // separately below — so this is sign-only, then explicit POST.
+            const signRes = await signZeroCapTxViaBurner({
+                unsignedTxBase64: step1.transaction,
+                flowName: 'jupiter_trigger_cancel_v2',
+            });
+            if (!signRes.ok) return { error: signRes.error, reason: signRes.reason };
+            signedCancelB64 = signRes.signedTxBase64;
+            signWallet = 'burner';
+        } else {
+            try { await ensureWalletAuthorized(); }
+            catch (e) { return { error: 'wallet_not_authorized', reason: e.message }; }
+            const signRes = await androidBridgeCall('/solana/sign-only', { transaction: step1.transaction }, 120000);
+            if (signRes.error) return { error: signRes.error };
+            if (!signRes.signedTransaction) return { error: 'No signed transaction returned from wallet' };
+            signedCancelB64 = signRes.signedTransaction;
+            signWallet = 'main';
+        }
+
+        // 7. Confirm cancel.
+        const confirmRes = await triggerV2.confirmCancel({
+            orderId,
+            pubkey: walletAddress,
+            token,
+            signedTransaction: signedCancelB64,
+            cancelRequestId: step1.cancelRequestId,
+        });
+        if (!confirmRes.ok) return { error: confirmRes.error, reason: confirmRes.reason };
+
+        return {
+            success: true,
+            orderId: confirmRes.id,
+            txSignature: confirmRes.txSignature,
+            status: 'cancelled',
+            wallet: signWallet,
+            creatorRole,
+        };
+    } catch (e) {
+        return { error: e.message };
+    }
+}
+
+// ============================================================================
 
 const handlers = {
     async solana_address(input, chatId) {
@@ -856,6 +1400,12 @@ const handlers = {
     // ========== JUPITER API TOOLS ==========
 
     async jupiter_trigger_create(input, chatId) {
+        // BAT-697 PR B: gate on useTriggerV2 flag. Default false → V1 path
+        // below. Flag flips in commit 4 of the staged rollout.
+        if (config.useTriggerV2 === true) {
+            return _jupiterTriggerCreateV2(input, chatId);
+        }
+
         if (!config.jupiterApiKey) {
             return {
                 error: 'Jupiter API key required',
@@ -1121,6 +1671,10 @@ const handlers = {
     },
 
     async jupiter_trigger_list(input, chatId) {
+        if (config.useTriggerV2 === true) {
+            return _jupiterTriggerListV2(input, chatId);
+        }
+
         if (!config.jupiterApiKey) {
             return {
                 error: 'Jupiter API key required',
@@ -1204,6 +1758,10 @@ const handlers = {
     },
 
     async jupiter_trigger_cancel(input, chatId) {
+        if (config.useTriggerV2 === true) {
+            return _jupiterTriggerCancelV2(input, chatId);
+        }
+
         if (!config.jupiterApiKey) {
             return {
                 error: 'Jupiter API key required',

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -491,18 +491,19 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         }
         const token = authResult.token;
 
-        // 10. Ensure vault (lazy — only on first create per wallet).
+        // 10. Ensure vault (lazy — registered via idempotent GET on first use).
         const vaultResult = await triggerV2.ensureVault(walletAddress, token);
         if (!vaultResult.ok) {
             return { error: vaultResult.error, reason: vaultResult.reason };
         }
-        const vaultAddress = vaultResult.vaultAddress;
+        const vaultAddress = vaultResult.vaultPubkey;
 
-        // 11. Craft deposit.
+        // 11. Craft deposit (outputMint is required by /deposit/craft).
         const craftResult = await triggerV2.depositCraft({
             pubkey: walletAddress,
             token,
             inputMint: inputToken.address,
+            outputMint: outputToken.address,
             inputAmount: String(inputAmountAtomic),
         });
         if (!craftResult.ok) {

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -148,7 +148,8 @@ const tools = [
                 triggerPriceUsd: { type: 'number', description: '[V2 mode only] USD price where the trigger fires (e.g., 80.50 for $80.50). Required in V2 mode. NOT accepted in V1 mode.' },
                 expiresAt: { type: 'number', description: '[V2 mode] Order expiration as Unix seconds OR milliseconds (auto-detected). Required in V2 mode if expiryTime not provided. NO 30-day default in V2 — must be explicit.' },
                 triggerCondition: { type: 'string', enum: ['above', 'below'], description: '[V2 mode] When to fire: "above" (price rises to trigger value) or "below" (price drops to trigger value). Auto-inferred from token pair when one side is a stablecoin; required for non-stable pairs.' },
-                slippageBps: { type: 'number', description: '[V2 mode] Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' }
+                slippageBps: { type: 'number', description: '[V2 mode] Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' },
+                triggerMint: { type: 'string', description: '[V2 mode] Mint address of the asset whose USD price the trigger watches. Auto-inferred when exactly one side of the pair is a stablecoin (SOL↔USDC → SOL is watched). REQUIRED for non-stable↔non-stable pairs (SOL↔JUP) and both-stable pairs (USDC↔USDT) — otherwise the order returns trigger_mint_required.' }
             },
             required: ['inputToken', 'outputToken', 'inputAmount']
         }
@@ -382,21 +383,25 @@ function _inferTriggerCondition(inputMint, outputMint, explicit) {
  *     trigger reads SOL's price → triggerMint = outputMint.
  *   - Selling a non-stable for a stable (SOL → USDC, "above $90"):
  *     trigger reads SOL's price → triggerMint = inputMint.
- *   - Non-stable ↔ non-stable (rare, e.g. SOL ↔ JUP): no clean
- *     inference; caller must pass explicit `input.triggerMint`. We
- *     default to outputMint so the caller's explicit override is the
- *     only correct path (the default will not fire usefully).
+ *   - Non-stable ↔ non-stable (rare, e.g. SOL ↔ JUP) OR both-stable
+ *     (USDC ↔ USDT): NO inference is safe — Jupiter would watch the
+ *     wrong asset's USD price and either fire on the wrong side or
+ *     never fire. Caller must pass explicit `input.triggerMint`.
+ *     Returns null to signal "ambiguous" so the handler can fail
+ *     closed with a clear `triggerMint_required` error instead of
+ *     silently routing to outputMint (PR #388 R5 finding).
  *
  * The pre-fix shipped `triggerMint = outputMint` unconditionally, which
  * for a sell-into-stable (e.g. SOL → USDC) made Jupiter watch USDC at
  * ~$1 — the documented "SOL ≥ $90" limit-sell would never trigger
- * (PR #388 R2 finding).
+ * (PR #388 R2 finding). R5 hardens the degenerate-pair path the same
+ * way: never let the wrong asset slip through silently.
  */
 function _inferTriggerMint(inputMint, outputMint, explicit) {
     if (typeof explicit === 'string' && explicit.length > 0) return explicit;
     if (_STABLE_MINTS.has(inputMint) && !_STABLE_MINTS.has(outputMint)) return outputMint;
     if (_STABLE_MINTS.has(outputMint) && !_STABLE_MINTS.has(inputMint)) return inputMint;
-    return outputMint; // both-stable or both-non-stable: degenerate; caller should override.
+    return null; // both-stable or both-non-stable: degenerate. Caller MUST pass explicit triggerMint.
 }
 
 async function _jupiterTriggerCreateV2(input, _chatId) {
@@ -595,7 +600,20 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         // pair (the asset whose USD price the trigger watches). Pre-fix
         // unconditionally used outputMint, which broke sell-into-stable
         // orders (SOL → USDC "above $90" would watch USDC's ~$1 price).
+        // PR #388 R5: for non-stable↔non-stable or both-stable pairs,
+        // _inferTriggerMint returns null — caller MUST pass triggerMint
+        // explicitly. Fail closed BEFORE building the deposit so we don't
+        // sign a tx for an order that would never fire (or fire on the
+        // wrong asset).
         const triggerMint = _inferTriggerMint(inputToken.address, outputToken.address, input.triggerMint);
+        if (!triggerMint) {
+            return {
+                error: 'trigger_mint_required',
+                reason: 'For non-stable↔non-stable pairs (e.g. SOL↔JUP) and both-stable pairs (e.g. USDC↔USDT), the trigger asset cannot be inferred safely — Jupiter would watch the wrong asset\'s USD price. Pass `triggerMint` explicitly to disambiguate.',
+                inputMint: inputToken.address,
+                outputMint: outputToken.address,
+            };
+        }
         const orderArgs = {
             inputMint: inputToken.address,
             inputAmount: String(inputAmountAtomic),
@@ -2835,4 +2853,4 @@ const handlers = {
     },
 };
 
-module.exports = { tools, handlers, _setNumberToDecimalString };
+module.exports = { tools, handlers, _setNumberToDecimalString, _inferTriggerMint };

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -645,10 +645,21 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         if (outputToken.warning) warnings.push(`⚠️ ${outputToken.symbol}: ${outputToken.warning}`);
         if (submitWarning) warnings.push(submitWarning);
 
-        // PR #388 R2: keep V1's `signature` field as an alias of `txSignature`
-        // so consumers (tool-result prompts, downstream parsers) that parse
-        // the V1 shape don't break when the flag is flipped.
+        // PR #388 R2: V1 alias for `signature` (V1 returned `signature`, V2
+        // canonical is `txSignature`). PR #388 R3: also surface V1's
+        // `triggerPrice` and `expiryTime` field names so consumers that
+        // parse the V1 shape don't see undefined when the flag flips.
+        //
+        // SEMANTIC NOTE on `triggerPrice`: V1's `triggerPrice` was a token
+        // ratio (e.g. 90 meaning "1 SOL = 90 USDC"). V2's `triggerPriceUsd`
+        // is a USD price. We alias `triggerPrice` to the USD value (not the
+        // ratio) because that's what the underlying order actually uses now —
+        // a consumer that interprets it as a ratio is already broken
+        // semantically by the V1→V2 cutover; preserving the field name at
+        // least keeps the field present so the consumer's parse doesn't blow
+        // up. Consumers SHOULD migrate to `triggerPriceUsd`.
         const _sig = orderResult.txSignature || dispatchResult.signature || null;
+        const _expiresAtSec = Math.floor(expiresAtMs / 1000);
         return {
             success: true,
             orderId,
@@ -659,9 +670,11 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
             outputToken: `${outputToken.symbol} (${outputToken.address})`,
             inputAmount: input.inputAmount,
             triggerPriceUsd,
+            triggerPrice: triggerPriceUsd, // V1 alias (semantic shifted ratio→USD; see comment above)
             triggerCondition,
             slippageBps,
-            expiresAt: Math.floor(expiresAtMs / 1000),
+            expiresAt: _expiresAtSec,
+            expiryTime: _expiresAtSec, // V1 alias (both Unix seconds)
             wallet: dispatchResult.wallet,
             vaultAddress,
             recovered: orderResult.recovered === true || undefined,
@@ -716,28 +729,40 @@ async function _jupiterTriggerListV2(input, _chatId) {
             // rawState, initialInputAmount, remainingInputAmount, fillPercent.
             // The first-draft status/vaultState/inputAmount fields don't exist
             // on the API — mapping them would return three `undefined`s per row.
+            // PR #388 R2 added inputToken/outputToken aliases. R3: also add
+            // V1's `inputAmount`, `triggerPrice`, `status`, `expiryTime`
+            // aliases so consumers that parse the V1 list shape don't see
+            // undefined when the flag flips. SEMANTIC NOTES:
+            //   - `inputAmount` ← initialInputAmount (same atomic-string semantic).
+            //   - `triggerPrice` ← triggerPriceUsd (V1 was a token ratio,
+            //     V2 is USD — see same comment on the create response above;
+            //     consumers SHOULD migrate to `triggerPriceUsd`).
+            //   - `status` ← orderState (same lowercase state vocabulary:
+            //     active/cancelled/expired/etc).
+            //   - `expiryTime` ← expiresAt converted ms→sec (V1 unit was
+            //     Unix seconds; V2 `expiresAt` is milliseconds).
             orders: listResult.orders.map(order => ({
                 orderId: order.id || order.orderId,
                 orderType: order.orderType,
                 inputMint: order.inputMint,
                 outputMint: order.outputMint,
-                // PR #388 R2: V1 listed orders under `inputToken`/`outputToken`
-                // aliases of the mint addresses. Kept here so consumers parsing
-                // the V1 shape don't see undefined when the flag is flipped.
-                // (V1 sometimes resolved these to symbols; we leave them as
-                // mints because the V2 API doesn't surface symbol metadata on
-                // history rows. Consumers needing symbols can resolveToken().)
                 inputToken: order.inputMint,
                 outputToken: order.outputMint,
                 initialInputAmount: order.initialInputAmount,
                 remainingInputAmount: order.remainingInputAmount,
+                inputAmount: order.initialInputAmount, // V1 alias
                 triggerPriceUsd: order.triggerPriceUsd,
+                triggerPrice: order.triggerPriceUsd, // V1 alias (semantic shifted ratio→USD)
                 triggerCondition: order.triggerCondition,
                 slippageBps: order.slippageBps,
                 orderState: order.orderState,
                 rawState: order.rawState,
+                status: order.orderState, // V1 alias
                 fillPercent: order.fillPercent,
                 expiresAt: order.expiresAt,
+                expiryTime: (typeof order.expiresAt === 'number' && order.expiresAt > 1e12)
+                    ? Math.floor(order.expiresAt / 1000)
+                    : order.expiresAt, // V1 alias in Unix SECONDS (V2 expiresAt is ms)
                 createdAt: order.createdAt,
             })),
         };

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -595,6 +595,21 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
                 outputMint: outputToken.address,
             };
         }
+        // PR #388 R8: validate the resolved triggerMint as a real Solana
+        // base58 address (32-byte Ed25519 pubkey). The auto-inferred path
+        // uses inputMint/outputMint which were already validated by upstream
+        // token resolution, so this only fires when the caller supplied an
+        // EXPLICIT `input.triggerMint` override — pre-fix a whitespace-only
+        // or otherwise malformed non-empty string passed the null-check and
+        // would only fail later at Jupiter's create endpoint (after auth +
+        // vault register + signed deposit). Fail closed here BEFORE any side
+        // effects.
+        if (!isValidSolanaAddress(triggerMint)) {
+            return {
+                error: 'trigger_mint_invalid',
+                reason: 'Explicit `triggerMint` is not a valid Solana base58 address (must base58-decode to 32 bytes). Pass a real mint pubkey.',
+            };
+        }
 
         // 8. Semantic validation (pure — fail fast before any network work).
         const validation = triggerV2.validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippageBps });

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -160,20 +160,31 @@ const tools = [
             slippageBps: { type: 'number', description: 'Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' },
             triggerMint: { type: 'string', description: 'Mint address of the asset whose USD price the trigger watches. Auto-inferred when exactly one side of the pair is a stablecoin (SOL↔USDC → SOL is watched). REQUIRED for non-stable↔non-stable pairs (SOL↔JUP) and both-stable pairs (USDC↔USDT).' },
         };
+        const v2Schema = {
+            type: 'object',
+            properties: { ...baseProperties, ...v2Properties },
+            required: ['inputToken', 'outputToken', 'inputAmount', 'triggerPriceUsd'],
+            // PR #388 R7: V2 handler hard-rejects with `expires_at_required`
+            // if NEITHER `expiresAt` nor `expiryTime` is provided. Encode
+            // that disjunction in the schema (anyOf) so the model/gate
+            // rejects the missing-expiry case at validation time rather than
+            // letting it reach the user-confirmation card and dying later.
+            anyOf: [
+                { required: ['expiresAt'] },
+                { required: ['expiryTime'] },
+            ],
+        };
+        const v1Schema = {
+            type: 'object',
+            properties: { ...baseProperties, ...v1Properties },
+            required: ['inputToken', 'outputToken', 'inputAmount', 'triggerPrice'],
+        };
         return {
             name: 'jupiter_trigger_create',
             description: v2Enabled
                 ? 'Create a trigger (limit) order on Jupiter (V2 API). Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when the USD price reaches `triggerPriceUsd`. **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup.'
                 : 'Create a trigger (limit) order on Jupiter (V1 API). Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when the output/input price ratio reaches `triggerPrice`. Use for: buy at lower price (limit buy) or sell at higher price (limit sell). **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup.',
-            input_schema: {
-                type: 'object',
-                properties: v2Enabled
-                    ? { ...baseProperties, ...v2Properties }
-                    : { ...baseProperties, ...v1Properties },
-                required: v2Enabled
-                    ? ['inputToken', 'outputToken', 'inputAmount', 'triggerPriceUsd']
-                    : ['inputToken', 'outputToken', 'inputAmount', 'triggerPrice'],
-            },
+            input_schema: v2Enabled ? v2Schema : v1Schema,
         };
     })(),
     {

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -134,17 +134,23 @@ const tools = [
     },
     {
         name: 'jupiter_trigger_create',
-        description: 'Create a trigger (limit) order on Jupiter. Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when price condition is met. Use for: buy at lower price (limit buy) or sell at higher price (limit sell). **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup.',
+        description: 'Create a trigger (limit) order on Jupiter. Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when price condition is met. Use for: buy at lower price (limit buy) or sell at higher price (limit sell). **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup. **Dual mode (BAT-697)**: when `config.useTriggerV2` is FALSE (default), pass V1 fields — `triggerPrice` (token ratio, e.g. 90 = "1 SOL = 90 USDC") + optional `expiryTime`. When TRUE, pass V2 fields — `triggerPriceUsd` (USD, e.g. 80.50) + required `expiresAt`. The two field families are semantically different and NOT interchangeable.',
         input_schema: {
             type: 'object',
             properties: {
                 inputToken: { type: 'string', description: 'Token to sell — symbol (e.g., "SOL") or mint address' },
                 outputToken: { type: 'string', description: 'Token to buy — symbol (e.g., "USDC") or mint address' },
                 inputAmount: { type: 'number', description: 'Amount of inputToken to sell (in human units)' },
-                triggerPrice: { type: 'number', description: 'Price at which order triggers (outputToken per inputToken, e.g., 90 means 1 SOL = 90 USDC)' },
-                expiryTime: { type: 'number', description: 'Order expiration timestamp (Unix seconds). Optional, defaults to 30 days from now.' }
+                // V1 fields (active when useTriggerV2 is false — the shipping default).
+                triggerPrice: { type: 'number', description: '[V1 mode only] Price as outputToken-per-inputToken ratio (e.g., 90 = "1 SOL = 90 USDC"). Required in V1 mode. NOT accepted in V2 mode (different semantic — V2 uses USD).' },
+                expiryTime: { type: 'number', description: '[V1 mode] Order expiration as Unix seconds. Optional in V1 (defaults to 30 days from now). Accepted in V2 mode as a legacy alias for `expiresAt` — V2 has NO default, one of expiryTime/expiresAt is required.' },
+                // V2 fields (active when useTriggerV2 is true — flag-gated, not yet default).
+                triggerPriceUsd: { type: 'number', description: '[V2 mode only] USD price where the trigger fires (e.g., 80.50 for $80.50). Required in V2 mode. NOT accepted in V1 mode.' },
+                expiresAt: { type: 'number', description: '[V2 mode] Order expiration as Unix seconds OR milliseconds (auto-detected). Required in V2 mode if expiryTime not provided. NO 30-day default in V2 — must be explicit.' },
+                triggerCondition: { type: 'string', enum: ['above', 'below'], description: '[V2 mode] When to fire: "above" (price rises to trigger value) or "below" (price drops to trigger value). Auto-inferred from token pair when one side is a stablecoin; required for non-stable pairs.' },
+                slippageBps: { type: 'number', description: '[V2 mode] Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' }
             },
-            required: ['inputToken', 'outputToken', 'inputAmount', 'triggerPrice']
+            required: ['inputToken', 'outputToken', 'inputAmount']
         }
     },
     {

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -494,6 +494,35 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         const { routeFor: _routeForTriggerV2 } = require('../caps/preflight');
         const routingHint = await _routeForTriggerV2('jupiter_trigger_create', input);
 
+        // PR #388 R9: over-cap fail-fast. routeFor returns
+        // {routingDecision:'burner', underCap:false} when the principal would
+        // breach a cap. Pre-fix, the V2 handler continued through burner
+        // pubkey lookup, Jupiter auth (server-side session), vault register
+        // (server-side vault row), AND deposit/craft (server-side deposit
+        // request id) before routeAndSign finally surfaced burner_over_cap.
+        // All of those side effects were wasted server state for an order
+        // that would never sign. Handle it here:
+        //   - With `input._allowMainFallback === true`: flip routing to
+        //     'main' BEFORE step 4 so the rest of the flow proceeds against
+        //     the MWA wallet (mirrors V1 routing semantics).
+        //   - Otherwise: refuse immediately with the same shape dispatch.js
+        //     would return, but before any Jupiter or burner-bridge state
+        //     is touched.
+        if (routingHint.routingDecision === 'burner' && routingHint.underCap === false) {
+            if (input._allowMainFallback === true) {
+                routingHint.routingDecision = 'main';
+                log(`[Jupiter Trigger V2] over-cap (${routingHint.reason || 'unknown'}) — _allowMainFallback set, flipping route to main BEFORE side effects`, 'INFO');
+            } else {
+                return {
+                    error: 'burner_over_cap',
+                    reason:
+                        `Burner over cap (${routingHint.reason || 'unknown'}). ` +
+                        'Raise the cap with wallet_set_caps, or retry with _allowMainFallback: true to use the main wallet (popup required).',
+                    capName: routingHint.capName,
+                };
+            }
+        }
+
         // 4. Resolve wallet address — burner pubkey if routing=burner, MWA pubkey otherwise.
         // If burner routing was chosen but the burner pubkey is unavailable
         // (bridge unreachable, not configured, etc.), we MUST also flip the

--- a/app/src/main/assets/nodejs-project/tools/solana.js
+++ b/app/src/main/assets/nodejs-project/tools/solana.js
@@ -132,28 +132,50 @@ const tools = [
             required: ['inputToken', 'outputToken', 'amount']
         }
     },
-    {
-        name: 'jupiter_trigger_create',
-        description: 'Create a trigger (limit) order on Jupiter. Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when price condition is met. Use for: buy at lower price (limit buy) or sell at higher price (limit sell). **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup. **Dual mode (BAT-697)**: when `config.useTriggerV2` is FALSE (default), pass V1 fields — `triggerPrice` (token ratio, e.g. 90 = "1 SOL = 90 USDC") + optional `expiryTime`. When TRUE, pass V2 fields — `triggerPriceUsd` (USD, e.g. 80.50) + required `expiresAt`. The two field families are semantically different and NOT interchangeable.',
-        input_schema: {
-            type: 'object',
-            properties: {
-                inputToken: { type: 'string', description: 'Token to sell — symbol (e.g., "SOL") or mint address' },
-                outputToken: { type: 'string', description: 'Token to buy — symbol (e.g., "USDC") or mint address' },
-                inputAmount: { type: 'number', description: 'Amount of inputToken to sell (in human units)' },
-                // V1 fields (active when useTriggerV2 is false — the shipping default).
-                triggerPrice: { type: 'number', description: '[V1 mode only] Price as outputToken-per-inputToken ratio (e.g., 90 = "1 SOL = 90 USDC"). Required in V1 mode. NOT accepted in V2 mode (different semantic — V2 uses USD).' },
-                expiryTime: { type: 'number', description: '[V1 mode] Order expiration as Unix seconds. Optional in V1 (defaults to 30 days from now). Accepted in V2 mode as a legacy alias for `expiresAt` — V2 has NO default, one of expiryTime/expiresAt is required.' },
-                // V2 fields (active when useTriggerV2 is true — flag-gated, not yet default).
-                triggerPriceUsd: { type: 'number', description: '[V2 mode only] USD price where the trigger fires (e.g., 80.50 for $80.50). Required in V2 mode. NOT accepted in V1 mode.' },
-                expiresAt: { type: 'number', description: '[V2 mode] Order expiration as Unix seconds OR milliseconds (auto-detected). Required in V2 mode if expiryTime not provided. NO 30-day default in V2 — must be explicit.' },
-                triggerCondition: { type: 'string', enum: ['above', 'below'], description: '[V2 mode] When to fire: "above" (price rises to trigger value) or "below" (price drops to trigger value). Auto-inferred from token pair when one side is a stablecoin; required for non-stable pairs.' },
-                slippageBps: { type: 'number', description: '[V2 mode] Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' },
-                triggerMint: { type: 'string', description: '[V2 mode] Mint address of the asset whose USD price the trigger watches. Auto-inferred when exactly one side of the pair is a stablecoin (SOL↔USDC → SOL is watched). REQUIRED for non-stable↔non-stable pairs (SOL↔JUP) and both-stable pairs (USDC↔USDT) — otherwise the order returns trigger_mint_required.' }
+    // PR #388 R6: the jupiter_trigger_create schema is flag-aware. V1 (default
+    // when config.useTriggerV2 is false) requires `triggerPrice`; V2 (when the
+    // flag is true) requires `triggerPriceUsd`. Pre-fix the schema relaxed
+    // `required` to allow BOTH callers, but that meant the model/gate would
+    // accept a V1 call missing triggerPrice and only fail at runtime with
+    // "Invalid trigger price". Build the schema once at module load against
+    // the active flag so the schema validator rejects bad calls upstream of
+    // the handler. Flag changes require a process restart (already true for
+    // most flag-gated paths here).
+    (() => {
+        const v2Enabled = config.useTriggerV2 === true;
+        const baseProperties = {
+            inputToken: { type: 'string', description: 'Token to sell — symbol (e.g., "SOL") or mint address' },
+            outputToken: { type: 'string', description: 'Token to buy — symbol (e.g., "USDC") or mint address' },
+            inputAmount: { type: 'number', description: 'Amount of inputToken to sell (in human units)' },
+        };
+        const v1Properties = {
+            triggerPrice: { type: 'number', description: 'Price as outputToken-per-inputToken ratio (e.g., 90 = "1 SOL = 90 USDC"). REQUIRED.' },
+            expiryTime: { type: 'number', description: 'Order expiration as Unix seconds. Optional; defaults to 30 days from now.' },
+        };
+        const v2Properties = {
+            triggerPriceUsd: { type: 'number', description: 'USD price where the trigger fires (e.g., 80.50 for $80.50). REQUIRED.' },
+            expiresAt: { type: 'number', description: 'Order expiration as Unix seconds OR milliseconds (auto-detected). REQUIRED (no silent default in V2).' },
+            expiryTime: { type: 'number', description: 'Legacy alias for `expiresAt` (Unix seconds). Accepted if `expiresAt` not provided. One of the two IS required.' },
+            triggerCondition: { type: 'string', enum: ['above', 'below'], description: 'When to fire: "above" (price rises to trigger) or "below" (price drops to trigger). Auto-inferred when one side of the pair is a stablecoin; required for non-stable pairs.' },
+            slippageBps: { type: 'number', description: 'Slippage tolerance in basis points (1-10000). Optional; defaults to 100 (1%).' },
+            triggerMint: { type: 'string', description: 'Mint address of the asset whose USD price the trigger watches. Auto-inferred when exactly one side of the pair is a stablecoin (SOL↔USDC → SOL is watched). REQUIRED for non-stable↔non-stable pairs (SOL↔JUP) and both-stable pairs (USDC↔USDT).' },
+        };
+        return {
+            name: 'jupiter_trigger_create',
+            description: v2Enabled
+                ? 'Create a trigger (limit) order on Jupiter (V2 API). Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when the USD price reaches `triggerPriceUsd`. **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup.'
+                : 'Create a trigger (limit) order on Jupiter (V1 API). Requires Jupiter API key (get free at portal.jup.ag). Order executes automatically when the output/input price ratio reaches `triggerPrice`. Use for: buy at lower price (limit buy) or sell at higher price (limit sell). **Routing (BAT-582)**: under burner caps -> silent burner sign; over cap or burner not configured -> Main wallet popup.',
+            input_schema: {
+                type: 'object',
+                properties: v2Enabled
+                    ? { ...baseProperties, ...v2Properties }
+                    : { ...baseProperties, ...v1Properties },
+                required: v2Enabled
+                    ? ['inputToken', 'outputToken', 'inputAmount', 'triggerPriceUsd']
+                    : ['inputToken', 'outputToken', 'inputAmount', 'triggerPrice'],
             },
-            required: ['inputToken', 'outputToken', 'inputAmount']
-        }
-    },
+        };
+    })(),
     {
         name: 'jupiter_trigger_list',
         description: 'List your active or historical limit/stop orders on Jupiter. Shows order status, prices, amounts, and expiration. Requires Jupiter API key.',
@@ -548,6 +570,20 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
                 reason: 'Could not infer triggerCondition from token pair. Pass triggerCondition: "above" or "below" explicitly.',
             };
         }
+        // PR #388 R6: resolve triggerMint and fail closed for ambiguous pairs
+        // BEFORE any Jupiter side effects (auth / vault register / deposit
+        // craft). Pre-fix this check ran after depositCraft, so an ambiguous
+        // pair without explicit triggerMint could leave a server-side vault
+        // + a wasted /deposit/craft request before returning the error.
+        const triggerMint = _inferTriggerMint(inputToken.address, outputToken.address, input.triggerMint);
+        if (!triggerMint) {
+            return {
+                error: 'trigger_mint_required',
+                reason: 'For non-stable↔non-stable pairs (e.g. SOL↔JUP) and both-stable pairs (e.g. USDC↔USDT), the trigger asset cannot be inferred safely — Jupiter would watch the wrong asset\'s USD price. Pass `triggerMint` explicitly to disambiguate.',
+                inputMint: inputToken.address,
+                outputMint: outputToken.address,
+            };
+        }
 
         // 8. Semantic validation (pure — fail fast before any network work).
         const validation = triggerV2.validateOrderArgs({ inputUsdValue, expiresAtMs, triggerPriceUsd, slippageBps });
@@ -596,24 +632,9 @@ async function _jupiterTriggerCreateV2(input, _chatId) {
         }
 
         // 13. routeAndSign for the deposit signing + orders/price POST.
-        // PR #388 R2: derive triggerMint from the non-stable side of the
-        // pair (the asset whose USD price the trigger watches). Pre-fix
-        // unconditionally used outputMint, which broke sell-into-stable
-        // orders (SOL → USDC "above $90" would watch USDC's ~$1 price).
-        // PR #388 R5: for non-stable↔non-stable or both-stable pairs,
-        // _inferTriggerMint returns null — caller MUST pass triggerMint
-        // explicitly. Fail closed BEFORE building the deposit so we don't
-        // sign a tx for an order that would never fire (or fire on the
-        // wrong asset).
-        const triggerMint = _inferTriggerMint(inputToken.address, outputToken.address, input.triggerMint);
-        if (!triggerMint) {
-            return {
-                error: 'trigger_mint_required',
-                reason: 'For non-stable↔non-stable pairs (e.g. SOL↔JUP) and both-stable pairs (e.g. USDC↔USDT), the trigger asset cannot be inferred safely — Jupiter would watch the wrong asset\'s USD price. Pass `triggerMint` explicitly to disambiguate.',
-                inputMint: inputToken.address,
-                outputMint: outputToken.address,
-            };
-        }
+        // triggerMint was resolved + validated in step 7 (above) BEFORE any
+        // Jupiter side effects. See PR #388 R2 (sell-into-stable bug) and
+        // R5/R6 (ambiguous-pair fail-closed + early-fail ordering).
         const orderArgs = {
             inputMint: inputToken.address,
             inputAmount: String(inputAmountAtomic),

--- a/app/src/main/assets/nodejs-project/wallet/dispatch.js
+++ b/app/src/main/assets/nodejs-project/wallet/dispatch.js
@@ -205,10 +205,18 @@ async function routeAndSign({ toolName, toolArgs, unsignedTxBase64, broadcastVia
     }
 
     // 4d. Commit on success — anchor the spend in the daily ledger.
+    // Coerce the signature to a non-empty string or null: a broadcast callback
+    // that returns a non-string `signature` (object/number from a future code
+    // path) must never reach /burner/commit as a malformed value. Trigger V2's
+    // ambiguous-recovery path legitimately commits with signature:null.
+    const commitSignature =
+        (typeof broadcastResult.signature === 'string' && broadcastResult.signature.length > 0)
+            ? broadcastResult.signature
+            : null;
     try {
         await androidBridgeCall('/burner/commit', {
             reservationId,
-            signature: broadcastResult.signature || null,
+            signature: commitSignature,
         }, 5000);
     } catch (e) {
         // Commit failure is logged but doesn't unwind a successful broadcast.

--- a/app/src/main/assets/nodejs-project/wallet/dispatch.js
+++ b/app/src/main/assets/nodejs-project/wallet/dispatch.js
@@ -360,8 +360,83 @@ async function recordJupiterOwnership(orderId, creatorWalletRole, flowName = 'ju
     }
 }
 
+/**
+ * BAT-697 PR B — sign a Jupiter Trigger V2 auth-challenge / deposit /
+ * confirm-cancel transaction via the burner WITHOUT consuming cap
+ * principal. Used for transaction-challenge V2 auth flows where the
+ * tx is a Memo-only auth payload (no value movement) and for the
+ * "sign a single tx, no broadcast" subpath shared by V2 cancel
+ * step-2 and ambiguous-create recovery.
+ *
+ * Differs from signCancelViaBurner in three ways:
+ *   - Caller controls broadcast (or skips it entirely — useful for auth
+ *     challenges where the "broadcast" is just POSTing to /auth/verify).
+ *   - No ownership tracking (no order ID exists yet for auth or for
+ *     create-deposit).
+ *   - 0-amount reservation: confirms burner is configured but never
+ *     touches cap state; always released, never committed.
+ *
+ * Returns { ok: true, signedTxBase64 } or { ok: false, error, reason }.
+ *
+ * Callers MUST call the broadcast/HTTP step themselves and not bake
+ * cap-state semantics around it — this helper is signing-only.
+ */
+async function signZeroCapTxViaBurner({ unsignedTxBase64, flowName = 'zero-cap-sign' }) {
+    const burner = getWallet('burner');
+    if (!burner) {
+        return { ok: false, error: 'no_burner_wallet', reason: 'getWallet("burner") returned null' };
+    }
+    const reserveRes = await androidBridgeCall('/burner/reserve', {
+        name: 'burner.pertx.sol',
+        atomicAmount: '0',
+        ttlMs: 60000,
+    }, 5000);
+    if (!reserveRes || reserveRes.error || !reserveRes.reservationId) {
+        return {
+            ok: false,
+            error: reserveRes && reserveRes.error ? reserveRes.error : 'reserve_failed',
+            reason: reserveRes && reserveRes.reason ? reserveRes.reason : 'zero-cap reservation failed',
+        };
+    }
+    const reservationId = reserveRes.reservationId;
+
+    let signedTxBase64;
+    try {
+        const signed = await burner.signer().signTransaction(unsignedTxBase64, { reservationId });
+        if (!signed || signed.error) {
+            await _release(reservationId, signed && signed.error ? signed.error : 'sign_failed');
+            return {
+                ok: false,
+                error: signed && signed.error ? signed.error : 'sign_failed',
+                reason: signed && signed.reason ? signed.reason : 'signing failed',
+            };
+        }
+        signedTxBase64 = signed.signedTxBase64;
+        if (!signedTxBase64) {
+            await _release(reservationId, 'no_signed_tx');
+            return { ok: false, error: 'sign_failed', reason: 'no signedTxBase64 in response' };
+        }
+    } catch (e) {
+        await _release(reservationId, 'sign_threw');
+        return { ok: false, error: 'sign_failed', reason: e.message };
+    }
+
+    // Always release — zero-cap reservation never accumulates spend.
+    try {
+        await androidBridgeCall('/burner/release', {
+            reservationId,
+            reason: `${flowName}_complete`,
+        }, 5000);
+    } catch (e) {
+        log(`[${flowName}] release after zero-cap sign failed: ${e.message}`, 'WARN');
+    }
+
+    return { ok: true, signedTxBase64 };
+}
+
 module.exports = {
     routeAndSign,
     signCancelViaBurner,
+    signZeroCapTxViaBurner,
     recordJupiterOwnership,
 };

--- a/app/src/main/assets/nodejs-project/wallet/dispatch.js
+++ b/app/src/main/assets/nodejs-project/wallet/dispatch.js
@@ -405,22 +405,51 @@ async function recordJupiterOwnership(orderId, creatorWalletRole, flowName = 'ju
  * Callers MUST call the broadcast/HTTP step themselves and not bake
  * cap-state semantics around it — this helper is signing-only.
  */
+// PR #388 R2: zero-cap reserve must work for any user whose burner has at
+// least one cap configured, not just users with a SOL cap. A user with
+// USDC-only caps (capPerTxSol: '0', capPerTxUsdc: set) routes USDC spends
+// through the burner; pre-fix this helper always reserved against the SOL
+// cap and would fail `burner_not_configured` for those users — blocking
+// V2 USDC orders before any deposit signing. We try SOL first (the common
+// case), then fall back to USDC on the specific `burner_not_configured`
+// error (and ONLY that error — other failures bubble up unchanged so we
+// don't mask transient issues).
+const _ZERO_CAP_CANDIDATES = ['burner.pertx.sol', 'burner.pertx.usdc'];
+async function _zeroCapReserveAny() {
+    let lastErr = null;
+    for (const name of _ZERO_CAP_CANDIDATES) {
+        const res = await androidBridgeCall('/burner/reserve', {
+            name,
+            atomicAmount: '0',
+            ttlMs: 60000,
+        }, 5000);
+        if (res && !res.error && res.reservationId) {
+            return { ok: true, reservationId: res.reservationId, capName: name };
+        }
+        lastErr = res;
+        // Only fall through to the next candidate when the burner reports
+        // "not configured" against THIS cap (which means the asset cap
+        // for this name is unset, not that the burner itself is missing).
+        // Bridge unreachable / TTL / other errors short-circuit so we
+        // don't paper over a real failure with a second redundant call.
+        if (!res || res.error !== 'burner_not_configured') break;
+    }
+    return {
+        ok: false,
+        error: (lastErr && lastErr.error) || 'reserve_failed',
+        reason: (lastErr && lastErr.reason)
+            || `zero-cap reservation failed against all candidate caps (${_ZERO_CAP_CANDIDATES.join(', ')})`,
+    };
+}
+
 async function signZeroCapTxViaBurner({ unsignedTxBase64, flowName = 'zero-cap-sign' }) {
     const burner = getWallet('burner');
     if (!burner) {
         return { ok: false, error: 'no_burner_wallet', reason: 'getWallet("burner") returned null' };
     }
-    const reserveRes = await androidBridgeCall('/burner/reserve', {
-        name: 'burner.pertx.sol',
-        atomicAmount: '0',
-        ttlMs: 60000,
-    }, 5000);
-    if (!reserveRes || reserveRes.error || !reserveRes.reservationId) {
-        return {
-            ok: false,
-            error: reserveRes && reserveRes.error ? reserveRes.error : 'reserve_failed',
-            reason: reserveRes && reserveRes.reason ? reserveRes.reason : 'zero-cap reservation failed',
-        };
+    const reserveRes = await _zeroCapReserveAny();
+    if (!reserveRes.ok) {
+        return { ok: false, error: reserveRes.error, reason: reserveRes.reason };
     }
     const reservationId = reserveRes.reservationId;
 

--- a/app/src/main/assets/nodejs-project/wallet/dispatch.js
+++ b/app/src/main/assets/nodejs-project/wallet/dispatch.js
@@ -87,16 +87,32 @@ const { log } = require('../config');
  * here as belt-and-suspenders — if routing says under-cap=false at this
  * point, something raced or the gate was bypassed; we return an error.
  */
-async function routeAndSign({ toolName, toolArgs, unsignedTxBase64, broadcastVia = 'rpc', broadcast, flowName = toolName }) {
+async function routeAndSign({ toolName, toolArgs, unsignedTxBase64, broadcastVia = 'rpc', broadcast, flowName = toolName, forceRouting = null }) {
     // 1. Decide routing.
     let route;
-    try {
-        route = await routeFor(toolName, toolArgs || {});
-    } catch (e) {
-        log(`[${flowName}] routeFor failed: ${e.message}`, 'WARN');
-        // Defensive: degrade to main path so the user sees an MWA popup
-        // rather than a silent failure.
-        route = { routingDecision: 'main', underCap: true, principalAtomic: null, capName: null };
+    if (forceRouting && (forceRouting.routingDecision === 'burner' || forceRouting.routingDecision === 'main')) {
+        // Caller already decided routing (e.g. handler observed a runtime
+        // constraint routeFor can't see, like "burner is in cap-allowing
+        // state per /burner/status, but the burner pubkey itself isn't
+        // reachable so we MUST fall back to main"). routeFor would otherwise
+        // re-compute routing from `toolArgs` alone and possibly return a
+        // burner decision the caller knew it had to override, producing a
+        // signer/fee-payer mismatch (PR #388 R2 finding).
+        route = {
+            routingDecision: forceRouting.routingDecision,
+            underCap: forceRouting.underCap !== undefined ? forceRouting.underCap : true,
+            principalAtomic: forceRouting.principalAtomic !== undefined ? forceRouting.principalAtomic : null,
+            capName: forceRouting.capName !== undefined ? forceRouting.capName : null,
+        };
+    } else {
+        try {
+            route = await routeFor(toolName, toolArgs || {});
+        } catch (e) {
+            log(`[${flowName}] routeFor failed: ${e.message}`, 'WARN');
+            // Defensive: degrade to main path so the user sees an MWA popup
+            // rather than a silent failure.
+            route = { routingDecision: 'main', underCap: true, principalAtomic: null, capName: null };
+        }
     }
 
     // 2. Burner over-cap defensive — gate should have blocked, but if we

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -332,14 +332,18 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(httpCalls.length, callsBefore);
     });
 
+    // BAT-697 live-API finding: /vault/register does NOT exist; an unregistered
+    // wallet GET returns 404 "Vault not found". ensureVault must fail loudly
+    // (vault_registration_unsupported) rather than POST a 404 route.
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { registered: false } });
-    _enqueue({ status: 200, data: { vaultAddress: 'NewVaUlT22222' } });
-    await check('GET unregistered → POST register → returns vault', async () => {
+    _enqueue({ status: 404, data: { error: 'Vault not found' } });
+    await check('GET unregistered (404) → vault_registration_unsupported (no register POST)', async () => {
+        const callsBefore = httpCalls.length;
         const r = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
-        assert.strictEqual(r.ok, true);
-        assert.strictEqual(r.vaultAddress, 'NewVaUlT22222');
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'vault_registration_unsupported');
+        assert.strictEqual(httpCalls.length, callsBefore + 1, 'must NOT make a second (register) call');
     });
 
     // ── depositCraft + submitCreateOrder happy path ─────────────────────────
@@ -562,10 +566,45 @@ function _buildTransferTx(payerB58) {
         assert.ok(/fee payer/i.test(r.reason), `expected fee-payer reason, got: ${r.reason}`);
     });
 
-    await check('REJECTS tx referencing SystemProgram (Transfer) — Memo-only guard', async () => {
+    await check('REJECTS tx referencing SystemProgram (Transfer) — value-moving guard', async () => {
         const tx = buildTxBytes({ accounts: [PAYER_BUF, SYS_BYTES], instrProgramIdx: 1 });
         const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
         assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+    });
+
+    // Multi-instruction builder for the Memo+ComputeBudget case — Jupiter's
+    // REAL challenge (verified live 2026-05-29) bundles a ComputeBudget instr
+    // alongside the Memo. A Memo-only guard would reject the real challenge.
+    const COMPUTE_BUDGET_BYTES = b58decodeStrict('ComputeBudget111111111111111111111111111111');
+    function buildMultiInstrTx({ accounts, instrIdxs, versioned = false }) {
+        const parts = [];
+        if (versioned) parts.push(Buffer.from([0x80]));
+        parts.push(Buffer.from([1, 0, 0]));
+        parts.push(cu16(accounts.length));
+        for (const a of accounts) parts.push(a);
+        parts.push(Buffer.alloc(32)); // blockhash
+        parts.push(cu16(instrIdxs.length));
+        for (const idx of instrIdxs) {
+            parts.push(Buffer.from([idx])); // program id index
+            parts.push(cu16(0));            // 0 accounts
+            parts.push(cu16(2));            // data len
+            parts.push(Buffer.from([0x01, 0x02]));
+        }
+        const message = Buffer.concat(parts);
+        return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+    }
+
+    await check('ACCEPTS Memo + ComputeBudget (Jupiter real-challenge shape)', async () => {
+        const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, MEMO_BYTES, COMPUTE_BUDGET_BYTES], instrIdxs: [2, 1] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, true, `expected accept, got: ${JSON.stringify(r)}`);
+    });
+
+    await check('REJECTS Memo + SystemProgram even when a Memo instr is present', async () => {
+        const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, MEMO_BYTES, SYS_BYTES], instrIdxs: [1, 2] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false, 'a value-moving instr alongside a Memo must still be rejected');
         assert.strictEqual(r.error, 'auth_tx_invalid');
     });
 

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -863,7 +863,12 @@ function _buildTransferTx(payerB58) {
     _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-recover-401' } });
     _enqueue({ status: 500, data: { error: 'jupiter_internal' } });
     _enqueue({ status: 401, data: { error: 'expired' } });
-    await check('401 from /orders/history during recovery → invalidateJwt + auth_expired', async () => {
+    // PR #388 R4: recovery 401 must route through `create_ambiguous_no_recovery`
+    // (NOT `auth_expired`) so the upstream broadcast callback commits the
+    // burner cap conservatively — the deposit may have landed and we just
+    // lost our only way to confirm it. The JWT cache is still invalidated
+    // so the next call re-auths cleanly.
+    await check('401 from /orders/history during recovery → invalidateJwt + ambiguous-no-recovery', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt-recover-401',
             inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
@@ -878,7 +883,8 @@ function _buildTransferTx(payerB58) {
                     triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
             });
             assert.strictEqual(submit.ok, false);
-            assert.strictEqual(submit.error, 'auth_expired');
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery',
+                'recovery 401 must commit-conservatively via ambiguous bucket (PR #388 R4)');
             // Confirm the JWT cache was invalidated — next auth should NOT hit cache.
             _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
             _enqueue({ status: 200, data: { token: 'jwt-fresh-after-recover' } });
@@ -888,6 +894,39 @@ function _buildTransferTx(payerB58) {
             assert.strictEqual(reauth.ok, true);
             assert.notStrictEqual(reauth.cached, true, 'recovery 401 must have invalidated the cache');
             assert.strictEqual(reauth.token, 'jwt-fresh-after-recover');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    // PR #388 R4: a transport throw during /orders/history must also route
+    // through the ambiguous bucket (the deposit may have landed and we lost
+    // our ability to confirm). Pre-fix, the throw propagated out and
+    // routeAndSign treated it as broadcast failure → released the burner
+    // reservation → under-counted spend if the deposit actually landed.
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-throw' } });
+    _enqueue({ status: 500, data: { error: 'jupiter_internal' } });
+    // Next dequeue intentionally throws (simulate transport error).
+    httpQueue.push(() => { throw new Error('ECONNRESET during /orders/history'); });
+    await check('transport throw during /orders/history → ambiguous-no-recovery (PR #388 R4)', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false);
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery',
+                'transport throw must commit-conservatively via ambiguous bucket (PR #388 R4)');
+            assert.ok(submit.reason && /threw/i.test(submit.reason),
+                `reason should mention the throw — got: ${submit.reason}`);
         } finally { global.setTimeout = origSetTimeout; }
     });
 

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -316,15 +316,15 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(httpCalls.length, 1, 'only the message-challenge HTTP call, no tx fallback');
     });
 
-    // ── ensureVault ─────────────────────────────────────────────────────────
+    // ── ensureVault (contract: GET /vault → vaultPubkey; GET /vault/register) ─
     console.log('\nensureVault:');
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { registered: true, vaultAddress: 'VaULTaddR111' } });
-    await check('GET vault returns registered + caches', async () => {
+    _enqueue({ status: 200, data: { userPubkey: FIXTURE_PUBKEY, vaultPubkey: 'VauLTpk111', privyVaultId: 'pv1' } });
+    await check('GET /vault returns vaultPubkey + caches', async () => {
         const r = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
         assert.strictEqual(r.ok, true);
-        assert.strictEqual(r.vaultAddress, 'VaULTaddR111');
+        assert.strictEqual(r.vaultPubkey, 'VauLTpk111');
         // Second call must hit cache, not HTTP.
         const callsBefore = httpCalls.length;
         const r2 = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
@@ -332,30 +332,31 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(httpCalls.length, callsBefore);
     });
 
-    // BAT-697 live-API finding: /vault/register does NOT exist; an unregistered
-    // wallet GET returns 404 "Vault not found". ensureVault must fail loudly
-    // (vault_registration_unsupported) rather than POST a 404 route.
+    // No vault yet → GET /vault 404, then idempotent GET /vault/register creates it.
     triggerV2._resetCachesForTests();
     _resetHttp();
     _enqueue({ status: 404, data: { error: 'Vault not found' } });
-    await check('GET unregistered (404) → vault_registration_unsupported (no register POST)', async () => {
+    _enqueue({ status: 200, data: { userPubkey: FIXTURE_PUBKEY, vaultPubkey: 'VauLTpk222', privyVaultId: 'pv2' } });
+    await check('GET /vault 404 → GET /vault/register (idempotent) → vaultPubkey', async () => {
         const callsBefore = httpCalls.length;
         const r = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
-        assert.strictEqual(r.ok, false);
-        assert.strictEqual(r.error, 'vault_registration_unsupported');
-        assert.strictEqual(httpCalls.length, callsBefore + 1, 'must NOT make a second (register) call');
+        assert.strictEqual(r.ok, true);
+        assert.strictEqual(r.vaultPubkey, 'VauLTpk222');
+        assert.strictEqual(httpCalls.length, callsBefore + 2, 'GET /vault then GET /vault/register');
+        // Both calls must be GET (no POST register).
+        assert.ok(httpCalls.slice(-2).every(c => c.options.method === 'GET'), 'vault calls must be GET');
     });
 
     // ── depositCraft + submitCreateOrder happy path ─────────────────────────
     console.log('\ndepositCraft + submitCreateOrder:');
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', depositRequestId: 'dr-001' } });
+    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', requestId: 'dr-001' } });
     _enqueue({ status: 200, data: { id: 'order-001', txSignature: 'sig-001' } });
     await check('happy path: craft → submit → order id', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
-            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
         });
         assert.strictEqual(craft.ok, true);
         assert.strictEqual(craft.depositRequestId, 'dr-001');
@@ -376,7 +377,7 @@ function _buildTransferTx(payerB58) {
     // ── submitCreateOrder: ambiguous + history-recovery ─────────────────────
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', depositRequestId: 'dr-002' } });
+    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', requestId: 'dr-002' } });
     _enqueue({ status: 500, data: { error: 'jupiter_internal' } });        // ambiguous create
     _enqueue({                                                                 // recovery /orders/history
         status: 200,
@@ -389,7 +390,7 @@ function _buildTransferTx(payerB58) {
     await check('ambiguous (500) + history match → success with recovered flag', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
-            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
         });
         // Use a stub setTimeout shim to skip the 5s recovery wait in tests
         const origSetTimeout = global.setTimeout;
@@ -416,13 +417,13 @@ function _buildTransferTx(payerB58) {
     // ── submitCreateOrder: ambiguous + history miss → no-recovery ───────────
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-003' } });
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-003' } });
     _enqueue({ status: 500, data: { error: 'oops' } });
     _enqueue({ status: 200, data: { orders: [] } });
     await check('ambiguous (500) + empty history → create_ambiguous_no_recovery', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
-            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
         });
         const origSetTimeout = global.setTimeout;
         global.setTimeout = (fn) => origSetTimeout(fn, 0);
@@ -645,7 +646,7 @@ function _buildTransferTx(payerB58) {
     console.log('\nrecovery hardening (BAT-697 review pass):');
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-fail' } });
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-fail' } });
     _enqueue({ status: 500, data: { error: 'oops' } });
     // History returns a FAILED order that still carries vaultState:pending_deposit
     // AND matches mint+amount — the pre-fix OR-logic would have matched it.
@@ -657,7 +658,7 @@ function _buildTransferTx(payerB58) {
     await check('failed order with vaultState:pending_deposit is NOT recovered', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
-            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
         });
         const origSetTimeout = global.setTimeout;
         global.setTimeout = (fn) => origSetTimeout(fn, 0);
@@ -675,7 +676,7 @@ function _buildTransferTx(payerB58) {
 
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-primary' } });
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-primary' } });
     _enqueue({ status: 500, data: { error: 'oops' } });
     // History exposes depositRequestId — primary correlation must match it
     // even though a SECOND same-amount active order also exists (no false alias).
@@ -688,7 +689,7 @@ function _buildTransferTx(payerB58) {
     await check('recovery prefers depositRequestId correlation over amount heuristic', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
-            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
         });
         const origSetTimeout = global.setTimeout;
         global.setTimeout = (fn) => origSetTimeout(fn, 0);

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -621,6 +621,40 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(r.error, 'auth_tx_invalid');
     });
 
+    // PR #388 R7 finding: a tx with a Memo instruction whose data length is
+    // 0 commits to NO challenge payload — the blind-sign guard is moot.
+    // Memo must carry actual bytes. Build a tx with the same structure as the
+    // happy-path multi-instr but force the memo's data length to zero.
+    function buildEmptyMemoTx({ accounts, instrIdxs }) {
+        const parts = [];
+        parts.push(Buffer.from([1, 0, 0]));
+        parts.push(cu16(accounts.length));
+        for (const a of accounts) parts.push(a);
+        parts.push(Buffer.alloc(32)); // blockhash
+        parts.push(cu16(instrIdxs.length));
+        for (const idx of instrIdxs) {
+            parts.push(Buffer.from([idx]));
+            parts.push(cu16(0)); // 0 accounts
+            parts.push(cu16(0)); // ZERO data — the regression
+        }
+        const message = Buffer.concat(parts);
+        return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+    }
+    await check('R7 REJECTS empty-Memo tx (Memo present but zero-byte data)', async () => {
+        const tx = buildEmptyMemoTx({ accounts: [PAYER_BUF, MEMO_BYTES], instrIdxs: [1] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false, 'a Memo with zero-byte data must NOT pass the blind-sign guard');
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+        assert.ok(/empty|zero-byte/i.test(r.reason || ''),
+            `expected empty/zero-byte reason, got: ${r.reason}`);
+    });
+    await check('R7 REJECTS empty-Memo + ComputeBudget combo (still no payload to commit)', async () => {
+        const tx = buildEmptyMemoTx({ accounts: [PAYER_BUF, MEMO_BYTES, COMPUTE_BUDGET_BYTES], instrIdxs: [2, 1] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false, 'empty-Memo cannot be salvaged by a sibling ComputeBudget instruction');
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+    });
+
     await check('REJECTS Memo + SystemProgram even when a Memo instr is present', async () => {
         const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, MEMO_BYTES, SYS_BYTES], instrIdxs: [1, 2] });
         const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -635,6 +635,12 @@ function _buildTransferTx(payerB58) {
         // continuation bit set but buffer ends → malformed → null
         assert.strictEqual(triggerV2._readCompactU16(Buffer.from([0x80]), 0), null);
     });
+    await check('_readCompactU16 rejects 3-byte sequence (strict 2-byte cap)', async () => {
+        // Pre-fix: this returned 32767 (silent u16 overflow risk).
+        // Post-fix: gate-at-top of loop refuses to read a 3rd byte.
+        assert.strictEqual(triggerV2._readCompactU16(Buffer.from([0xFF, 0xFF, 0x01]), 0), null);
+        assert.strictEqual(triggerV2._readCompactU16(Buffer.from([0x80, 0x80, 0x00]), 0), null);
+    });
     await check('parser handles a tx with a multi-byte account count (130 accounts)', async () => {
         // 130 accounts: payer + memo + 128 filler. instruction targets memo (idx 1).
         const accounts = [PAYER_BUF, MEMO_BYTES];
@@ -742,6 +748,95 @@ function _buildTransferTx(payerB58) {
             });
             assert.strictEqual(submit.ok, false, 'old unrelated order must not be falsely matched');
             assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    // ── submitCreateOrder: 2xx-with-id acceptance + 2xx-without-id recovery ─
+    // Pre-fix the success gate demanded status===200 exactly; a 201/202 with
+    // a valid order id silently fell into create_failed even though the order
+    // was live on-chain — funds/cap inconsistency.
+    console.log('\nsubmitCreateOrder 2xx handling (BAT-697 double-check):');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-201' } });
+    _enqueue({ status: 201, data: { id: 'order-201', txSignature: 'sig-201' } });
+    await check('HTTP 201 with id is accepted as success', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const submit = await triggerV2.submitCreateOrder({
+            token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+            order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+        });
+        assert.strictEqual(submit.ok, true, 'a 201 + id must be a success, not a hidden failure');
+        assert.strictEqual(submit.id, 'order-201');
+    });
+
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-202' } });
+    _enqueue({ status: 202, data: { /* no id */ } });
+    _enqueue({ status: 200, data: { orders: [] } });
+    await check('HTTP 202 without id triggers recovery (ambiguous)', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false);
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    // ── Recovery: 401 from /orders/history invalidates JWT ──────────────────
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    // Prime the JWT cache by running authenticate.
+    _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+    _enqueue({ status: 200, data: { token: 'jwt-recover-401' } });
+    await triggerV2.authenticate(FIXTURE_PUBKEY, {
+        signTransaction: async () => 'X', signMessage: null,
+    });
+    // Now drive an ambiguous create → recovery path that 401's.
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-recover-401' } });
+    _enqueue({ status: 500, data: { error: 'jupiter_internal' } });
+    _enqueue({ status: 401, data: { error: 'expired' } });
+    await check('401 from /orders/history during recovery → invalidateJwt + auth_expired', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt-recover-401',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt-recover-401', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false);
+            assert.strictEqual(submit.error, 'auth_expired');
+            // Confirm the JWT cache was invalidated — next auth should NOT hit cache.
+            _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+            _enqueue({ status: 200, data: { token: 'jwt-fresh-after-recover' } });
+            const reauth = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+                signTransaction: async () => 'X', signMessage: null,
+            });
+            assert.strictEqual(reauth.ok, true);
+            assert.notStrictEqual(reauth.cached, true, 'recovery 401 must have invalidated the cache');
+            assert.strictEqual(reauth.token, 'jwt-fresh-after-recover');
         } finally { global.setTimeout = origSetTimeout; }
     });
 

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -382,9 +382,11 @@ function _buildTransferTx(payerB58) {
     _enqueue({                                                                 // recovery /orders/history
         status: 200,
         data: { orders: [
-            { id: 'order-recovered-002', status: 'pending_deposit',
-              inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
-              createdAt: new Date().toISOString() },
+            { id: 'order-recovered-002', orderState: 'pending_deposit',
+              inputMint: FIXTURE_INPUT_MINT, initialInputAmount: '1000000',
+              remainingInputAmount: '1000000',
+              createdAt: new Date().toISOString(),
+              events: [{ type: 'deposit', txSignature: 'deposit-sig-recovered', state: 'success' }] },
         ] },
     });
     await check('ambiguous (500) + history match → success with recovered flag', async () => {
@@ -642,20 +644,23 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(r.ok, true, `expected accept with 130 accounts, got: ${JSON.stringify(r)}`);
     });
 
-    // ── recovery: terminal-fail orders must NOT be reported as recovered ────
-    console.log('\nrecovery hardening (BAT-697 review pass):');
+    // ── recovery hardening (real-API row shape, verified live 2026-05-30) ──
+    // History rows use orderState/initialInputAmount/events[]; NO status,
+    // vaultState, inputAmount, or depositRequestId fields on the row.
+    console.log('\nrecovery hardening (real-API row shape):');
+
+    // (a) Terminal-state orders MUST NOT be reported as recovered.
     triggerV2._resetCachesForTests();
     _resetHttp();
     _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-fail' } });
     _enqueue({ status: 500, data: { error: 'oops' } });
-    // History returns a FAILED order that still carries vaultState:pending_deposit
-    // AND matches mint+amount — the pre-fix OR-logic would have matched it.
     _enqueue({ status: 200, data: { orders: [
-        { id: 'dead-order', status: 'failed', vaultState: 'pending_deposit',
-          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        { id: 'dead-order', orderState: 'cancelled', rawState: 'cancelled',
+          inputMint: FIXTURE_INPUT_MINT,
+          initialInputAmount: '1000000', remainingInputAmount: '1000000',
           createdAt: new Date().toISOString() },
     ] } });
-    await check('failed order with vaultState:pending_deposit is NOT recovered', async () => {
+    await check('terminal orderState (cancelled) is NOT recovered', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
             inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
@@ -674,19 +679,20 @@ function _buildTransferTx(payerB58) {
         } finally { global.setTimeout = origSetTimeout; }
     });
 
+    // (b) Active order matches on real fields (orderState/initialInputAmount/events);
+    // recovered result surfaces the deposit-event txSignature.
     triggerV2._resetCachesForTests();
     _resetHttp();
-    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-primary' } });
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-active' } });
     _enqueue({ status: 500, data: { error: 'oops' } });
-    // History exposes depositRequestId — primary correlation must match it
-    // even though a SECOND same-amount active order also exists (no false alias).
     _enqueue({ status: 200, data: { orders: [
-        { id: 'unrelated-same-amount', status: 'active',
-          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000', createdAt: new Date().toISOString() },
-        { id: 'our-order', status: 'active', depositRequestId: 'dr-primary',
-          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000', createdAt: new Date().toISOString() },
+        { id: 'our-order', orderState: 'active', rawState: 'active',
+          inputMint: FIXTURE_INPUT_MINT,
+          initialInputAmount: '1000000', remainingInputAmount: '1000000',
+          createdAt: new Date().toISOString(),
+          events: [{ type: 'deposit', txSignature: 'real-deposit-sig', state: 'success' }] },
     ] } });
-    await check('recovery prefers depositRequestId correlation over amount heuristic', async () => {
+    await check('active order matched on real row shape + deposit txSig surfaced', async () => {
         const craft = await triggerV2.depositCraft({
             pubkey: FIXTURE_PUBKEY, token: 'jwt',
             inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
@@ -701,8 +707,41 @@ function _buildTransferTx(payerB58) {
                     triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
             });
             assert.strictEqual(submit.ok, true);
-            assert.strictEqual(submit.id, 'our-order', 'must match by depositRequestId, not the unrelated same-amount order');
+            assert.strictEqual(submit.id, 'our-order');
             assert.strictEqual(submit.recovered, true);
+            assert.strictEqual(submit.txSignature, 'real-deposit-sig', 'should surface deposit txSignature from events[]');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    // (c) Stale identical order (outside the time window) is NOT matched.
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-stale' } });
+    _enqueue({ status: 500, data: { error: 'oops' } });
+    // An order from 10 minutes ago with identical mint+amount must not be falsely
+    // matched as "ours" — the tight time window is the only safeguard now.
+    _enqueue({ status: 200, data: { orders: [
+        { id: 'stale-other-order', orderState: 'active', rawState: 'active',
+          inputMint: FIXTURE_INPUT_MINT,
+          initialInputAmount: '1000000', remainingInputAmount: '1000000',
+          createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
+    ] } });
+    await check('stale same-amount order outside time window is NOT matched', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false, 'old unrelated order must not be falsely matched');
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
         } finally { global.setTimeout = origSetTimeout; }
     });
 

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -705,13 +705,57 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(r.ok, false);
         assert.ok(/truncated/i.test(r.reason || ''));
     });
-    await check('R10 _validateComputeBudgetInstr accepts unknown tags (heap frame, deprecated RequestUnits)', async () => {
-        // 0x00 RequestUnits, 0x01 RequestHeapFrame, 0x04 SetLoadedAccountsDataSizeLimit
-        // None drain SOL → accept silently.
-        for (const tag of [0x00, 0x01, 0x04]) {
+    await check('R10 _validateComputeBudgetInstr accepts non-fee-affecting tags (HeapFrame, LoadedAccountsDataSizeLimit)', async () => {
+        // 0x01 RequestHeapFrame, 0x04 SetLoadedAccountsDataSizeLimit
+        // Neither drains SOL → accept silently.
+        for (const tag of [0x01, 0x04]) {
             const r = triggerV2._validateComputeBudgetInstr(Buffer.from([tag, 0, 0, 0, 0]));
             assert.strictEqual(r.ok, true, `tag 0x0${tag} (no fee impact) should be accepted`);
         }
+    });
+
+    // PR #388 R11 finding: tag 0x00 (RequestUnitsDeprecated) carries a
+    // u32 `additional_fee` lamport field. Pre-R11 it was accepted as
+    // "unknown safe" — that left a SOL-drain path the same magnitude as
+    // the unbounded SetComputeUnitPrice path. Now decoded + capped.
+    await check('R11 _validateComputeBudgetInstr accepts RequestUnitsDeprecated with zero additional_fee', async () => {
+        // tag(1) + units(4) + additional_fee(4) = 9 bytes
+        const data = Buffer.alloc(9);
+        data[0] = 0x00;
+        data.writeUInt32LE(150_000, 1);  // units, under cap
+        data.writeUInt32LE(0, 5);        // additional_fee = 0
+        assert.strictEqual(triggerV2._validateComputeBudgetInstr(data).ok, true);
+    });
+    await check('R11 _validateComputeBudgetInstr accepts RequestUnitsDeprecated with additional_fee at cap', async () => {
+        const data = Buffer.alloc(9);
+        data[0] = 0x00;
+        data.writeUInt32LE(triggerV2._AUTH_MAX_CU_LIMIT, 1);
+        data.writeUInt32LE(triggerV2._AUTH_MAX_ADDITIONAL_FEE_LAMPORTS, 5);
+        assert.strictEqual(triggerV2._validateComputeBudgetInstr(data).ok, true);
+    });
+    await check('R11 _validateComputeBudgetInstr REJECTS RequestUnitsDeprecated with additional_fee above cap (the attack value)', async () => {
+        const data = Buffer.alloc(9);
+        data[0] = 0x00;
+        data.writeUInt32LE(150_000, 1);
+        data.writeUInt32LE(0xFFFFFFFF, 5); // u32::MAX lamports ≈ 4.29 SOL drain pre-fix
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false, 'u32::MAX additional_fee was the deprecated fee-drain vector');
+        assert.ok(/additional_fee/i.test(r.reason || ''));
+    });
+    await check('R11 _validateComputeBudgetInstr REJECTS RequestUnitsDeprecated with units above cap', async () => {
+        const data = Buffer.alloc(9);
+        data[0] = 0x00;
+        data.writeUInt32LE(triggerV2._AUTH_MAX_CU_LIMIT + 1, 1);
+        data.writeUInt32LE(0, 5);
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false);
+        assert.ok(/units/i.test(r.reason || ''));
+    });
+    await check('R11 _validateComputeBudgetInstr REJECTS truncated RequestUnitsDeprecated (5 bytes instead of 9)', async () => {
+        const data = Buffer.from([0x00, 0, 0, 0, 0]); // tag + units only, missing additional_fee
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false);
+        assert.ok(/truncated/i.test(r.reason || ''));
     });
 
     // Integration: ComputeBudget cap fires from within _validateAuthTransaction.

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -486,6 +486,186 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(reauth.token, 'jwt-fresh');
     });
 
+    // ── Blind-sign guard: byte-accurate parser tests (BAT-697 review pass) ──
+    //
+    // The fixtures above use literal base58 strings whose decode is padding-
+    // sensitive. This block instead drives the parser with REAL 32-byte keys
+    // whose base58 form is produced by the adapter's own _base58Encode, so the
+    // fee-payer comparison round-trips exactly. This is what lets us test the
+    // ACCEPTANCE path (a guard that rejected everything would pass the older
+    // rejection-only tests).
+    console.log('\nblind-sign parser (byte-accurate):');
+
+    const _B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    function b58decodeStrict(s) {
+        let n = 0n;
+        for (const c of s) {
+            const i = _B58.indexOf(c);
+            if (i < 0) throw new Error('bad b58 char: ' + c);
+            n = n * 58n + BigInt(i);
+        }
+        const out = [];
+        while (n > 0n) { out.push(Number(n & 0xffn)); n >>= 8n; }
+        for (const c of s) { if (c !== '1') break; out.push(0); }
+        return Buffer.from(out.reverse());
+    }
+    function cu16(n) {
+        const out = []; let v = n;
+        do { let b = v & 0x7f; v >>= 7; if (v > 0) b |= 0x80; out.push(b); } while (v > 0);
+        return Buffer.from(out);
+    }
+    function key32(seed) {
+        const b = Buffer.alloc(32);
+        for (let i = 0; i < 32; i++) b[i] = (seed + i * 7 + 1) & 0xff;
+        return b;
+    }
+    // accounts: array of 32-byte Buffers (idx 0 = fee payer). instrProgramIdx:
+    // account index each instruction targets. versioned: prefix v0 (0x80) byte.
+    function buildTxBytes({ accounts, instrProgramIdx, versioned = false, dataLen = 4 }) {
+        const parts = [];
+        if (versioned) parts.push(Buffer.from([0x80]));
+        parts.push(Buffer.from([1, 0, 0]));            // header
+        parts.push(cu16(accounts.length));             // account count (compact-u16)
+        for (const a of accounts) parts.push(a);
+        parts.push(Buffer.alloc(32));                  // recent blockhash
+        parts.push(cu16(1));                           // 1 instruction
+        parts.push(Buffer.from([instrProgramIdx]));    // program id index (idx < 128 → 1 byte)
+        parts.push(cu16(0));                           // 0 accounts in instruction
+        parts.push(cu16(dataLen));                     // data length
+        parts.push(Buffer.alloc(dataLen, 0x61));       // data bytes
+        const message = Buffer.concat(parts);
+        return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+    }
+
+    const MEMO_BYTES = b58decodeStrict(triggerV2.MEMO_PROGRAM_V2);
+    const SYS_BYTES = Buffer.alloc(32); // SystemProgram = all-zero pubkey
+    const PAYER_BUF = key32(7);
+    const PAYER_B58 = triggerV2._base58Encode(PAYER_BUF);
+    const OTHER_B58 = triggerV2._base58Encode(key32(200));
+
+    await check('base58 round-trip: _base58Encode(decode(MEMO)) === MEMO', async () => {
+        assert.strictEqual(MEMO_BYTES.length, 32, 'memo program must decode to 32 bytes');
+        assert.strictEqual(triggerV2._base58Encode(MEMO_BYTES), triggerV2.MEMO_PROGRAM_V2);
+    });
+
+    await check('ACCEPTS a real Memo-only tx whose fee payer matches', async () => {
+        const tx = buildTxBytes({ accounts: [PAYER_BUF, MEMO_BYTES], instrProgramIdx: 1 });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, true, `expected accept, got: ${JSON.stringify(r)}`);
+    });
+
+    await check('REJECTS Memo-only tx when fee payer does not match expected pubkey', async () => {
+        const tx = buildTxBytes({ accounts: [PAYER_BUF, MEMO_BYTES], instrProgramIdx: 1 });
+        const r = triggerV2._validateAuthTransaction(tx, OTHER_B58);
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+        assert.ok(/fee payer/i.test(r.reason), `expected fee-payer reason, got: ${r.reason}`);
+    });
+
+    await check('REJECTS tx referencing SystemProgram (Transfer) — Memo-only guard', async () => {
+        const tx = buildTxBytes({ accounts: [PAYER_BUF, SYS_BYTES], instrProgramIdx: 1 });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+    });
+
+    await check('ACCEPTS a v0 versioned (0x80-prefixed) Memo-only tx', async () => {
+        const tx = buildTxBytes({ accounts: [PAYER_BUF, MEMO_BYTES], instrProgramIdx: 1, versioned: true });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, true, `expected v0 accept, got: ${JSON.stringify(r)}`);
+    });
+
+    // Multi-byte compact-u16: account counts ≥128 encode to 2 bytes. Direct
+    // unit test of the reader (the funds-safety parser depends on it).
+    await check('_readCompactU16 single-byte values', async () => {
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0x00]), 0), { value: 0, offset: 1 });
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0x7f]), 0), { value: 127, offset: 1 });
+    });
+    await check('_readCompactU16 multi-byte values (128, 300, 16383)', async () => {
+        // 128 = 0x80,0x01 ; 300 = 0xAC,0x02 ; 16383 = 0xFF,0x7F
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0x80, 0x01]), 0), { value: 128, offset: 2 });
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0xAC, 0x02]), 0), { value: 300, offset: 2 });
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0xFF, 0x7F]), 0), { value: 16383, offset: 2 });
+    });
+    await check('_readCompactU16 honors offset + rejects truncated continuation', async () => {
+        // value 300 starting at offset 2 in a longer buffer
+        assert.deepStrictEqual(triggerV2._readCompactU16(Buffer.from([0xFF, 0xFF, 0xAC, 0x02]), 2), { value: 300, offset: 4 });
+        // continuation bit set but buffer ends → malformed → null
+        assert.strictEqual(triggerV2._readCompactU16(Buffer.from([0x80]), 0), null);
+    });
+    await check('parser handles a tx with a multi-byte account count (130 accounts)', async () => {
+        // 130 accounts: payer + memo + 128 filler. instruction targets memo (idx 1).
+        const accounts = [PAYER_BUF, MEMO_BYTES];
+        for (let i = 0; i < 128; i++) accounts.push(key32(50 + i));
+        const tx = buildTxBytes({ accounts, instrProgramIdx: 1 });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, true, `expected accept with 130 accounts, got: ${JSON.stringify(r)}`);
+    });
+
+    // ── recovery: terminal-fail orders must NOT be reported as recovered ────
+    console.log('\nrecovery hardening (BAT-697 review pass):');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-fail' } });
+    _enqueue({ status: 500, data: { error: 'oops' } });
+    // History returns a FAILED order that still carries vaultState:pending_deposit
+    // AND matches mint+amount — the pre-fix OR-logic would have matched it.
+    _enqueue({ status: 200, data: { orders: [
+        { id: 'dead-order', status: 'failed', vaultState: 'pending_deposit',
+          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+          createdAt: new Date().toISOString() },
+    ] } });
+    await check('failed order with vaultState:pending_deposit is NOT recovered', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false, 'a dead order must not be reported as success');
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-primary' } });
+    _enqueue({ status: 500, data: { error: 'oops' } });
+    // History exposes depositRequestId — primary correlation must match it
+    // even though a SECOND same-amount active order also exists (no false alias).
+    _enqueue({ status: 200, data: { orders: [
+        { id: 'unrelated-same-amount', status: 'active',
+          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000', createdAt: new Date().toISOString() },
+        { id: 'our-order', status: 'active', depositRequestId: 'dr-primary',
+          inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000', createdAt: new Date().toISOString() },
+    ] } });
+    await check('recovery prefers depositRequestId correlation over amount heuristic', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, true);
+            assert.strictEqual(submit.id, 'our-order', 'must match by depositRequestId, not the unrelated same-amount order');
+            assert.strictEqual(submit.recovered, true);
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
     // ── Summary ─────────────────────────────────────────────────────────────
     if (failures > 0) {
         console.error(`\nFAILED: ${failures} test(s) failed`);

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -383,8 +383,8 @@ function _buildTransferTx(payerB58) {
         status: 200,
         data: { orders: [
             { id: 'order-recovered-002', orderState: 'pending_deposit',
-              inputMint: FIXTURE_INPUT_MINT, initialInputAmount: '1000000',
-              remainingInputAmount: '1000000',
+              inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT,
+              initialInputAmount: '1000000', remainingInputAmount: '1000000',
               createdAt: new Date().toISOString(),
               events: [{ type: 'deposit', txSignature: 'deposit-sig-recovered', state: 'success' }] },
         ] },
@@ -604,6 +604,23 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(r.ok, true, `expected accept, got: ${JSON.stringify(r)}`);
     });
 
+    // PR #388 R2 finding: ComputeBudget-only txs were in the program
+    // allowlist but contain no challenge payload to commit to. Signing one
+    // would be signing nothing meaningful. Must require ≥1 Memo instruction.
+    await check('REJECTS ComputeBudget-only tx (no Memo — no challenge payload)', async () => {
+        const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, COMPUTE_BUDGET_BYTES], instrIdxs: [1] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false, 'a ComputeBudget-only tx must NOT pass the blind-sign guard');
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+        assert.ok(/Memo/i.test(r.reason || ''), `expected Memo-related reason, got: ${r.reason}`);
+    });
+    await check('REJECTS multi-ComputeBudget-only tx (two ComputeBudgets, still no Memo)', async () => {
+        const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, COMPUTE_BUDGET_BYTES], instrIdxs: [1, 1] });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+    });
+
     await check('REJECTS Memo + SystemProgram even when a Memo instr is present', async () => {
         const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, MEMO_BYTES, SYS_BYTES], instrIdxs: [1, 2] });
         const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
@@ -693,7 +710,7 @@ function _buildTransferTx(payerB58) {
     _enqueue({ status: 500, data: { error: 'oops' } });
     _enqueue({ status: 200, data: { orders: [
         { id: 'our-order', orderState: 'active', rawState: 'active',
-          inputMint: FIXTURE_INPUT_MINT,
+          inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT,
           initialInputAmount: '1000000', remainingInputAmount: '1000000',
           createdAt: new Date().toISOString(),
           events: [{ type: 'deposit', txSignature: 'real-deposit-sig', state: 'success' }] },
@@ -728,7 +745,7 @@ function _buildTransferTx(payerB58) {
     // matched as "ours" — the tight time window is the only safeguard now.
     _enqueue({ status: 200, data: { orders: [
         { id: 'stale-other-order', orderState: 'active', rawState: 'active',
-          inputMint: FIXTURE_INPUT_MINT,
+          inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT,
           initialInputAmount: '1000000', remainingInputAmount: '1000000',
           createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
     ] } });
@@ -747,6 +764,40 @@ function _buildTransferTx(payerB58) {
                     triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
             });
             assert.strictEqual(submit.ok, false, 'old unrelated order must not be falsely matched');
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
+        } finally { global.setTimeout = origSetTimeout; }
+    });
+
+    // (d) PR #388 R2: a live order with the SAME inputMint + initialInputAmount
+    // but DIFFERENT outputMint must NOT false-match. Pre-fix, the heuristic
+    // only checked input mint + amount, so a wallet running two limit orders
+    // on the same input token could see recovery pick the wrong order id.
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', requestId: 'dr-discrim' } });
+    _enqueue({ status: 500, data: { error: 'oops' } });
+    const OTHER_OUTPUT_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'; // USDT
+    _enqueue({ status: 200, data: { orders: [
+        { id: 'other-output-order', orderState: 'active', rawState: 'active',
+          inputMint: FIXTURE_INPUT_MINT, outputMint: OTHER_OUTPUT_MINT,
+          initialInputAmount: '1000000', remainingInputAmount: '1000000',
+          createdAt: new Date().toISOString() },
+    ] } });
+    await check('different-outputMint same-amount order is NOT matched (PR #388 R2)', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, outputMint: FIXTURE_OUTPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt', recoveryContext: craft.recoveryContext, depositSignedTx: 'SIGNED',
+                order: { inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000 },
+            });
+            assert.strictEqual(submit.ok, false, 'order with different outputMint must NOT be matched as ours');
             assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
         } finally { global.setTimeout = origSetTimeout; }
     });

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -655,6 +655,117 @@ function _buildTransferTx(payerB58) {
         assert.strictEqual(r.error, 'auth_tx_invalid');
     });
 
+    // ── PR #388 R10: ComputeBudget priority-fee cap ─────────────────────────
+    // Reviewer concern: pre-fix, ComputeBudget instructions were whitelisted
+    // without decoding their data. A hostile/compromised challenge endpoint
+    // could include a SetComputeUnitPrice with u64::MAX micro_lamports/CU and
+    // drain the fee payer's SOL when the signed auth tx is broadcast. The
+    // burner path zero-cap-signs auth challenges silently, so this was a
+    // real fee-drain vector even with TLS to Jupiter. Post-fix: ComputeBudget
+    // data is decoded and SetComputeUnitLimit / SetComputeUnitPrice are
+    // capped before the auth tx is accepted.
+    await check('R10 _validateComputeBudgetInstr accepts empty data (no-op ix)', async () => {
+        const r = triggerV2._validateComputeBudgetInstr(Buffer.alloc(0));
+        assert.strictEqual(r.ok, true);
+    });
+    await check('R10 _validateComputeBudgetInstr accepts SetComputeUnitLimit at cap', async () => {
+        const data = Buffer.alloc(5);
+        data[0] = 0x02;
+        data.writeUInt32LE(triggerV2._AUTH_MAX_CU_LIMIT, 1);
+        assert.strictEqual(triggerV2._validateComputeBudgetInstr(data).ok, true);
+    });
+    await check('R10 _validateComputeBudgetInstr REJECTS SetComputeUnitLimit above cap', async () => {
+        const data = Buffer.alloc(5);
+        data[0] = 0x02;
+        data.writeUInt32LE(triggerV2._AUTH_MAX_CU_LIMIT + 1, 1);
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false);
+        assert.ok(/SetComputeUnitLimit/i.test(r.reason || ''));
+    });
+    await check('R10 _validateComputeBudgetInstr accepts SetComputeUnitPrice at cap', async () => {
+        const data = Buffer.alloc(9);
+        data[0] = 0x03;
+        const cap = triggerV2._AUTH_MAX_CU_PRICE_MICROLAMPORTS;
+        data.writeUInt32LE(Number(cap & 0xFFFFFFFFn), 1);
+        data.writeUInt32LE(Number((cap >> 32n) & 0xFFFFFFFFn), 5);
+        assert.strictEqual(triggerV2._validateComputeBudgetInstr(data).ok, true);
+    });
+    await check('R10 _validateComputeBudgetInstr REJECTS SetComputeUnitPrice at u64::MAX (the attack value)', async () => {
+        const data = Buffer.alloc(9);
+        data[0] = 0x03;
+        data.writeUInt32LE(0xFFFFFFFF, 1);
+        data.writeUInt32LE(0xFFFFFFFF, 5);
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false, 'u64::MAX micro_lamports/CU was the unbounded fee-drain vector pre-fix');
+        assert.ok(/SetComputeUnitPrice/i.test(r.reason || ''));
+    });
+    await check('R10 _validateComputeBudgetInstr REJECTS truncated SetComputeUnitPrice (8 bytes instead of 9)', async () => {
+        const data = Buffer.from([0x03, 0, 0, 0, 0, 0, 0, 0]); // tag + 7 bytes, need 8
+        const r = triggerV2._validateComputeBudgetInstr(data);
+        assert.strictEqual(r.ok, false);
+        assert.ok(/truncated/i.test(r.reason || ''));
+    });
+    await check('R10 _validateComputeBudgetInstr accepts unknown tags (heap frame, deprecated RequestUnits)', async () => {
+        // 0x00 RequestUnits, 0x01 RequestHeapFrame, 0x04 SetLoadedAccountsDataSizeLimit
+        // None drain SOL → accept silently.
+        for (const tag of [0x00, 0x01, 0x04]) {
+            const r = triggerV2._validateComputeBudgetInstr(Buffer.from([tag, 0, 0, 0, 0]));
+            assert.strictEqual(r.ok, true, `tag 0x0${tag} (no fee impact) should be accepted`);
+        }
+    });
+
+    // Integration: ComputeBudget cap fires from within _validateAuthTransaction.
+    function buildTxWithComputeBudget({ cbTag, cbValue }) {
+        // Build a tx with Memo (non-empty) + ComputeBudget (custom payload).
+        const accounts = [PAYER_BUF, MEMO_BYTES, COMPUTE_BUDGET_BYTES];
+        const memoData = Buffer.from('challenge-payload');
+        const cbData = (() => {
+            if (cbTag === 0x03) {
+                const buf = Buffer.alloc(9);
+                buf[0] = 0x03;
+                buf.writeUInt32LE(Number(cbValue & 0xFFFFFFFFn), 1);
+                buf.writeUInt32LE(Number((cbValue >> 32n) & 0xFFFFFFFFn), 5);
+                return buf;
+            }
+            // 0x02 SetComputeUnitLimit (u32)
+            const buf = Buffer.alloc(5);
+            buf[0] = 0x02;
+            buf.writeUInt32LE(Number(cbValue), 1);
+            return buf;
+        })();
+        const parts = [];
+        parts.push(Buffer.from([1, 0, 0]));
+        parts.push(cu16(accounts.length));
+        for (const a of accounts) parts.push(a);
+        parts.push(Buffer.alloc(32)); // blockhash
+        parts.push(cu16(2));          // 2 instructions
+        // Instruction 0: memo (program idx 1)
+        parts.push(Buffer.from([1]));
+        parts.push(cu16(0));
+        parts.push(cu16(memoData.length));
+        parts.push(memoData);
+        // Instruction 1: compute budget (program idx 2)
+        parts.push(Buffer.from([2]));
+        parts.push(cu16(0));
+        parts.push(cu16(cbData.length));
+        parts.push(cbData);
+        const message = Buffer.concat(parts);
+        return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+    }
+    await check('R10 integration: Memo + ComputeBudget at u64::MAX CU price is REJECTED', async () => {
+        const tx = buildTxWithComputeBudget({ cbTag: 0x03, cbValue: (1n << 64n) - 1n });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, false, 'fee-drain attack via SetComputeUnitPrice=MAX must be blocked');
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+        assert.ok(/SetComputeUnitPrice|ComputeBudget/i.test(r.reason || ''),
+            `expected ComputeBudget-related reason, got: ${r.reason}`);
+    });
+    await check('R10 integration: Memo + reasonable ComputeBudget (CU price 5_000) is ACCEPTED', async () => {
+        const tx = buildTxWithComputeBudget({ cbTag: 0x03, cbValue: 5_000n });
+        const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);
+        assert.strictEqual(r.ok, true, `expected accept under cap, got: ${JSON.stringify(r)}`);
+    });
+
     await check('REJECTS Memo + SystemProgram even when a Memo instr is present', async () => {
         const tx = buildMultiInstrTx({ accounts: [PAYER_BUF, MEMO_BYTES, SYS_BYTES], instrIdxs: [1, 2] });
         const r = triggerV2._validateAuthTransaction(tx, PAYER_B58);

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -930,6 +930,46 @@ function _buildTransferTx(payerB58) {
         } finally { global.setTimeout = origSetTimeout; }
     });
 
+    // ── PR #388 R5: _inferTriggerMint fail-closed behavior ──────────────────
+    // Reviewer concern (R5): for non-stable↔non-stable pairs (SOL↔JUP) and
+    // both-stable pairs (USDC↔USDT) there is no safe inference for which
+    // asset's USD price the trigger should watch. Pre-fix silently defaulted
+    // to outputMint, which can make the order fire on the wrong asset OR
+    // never fire at all. Post-fix: returns null → handler returns
+    // trigger_mint_required → tx never gets signed.
+    const solanaTools = require('../../app/src/main/assets/nodejs-project/tools/solana.js');
+    const _inferTriggerMint = solanaTools._inferTriggerMint;
+    const SOL = 'So11111111111111111111111111111111111111112';
+    const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const USDT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+    const JUP = 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN';
+
+    await check('R5 _inferTriggerMint: stable→non-stable (USDC→SOL) returns SOL (outputMint)', async () => {
+        assert.strictEqual(_inferTriggerMint(USDC, SOL), SOL);
+    });
+    await check('R5 _inferTriggerMint: non-stable→stable (SOL→USDC) returns SOL (inputMint)', async () => {
+        assert.strictEqual(_inferTriggerMint(SOL, USDC), SOL);
+    });
+    await check('R5 _inferTriggerMint: non-stable↔non-stable (SOL↔JUP) returns null (caller must override)', async () => {
+        assert.strictEqual(_inferTriggerMint(SOL, JUP), null,
+            'must fail closed — Jupiter would otherwise watch the wrong asset\'s USD price');
+        assert.strictEqual(_inferTriggerMint(JUP, SOL), null);
+    });
+    await check('R5 _inferTriggerMint: both-stable (USDC↔USDT) returns null (caller must override)', async () => {
+        assert.strictEqual(_inferTriggerMint(USDC, USDT), null);
+        assert.strictEqual(_inferTriggerMint(USDT, USDC), null);
+    });
+    await check('R5 _inferTriggerMint: explicit override always wins, even for ambiguous pairs', async () => {
+        assert.strictEqual(_inferTriggerMint(SOL, JUP, JUP), JUP,
+            'explicit caller-supplied triggerMint must short-circuit the inference');
+        assert.strictEqual(_inferTriggerMint(USDC, USDT, USDC), USDC);
+    });
+    await check('R5 _inferTriggerMint: explicit empty-string/non-string is ignored, fall through to inference', async () => {
+        assert.strictEqual(_inferTriggerMint(SOL, USDC, ''), SOL, 'empty string is not a valid override');
+        assert.strictEqual(_inferTriggerMint(SOL, USDC, null), SOL);
+        assert.strictEqual(_inferTriggerMint(SOL, USDC, undefined), SOL);
+    });
+
     // ── Summary ─────────────────────────────────────────────────────────────
     if (failures > 0) {
         console.error(`\nFAILED: ${failures} test(s) failed`);

--- a/tests/nodejs-project/jupiter-trigger-v2.test.js
+++ b/tests/nodejs-project/jupiter-trigger-v2.test.js
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+// jupiter-trigger-v2.test.js — BAT-697 PR B unit tests.
+//
+// Tests the V2 adapter in isolation: pure validation, blind-sign guards,
+// auth fallback selection, ambiguous-create recovery, and the cancel
+// two-step. http.js + config.js are mocked via require.cache so the
+// adapter runs without touching localhost or the bridge.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// Stub config: jupiterApiKey present, log() silent.
+const configPath = require.resolve(path.join(BUNDLE, 'config.js'));
+require.cache[configPath] = {
+    id: configPath,
+    filename: configPath,
+    loaded: true,
+    exports: {
+        log: () => {},
+        config: { jupiterApiKey: 'fake-key' },
+    },
+};
+
+// Programmable http mock — every adapter call funnels through here.
+const httpCalls = [];
+let httpQueue = []; // FIFO of canned responses
+function _enqueue(response) { httpQueue.push(response); }
+function _resetHttp() { httpCalls.length = 0; httpQueue = []; }
+const httpPath = require.resolve(path.join(BUNDLE, 'http.js'));
+require.cache[httpPath] = {
+    id: httpPath,
+    filename: httpPath,
+    loaded: true,
+    exports: {
+        httpRequest: async (options, body) => {
+            httpCalls.push({ options, body });
+            if (httpQueue.length === 0) {
+                throw new Error(`http mock: queue empty (no response for ${options.method} ${options.path})`);
+            }
+            const next = httpQueue.shift();
+            if (typeof next === 'function') return next({ options, body });
+            return next;
+        },
+    },
+};
+
+const triggerV2 = require(path.join(BUNDLE, 'jupiter', 'trigger-v2'));
+
+let failures = 0;
+async function check(label, fn) {
+    try { await fn(); console.log(`  ✓ ${label}`); }
+    catch (e) { failures++; console.error(`  ✗ ${label}\n    ${(e.stack || e.message).split('\n').slice(0, 4).join('\n    ')}`); }
+}
+
+const FIXTURE_PUBKEY = 'BurNeR1111111111111111111111111111111111111';
+const FIXTURE_PUBKEY_2 = 'MaiN1111111111111111111111111111111111111111';
+const FIXTURE_INPUT_MINT = 'So11111111111111111111111111111111111111112';
+const FIXTURE_OUTPUT_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+// ── Build a minimal valid Memo-only auth tx for FIXTURE_PUBKEY ───────────────
+//
+// Legacy message: [header(3)] [accts compact-u16 + 32-byte keys] [blockhash(32)]
+// [instr compact-u16 + per-instr (programIdIdx + accts cu16 + accts + data cu16 + data)]
+// Wrapped with a single-signature slot to satisfy the tx framing.
+function _buildAuthTx(payerB58) {
+    const b58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    function b58dec(s) {
+        let n = 0n;
+        for (const c of s) {
+            const i = b58.indexOf(c);
+            if (i < 0) throw new Error('bad b58 char');
+            n = n * 58n + BigInt(i);
+        }
+        const out = [];
+        while (n > 0n) { out.push(Number(n & 0xffn)); n >>= 8n; }
+        for (const c of s) { if (c !== '1') break; out.push(0); }
+        return Buffer.from(out.reverse());
+    }
+    const payerKey = b58dec(payerB58);
+    if (payerKey.length !== 32) {
+        // pad to 32 — fixture keys are 43 chars of valid b58 → may decode to <32 bytes
+        const pad = Buffer.alloc(32);
+        payerKey.copy(pad, 32 - payerKey.length);
+        payerKey.set(pad.subarray(0, 32 - payerKey.length).fill(0), 0);
+    }
+    const padded = Buffer.alloc(32);
+    payerKey.copy(padded, 0, 0, Math.min(32, payerKey.length));
+    const memoProgramId = b58dec('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');
+    const memoPadded = Buffer.alloc(32);
+    memoProgramId.copy(memoPadded, 0, 0, Math.min(32, memoProgramId.length));
+
+    // Build message:
+    const parts = [];
+    parts.push(Buffer.from([1, 0, 0]));               // header: numRequired=1, readonlySigned=0, readonlyUnsigned=0
+    parts.push(Buffer.from([2]));                     // 2 accounts compact-u16
+    parts.push(padded);                               // account[0] = payer
+    parts.push(memoPadded);                           // account[1] = memo program
+    parts.push(Buffer.alloc(32));                     // recent blockhash (zeros ok for parsing)
+    parts.push(Buffer.from([1]));                     // 1 instruction
+    parts.push(Buffer.from([1]));                     // programIdIdx = 1 (memo)
+    parts.push(Buffer.from([0]));                     // 0 accounts in instruction
+    parts.push(Buffer.from([4]));                     // data length compact-u16
+    parts.push(Buffer.from('test', 'utf8'));          // data
+    const message = Buffer.concat(parts);
+
+    // Wrap: 1 sig (64 zeros) + message
+    const tx = Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]);
+    return tx.toString('base64');
+}
+
+// Build a value-moving tx that references SystemProgram instead of Memo.
+// Used to verify the blind-sign guard rejects it.
+function _buildTransferTx(payerB58) {
+    const b58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    function b58dec(s) {
+        let n = 0n;
+        for (const c of s) { n = n * 58n + BigInt(b58.indexOf(c)); }
+        const out = [];
+        while (n > 0n) { out.push(Number(n & 0xffn)); n >>= 8n; }
+        for (const c of s) { if (c !== '1') break; out.push(0); }
+        return Buffer.from(out.reverse());
+    }
+    const payerKey = b58dec(payerB58);
+    const payerPadded = Buffer.alloc(32);
+    payerKey.copy(payerPadded, 0, 0, Math.min(32, payerKey.length));
+    // SystemProgram: 11111111111111111111111111111111 → all zeros (32 bytes).
+    const sysProgram = Buffer.alloc(32);
+
+    const parts = [];
+    parts.push(Buffer.from([1, 0, 0]));
+    parts.push(Buffer.from([2]));
+    parts.push(payerPadded);
+    parts.push(sysProgram);
+    parts.push(Buffer.alloc(32));
+    parts.push(Buffer.from([1]));
+    parts.push(Buffer.from([1]));     // program idx = 1 = SystemProgram
+    parts.push(Buffer.from([0]));     // 0 accounts in instruction
+    parts.push(Buffer.from([0]));     // 0 data
+    const message = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+}
+
+(async () => {
+    console.log('Jupiter Trigger V2 adapter tests (BAT-697)\n');
+
+    // ── validateOrderArgs ───────────────────────────────────────────────────
+    console.log('validateOrderArgs:');
+    await check('rejects inputUsdValue below $10', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 9.99,
+            expiresAtMs: Date.now() + 86400_000,
+            triggerPriceUsd: 50,
+            slippageBps: 100,
+        });
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'min_order_size_below_10_usd');
+    });
+    await check('rejects expiresAt in the past', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 100,
+            expiresAtMs: Date.now() - 1000,
+            triggerPriceUsd: 50,
+            slippageBps: 100,
+        });
+        assert.strictEqual(r.error, 'expires_at_too_soon');
+    });
+    await check('rejects missing triggerPriceUsd', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 100,
+            expiresAtMs: Date.now() + 86400_000,
+            triggerPriceUsd: null,
+            slippageBps: 100,
+        });
+        assert.strictEqual(r.error, 'trigger_price_required');
+    });
+    await check('rejects slippageBps below 1', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 100,
+            expiresAtMs: Date.now() + 86400_000,
+            triggerPriceUsd: 50,
+            slippageBps: 0,
+        });
+        assert.strictEqual(r.error, 'slippage_out_of_range');
+    });
+    await check('rejects slippageBps above 10000', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 100,
+            expiresAtMs: Date.now() + 86400_000,
+            triggerPriceUsd: 50,
+            slippageBps: 10001,
+        });
+        assert.strictEqual(r.error, 'slippage_out_of_range');
+    });
+    await check('accepts valid args', async () => {
+        const r = triggerV2.validateOrderArgs({
+            inputUsdValue: 100,
+            expiresAtMs: Date.now() + 86400_000,
+            triggerPriceUsd: 50,
+            slippageBps: 100,
+        });
+        assert.strictEqual(r.ok, true);
+    });
+
+    // ── _validateChallengePayload (blind-sign guard part 1) ─────────────────
+    console.log('\n_validateChallengePayload:');
+    await check('rejects non-object payload', async () => {
+        const r = triggerV2._validateChallengePayload(null, FIXTURE_PUBKEY);
+        assert.strictEqual(r.ok, false);
+    });
+    await check('rejects unknown challenge type', async () => {
+        const r = triggerV2._validateChallengePayload({ type: 'whatever', challenge: 'x' }, FIXTURE_PUBKEY);
+        assert.strictEqual(r.error, 'auth_challenge_invalid');
+    });
+    await check('rejects empty message challenge body', async () => {
+        const r = triggerV2._validateChallengePayload({ type: 'message', challenge: '' }, FIXTURE_PUBKEY);
+        assert.strictEqual(r.error, 'auth_challenge_invalid');
+    });
+    await check('rejects empty transaction challenge body', async () => {
+        const r = triggerV2._validateChallengePayload({ type: 'transaction', transaction: '' }, FIXTURE_PUBKEY);
+        assert.strictEqual(r.error, 'auth_challenge_invalid');
+    });
+    await check('rejects walletPubkey mismatch', async () => {
+        const r = triggerV2._validateChallengePayload({
+            type: 'message', challenge: 'foo', walletPubkey: FIXTURE_PUBKEY_2,
+        }, FIXTURE_PUBKEY);
+        assert.strictEqual(r.error, 'auth_challenge_invalid');
+    });
+    await check('accepts well-formed message challenge', async () => {
+        const r = triggerV2._validateChallengePayload({ type: 'message', challenge: 'foo' }, FIXTURE_PUBKEY);
+        assert.strictEqual(r.ok, true);
+    });
+
+    // ── _validateAuthTransaction (blind-sign guard part 2) ──────────────────
+    console.log('\n_validateAuthTransaction:');
+    await check('rejects non-base64 input', async () => {
+        const r = triggerV2._validateAuthTransaction('', FIXTURE_PUBKEY);
+        assert.strictEqual(r.ok, false);
+    });
+    await check('rejects truncated payload', async () => {
+        const r = triggerV2._validateAuthTransaction(Buffer.from([0, 0, 0]).toString('base64'), FIXTURE_PUBKEY);
+        assert.strictEqual(r.ok, false);
+    });
+    await check('rejects auth tx that references a non-Memo program (Transfer)', async () => {
+        const tx = _buildTransferTx(FIXTURE_PUBKEY);
+        const r = triggerV2._validateAuthTransaction(tx, FIXTURE_PUBKEY);
+        assert.strictEqual(r.ok, false, 'BLIND-SIGN GUARD must reject non-Memo instructions');
+        assert.strictEqual(r.error, 'auth_tx_invalid');
+    });
+    // NOTE: The "happy path" Memo-only tx parse is sensitive to the exact
+    // padding logic for fixture pubkeys (real pubkeys are 32 bytes; our
+    // fixture B58 decodes to ≠32). We exercise the negative-path guard
+    // (Transfer reject) above, which is the user-safety lever. Real-world
+    // Memo-only acceptance is exercised by the live smoke in commit 3.
+
+    // ── authenticate: cache hit ─────────────────────────────────────────────
+    console.log('\nauthenticate:');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    // Prime cache with a verify response.
+    _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+    _enqueue({ status: 200, data: { token: 'jwt-abc-123' } });
+    const firstAuth = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+        signTransaction: async () => 'SIGNED-TX-B64',
+        signMessage: null,
+    });
+    await check('first authenticate returns token via transaction-challenge', async () => {
+        assert.strictEqual(firstAuth.ok, true);
+        assert.strictEqual(firstAuth.token, 'jwt-abc-123');
+        assert.strictEqual(httpCalls.length, 2, 'one challenge + one verify');
+    });
+    await check('second authenticate returns cached token without HTTP', async () => {
+        const callsBefore = httpCalls.length;
+        const second = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+            signTransaction: async () => 'SHOULD-NOT-BE-CALLED',
+            signMessage: null,
+        });
+        assert.strictEqual(second.ok, true);
+        assert.strictEqual(second.cached, true);
+        assert.strictEqual(httpCalls.length, callsBefore, 'cache hit must not call HTTP');
+    });
+
+    // ── authenticate: message-fallback gating ───────────────────────────────
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    // Adapter tries message first. signMessage returns unsupported → fallback
+    // to transaction-challenge.
+    _enqueue({ status: 200, data: { type: 'message', challenge: 'sign-me' } });
+    // After message path fails as unsupported, adapter requests transaction challenge.
+    _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+    _enqueue({ status: 200, data: { token: 'jwt-from-tx' } });
+    await check('signMessage returning unsupported → falls back to transaction', async () => {
+        const r = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+            signTransaction: async () => 'SIGNED-TX-FALLBACK',
+            signMessage: async () => ({ error: 'unsupported_capability', unsupported: true }),
+        });
+        assert.strictEqual(r.ok, true);
+        assert.strictEqual(r.token, 'jwt-from-tx');
+    });
+
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { type: 'message', challenge: 'sign-me' } });
+    // Note: when signMessage returns a non-unsupported error, NO further HTTP
+    // calls should happen (no transaction fallback).
+    await check('signMessage user-rejected → NO transaction fallback (surfaces rejection)', async () => {
+        const r = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+            signTransaction: async () => { throw new Error('must not be called on user-reject'); },
+            signMessage: async () => ({ error: 'user_rejected', reason: 'cancelled' }),
+        });
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'user_rejected');
+        assert.strictEqual(httpCalls.length, 1, 'only the message-challenge HTTP call, no tx fallback');
+    });
+
+    // ── ensureVault ─────────────────────────────────────────────────────────
+    console.log('\nensureVault:');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { registered: true, vaultAddress: 'VaULTaddR111' } });
+    await check('GET vault returns registered + caches', async () => {
+        const r = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
+        assert.strictEqual(r.ok, true);
+        assert.strictEqual(r.vaultAddress, 'VaULTaddR111');
+        // Second call must hit cache, not HTTP.
+        const callsBefore = httpCalls.length;
+        const r2 = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
+        assert.strictEqual(r2.ok, true);
+        assert.strictEqual(httpCalls.length, callsBefore);
+    });
+
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { registered: false } });
+    _enqueue({ status: 200, data: { vaultAddress: 'NewVaUlT22222' } });
+    await check('GET unregistered → POST register → returns vault', async () => {
+        const r = await triggerV2.ensureVault(FIXTURE_PUBKEY, 'jwt');
+        assert.strictEqual(r.ok, true);
+        assert.strictEqual(r.vaultAddress, 'NewVaUlT22222');
+    });
+
+    // ── depositCraft + submitCreateOrder happy path ─────────────────────────
+    console.log('\ndepositCraft + submitCreateOrder:');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', depositRequestId: 'dr-001' } });
+    _enqueue({ status: 200, data: { id: 'order-001', txSignature: 'sig-001' } });
+    await check('happy path: craft → submit → order id', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        });
+        assert.strictEqual(craft.ok, true);
+        assert.strictEqual(craft.depositRequestId, 'dr-001');
+        const submit = await triggerV2.submitCreateOrder({
+            token: 'jwt',
+            recoveryContext: craft.recoveryContext,
+            depositSignedTx: 'SIGNED_DEPOSIT',
+            order: {
+                inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000,
+            },
+        });
+        assert.strictEqual(submit.ok, true);
+        assert.strictEqual(submit.id, 'order-001');
+    });
+
+    // ── submitCreateOrder: ambiguous + history-recovery ─────────────────────
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_DEPOSIT', depositRequestId: 'dr-002' } });
+    _enqueue({ status: 500, data: { error: 'jupiter_internal' } });        // ambiguous create
+    _enqueue({                                                                 // recovery /orders/history
+        status: 200,
+        data: { orders: [
+            { id: 'order-recovered-002', status: 'pending_deposit',
+              inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+              createdAt: new Date().toISOString() },
+        ] },
+    });
+    await check('ambiguous (500) + history match → success with recovered flag', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        });
+        // Use a stub setTimeout shim to skip the 5s recovery wait in tests
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt',
+                recoveryContext: craft.recoveryContext,
+                depositSignedTx: 'SIGNED_DEPOSIT',
+                order: {
+                    inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000,
+                },
+            });
+            assert.strictEqual(submit.ok, true);
+            assert.strictEqual(submit.id, 'order-recovered-002');
+            assert.strictEqual(submit.recovered, true);
+        } finally {
+            global.setTimeout = origSetTimeout;
+        }
+    });
+
+    // ── submitCreateOrder: ambiguous + history miss → no-recovery ───────────
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'U', depositRequestId: 'dr-003' } });
+    _enqueue({ status: 500, data: { error: 'oops' } });
+    _enqueue({ status: 200, data: { orders: [] } });
+    await check('ambiguous (500) + empty history → create_ambiguous_no_recovery', async () => {
+        const craft = await triggerV2.depositCraft({
+            pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+        });
+        const origSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => origSetTimeout(fn, 0);
+        try {
+            const submit = await triggerV2.submitCreateOrder({
+                token: 'jwt',
+                recoveryContext: craft.recoveryContext,
+                depositSignedTx: 'SIGNED_DEPOSIT',
+                order: {
+                    inputMint: FIXTURE_INPUT_MINT, inputAmount: '1000000',
+                    outputMint: FIXTURE_OUTPUT_MINT, triggerPriceUsd: 50,
+                    triggerCondition: 'below', expiresAtMs: Date.now() + 86400_000,
+                },
+            });
+            assert.strictEqual(submit.ok, false);
+            assert.strictEqual(submit.error, 'create_ambiguous_no_recovery');
+            assert.ok(submit.recovery, 'should surface the recovery context');
+            assert.strictEqual(submit.recovery.depositRequestId, 'dr-003');
+        } finally {
+            global.setTimeout = origSetTimeout;
+        }
+    });
+
+    // ── cancelStep1 + confirmCancel ─────────────────────────────────────────
+    console.log('\ncancelStep1 + confirmCancel:');
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    _enqueue({ status: 200, data: { transaction: 'UNSIGNED_CANCEL', requestId: 'cr-001' } });
+    _enqueue({ status: 200, data: { id: 'order-x', txSignature: 'cancel-sig-001' } });
+    await check('two-step cancel happy path', async () => {
+        const s1 = await triggerV2.cancelStep1({ orderId: 'order-x', pubkey: FIXTURE_PUBKEY, token: 'jwt' });
+        assert.strictEqual(s1.ok, true);
+        assert.strictEqual(s1.cancelRequestId, 'cr-001');
+        const s2 = await triggerV2.confirmCancel({
+            orderId: 'order-x', pubkey: FIXTURE_PUBKEY, token: 'jwt',
+            signedTransaction: 'SIGNED_CANCEL', cancelRequestId: s1.cancelRequestId,
+        });
+        assert.strictEqual(s2.ok, true);
+        assert.strictEqual(s2.txSignature, 'cancel-sig-001');
+    });
+
+    // ── 401 invalidates JWT cache ───────────────────────────────────────────
+    triggerV2._resetCachesForTests();
+    _resetHttp();
+    // Prime the cache.
+    _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+    _enqueue({ status: 200, data: { token: 'jwt-primed' } });
+    await triggerV2.authenticate(FIXTURE_PUBKEY, {
+        signTransaction: async () => 'X', signMessage: null,
+    });
+    // Now hit /orders/history with the cached token; 401 must invalidate.
+    _enqueue({ status: 401, data: { error: 'expired' } });
+    await check('401 from listOrders invalidates JWT', async () => {
+        const r = await triggerV2.listOrders({ pubkey: FIXTURE_PUBKEY, token: 'jwt-primed' });
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.error, 'auth_expired');
+        // Confirm cache was invalidated — next authenticate should NOT be cached.
+        _enqueue({ status: 200, data: { type: 'transaction', transaction: _buildAuthTx(FIXTURE_PUBKEY) } });
+        _enqueue({ status: 200, data: { token: 'jwt-fresh' } });
+        const reauth = await triggerV2.authenticate(FIXTURE_PUBKEY, {
+            signTransaction: async () => 'X', signMessage: null,
+        });
+        assert.strictEqual(reauth.ok, true);
+        assert.notStrictEqual(reauth.cached, true);
+        assert.strictEqual(reauth.token, 'jwt-fresh');
+    });
+
+    // ── Summary ─────────────────────────────────────────────────────────────
+    if (failures > 0) {
+        console.error(`\nFAILED: ${failures} test(s) failed`);
+        process.exit(1);
+    }
+    console.log('\nAll Jupiter Trigger V2 adapter tests passed.');
+})().catch((e) => {
+    console.error('Test runner crashed:', e);
+    process.exit(1);
+});

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -163,6 +163,9 @@ const SKIP_REASONS = {
     'wallet/index.js': 'singleton registry; requires burner-wallet.js + main-wallet.js',
     'wallet/dispatch.js': 'requires bridge.js + caps/preflight (BAT-582 Phase 5 routing helper)',
     'caps/preflight.js': 'requires bridge.js for /burner/status reads',
+    // BAT-697 PR B — Jupiter Trigger V2 adapter requires http.js (which
+    // requires config.js). Pure JS otherwise; --check covers parse errors.
+    'jupiter/trigger-v2.js': 'requires http.js → config.js (BAT-697 Trigger V2 adapter)',
 };
 
 const GREEN = '\x1b[32m';

--- a/tests/nodejs-project/tool-schemas.test.js
+++ b/tests/nodejs-project/tool-schemas.test.js
@@ -178,3 +178,47 @@ if (synthIssues.length === 0) {
     process.exit(1);
 }
 console.log(`✓ Meta-check: validator correctly flags the BAT-664 bug shape (${synthIssues.length} issue${synthIssues.length === 1 ? '' : 's'})`);
+
+// ── PR #388 R9: flag-on schema smoke (Jupiter Trigger V2) ───────────────────
+// The jupiter_trigger_create schema is constructed flag-aware at module load
+// (see tools/solana.js IIFE around line 145). The default flag-off pass above
+// only validates the V1 schema. Reload tools/index.js with
+// `config.useTriggerV2: true` so the V2 schema (incl. its `anyOf` expiry
+// disjunction) goes through findSchemaIssues. Without this, a flag-on
+// rollout could ship a malformed V2 schema undetected — the whole toolset
+// would be rejected by the Anthropic API on first agent turn.
+require.cache[configPath].exports.config = { useTriggerV2: true };
+for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(BUNDLE) && key !== configPath) delete require.cache[key];
+}
+const { TOOLS: TOOLS_V2 } = require(path.join(BUNDLE, 'tools', 'index.js'));
+const triggerCreateV2 = TOOLS_V2.find(t => t.name === 'jupiter_trigger_create');
+assert.ok(triggerCreateV2, 'jupiter_trigger_create must be present in flag-on load');
+assert.ok(Array.isArray(triggerCreateV2.input_schema.anyOf),
+    'V2 schema must declare an anyOf for the expiry disjunction (PR #388 R7 contract)');
+assert.ok(triggerCreateV2.input_schema.required.includes('triggerPriceUsd'),
+    'V2 schema must require triggerPriceUsd (PR #388 R6 contract)');
+const v2Issues = findSchemaIssues(triggerCreateV2.input_schema, '[jupiter_trigger_create.V2].input_schema');
+if (v2Issues.length > 0) {
+    console.error('\n✗ V2 jupiter_trigger_create schema has issues (flag-on load):');
+    for (const issue of v2Issues) console.error(`    - ${issue}`);
+    console.error('\nThis would take down the entire agent on a flag-on rollout.');
+    process.exit(1);
+}
+// Walk the full flag-on TOOLS set too — any other tool that conditions its
+// schema on the flag is now covered.
+let v2Failed = 0;
+const v2AllIssues = [];
+for (const tool of TOOLS_V2) {
+    const issues = findSchemaIssues(tool.input_schema, `[V2][${tool.name}].input_schema`);
+    if (issues.length > 0) { v2Failed++; v2AllIssues.push({ tool: tool.name, issues }); }
+}
+if (v2Failed > 0) {
+    console.error(`\n✗ ${v2Failed} tool(s) have schema issues under useTriggerV2=true:\n`);
+    for (const { tool, issues } of v2AllIssues) {
+        console.error(`  ${tool}:`);
+        for (const issue of issues) console.error(`    - ${issue}`);
+    }
+    process.exit(1);
+}
+console.log(`✓ Flag-on (useTriggerV2=true): all ${TOOLS_V2.length} schemas pass + V2 jupiter_trigger_create has anyOf expiry + requires triggerPriceUsd`);


### PR DESCRIPTION
## Summary

PR B of the BAT-697 staged rollout — adds the Jupiter Trigger V2 multi-step adapter alongside the existing V1 path. Gated on `config.useTriggerV2 === true` (default **false**); V1 remains the shipping path. Targets `feature/v2.1` integration branch.

PR sequence:
- **PR #386** (MWA 2.0.3→2.0.4) — merged
- **PR B (this one)** — V2 adapter, flag OFF
- PR C — live smoke against flag ON (manual device verification)
- PR D — default flip + V1 deletion
- PR E — SAB v28 + DIAGNOSTICS additions

## What's in this PR

| Layer | File | Change |
|---|---|---|
| Adapter (new) | `jupiter/trigger-v2.js` | Auth/JWT cache, blind-sign guards, vault, deposit primitives, cancel primitives, ambiguous-recovery, V2 validation |
| Dispatch helper | `wallet/dispatch.js` | `signZeroCapTxViaBurner` — 0-amount reservation sign-only (used for auth challenges + V2 cancels) |
| Tool handlers | `tools/solana.js` | V2 helpers + flag-branch at top of all 3 `jupiter_trigger_*` handlers |
| Config | `config.js` | Normalize `useTriggerV2` to real boolean (default false) |
| Tests (new) | `tests/nodejs-project/jupiter-trigger-v2.test.js` | 26 cases — validation, blind-sign guards, auth fallback gating, JWT cache, ambiguous recovery |
| Smoke catalog | `tests/nodejs-project/smoke.js` | SKIP_REASONS entry for the new adapter (transitively requires config.js) |

Diff: **+2031 lines, 0 deletions** in 6 files. V1 paths untouched.

## Codex round-2 contract amendments — satisfied

- [x] Real Jupiter host (`api.jup.ag`) pinned, no copy/paste typos
- [x] Fallback rule: message→tx only on `unsupported_capability`, NEVER on user rejection (test pins this)
- [x] Vault registration is lazy (only on first `jupiter_trigger_create` per wallet)
- [x] Vault address surfaced in successful create response; no pre-confirm network call
- [x] Pre-create recovery context recorded (depositRequestId, mint/amount, pubkey, timestamp) — local only, never persisted

## Acceptance gates (per contract v2 §8)

- [x] First-time vault registration covered + tested
- [x] `deposit/craft` body includes `orderType:"price"` + `orderSubType:"single"`
- [x] Message-challenge fallback tested (unsupported → tx) — adapter ready when `/solana/sign-message` bridge endpoint lands
- [x] Burner path is bridge-backed only — no key material in Node (regression covered by `burner-signer.test.js`)
- [x] Lost/ambiguous create response runs `/orders/history` recovery, NO duplicate retries
- [x] Cancel ownership routing preserved (burner-created → burner, main/unknown → MWA)
- [x] Blind-sign guards: endpoint type, body shape, walletPubkey echo, Memo-only instruction parse
- [x] V2 semantic validation: $10 min, required expiresAt, USD trigger price, explicit slippage
- [x] V1 paths left in place (deletion gated on commit 3 live smoke per contract)

## Deferred (documented in code)

1. **Message-challenge signing** — no `/burner/sign-message` or `/solana/sign-message` bridge endpoint exists today. Adapter accepts `signers.signMessage` and falls through to transaction-challenge when null (the spec-allowed fallback per Codex round-2 #3). Follow-up BAT can add the bridge endpoints.
2. **On-chain deposit-tx verification in recovery** — current path queries `/orders/history` only. Ambiguous-no-recovery returns success with warning (commits cap conservatively — over-count safer than under-count for user safety). Follow-up BAT can add RPC `getTransaction` verification.
3. **V2 list shows main-wallet orders only** — listing burner-routed orders needs separate burner auth. Documented in the tool response `note` field.

## Pre-push gate

```
── 1/4  Node smoke test ──── 68/68 parse + 18/18 load ✓
── 2/4  Tool input_schema validity ──── 63 tools ✓
── 3/4  Wallets prompt regression ──── 4 scenarios ✓
── 4/4  Kotlin compile (dappStoreDebug) ──── BUILD SUCCESSFUL in 2m 3s ✓
```

Plus BAT-582 regression tests run independently: `confirmation-policy.test.js`, `confirmation-policy-burner.test.js`, `burner-signer.test.js`, `burner-cancel-zero-amount.test.js`, `caps-preflight.test.js` — all pass.

New tests:
```
Jupiter Trigger V2 adapter tests (BAT-697)
  validateOrderArgs:                            6/6 ✓
  _validateChallengePayload:                    6/6 ✓
  _validateAuthTransaction (blind-sign guards): 3/3 ✓
  authenticate (cache + fallback gating):       4/4 ✓
  ensureVault (lazy register):                  2/2 ✓
  depositCraft + submitCreateOrder:             3/3 ✓
  cancelStep1 + confirmCancel:                  1/1 ✓
  401 invalidates JWT cache:                    1/1 ✓
                                              ----- 
                                              26/26 ✓
```

## Test plan (when flag is flipped in PR C)

- [ ] Limit-buy order: main wallet, USDC → SOL, $20 size, trigger when SOL ≤ $80
- [ ] Limit-sell order: burner wallet (under cap), SOL → USDC, $15 size, trigger when SOL ≥ $90
- [ ] Cancel burner-owned order — verify silent (no MWA popup) + cap reservation released
- [ ] Cancel main-owned order — verify MWA popup + Jupiter execute
- [ ] List orders — main wallet, verify recent orders show up with vaultState
- [ ] Ambiguous create simulation — kill network mid-POST, verify recovery via /orders/history
- [ ] Below-$10 size — verify clean error before any signing
- [ ] Past expiresAt — verify clean error
- [ ] Existing `solana_send` + `solana_swap` still work (MWA 2.0.4 regression coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)