### PR TITLE
feat: Usepod AI provider — BAT-971

### DIFF
--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -85,7 +85,7 @@ grep -i "429\|rate.limit\|Retry-After" node_debug.log | tail -10
 
 ---
 
-## LLM API (Claude / OpenAI / OpenRouter / Custom)
+## LLM API (Claude / OpenAI / OpenRouter / Custom / Usepod)
 
 ### Transport Timeout (Stream Drops)
 **Symptoms:** Responses cut off mid-stream, `[Trace]` entries in logs showing high latency, user sees partial or no response.
@@ -143,6 +143,42 @@ grep -i "custom provider\|ECONNREFUSED\|UNABLE_TO_VERIFY\|Unexpected token" node
 2. Check auth: API key and/or custom headers must match what the gateway expects
 3. Guide the user to Settings > AI Provider > Custom to review URL, key, headers, format, and model ID
 4. For SSL issues: suggest the user switch to an endpoint with a valid certificate, or use HTTP (if local/trusted)
+
+### Usepod — Token Not Funded / Invalid / Price Ceiling
+**Symptoms:** All API calls fail immediately on the Usepod provider. Common error variants:
+- "Fund your Usepod token at https://usepod.ai/dashboard." (HTTP 402)
+- "No Usepod provider available under your current price ceiling. …" (HTTP 402, `error.type === "no_provider_at_price"`)
+- "Invalid Usepod token format. Re-check the UUID in Settings → AI Provider → Usepod." (HTTP 401, `error.message: "unauthorized: invalid token format"`)
+- "Usepod token is unfunded or unknown. Fund or re-check the token at https://usepod.ai/dashboard." (HTTP 401, `error.message: "unauthorized: token not found or not activated"` — empirically Usepod combines unfunded and unknown-token into one 401 message)
+- "Invalid Usepod token. Re-check Settings → AI Provider → Usepod → Token." (HTTP 401, other message)
+
+**Setup model — Settings-first (BAT-971 / Codex v2.2):**
+Usepod is the only provider where Telegram `/provider usepod` cannot do first-time setup. The user MUST first configure both:
+- `usepodToken` — UUID from the Usepod dashboard (`https://usepod.ai/dashboard`); stored masked / encrypted in Android Keystore.
+- `usepodModel` — the freeform model id their token has access to (Usepod publishes no fixed list — read it off the dashboard).
+
+…in Settings → AI Provider → Usepod. Only AFTER both are saved does `/provider usepod` switch successfully. The handler refuses with: "Set a Usepod model in Settings → AI Provider → Usepod first." This is intentional: `/model <id>` validates against the **current** provider (e.g. Claude), so it cannot set a freeform Usepod model before the switch.
+
+**Funding (external — SeekerClaw does NOT custody):**
+Per-request billing is USDC on Solana mainnet. The user funds the token by sending USDC to the deposit address (shown on the dashboard) with the `deposit_code` in the tx memo. SeekerClaw does NOT auto-fund or custody — funding is fully external in this version. If users ask the agent to "fund my Usepod token", explain that this v1 doesn't have that capability and point them at the dashboard.
+
+**Check:**
+```
+grep -i "Usepod\|usepod.ai\|X-Balance-Remaining" node_debug.log | tail -20
+read agent_settings.json   # confirm usepodToken non-blank (UUID) and usepodModel non-blank
+```
+
+**Diagnosis & fix:**
+- **402 (unfunded):** Token registered but balance is zero. User needs to send USDC to the deposit address. After USDC lands, requests start working — no app restart needed (the token activates server-side).
+- **402 `no_provider_at_price`:** A request-level price ceiling was set (likely via a future `X-Pod-Max-Price-Input`/`-Output` header — not user-configurable in v1) and no marketplace provider met it. v1 does NOT expose price-ceiling UI, so this error should be rare; if it appears, suggest the user check the dashboard.
+- **401 "invalid token format":** Caller-side UUID validator should have caught this before the request fired. If it didn't, the user pasted whitespace / a full URL / a non-UUID — re-paste a clean UUID into Settings → AI Provider → Usepod → Token.
+- **401 "not found or not activated":** Unfunded (most common) OR truly invalid token. Point user at the dashboard to confirm the token exists + check balance.
+- **`X-Balance-Remaining` header:** Public docs say Usepod returns this on inference responses (microunits). The adapter parses and logs once per session ("[Usepod] X-Balance-Remaining observed: N microunits"). If you see "$0.0000 USDC", the token is empty and next request will 402.
+
+**Secrets / token redaction:**
+`usepodToken` is a secret. Two redaction passes cover it: literal-value redaction (security.js's `_dynamicPatterns` branch produces `[REDACTED:usepodToken]`) AND a URL-path-form regex that replaces `/proxy/<uuid>/...` with `/proxy/[REDACTED]/<...>` in any log/error/stack-trace string. The sentinel-token regression test (`tests/nodejs-project/usepod-token-redaction.test.js`) asserts zero raw UUID across all captures. `usepodModel` is NOT a secret — model IDs are public marketplace strings.
+
+---
 
 ### OpenAI Codex OAuth — Token Refresh Failure
 **Symptoms:** Agent stops responding on OpenAI OAuth. Log shows `[OpenAI] OAuth refresh failed` or `OAuth token refresh failed`. Subsequent API calls return 401.

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -943,6 +943,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     lines.push('To check current runtime settings, read **agent_settings.json** — it contains heartbeat interval, API keys, and other tunable values.');
     lines.push('API keys for services like Jupiter are configured in Android Settings for secure persistent storage. Search provider keys (Brave, Perplexity, Exa, Tavily, Firecrawl) — configure in Settings > Search Provider.');
     lines.push('**Custom provider:** If PROVIDER is "custom", you are running through a user-configured OpenAI-compatible gateway. The user set this up in Settings > AI Provider > Custom with a base URL, API key, optional custom headers, and a model ID. If the custom endpoint fails, guide the user to Settings > AI Provider to verify the base URL and credentials.');
+    lines.push('**Usepod provider:** If PROVIDER is "usepod", you are running through the Usepod inference marketplace (https://usepod.ai). Setup is Settings-first: the user configures both a usepodToken (UUID) and a usepodModel (the model name from the Usepod dashboard) in Settings > AI Provider > Usepod. Telegram\'s `/provider usepod` only works AFTER that — it cannot set the model itself, and it never carries the prior provider\'s model into Usepod. Per-request billing is in USDC on Solana mainnet; if requests start failing with HTTP 402, the token needs funding at https://usepod.ai/dashboard. SeekerClaw does NOT custody or auto-fund the token in this version — funding is external.');
     lines.push('');
     lines.push('However, if a user provides a key directly in conversation:');
     lines.push('1. Save it to agent_settings.json under apiKeys.<service> (e.g. apiKeys.perplexity)');
@@ -956,7 +957,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     lines.push('');
     lines.push('Note: Keys in agent_settings.json persist across restarts. After saving a key, built-in tools (web_search, Jupiter, etc.) pick it up immediately — no restart needed.');
     lines.push('If asked about config issues, check agent_settings.json and PLATFORM.md.');
-    lines.push('**Quick model/provider switch from chat (BAT-504):** Users can run `/model <name>` and `/provider <claude|openai|openrouter|custom>` directly in Telegram instead of opening Settings → AI Provider. Both write to runtime_state.json (live overlay) and survive restart. If the user asks how to switch model or provider, point them at these commands first.');
+    lines.push('**Quick model/provider switch from chat (BAT-504):** Users can run `/model <name>` and `/provider <claude|openai|openrouter|custom|usepod>` directly in Telegram instead of opening Settings → AI Provider. Both write to runtime_state.json (live overlay) and survive restart. If the user asks how to switch model or provider, point them at these commands first. Note: `/provider usepod` is Settings-first — it refuses to switch if the user has not configured a Usepod token + model in Settings yet (it cannot set the model itself, because `/model <id>` validates against the *current* provider).');
     lines.push('');
 
     // Environment Variables — user-set secrets accessible to tool code (BAT-495)

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -312,12 +312,24 @@ const CUSTOM_KEY = normalizeSecret(config.customApiKey || '');
 const CUSTOM_BASE_URL = (typeof config.customBaseUrl === 'string' ? config.customBaseUrl : '').trim();
 const CUSTOM_HEADERS_RAW = (typeof config.customHeaders === 'string' ? config.customHeaders : '').trim();
 const CUSTOM_FORMAT = (typeof config.customFormat === 'string' ? config.customFormat : 'chat_completions').trim().toLowerCase();
+// BAT-971: Usepod token (UUID, in URL path) + dedicated Usepod model field
+// (per Codex v2.2 — separate from generic config.model to prove the model was
+// intentionally configured FOR USEPOD, not silently carried from Claude/OpenAI).
+const USEPOD_TOKEN = normalizeSecret(config.usepodToken || '');
+const USEPOD_MODEL = (typeof config.usepodModel === 'string' ? config.usepodModel : '').trim();
+// UUID validator (used at startup AND per-request in providers/usepod.js to
+// guard URL construction — rejects path-injection characters and non-UUID input)
+const USEPOD_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isValidUsepodToken(token) {
+    return typeof token === 'string' && USEPOD_UUID_RE.test(token.trim());
+}
 const OPENROUTER_FALLBACK_MODEL = (typeof config.openrouterFallbackModel === 'string' ? config.openrouterFallbackModel : '').trim();
 const OPENROUTER_MODEL_CONTEXT = parseInt(config.openrouterModelContext, 10) || 0;
 const OPENROUTER_FALLBACK_CONTEXT = parseInt(config.openrouterFallbackContext, 10) || 0;
 const _defaultModel = PROVIDER === 'openai' ? 'gpt-5.4'
     : PROVIDER === 'openrouter' ? 'anthropic/claude-sonnet-4-6'
     : PROVIDER === 'custom' ? ''
+    : PROVIDER === 'usepod' ? USEPOD_MODEL
     : 'claude-opus-4-7';
 // BAT-513: model resolves from runtime_state.json first, then
 // config.json, then the per-provider safe default. The agent_settings.json
@@ -510,6 +522,7 @@ const MCP_SERVERS = (config.mcpServers || [])
 const _activeKey = PROVIDER === 'openai' ? (OPENAI_AUTH_TYPE === 'oauth' ? OPENAI_OAUTH_TOKEN : OPENAI_KEY)
     : PROVIDER === 'openrouter' ? OPENROUTER_KEY
     : PROVIDER === 'custom' ? CUSTOM_KEY
+    : PROVIDER === 'usepod' ? USEPOD_TOKEN
     : ANTHROPIC_KEY;
 if (CHANNEL === 'telegram' && !BOT_TOKEN) {
     log('ERROR: Missing required config (botToken) for Telegram channel', 'ERROR');
@@ -523,6 +536,7 @@ if (!_activeKey) {
     const keyName = PROVIDER === 'openai' ? 'openaiApiKey or openaiOAuthToken'
         : PROVIDER === 'openrouter' ? 'openrouterApiKey'
         : PROVIDER === 'custom' ? 'customApiKey'
+        : PROVIDER === 'usepod' ? 'usepodToken'
         : AUTH_TYPE === 'setup_token' ? 'setupToken'
         : 'anthropicApiKey';
     log(`ERROR: Missing required config (${keyName}) for provider "${PROVIDER}"`, 'ERROR');
@@ -536,6 +550,21 @@ if (PROVIDER === 'custom' && !CUSTOM_BASE_URL) {
 
 if (PROVIDER === 'custom' && !MODEL) {
     log('ERROR: Missing required config (model) for provider "custom"', 'ERROR');
+    process.exit(1);
+}
+
+// BAT-971: Usepod validation gate. Token MUST be a valid UUID (path-segment
+// safety — rejects /, ?, #, .., whitespace, full URLs). Model MUST be non-blank
+// (per v2.2 — gate-side enforcement of the Settings-first invariant; the
+// model-catalog.hasCredentialsFor branch enforces this at /provider switch
+// time too, this is the boot-time backstop).
+if (PROVIDER === 'usepod' && !isValidUsepodToken(USEPOD_TOKEN)) {
+    log('ERROR: usepodToken is not a valid UUID — refusing to construct API URLs', 'ERROR');
+    process.exit(1);
+}
+
+if (PROVIDER === 'usepod' && !USEPOD_MODEL) {
+    log('ERROR: Missing required config (usepodModel) for provider "usepod"', 'ERROR');
     process.exit(1);
 }
 
@@ -833,6 +862,9 @@ module.exports = {
     CUSTOM_HEADERS,
     CUSTOM_FORMAT,
     CUSTOM_ENDPOINT,
+    USEPOD_TOKEN,
+    USEPOD_MODEL,
+    isValidUsepodToken,
     OPENROUTER_FALLBACK_MODEL,
     OPENROUTER_MODEL_CONTEXT,
     OPENROUTER_FALLBACK_CONTEXT,

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -683,7 +683,17 @@ async function handleProviderCommand(chatId, args, messageId = null) {
         return `❌ ${cred.reason}`;
     }
 
-    const newModel = modelCatalog.defaultModelForProvider(newProvider, newAuthType);
+    // BAT-971: For Usepod, the new model comes from the dedicated
+    // `usepodModel` config field — NOT the registry's blank default, and
+    // CRUCIALLY never carried from the prior provider's model. The
+    // `hasCredentialsFor('usepod')` gate above guarantees `usepodModel` is
+    // non-blank, so this is always usable. The downstream
+    // `runtimeStateModelToWrite = newModel || state.model` would otherwise
+    // silently inherit `claude-opus-*` / `gpt-*` from the current provider,
+    // violating Codex v2.2 fix #4 ("Do NOT silently carry an old model").
+    const newModel = newProvider === 'usepod'
+        ? (typeof runtimeConfig.usepodModel === 'string' ? runtimeConfig.usepodModel.trim() : '')
+        : modelCatalog.defaultModelForProvider(newProvider, newAuthType);
 
     // Write `model` only when the new provider has a concrete default
     // (claude/openai/openrouter). For freeform providers (custom) where

--- a/app/src/main/assets/nodejs-project/model-catalog.js
+++ b/app/src/main/assets/nodejs-project/model-catalog.js
@@ -266,6 +266,19 @@ function hasCredentialsFor(config, providerId, authType) {
                 return { ok: false, reason: 'No Custom provider base URL. Set it in Settings → Provider → Custom.' };
             }
             return { ok: true };
+        case 'usepod':
+            // BAT-971: Settings-first flow (Codex v2.2). The gate must prove
+            // the model was intentionally configured FOR USEPOD — checking
+            // `config.model` would falsely pass when the active provider
+            // is Claude/OpenAI with `claude-opus-*` / `gpt-*` as the model,
+            // silently carrying a non-Usepod model into Usepod on switch.
+            // The dedicated `usepodModel` config field is set only by
+            // ProviderConfigScreen's Usepod branch, so non-blank means
+            // "user intentionally chose this model for Usepod".
+            if (!nonBlank(config.usepodToken) || !nonBlank(config.usepodModel)) {
+                return { ok: false, reason: 'Set a Usepod model in Settings → AI Provider → Usepod first.' };
+            }
+            return { ok: true };
         default:
             return { ok: false, reason: `Unknown provider: ${providerId}` };
     }

--- a/app/src/main/assets/nodejs-project/model-registry.json
+++ b/app/src/main/assets/nodejs-project/model-registry.json
@@ -61,6 +61,17 @@
       "freeform": true,
       "defaultModel": "",
       "models": []
+    },
+    {
+      "id": "usepod",
+      "displayName": "Usepod",
+      "authTypes": ["api_key"],
+      "keyHint": "usepod token (UUID)",
+      "consoleUrl": "https://usepod.ai/dashboard",
+      "keysUrl": "https://usepod.ai/dashboard",
+      "freeform": true,
+      "defaultModel": "",
+      "models": []
     }
   ]
 }

--- a/app/src/main/assets/nodejs-project/providers/index.js
+++ b/app/src/main/assets/nodejs-project/providers/index.js
@@ -35,5 +35,6 @@ register(require('./claude'));
 register(require('./openai'));
 register(require('./openrouter'));
 register(require('./custom'));
+register(require('./usepod'));
 
 module.exports = { getAdapter, listProviders, register };

--- a/app/src/main/assets/nodejs-project/providers/usepod.js
+++ b/app/src/main/assets/nodejs-project/providers/usepod.js
@@ -1,0 +1,265 @@
+// SeekerClaw — providers/usepod.js
+// Usepod (inference marketplace) provider adapter — BAT-971.
+//
+// Wire shape: OpenAI-compatible Chat Completions. Pure wire-format
+// translation (messages/tools/vision/system prompt/parse) is delegated to
+// openrouter.js. Everything that could leak OpenRouter-specific behavior
+// into Usepod requests is OWN here:
+//
+//   - endpoint / testEndpoint: token spliced into URL path
+//     (https://api.usepod.ai/proxy/<TOKEN>/v1/...) with per-request UUID
+//     validation. Throws a typed error rather than constructing a malformed
+//     URL if the token doesn't pass the validator.
+//   - buildHeaders: Content-Type + dummy Authorization only. NO HTTP-Referer,
+//     NO X-Title, NO OpenRouter API key. The Authorization value is
+//     intentionally a non-secret literal — the real credential is in the path.
+//   - formatRequest: clean OpenAI chat-completions body (model, stream,
+//     max_tokens, messages, tools). NO provider routing, NO fallback,
+//     NO cache_control, NO OpenRouter-only fields. Mirrors custom.js's
+//     chat_completions branch.
+//   - classifyError: distinguishes 402 unfunded vs price-ceiling, 401
+//     unfunded vs invalid-format (per the live-probe characterization in
+//     BAT-971 PR description). All user-facing strings say "Usepod", not
+//     "OpenRouter".
+//   - parseRateLimitHeaders: parses X-Balance-Remaining if Usepod returns
+//     it (public docs mention this header on inference responses). Logs
+//     once per session for diagnosability.
+//
+// Security: usepodToken is a UUID secret. It's redacted via security.js
+// (literal-value branch in rebuildRedactPatterns + URL-path regex pass in
+// redactSecrets). The sentinel-token regression test asserts no raw UUID
+// in any log/error/dump across the full adapter exercise.
+
+'use strict';
+
+// Look the token up via property access (NOT destructured-at-require-time) so
+// the dynamic endpoint getter sees fresh config values. In production this is
+// a const value (config.js exports are frozen at module load), so behavior is
+// identical to destructuring. In unit tests, the require.cache stub uses an
+// `get USEPOD_TOKEN()` getter so each lookup observes the latest test fixture.
+const _config = require('../config');
+const { isValidUsepodToken, log } = _config;
+
+const openrouter = require('./openrouter');
+
+// One-shot log gate for X-Balance-Remaining — Usepod returns this header
+// per the public docs (Codex flagged it during v2 review). We log the first
+// observation each process lifetime so a power user can confirm the gateway
+// is reporting balance; subsequent responses don't spam the log.
+let _balanceHeaderLoggedThisSession = false;
+
+// ── URL construction with per-request UUID validation ───────────────────────
+
+const USEPOD_HOSTNAME = 'api.usepod.ai';
+
+function _currentToken() {
+    return _config.USEPOD_TOKEN;
+}
+
+function _requireValidToken() {
+    if (!isValidUsepodToken(_currentToken())) {
+        // Throwing here is preferred over constructing a malformed URL —
+        // a thrown error surfaces a clean user message via the chat error
+        // path, where construction would either 404 silently or (worse)
+        // hit a path that does match something. Validator rejects path-
+        // injection chars (/, ?, #, .., whitespace, full URLs).
+        const err = new Error('usepodToken is not a valid UUID — refusing to construct API URL');
+        err.code = 'USEPOD_INVALID_TOKEN';
+        throw err;
+    }
+}
+
+// ── Own adapter surface ─────────────────────────────────────────────────────
+
+// Dynamic getters mirror custom.js's pattern. The endpoint changes whenever
+// USEPOD_TOKEN changes (which today only happens at restart, but the dynamic
+// shape future-proofs for live updates).
+const endpoint = {
+    get hostname() { return USEPOD_HOSTNAME; },
+    get path() {
+        _requireValidToken();
+        return '/proxy/' + _currentToken().trim() + '/v1/chat/completions';
+    },
+};
+
+const testEndpoint = {
+    get hostname() { return USEPOD_HOSTNAME; },
+    get path() {
+        _requireValidToken();
+        return '/proxy/' + _currentToken().trim() + '/balance';
+    },
+    method: 'GET',
+};
+
+// Minimal headers. The Authorization value is a non-secret literal — Usepod
+// accepts any non-empty Authorization (the real credential is in the path).
+// NOT delegated to openrouter.buildHeaders, which would add HTTP-Referer /
+// X-Title / OpenRouter routing headers that Usepod doesn't need and may
+// silently mis-route on.
+// eslint-disable-next-line no-unused-vars
+function buildHeaders(_apiKey) {
+    return {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer UsePod',
+    };
+}
+
+// Clean OpenAI chat-completions body. `input` is already-translated
+// chat-completions messages (handed in by ai.js — Codex v2 fix #2 and
+// v2.1 clarification). NO re-translation here. Mirrors custom.js:268-275.
+// NO provider routing, NO fallback chain, NO cache_control, NO OpenRouter-
+// only fields.
+// eslint-disable-next-line no-unused-vars
+function formatRequest(model, maxTokens, instructions, input, tools, _requestOptions) {
+    const body = {
+        model,
+        stream: true,
+        max_tokens: maxTokens,
+        messages: [{ role: 'system', content: instructions }, ...input],
+    };
+    if (tools && tools.length > 0) body.tools = tools;
+    return JSON.stringify(body);
+}
+
+// 402 unfunded vs price-ceiling; 401 unfunded vs invalid-format. Live-probe
+// (BAT-971 PR description) characterized the 401 message split:
+//   - "unauthorized: token not found or not activated" → unfunded OR unknown
+//     (Usepod combines them server-side; no caller-side distinction)
+//   - "unauthorized: invalid token format" → malformed UUID (also caught
+//     by our client-side validator before the request fires)
+// 402:
+//   - error.type === 'no_provider_at_price' → ceiling exceeded
+//   - otherwise → unfunded
+function classifyError(status, data) {
+    const errType = data && data.error && typeof data.error.type === 'string' ? data.error.type : '';
+    const errMessage = data && data.error && typeof data.error.message === 'string' ? data.error.message : '';
+
+    if (status === 402) {
+        if (errType === 'no_provider_at_price') {
+            const details = data && data.error && data.error.details;
+            const minIn = details && typeof details.suggested_min_input_per_1m === 'number'
+                ? details.suggested_min_input_per_1m : null;
+            const minOut = details && typeof details.suggested_min_output_per_1m === 'number'
+                ? details.suggested_min_output_per_1m : null;
+            const suffix = (minIn !== null && minOut !== null)
+                ? ` Suggested minimums: ${minIn} input / ${minOut} output (microunits per 1M tokens).`
+                : '';
+            return {
+                type: 'price_ceiling',
+                retryable: false,
+                userMessage: 'No Usepod provider available under your current price ceiling. '
+                    + 'Either raise the ceiling or check the dashboard at https://usepod.ai/dashboard.'
+                    + suffix,
+            };
+        }
+        return {
+            type: 'unfunded',
+            retryable: false,
+            userMessage: 'Fund your Usepod token at https://usepod.ai/dashboard.',
+        };
+    }
+    if (status === 401) {
+        if (/invalid token format/i.test(errMessage)) {
+            return {
+                type: 'auth',
+                retryable: false,
+                userMessage: 'Invalid Usepod token format. Re-check the UUID in Settings → AI Provider → Usepod.',
+            };
+        }
+        if (/not found or not activated/i.test(errMessage)) {
+            // Per live-probe: this message covers BOTH unfunded-but-registered
+            // AND unknown tokens. Surface a combined hint that covers both
+            // recovery paths without falsely accusing the user of pasting
+            // a bad token.
+            return {
+                type: 'auth_or_unfunded',
+                retryable: false,
+                userMessage: 'Usepod token is unfunded or unknown. Fund or re-check the token at https://usepod.ai/dashboard.',
+            };
+        }
+        return {
+            type: 'auth',
+            retryable: false,
+            userMessage: 'Invalid Usepod token. Re-check Settings → AI Provider → Usepod → Token.',
+        };
+    }
+    if (status === 403) {
+        return {
+            type: 'auth',
+            retryable: false,
+            userMessage: 'Usepod rejected the request (403). Re-check your token in Settings.',
+        };
+    }
+    if (status === 429) {
+        return {
+            type: 'rate_limit',
+            retryable: true,
+            userMessage: 'Usepod rate-limited. Retrying in a moment...',
+        };
+    }
+    if (status >= 500 && status < 600) {
+        return {
+            type: 'server',
+            retryable: true,
+            userMessage: 'Usepod is temporarily unavailable. Retrying...',
+        };
+    }
+    const rawReason = (errMessage || '').replace(/[*_`\[\]()~>#+\-=|{}.!]/g, '').slice(0, 200).trim();
+    return {
+        type: 'unknown',
+        retryable: false,
+        userMessage: rawReason
+            ? `Usepod error (${status}): ${rawReason}`
+            : `Unexpected Usepod error (${status}). Please try again.`,
+    };
+}
+
+// Parse X-Balance-Remaining (public docs flagged by Codex v2). Falls back
+// gracefully when the header is absent. Logs the first observation per
+// process for diagnosability. Standard rate-limit fields are absent for
+// Usepod (no anthropic-ratelimit-* equivalents) — we return Infinity for
+// tokensRemaining so the rate-limiter never throttles a session that's
+// actually fine.
+function parseRateLimitHeaders(headers) {
+    const empty = { tokensRemaining: Infinity, tokensReset: '' };
+    if (!headers) return empty;
+    const balanceRaw = headers['x-balance-remaining'];
+    if (typeof balanceRaw === 'string' && balanceRaw.length > 0) {
+        const micro = parseInt(balanceRaw, 10);
+        if (Number.isFinite(micro) && micro >= 0 && !_balanceHeaderLoggedThisSession) {
+            _balanceHeaderLoggedThisSession = true;
+            const usdc = (micro / 1_000_000).toFixed(4);
+            log(`[Usepod] X-Balance-Remaining observed: ${micro} microunits (~$${usdc} USDC)`, 'INFO');
+        }
+    }
+    return empty;
+}
+
+// ── Module export — own surface + pure-translation delegates ────────────────
+
+module.exports = {
+    id: 'usepod',
+    name: 'Usepod',
+
+    // Own (NOT delegated)
+    endpoint,
+    testEndpoint,
+    buildHeaders,
+    formatRequest,
+    classifyError,
+    parseRateLimitHeaders,
+    streamProtocol: 'chat-completions',
+    supportsCache: false,
+    authTypes: ['api_key'],
+
+    // Delegated to openrouter.js — pure wire-format translation only.
+    // No OpenRouter-specific decoration in any of these paths (verified at
+    // adapter design time; tests pin the assertion).
+    toApiMessages: openrouter.toApiMessages,
+    fromApiResponse: openrouter.fromApiResponse,
+    formatSystemPrompt: openrouter.formatSystemPrompt,
+    formatTools: openrouter.formatTools,
+    formatVision: openrouter.formatVision,
+    normalizeUsage: openrouter.normalizeUsage,
+    classifyNetworkError: openrouter.classifyNetworkError,
+};

--- a/app/src/main/assets/nodejs-project/runtime-state.js
+++ b/app/src/main/assets/nodejs-project/runtime-state.js
@@ -86,6 +86,7 @@ _VALID_AUTH_TYPES.claude = new Set(['api_key', 'setup_token']);
 _VALID_AUTH_TYPES.openai = new Set(['api_key', 'oauth']);
 _VALID_AUTH_TYPES.openrouter = new Set(['api_key']);
 _VALID_AUTH_TYPES.custom = new Set(['api_key']);
+_VALID_AUTH_TYPES.usepod = new Set(['api_key']);
 const VALID_AUTH_TYPES = Object.freeze(_VALID_AUTH_TYPES);
 
 function validateMatrix(provider, authType) {

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -73,6 +73,20 @@ function rebuildRedactPatterns() {
             patterns.push({ rx: new RegExp(_escRx(config[key]), 'g'), replacement: `[REDACTED:${key}]` });
         }
     }
+    // BAT-971: usepodToken is a UUID (not an *ApiKey-suffixed field), so the
+    // loop above won't pick it up. Codex v2.2 fix #1: register it explicitly
+    // via the same _dynamicPatterns mechanism so it produces [REDACTED:usepodToken]
+    // (not [REDACTED_ENV] from registerRedactedSecret). The URL-path-form pass
+    // in redactSecrets covers the case where the token appears spliced into a
+    // /proxy/<uuid>/... path string even if the bare value isn't matched.
+    if (config.usepodToken
+        && typeof config.usepodToken === 'string'
+        && config.usepodToken.length >= 8) {
+        patterns.push({
+            rx: new RegExp(_escRx(config.usepodToken), 'g'),
+            replacement: '[REDACTED:usepodToken]',
+        });
+    }
     // BAT-514: MCP server auth tokens are no longer iterated at
     // startup — tokens aren't in `MCP_SERVERS` post-migration (they
     // live in encrypted per-id files under `filesDir/mcp_tokens/<id>`
@@ -102,6 +116,14 @@ function redactSecrets(msg) {
     // Redact OpenAI API keys (sk-proj-..., sk-...)
     msg = msg.replace(/sk-proj-[a-zA-Z0-9_-]{20,}/g, 'sk-proj-***');
     msg = msg.replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***');
+    // BAT-971: redact Usepod token in URL-path form (/proxy/<uuid>/...) — covers
+    // error stack traces, log lines, and any other string where the token landed
+    // in a path even when the literal-value redaction missed it (e.g. a partial
+    // concat, a test fixture, or pre-rebuild log lines). Broadened from just
+    // /balance|/v1 to all path tails so /completions, /models, query strings,
+    // and future Usepod paths are all covered. Runs BEFORE the bridge-token
+    // line so the path replacement is intact when later passes scan the string.
+    msg = msg.replace(/\/proxy\/[0-9a-fA-F-]{32,36}\/[A-Za-z0-9_./?&=-]*/g, '/proxy/[REDACTED]/<...>');
     // Redact bridge tokens (UUID format)
     if (BRIDGE_TOKEN) msg = msg.replace(new RegExp(_escRx(BRIDGE_TOKEN), 'g'), '***bridge-token***');
     // Redact Jupiter API key + MCP auth tokens (cached literal patterns)

--- a/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/config/ConfigManager.kt
@@ -61,6 +61,14 @@ data class AppConfig(
     val customBaseUrl: String = "",
     val customHeaders: String = "",
     val customFormat: String = "chat_completions",
+    // BAT-971: Usepod (inference marketplace) credentials. usepodToken is a UUID
+    // secret (stored encrypted, redacted in logs). usepodModel is a freeform model
+    // id (plaintext — model ids are public marketplace strings). Settings-first
+    // setup: both must be non-blank before /provider usepod can switch in
+    // (Codex v2.2). Survives provider switches; on switch-back into usepod, the
+    // mirror in updateConfigField restores config.model from this field.
+    val usepodToken: String = "",
+    val usepodModel: String = "",
     val channel: String = "telegram",
     val discordBotToken: String = "",
     val discordOwnerId: String = "",
@@ -231,6 +239,9 @@ object ConfigManager {
     private const val KEY_CUSTOM_BASE_URL = "custom_base_url"
     private const val KEY_CUSTOM_HEADERS_ENC = "custom_headers_enc"
     private const val KEY_CUSTOM_FORMAT = "custom_format"
+    // BAT-971
+    private const val KEY_USEPOD_TOKEN_ENC = "usepod_token_enc"
+    private const val KEY_USEPOD_MODEL = "usepod_model"
     private const val KEY_CHANNEL = "channel"
     private const val KEY_DISCORD_BOT_TOKEN_ENC = "discord_bot_token_enc"
     private const val KEY_DISCORD_OWNER_ID = "discord_owner_id"
@@ -530,6 +541,15 @@ object ConfigManager {
             editor.remove(KEY_CUSTOM_HEADERS_ENC)
         }
         editor.putString(KEY_CUSTOM_FORMAT, config.customFormat)
+
+        // BAT-971: Usepod token (encrypted, secret) + model (plaintext, public id)
+        if (config.usepodToken.isNotBlank()) {
+            val encUsepod = KeystoreHelper.encrypt(config.usepodToken)
+            editor.putString(KEY_USEPOD_TOKEN_ENC, Base64.encodeToString(encUsepod, Base64.NO_WRAP))
+        } else {
+            editor.remove(KEY_USEPOD_TOKEN_ENC)
+        }
+        editor.putString(KEY_USEPOD_MODEL, config.usepodModel)
 
         editor.putString(KEY_CHANNEL, config.channel)
         if (config.discordBotToken.isNotBlank()) {
@@ -1082,6 +1102,17 @@ object ConfigManager {
             ""
         }
 
+        // BAT-971: Usepod token (secret — Keystore encrypted). The model is plaintext
+        // and read straight from prefs below in the AppConfig instantiation.
+        val usepodToken = try {
+            val enc = p.getString(KEY_USEPOD_TOKEN_ENC, null)
+            if (enc != null) KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP)) else ""
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to decrypt Usepod token", e)
+            LogCollector.append("[Config] Failed to decrypt Usepod token: ${e.javaClass.simpleName}", LogLevel.ERROR)
+            ""
+        }
+
         val discordBotToken = try {
             val enc = p.getString(KEY_DISCORD_BOT_TOKEN_ENC, null)
             if (enc != null) KeystoreHelper.decrypt(Base64.decode(enc, Base64.NO_WRAP)) else ""
@@ -1183,6 +1214,8 @@ object ConfigManager {
             customBaseUrl = p.getString(KEY_CUSTOM_BASE_URL, "") ?: "",
             customHeaders = customHeaders,
             customFormat = p.getString(KEY_CUSTOM_FORMAT, "chat_completions") ?: "chat_completions",
+            usepodToken = usepodToken,
+            usepodModel = p.getString(KEY_USEPOD_MODEL, "") ?: "",
             channel = p.getString(KEY_CHANNEL, "telegram") ?: "telegram",
             discordBotToken = discordBotToken,
             discordOwnerId = loadOwnerIdFromFile(context, "discord"),
@@ -1586,6 +1619,20 @@ object ConfigManager {
             "customBaseUrl" -> config.copy(customBaseUrl = value)
             "customHeaders" -> config.copy(customHeaders = value)
             "customFormat" -> config.copy(customFormat = value)
+            "usepodToken" -> config.copy(usepodToken = value)
+            "usepodModel" -> {
+                // BAT-971 / Codex v2.2 mirror: when the active provider IS usepod,
+                // also write the same value to config.model so the running agent
+                // picks it up on the next AI turn (config.model is what `MODEL` in
+                // Node-side config.js resolves from). When provider != usepod, just
+                // update usepodModel — the field survives provider switches and is
+                // restored on switch-back via ProviderConfigScreen.switchProvider.
+                if (config.provider == "usepod") {
+                    config.copy(usepodModel = value, model = value)
+                } else {
+                    config.copy(usepodModel = value)
+                }
+            }
             "channel" -> config.copy(channel = value)
             "discordBotToken" -> config.copy(discordBotToken = value)
             "discordOwnerId" -> {
@@ -1746,6 +1793,12 @@ object ConfigManager {
             if (config.customBaseUrl.isNotBlank()) put("customBaseUrl", config.customBaseUrl)
             if (config.customHeaders.isNotBlank()) put("customHeaders", config.customHeaders)
             if (config.customFormat.isNotBlank()) put("customFormat", config.customFormat)
+            // BAT-971: Usepod credentials. Token is secret (still written here because
+            // Node's config.js reads it from the workspace JSON; security.js's redaction
+            // pipeline guards every log/error site downstream — usepod_token never reaches
+            // a log line in plaintext). Model is plaintext (public marketplace id).
+            if (config.usepodToken.isNotBlank()) put("usepodToken", config.usepodToken)
+            if (config.usepodModel.isNotBlank()) put("usepodModel", config.usepodModel)
             put("channel", config.channel)
             if (config.discordBotToken.isNotBlank()) put("discordBotToken", config.discordBotToken)
             if (config.discordOwnerId.isNotBlank()) put("discordOwnerId", config.discordOwnerId)
@@ -1848,10 +1901,17 @@ object ConfigManager {
             }
             "openrouter" -> config.openrouterApiKey.isNotBlank()
             "custom" -> config.customApiKey.isNotBlank() && config.customBaseUrl.isNotBlank()
+            // BAT-971: Usepod requires BOTH token AND model. usepodModel is the
+            // gate that proves the model was intentionally configured for Usepod
+            // (Codex v2.2 — config.model alone would falsely pass with the prior
+            // provider's model). The model_missing branch below catches the
+            // model-blank edge separately so the error message is precise.
+            "usepod" -> config.usepodToken.isNotBlank() && config.usepodModel.isNotBlank()
             else -> config.activeCredential.isNotBlank()
         }
         if (!hasCredential) return "missing_credential"
         if (config.provider == "custom" && config.model.isBlank()) return "missing_model"
+        if (config.provider == "usepod" && config.usepodModel.isBlank()) return "missing_model"
         return null
     }
 
@@ -1861,6 +1921,7 @@ object ConfigManager {
             "apiSet=${config.anthropicApiKey.isNotBlank()} setupTokenSet=${config.setupToken.isNotBlank()} " +
             "openaiSet=${config.openaiApiKey.isNotBlank()} openrouterSet=${config.openrouterApiKey.isNotBlank()} " +
             "customSet=${config.customApiKey.isNotBlank()} " +
+            "usepodSet=${config.usepodToken.isNotBlank() && config.usepodModel.isNotBlank()} " +
             "activeSet=${config.activeCredential.isNotBlank()} model=${config.model} " +
             "channel=${config.channel} discordSet=${config.discordBotToken.isNotBlank()}"
     }

--- a/app/src/main/java/com/seekerclaw/app/state/RuntimeStateStore.kt
+++ b/app/src/main/java/com/seekerclaw/app/state/RuntimeStateStore.kt
@@ -297,6 +297,10 @@ object RuntimeStateStore {
         "openai" -> authType == "api_key" || authType == "oauth"
         "openrouter" -> authType == "api_key"
         "custom" -> authType == "api_key"
+        // BAT-971: Usepod uses api_key auth (the dummy Authorization header
+        // is irrelevant since the real credential is in the URL path).
+        // Mirrors Node-side runtime-state.js `_VALID_AUTH_TYPES.usepod`.
+        "usepod" -> authType == "api_key"
         else -> false
     }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -272,6 +272,28 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             else -> "api_key"
         }
 
+        // BAT-971 / Codex v2.2: Settings-first gate for switching INTO Usepod.
+        // Both usepodToken AND usepodModel must be non-blank before we commit to
+        // a provider switch — otherwise the post-restart Node would either fail
+        // its config-load gate (config.js exits with `missing required config
+        // (usepodToken)` / `(usepodModel)`) OR (if we let the model fall through
+        // to savedModel) silently carry the prior provider's model into Usepod,
+        // violating "Do NOT silently carry an old model" (v2.2 fix #4). The
+        // /provider usepod Telegram handler in message-handler.js enforces the
+        // same rule via hasCredentialsFor('usepod'); this is the UI-side mirror.
+        if (newProviderId == "usepod") {
+            val tokenSet = current.usepodToken.isNotBlank()
+            val modelSet = current.usepodModel.isNotBlank()
+            if (!tokenSet || !modelSet) {
+                android.widget.Toast.makeText(
+                    context,
+                    "Set a Usepod model first.",
+                    android.widget.Toast.LENGTH_LONG,
+                ).show()
+                return
+            }
+        }
+
         // Resolve the effective model for the new provider.
         val modelsForNew = modelsForProvider(newProviderId, effectiveAuthType)
         val savedModel = prefs.getString("lastModel_$newProviderId", null)
@@ -280,9 +302,22 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
             val defaultModel = when (newProviderId) {
                 "openrouter" -> OPENROUTER_DEFAULT_MODEL
                 "custom" -> ""
+                // BAT-971: For Usepod, the "default" model is the user's dedicated
+                // `usepodModel` config field — NOT a registry blank, and NEVER the
+                // savedModel (lastModel_usepod SharedPref) which could be stale or
+                // mismatched. The gate above guarantees usepodModel is non-blank here.
+                "usepod" -> current.usepodModel
                 else -> ""
             }
-            savedModel?.takeIf { it.isNotBlank() } ?: defaultModel
+            // BAT-971: Usepod is special — savedModel (the cross-provider lastModel_
+            // SharedPref) is bypassed; the dedicated usepodModel field is the only
+            // source. Other freeform providers (openrouter, custom) keep the
+            // existing savedModel-fallback behavior.
+            if (newProviderId == "usepod") {
+                defaultModel
+            } else {
+                savedModel?.takeIf { it.isNotBlank() } ?: defaultModel
+            }
         } else {
             if (modelsForNew.any { it.id == currentModel }) {
                 // Current model is still valid — keep it.
@@ -546,6 +581,27 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             showDivider = false,
                         )
                     }
+                    "usepod" -> {
+                        // BAT-971: Settings-first Usepod branch. Both Model AND Token
+                        // are required. Saving the model while provider=usepod triggers
+                        // ConfigManager's mirror (writes config.model = usepodModel too),
+                        // so the running agent picks up the saved model on next AI turn.
+                        ConfigField(
+                            label = "Model",
+                            value = config?.usepodModel?.ifBlank { "Not set" } ?: "Not set",
+                            onClick = { editField = "usepodModel"; editLabel = "Model ID"; editValue = config?.usepodModel ?: "" },
+                            info = "Type the model your token has access to (read it off the Usepod dashboard).",
+                            isRequired = true,
+                        )
+                        ConfigField(
+                            label = "Token",
+                            value = maskKey(config?.usepodToken),
+                            onClick = { editField = "usepodToken"; editLabel = "Usepod Token (UUID)"; editValue = config?.usepodToken ?: "" },
+                            info = "Get your token at https://usepod.ai/dashboard. Fund it with USDC on Solana before requests work (until funded, you'll see HTTP 402).",
+                            isRequired = true,
+                            showDivider = false,
+                        )
+                    }
                 }
             }
 
@@ -605,6 +661,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                     format = config?.customFormat ?: "chat_completions",
                                     extraHeaders = config?.customHeaders ?: "",
                                 )
+                                "usepod" -> testUsepodConnection(config?.usepodToken ?: "")
                                 else -> {
                                     // Use Anthropic-specific credential derived from authType
                                     val authType = config?.authType ?: "api_key"
@@ -1265,6 +1322,90 @@ private suspend fun testCustomConnection(
         } catch (_: java.net.SocketTimeoutException) { error("Connection timed out")
         } catch (_: java.io.IOException) { error("Network unreachable or timeout")
         } finally { conn.disconnect() }
+    }
+}
+
+// BAT-971: Connection test for the Usepod provider. Hits GET
+// /proxy/<token>/balance and surfaces:
+//   - 200 + is_active=true + balance>0 → Success (the action button shows
+//     "Connection successful!" — matches other providers' convention)
+//   - 200 + is_active=false / usdc_balance=0 → soft Error "Token valid but
+//     unfunded — add USDC at usepod.ai/dashboard" (the token is structurally
+//     valid but won't work for inference until funded; surfacing as Error
+//     lets the user see they need to take an action)
+//   - 401 with "invalid token format" → Error "Invalid token format" (rare;
+//     the UUID gate in this function should catch it client-side first)
+//   - 401 with "not found or not activated" → Error "Token is unfunded or
+//     unknown" (empirically Usepod's balance endpoint returns this 401 for
+//     BOTH unfunded-but-registered AND unknown tokens — combined into one
+//     server-side message; see BAT-971 PR description for the live-probe matrix)
+//   - 401 (other) → Error "Invalid token"
+//   - 4xx other / 5xx → degrade to soft success per Codex v2.2 fix #5: if
+//     the balance endpoint shape diverges from what we expect, don't block
+//     the provider UI; let the first real request surface the issue
+private suspend fun testUsepodConnection(token: String): Result<Unit> = withContext(Dispatchers.IO) {
+    runCatching {
+        val trimmed = token.trim()
+        if (trimmed.isBlank()) error("Token is empty")
+        // Client-side UUID validation mirrors Node's isValidUsepodToken. Catches
+        // path-injection chars (/, ?, #, ..) and full URLs before they ever hit
+        // the network. The server's "invalid token format" 401 would catch them
+        // too, but a clean client-side reject is faster + uses no Usepod quota.
+        val uuidRe = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", RegexOption.IGNORE_CASE)
+        if (!uuidRe.matches(trimmed)) {
+            error("Invalid token format — paste the UUID from https://usepod.ai/dashboard")
+        }
+        val url = java.net.URL("https://api.usepod.ai/proxy/$trimmed/balance")
+        val conn = url.openConnection() as java.net.HttpURLConnection
+        conn.requestMethod = "GET"
+        conn.connectTimeout = 15000
+        conn.readTimeout = 15000
+        try {
+            val status = conn.responseCode
+            if (status in 200..299) {
+                val body = try { conn.inputStream?.bufferedReader()?.use { it.readText() } ?: "" } catch (_: Exception) { "" }
+                val isActive = try { org.json.JSONObject(body).optBoolean("is_active", false) } catch (_: Exception) { false }
+                val micro = try { org.json.JSONObject(body).optLong("usdc_balance", 0L) } catch (_: Exception) { 0L }
+                if (isActive && micro > 0L) {
+                    // Funded path — success.
+                    return@runCatching
+                }
+                error("Token valid but unfunded — add USDC at https://usepod.ai/dashboard")
+            }
+            // Read the error body once so we can branch on `error.message`.
+            val errorBody = try { (conn.errorStream ?: conn.inputStream)?.bufferedReader()?.use { it.readText() } ?: "" } catch (_: Exception) { "" }
+            val apiMessage = try {
+                org.json.JSONObject(errorBody).optJSONObject("error")?.optString("message", "") ?: ""
+            } catch (_: Exception) { "" }
+            when (status) {
+                401, 404 -> {
+                    val msg = when {
+                        apiMessage.contains("invalid token format", ignoreCase = true) ->
+                            "Invalid token format — paste the UUID from https://usepod.ai/dashboard"
+                        apiMessage.contains("not found or not activated", ignoreCase = true) ->
+                            "Token is unfunded or unknown — add USDC at https://usepod.ai/dashboard"
+                        else -> "Invalid token — recheck Settings"
+                    }
+                    error(msg)
+                }
+                429 -> error("Rate limited — try again in a moment")
+                in 500..599 -> {
+                    // Codex v2.2 fix #5 degrade path: server-side outage shouldn't block
+                    // the provider UI. The first real request will surface the real issue.
+                    return@runCatching
+                }
+                else -> {
+                    // Degrade path for unexpected status codes.
+                    return@runCatching
+                }
+            }
+        } catch (_: java.net.SocketTimeoutException) {
+            error("Connection timed out")
+        } catch (_: java.io.IOException) {
+            error("Network unreachable or timeout")
+        } finally {
+            conn.disconnect()
+        }
     }
 }
 

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -135,6 +135,7 @@ const SKIP_REASONS = {
     'providers/openai.js': 'requires config.js',
     'providers/openrouter.js': 'requires config.js',
     'providers/custom.js': 'requires config.js',
+    'providers/usepod.js': 'requires config.js',
     'tools/index.js': 'requires main.js + handlers',
     'tools/android.js': 'requires bridge.js',
     'tools/cron.js': 'requires cron.js',

--- a/tests/nodejs-project/usepod-adapter.test.js
+++ b/tests/nodejs-project/usepod-adapter.test.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// usepod-adapter.test.js — pin BAT-971 v2.2 Usepod adapter contract:
+//
+//  - Endpoint construction: valid UUID → /proxy/<TOKEN>/v1/chat/completions
+//  - Endpoint refusal: invalid token (blank, non-UUID, URL-with-slashes,
+//    .., whitespace) → throws typed error, NEVER constructs a malformed URL
+//  - buildHeaders: minimal (Content-Type + dummy Authorization) — NO
+//    HTTP-Referer, NO X-Title, NO OpenRouter API key
+//  - formatRequest: clean OpenAI chat-completions body — NO `provider`,
+//    NO `cache_control`, NO OpenRouter-only fields. `input` treated as
+//    already-translated chat-completions messages (Codex v2.1 fix #2)
+//  - classifyError: 402 unfunded vs `no_provider_at_price` (Codex v2 fix #6);
+//    401 invalid-format vs not-found-or-not-activated (per BAT-971
+//    live-probe characterization)
+//  - parseRateLimitHeaders: parses X-Balance-Remaining if present
+//
+// Run: node tests/nodejs-project/usepod-adapter.test.js
+// Exit: 0 = all pass, 1 = at least one failure
+
+'use strict';
+
+const path = require('path');
+
+// Stub config.js so the adapter loads without a real config.json or running
+// validation gates. The token here is a valid UUID so the dynamic endpoint
+// getter doesn't throw under the adapter's own UUID pre-flight.
+const VALID_TOKEN = '11111111-2222-3333-4444-555555555555';
+const stubConfigPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+const USEPOD_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+let _currentToken = VALID_TOKEN;
+require.cache[stubConfigPath] = {
+    id: stubConfigPath,
+    filename: stubConfigPath,
+    loaded: true,
+    exports: {
+        // The adapter destructures these three at require-time:
+        get USEPOD_TOKEN() { return _currentToken; },
+        isValidUsepodToken: (t) => typeof t === 'string' && USEPOD_UUID_RE.test(t.trim()),
+        log: () => {},
+    },
+};
+
+const usepod = require('../../app/src/main/assets/nodejs-project/providers/usepod');
+// Also load openrouter to verify the delegated functions are bound, not
+// re-implemented (the v2.2 design splits OWN vs DELEGATED explicitly).
+const openrouter = require('../../app/src/main/assets/nodejs-project/providers/openrouter');
+
+let failures = 0;
+function assertEq(label, actual, expected) {
+    const a = JSON.stringify(actual);
+    const e = JSON.stringify(expected);
+    if (a === e) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}\n  actual:   ${a}\n  expected: ${e}`); failures++; }
+}
+function assertOk(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+function assertThrows(label, fn, expectedCode = null) {
+    try {
+        fn();
+        console.log(`FAIL: ${label} — expected throw, got none`);
+        failures++;
+    } catch (e) {
+        if (expectedCode && e.code !== expectedCode) {
+            console.log(`FAIL: ${label} — wrong code (expected=${expectedCode} actual=${e.code})`);
+            failures++;
+        } else {
+            console.log(`PASS: ${label} — threw as expected`);
+        }
+    }
+}
+
+// ─── Endpoint construction ──────────────────────────────────────────────────
+
+console.log('── Endpoint construction ──');
+
+_currentToken = VALID_TOKEN;
+assertEq(
+    'endpoint with valid token produces /proxy/<TOKEN>/v1/chat/completions',
+    { hostname: usepod.endpoint.hostname, path: usepod.endpoint.path },
+    { hostname: 'api.usepod.ai', path: `/proxy/${VALID_TOKEN}/v1/chat/completions` },
+);
+
+assertEq(
+    'testEndpoint with valid token produces /proxy/<TOKEN>/balance (GET)',
+    { hostname: usepod.testEndpoint.hostname, path: usepod.testEndpoint.path, method: usepod.testEndpoint.method },
+    { hostname: 'api.usepod.ai', path: `/proxy/${VALID_TOKEN}/balance`, method: 'GET' },
+);
+
+// ─── Endpoint refusal on invalid tokens ─────────────────────────────────────
+
+console.log('── Endpoint refusal on invalid tokens ──');
+
+for (const bad of ['', '   ', 'not-a-uuid', '../etc/passwd', 'a/b/c', 'a?b=c', 'a#b', 'https://evil.com/']) {
+    _currentToken = bad;
+    assertThrows(
+        `endpoint refuses invalid token: ${JSON.stringify(bad)}`,
+        () => usepod.endpoint.path,
+        'USEPOD_INVALID_TOKEN',
+    );
+    assertThrows(
+        `testEndpoint refuses invalid token: ${JSON.stringify(bad)}`,
+        () => usepod.testEndpoint.path,
+        'USEPOD_INVALID_TOKEN',
+    );
+}
+
+// ─── buildHeaders: minimal, no OpenRouter decorations ───────────────────────
+
+console.log('── buildHeaders minimal ──');
+
+const headers = usepod.buildHeaders('ignored-key-arg');
+assertEq('buildHeaders has exactly Content-Type + Authorization', Object.keys(headers).sort(), ['Authorization', 'Content-Type']);
+assertEq('Authorization is the dummy literal "Bearer UsePod"', headers.Authorization, 'Bearer UsePod');
+assertOk('buildHeaders does NOT include HTTP-Referer', !('HTTP-Referer' in headers));
+assertOk('buildHeaders does NOT include X-Title', !('X-Title' in headers));
+
+// ─── formatRequest: clean OpenAI body, no OpenRouter-only fields ────────────
+
+console.log('── formatRequest clean body ──');
+
+const sampleInput = [
+    { role: 'user', content: 'hello' },
+];
+const bodyStr = usepod.formatRequest('some-model', 1024, 'sys', sampleInput, []);
+const body = JSON.parse(bodyStr);
+assertEq('body has exactly model + stream + max_tokens + messages', Object.keys(body).sort(), ['max_tokens', 'messages', 'model', 'stream']);
+assertEq('model is what was passed in', body.model, 'some-model');
+assertEq('stream is true', body.stream, true);
+assertEq('max_tokens is what was passed in', body.max_tokens, 1024);
+assertEq('messages prepends system then spreads input', body.messages, [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'hello' },
+]);
+assertOk('body has NO provider routing field', !('provider' in body));
+assertOk('body has NO cache_control field', !('cache_control' in body));
+assertOk('body has NO transforms field', !('transforms' in body));
+assertOk('body has NO route field', !('route' in body));
+
+// With tools
+const bodyToolsStr = usepod.formatRequest('m', 100, 'sys', [], [{ type: 'function', function: { name: 'foo' } }]);
+const bodyTools = JSON.parse(bodyToolsStr);
+assertEq('body with tools includes tools array', bodyTools.tools, [{ type: 'function', function: { name: 'foo' } }]);
+
+// Without tools → no tools key (omitted, not null)
+const bodyNoToolsStr = usepod.formatRequest('m', 100, 'sys', [], []);
+const bodyNoTools = JSON.parse(bodyNoToolsStr);
+assertOk('body without tools omits tools key', !('tools' in bodyNoTools));
+
+// ─── classifyError ──────────────────────────────────────────────────────────
+
+console.log('── classifyError 402 unfunded vs no_provider_at_price ──');
+
+const e402Unfunded = usepod.classifyError(402, { error: { type: 'insufficient_balance', message: 'fund it' } });
+assertEq('402 generic → type=unfunded', e402Unfunded.type, 'unfunded');
+assertOk('402 unfunded message mentions usepod.ai/dashboard', /usepod\.ai\/dashboard/.test(e402Unfunded.userMessage));
+
+const e402Ceiling = usepod.classifyError(402, {
+    error: {
+        type: 'no_provider_at_price',
+        message: 'too cheap',
+        details: { suggested_min_input_per_1m: 500000, suggested_min_output_per_1m: 800000 },
+    },
+});
+assertEq('402 no_provider_at_price → type=price_ceiling', e402Ceiling.type, 'price_ceiling');
+assertOk('price_ceiling message mentions ceiling', /price ceiling/i.test(e402Ceiling.userMessage));
+assertOk('price_ceiling interpolates suggested minimums', /500000.*800000/.test(e402Ceiling.userMessage));
+
+console.log('── classifyError 401 invalid-format vs not-found-or-not-activated ──');
+
+const e401Format = usepod.classifyError(401, { error: { type: 'unauthorized', message: 'unauthorized: invalid token format' } });
+assertEq('401 invalid token format → type=auth', e401Format.type, 'auth');
+assertOk('401 invalid-format message says "Invalid Usepod token format"', /invalid usepod token format/i.test(e401Format.userMessage));
+
+const e401NotFound = usepod.classifyError(401, { error: { type: 'unauthorized', message: 'unauthorized: token not found or not activated' } });
+assertEq('401 not found or not activated → type=auth_or_unfunded', e401NotFound.type, 'auth_or_unfunded');
+assertOk('401 not-found message mentions "unfunded or unknown"', /unfunded or unknown/i.test(e401NotFound.userMessage));
+
+const e401Other = usepod.classifyError(401, { error: { type: 'unauthorized', message: 'something else' } });
+assertEq('401 other → type=auth', e401Other.type, 'auth');
+assertOk('401 other message says "Invalid Usepod token"', /invalid usepod token/i.test(e401Other.userMessage));
+
+console.log('── classifyError messages never leak "OpenRouter" branding ──');
+
+for (const [label, status, data] of [
+    ['402 unfunded', 402, {}],
+    ['402 ceiling', 402, { error: { type: 'no_provider_at_price' } }],
+    ['401 format', 401, { error: { message: 'unauthorized: invalid token format' } }],
+    ['401 not-found', 401, { error: { message: 'unauthorized: token not found or not activated' } }],
+    ['429', 429, {}],
+    ['500', 500, {}],
+    ['418', 418, { error: { message: 'teapot' } }],
+]) {
+    const r = usepod.classifyError(status, data);
+    assertOk(
+        `classifyError(${label}) does not leak "OpenRouter"`,
+        !/OpenRouter|openrouter/.test(r.userMessage || ''),
+        r.userMessage,
+    );
+}
+
+// ─── parseRateLimitHeaders: X-Balance-Remaining parsed if present ───────────
+
+console.log('── parseRateLimitHeaders ──');
+
+const rNo = usepod.parseRateLimitHeaders(null);
+assertEq('parseRateLimitHeaders(null) → infinity remaining', rNo.tokensRemaining, Infinity);
+
+const rWithBalance = usepod.parseRateLimitHeaders({ 'x-balance-remaining': '5000000' });
+assertOk('parseRateLimitHeaders with X-Balance-Remaining returns infinity (no rate-limit semantics)', rWithBalance.tokensRemaining === Infinity);
+
+// ─── Module surface ─────────────────────────────────────────────────────────
+
+console.log('── Module surface: delegate is openrouter, not own re-implementation ──');
+
+assertOk('toApiMessages is delegated to openrouter (same function ref)', usepod.toApiMessages === openrouter.toApiMessages);
+assertOk('fromApiResponse is delegated to openrouter', usepod.fromApiResponse === openrouter.fromApiResponse);
+assertOk('formatSystemPrompt is delegated to openrouter', usepod.formatSystemPrompt === openrouter.formatSystemPrompt);
+assertOk('formatTools is delegated to openrouter', usepod.formatTools === openrouter.formatTools);
+assertOk('formatVision is delegated to openrouter', usepod.formatVision === openrouter.formatVision);
+assertOk('normalizeUsage is delegated to openrouter', usepod.normalizeUsage === openrouter.normalizeUsage);
+assertOk('classifyNetworkError is delegated to openrouter', usepod.classifyNetworkError === openrouter.classifyNetworkError);
+
+assertOk('buildHeaders is OWN (not openrouter.buildHeaders)', usepod.buildHeaders !== openrouter.buildHeaders);
+assertOk('formatRequest is OWN', usepod.formatRequest !== openrouter.formatRequest);
+assertOk('classifyError is OWN', usepod.classifyError !== openrouter.classifyError);
+assertOk('parseRateLimitHeaders is OWN', usepod.parseRateLimitHeaders !== openrouter.parseRateLimitHeaders);
+
+assertEq('streamProtocol is chat-completions', usepod.streamProtocol, 'chat-completions');
+assertEq('supportsCache is false', usepod.supportsCache, false);
+assertEq('authTypes is [api_key]', usepod.authTypes, ['api_key']);
+assertEq('id is usepod', usepod.id, 'usepod');
+
+console.log('');
+if (failures > 0) {
+    console.log(`FAIL: ${failures} test(s) failed.`);
+    process.exit(1);
+} else {
+    console.log('PASS: all usepod adapter contract tests passed.');
+    process.exit(0);
+}

--- a/tests/nodejs-project/usepod-token-redaction.test.js
+++ b/tests/nodejs-project/usepod-token-redaction.test.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// usepod-token-redaction.test.js — Codex v1 amendment #1 / v2.2 contract:
+// The Usepod token UUID must NEVER appear in any log/error/dump/config-snapshot
+// output. Two redaction passes cover it: (a) literal-value via the dynamic
+// patterns branch in `rebuildRedactPatterns`, (b) URL-path-form via a regex
+// pass in `redactSecrets`. This test pins both with a sentinel UUID and
+// asserts ZERO raw UUID across all captures.
+//
+// The assertion is property-based ("no raw UUID anywhere") rather than
+// placeholder-specific ("must produce [REDACTED:usepodToken]") per Codex v2
+// fix #1 — the placeholder produced by the literal-value pass is not the
+// load-bearing contract; the no-leak property is.
+//
+// Run: node tests/nodejs-project/usepod-token-redaction.test.js
+// Exit: 0 = sentinel never leaks, 1 = at least one leak
+
+'use strict';
+
+const path = require('path');
+
+// Sentinel UUID. Choosing all-`a` so accidental matches on real UUIDs in
+// other test fixtures are impossible.
+const SENTINEL = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+// Stub config.js so security.js can load. The stub provides only the fields
+// security.js actually reads at top level (BRIDGE_TOKEN, workDir, log) plus
+// the `config` namespace it iterates in rebuildRedactPatterns.
+const stubConfigPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[stubConfigPath] = {
+    id: stubConfigPath,
+    filename: stubConfigPath,
+    loaded: true,
+    exports: {
+        BRIDGE_TOKEN: '',
+        workDir: __dirname,
+        log: () => {},
+        // `config` is the OBJECT rebuildRedactPatterns iterates. The Usepod
+        // branch reads `config.usepodToken` — must match the sentinel exactly.
+        config: {
+            usepodToken: SENTINEL,
+            // A couple of unrelated ApiKey-suffix fields prove the existing
+            // *ApiKey loop still works alongside the new non-suffixed branch.
+            braveApiKey: 'BSA1234567890abcdef',
+            openrouterApiKey: 'sk-or-v1-1234567890abcdef1234567890',
+        },
+    },
+};
+
+const { redactSecrets, rebuildRedactPatterns } = require('../../app/src/main/assets/nodejs-project/security');
+
+// Re-build patterns now that the stub `config.usepodToken` is in place
+// (security.js already called this once at module load; doing it again is
+// idempotent and ensures the test reflects the stubbed fixture).
+rebuildRedactPatterns();
+
+let failures = 0;
+function assertNoLeak(label, output) {
+    if (typeof output !== 'string' || !output.includes(SENTINEL)) {
+        console.log(`PASS: ${label}`);
+    } else {
+        console.log(`FAIL: ${label}\n  sentinel leaked into output: ${output}`);
+        failures++;
+    }
+}
+function assertReplaced(label, raw, expectedSubstring) {
+    const out = redactSecrets(raw);
+    assertNoLeak(label, out);
+    if (typeof out === 'string' && out.includes(expectedSubstring)) {
+        console.log(`PASS: ${label} — redaction substring present`);
+    } else if (typeof out === 'string') {
+        console.log(`INFO: ${label} — no specific placeholder asserted, but no leak detected`);
+    }
+}
+
+// ─── Exercise A: literal token in arbitrary log lines ─────────────────────
+
+console.log('── Literal-value redaction (sentinel never leaks) ──');
+
+assertReplaced(
+    'literal token in info log',
+    `[Usepod] Initialized with token=${SENTINEL} on ${new Date(0).toISOString()}`,
+    '[REDACTED',
+);
+
+assertReplaced(
+    'literal token in error stack message',
+    `Error: failed to call api.usepod.ai (token=${SENTINEL}): connection refused`,
+    '[REDACTED',
+);
+
+assertReplaced(
+    'literal token in JSON-serialized config snapshot',
+    JSON.stringify({ provider: 'usepod', usepodToken: SENTINEL, usepodModel: 'test-model' }),
+    '[REDACTED',
+);
+
+// ─── Exercise B: URL-path-form redaction ──────────────────────────────────
+
+console.log('── URL-path-form redaction (/proxy/<uuid>/...) ──');
+
+assertReplaced(
+    '/balance path is redacted',
+    `GET https://api.usepod.ai/proxy/${SENTINEL}/balance returned 401`,
+    '/proxy/[REDACTED]/',
+);
+
+assertReplaced(
+    '/v1/chat/completions path is redacted',
+    `POST https://api.usepod.ai/proxy/${SENTINEL}/v1/chat/completions stream=true`,
+    '/proxy/[REDACTED]/',
+);
+
+assertReplaced(
+    '/v1/models path is redacted (broadened regex catches all /proxy/<uuid>/* paths)',
+    `[trace] GET /proxy/${SENTINEL}/v1/models returned 200`,
+    '/proxy/[REDACTED]/',
+);
+
+assertReplaced(
+    '/completions path is redacted (no /v1 prefix variation)',
+    `[trace] /proxy/${SENTINEL}/completions`,
+    '/proxy/[REDACTED]/',
+);
+
+assertReplaced(
+    'path with query string is redacted',
+    `/proxy/${SENTINEL}/v1/chat/completions?stream=true&debug=1`,
+    '/proxy/[REDACTED]/',
+);
+
+// ─── Exercise C: combined leak (sentinel appears in multiple forms) ─────
+
+console.log('── Combined leak scenarios ──');
+
+const combinedMsg =
+    `Failed request: token=${SENTINEL} url=https://api.usepod.ai/proxy/${SENTINEL}/balance ` +
+    `body={"error":"unauthorized","at":"${SENTINEL}"} — retrying`;
+assertNoLeak('combined: literal + path-form + JSON embedding all redacted', redactSecrets(combinedMsg));
+
+// ─── Exercise D: ensure pre-existing redactions still work ──────────────
+
+console.log('── Pre-existing redactions unaffected ──');
+
+const braveLog = `[Brave] using key=BSA1234567890abcdef for search`;
+const out = redactSecrets(braveLog);
+if (out.includes('BSA1234567890abcdef')) {
+    console.log(`FAIL: brave key leaked (regression in *ApiKey redaction path)`);
+    failures++;
+} else {
+    console.log('PASS: BSA-prefixed key still redacted (no regression)');
+}
+
+const openrouterLog = `[OR] using sk-or-v1-1234567890abcdef1234567890`;
+const out2 = redactSecrets(openrouterLog);
+if (out2.includes('sk-or-v1-1234567890abcdef1234567890')) {
+    console.log(`FAIL: openrouter key leaked (regression in sk-or- redaction)`);
+    failures++;
+} else {
+    console.log('PASS: sk-or- key still redacted (no regression)');
+}
+
+// ─── Exercise E: token rotation rebuilds patterns ───────────────────────
+
+console.log('── Token rotation: rebuildRedactPatterns updates the literal-value pass ──');
+
+const OLD_TOKEN = SENTINEL;
+const NEW_TOKEN = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+// Simulate token rotation: update the stubbed config + rebuild
+require.cache[stubConfigPath].exports.config.usepodToken = NEW_TOKEN;
+rebuildRedactPatterns();
+
+assertReplaced(
+    'after rotation, NEW token is redacted (literal-value)',
+    `[Usepod] now using token=${NEW_TOKEN}`,
+    '[REDACTED',
+);
+
+// Path-form regex catches BOTH old AND new tokens (it's UUID-shape based,
+// not literal-value based) — important for log lines written BEFORE the
+// rotation that still contain old-token paths.
+assertReplaced(
+    'path-form regex catches OLD token URL even after rotation',
+    `[trace] /proxy/${OLD_TOKEN}/balance — stale log entry`,
+    '/proxy/[REDACTED]/',
+);
+assertReplaced(
+    'path-form regex catches NEW token URL',
+    `[trace] /proxy/${NEW_TOKEN}/balance`,
+    '/proxy/[REDACTED]/',
+);
+
+// ─── Summary ─────────────────────────────────────────────────────────────
+
+console.log('');
+if (failures > 0) {
+    console.log(`FAIL: ${failures} sentinel-token leak(s) detected.`);
+    process.exit(1);
+} else {
+    console.log('PASS: sentinel UUID never appeared in any redacted output.');
+    process.exit(0);
+}


### PR DESCRIPTION
## Summary

Adds **[Usepod](https://usepod.ai)** (inference marketplace, OpenAI-compatible drop-in, USDC-on-Solana billing) as a first-class AI provider. Modeled on OpenRouter (masked credential + freeform model) with one twist: the credential is a UUID in the URL path (`/proxy/<TOKEN>/v1/...`) instead of an Authorization header.

Contract: **[BAT-971 v2.2](https://linear.app/batcave/issue/BAT-971/usepod-ai-provider-dedicated-openrouter-shaped-provider-contract-v22)** — Codex sign-off received 2026-05-30 13:38 (comment `9449393c-18f1-46ab-8c68-d1360bd598d3`): _"BAT-971 is cleared to start implementation on `feature/BAT-971`."_

Setup is **Settings-first** (per Codex v2.2): both `usepodToken` and `usepodModel` must be saved in Settings → AI Provider → Usepod before `/provider usepod` from Telegram can switch in. On switch-in, `runtime-state.model = config.usepodModel` — **NEVER** carried from the prior provider's model (the critical "no model carry-over" invariant; tested).

## Adapter design (own vs delegated split per v2.2)

**OWN (must not leak OpenRouter-specific behavior):**
- `endpoint` / `testEndpoint` — UUID-validated, token spliced into path; throws typed error if token invalid
- `buildHeaders` — minimal: `Content-Type` + dummy `Authorization: Bearer UsePod`. **No** HTTP-Referer / X-Title / OpenRouter key
- `formatRequest` — clean OpenAI chat-completions body. **No** provider routing / fallback / cache_control. `input` treated as already-translated chat-completions messages (per Codex v2.1 fix #2; mirrors `custom.js:268-275`)
- `classifyError` — distinguishes 402 unfunded vs `no_provider_at_price`; 401 invalid-format vs not-found-or-not-activated (per empirical live-probe). Never leaks _OpenRouter_ branding to user messages
- `parseRateLimitHeaders` — parses `X-Balance-Remaining` if present (Codex flagged from public docs)

**Delegated to `openrouter.js` (pure wire-format translation only):**
`toApiMessages`, `fromApiResponse`, `formatSystemPrompt`, `formatTools`, `formatVision`, `normalizeUsage`, `classifyNetworkError`

## Security gates

- **Token classification:** `usepodToken` is a UUID secret (not `*ApiKey`-named, so the existing redaction's `*ApiKey` loop won't pick it up — explicit branch added).
- **UUID validator** at config-load AND per request build — rejects `/`, `?`, `#`, `..`, whitespace, full URLs.
- **Redaction pipeline:** (a) literal-value via dynamic patterns branch → `[REDACTED:usepodToken]`; (b) URL-path-form regex `/proxy/<uuid>/[A-Za-z0-9_./?&=-]*` → `/proxy/[REDACTED]/<...>` (broadened beyond `/balance|/v1` to cover `/completions`, `/models`, future paths, paths with query strings).
- **Sentinel-token regression test** asserts ZERO raw UUID across all redacted output (literal, path-form, JSON snapshot, combined, token-rotation).

## Live-probe outcome (Codex v2.2 fix #5)

Registered a test Usepod token and probed `/proxy/<token>/balance` directly. Findings:

| Token state | Status | `error.message` |
|---|---|---|
| Valid UUID, unfunded/unknown | **401** | `unauthorized: token not found or not activated` |
| Malformed (non-UUID, slashes, etc.) | **401** | `unauthorized: invalid token format` |
| Valid UUID, funded | 200 | (untested w/o real funding) |

Diverges from the client-onboard skill docs (which implied 200 + `is_active: false` for unfunded). The adapter and `testUsepodConnection` (Kotlin) both parse `error.message` to distinguish "unfunded/unknown" from "format invalid". Per Codex's degrade path, the Kotlin connection-test still surfaces a useful message in every branch; if the response shape ever diverges further, the test falls back to "Token format valid. Funded status will be confirmed on first request." rather than blocking the provider UI.

## Telegram surface

- `/provider usepod` refuses with: \`Set a Usepod model in Settings → AI Provider → Usepod first.\` (Codex's exact copy — does **not** mention `/model <id>`, which validates against the current provider).
- On successful switch: `runtime-state.model = config.usepodModel`; never carried from prior provider.
- Drift-guard test catches a half-edit.

## Files changed (16)

| File | Change |
|---|---|
| `model-registry.json` | Add `usepod` entry (freeform, defaultModel \`\"\"\`) |
| `model-catalog.js` | `hasCredentialsFor('usepod')` gates on token+usepodModel both non-blank |
| `providers/usepod.js` | New adapter (own + delegated split) |
| `providers/index.js` | Register usepod |
| `config.js` | `USEPOD_TOKEN`, `USEPOD_MODEL`, UUID validator, `_activeKey`, missing-key map, validation gates, exports |
| `runtime-state.js` | `_VALID_AUTH_TYPES.usepod = api_key` |
| `security.js` | Dynamic-pattern branch + broadened URL-path regex |
| `message-handler.js` | `/provider usepod` uses `config.usepodModel` (never `state.model`) |
| `ai.js` | `buildSystemBlocks` Usepod paragraph + `/provider` list extension |
| `DIAGNOSTICS.md` | Usepod section (Settings-first, 402 paths, redaction notes) |
| `ConfigManager.kt` | `usepodToken` (encrypted) + `usepodModel` (plaintext) + mirror in `updateConfigField` + validation + redactedSnapshot |
| `RuntimeStateStore.kt` | usepod matrix mirror |
| `ProviderConfigScreen.kt` | Usepod branch + switchProvider blank-model gate + `testUsepodConnection` (4 branches + degrade) |
| `tests/nodejs-project/smoke.js` | Register `providers/usepod.js` in SKIP_REASONS |
| `tests/nodejs-project/usepod-adapter.test.js` | **NEW** — contract test (endpoint, headers, body, error split, no-OR-leak) |
| `tests/nodejs-project/usepod-token-redaction.test.js` | **NEW** — sentinel UUID regression |

## Test plan

- [x] `scripts/pre-push-check.sh` green (Node smoke + tool-schemas + wallets prompt + Kotlin compile)
- [x] `node tests/nodejs-project/usepod-adapter.test.js` — all contract assertions pass
- [x] `node tests/nodejs-project/usepod-token-redaction.test.js` — sentinel UUID never appears in any redacted output
- [ ] **SAB audit** (mandatory — touches `buildSystemBlocks()` + `DIAGNOSTICS.md` per BAT-503 gate) — to run pre-Copilot-clean and fold any gaps into this PR
- [ ] Copilot review → iterate to zero blockers
- [ ] Device test (post-Copilot-clean only):
    - Fresh install → Settings → switch to Usepod → paste token → leave model blank → save Switch → refused with \`Set a Usepod model first.\`
    - Type a Usepod model → save → switch succeeds → connection test passes
    - Fund token (few cents USDC) → connection test shows balance
    - Send Telegram message → real chat completion arrives via the Usepod-typed model
    - **logcat + agent log grep for token UUID → zero matches**
    - Switch to Claude → switch back via `/provider usepod` from Telegram → uses `config.usepodModel`, NOT the Claude model
    - Fresh install → switch to Claude → never visit Usepod in Settings → `/provider usepod` → refused with Codex's exact copy
    - Force 401 (bad token) → \`Invalid Usepod token\` message
    - Settings → Export → re-import → both `usepodToken` and `usepodModel` round-trip, token masked

## Self-Awareness Checklist (per `.github/PULL_REQUEST_TEMPLATE.md`)

- [ ] **SAB-audited** — will run before merge
- [ ] N/A

## Out of scope (separate follow-up tickets)

- In-app `/v1/register` flow
- Balance polling / auto-activation UI
- One-tap USDC funding via burner wallet (BAT-582 rails)
- Price-ceiling `X-Pod-Max-Price-*` UI
- Model discovery via `/v1/models`
- Anthropic `/v1/messages` surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)