### PR TITLE
feat: bridge HTTP layer hardening — live balance, token hot-reload, DNS-rebind defense (BAT-1001)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,11 @@ jobs:
             wallet-registry \
             wallet-set-caps-errors \
             x402 \
-            x402-v2-tx
+            x402-v2-tx \
+            internal-control-server \
+            internal-control-server-token-rotation \
+            internal-control-server-proxy-passthrough \
+            bridge-token-reload
           do
             echo "── $t ──"
             node "tests/nodejs-project/${t}.test.js"

--- a/app/src/main/assets/nodejs-project/bridge.js
+++ b/app/src/main/assets/nodejs-project/bridge.js
@@ -4,18 +4,41 @@
 
 const http = require('http');
 
-const { BRIDGE_TOKEN, log } = require('./config');
+// BAT-1001 PR-B: per-call getBridgeToken (not the startup-frozen
+// BRIDGE_TOKEN constant) so a Kotlin-side token rotation
+// (SeekerClawService writes a fresh UUID on every service start)
+// is picked up on the very next request without a Node restart.
+// Pre-fix, a long-lived `:node` process that survived a service
+// toggle held the stale token forever and every bridge call 403'd.
+const { getBridgeToken, log } = require('./config');
 
 // ============================================================================
 // ANDROID BRIDGE HTTP CLIENT
 // ============================================================================
 
-// Helper for Android Bridge HTTP calls
-// timeoutMs: default 10s for quick calls, use longer for interactive flows (wallet approval)
+// Helper for Android Bridge HTTP calls.
+// timeoutMs: default 10s for quick calls, use longer for interactive flows
+// (wallet approval).
+//
+// BAT-1001: implements a single-shot retry on HTTP 403. AndroidBridge.kt
+// returns 403 (NOT 401 — verified at AndroidBridge.kt:163) when the
+// bridge-token mismatches. On 403 we re-read the token from disk
+// (covers the race where Kotlin rotated mid-request) and retry once.
+// Cap at exactly one retry (per Codex BAT-1001 v1.1 sign-off #3) — a
+// second 403 surfaces cleanly so persistent auth failures aren't
+// masked as latency. No exponential backoff: this is auth refresh,
+// not transport-failure backoff.
 async function androidBridgeCall(endpoint, data = {}, timeoutMs = 10000) {
-    return new Promise((resolve) => {
-        const postData = JSON.stringify(data);
+    const postData = JSON.stringify(data);
+    return _sendOnce(endpoint, postData, timeoutMs, /* allowRetry */ true);
+}
 
+function _sendOnce(endpoint, postData, timeoutMs, allowRetry) {
+    return new Promise((resolve) => {
+        // Read the token at request-build time, not at module-load
+        // time. The file read is cheap (36-byte UUID, hot OS cache)
+        // and the auth-refresh semantics REQUIRE the live value.
+        const token = getBridgeToken();
         const req = http.request({
             hostname: '127.0.0.1',
             port: 8765,
@@ -24,14 +47,29 @@ async function androidBridgeCall(endpoint, data = {}, timeoutMs = 10000) {
             headers: {
                 'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(postData),
-                'X-Bridge-Token': BRIDGE_TOKEN
+                'X-Bridge-Token': token,
             },
-            timeout: timeoutMs
+            timeout: timeoutMs,
         }, (res) => {
+            // BAT-1001: capture status BEFORE consuming body so the
+            // 403-retry path can short-circuit without parsing.
+            const status = res.statusCode;
             res.setEncoding('utf8');
             let body = '';
             res.on('data', chunk => body += chunk);
             res.on('end', () => {
+                if (status === 403 && allowRetry) {
+                    // Single-shot retry: the next call to
+                    // getBridgeToken() re-reads the disk file, so the
+                    // retry uses whatever value Kotlin currently has.
+                    // Persistent 403 (e.g. AndroidBridge genuinely
+                    // rejected this caller, or the bridge process is
+                    // gone) falls through to the second attempt
+                    // returning its body — which the caller surfaces
+                    // as a hard error.
+                    _sendOnce(endpoint, postData, timeoutMs, /* allowRetry */ false).then(resolve);
+                    return;
+                }
                 try {
                     resolve(JSON.parse(body));
                 } catch (e) {

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -411,6 +411,28 @@ function getSearchProvider() {
     return _agentPreferencesModule.DEFAULTS.searchProvider;
 }
 
+// BAT-1001 PR-B: per-call read of the bridge token so a Kotlin-side
+// rotation (SeekerClawService writes a fresh UUID on every service
+// start, see ServiceState.writeBridgeToken at ServiceState.kt:185-201)
+// is picked up on the very next bridge / control-server request
+// without restarting Node. Mirrors the BAT-515 hot-reload shape
+// (getAgentName / getSearchProvider above) but reads a
+// sibling-of-workspace file via path.dirname(workDir) — same
+// precedent as runtime-state.js:113, mcp-servers.js, agent-preferences.js.
+// Kotlin writes the token at `filesDir/bridge_token`, NOT under
+// `workspace/`. Returns the trimmed token, or the cold-start
+// BRIDGE_TOKEN fallback on any read failure (ENOENT, perm denied,
+// blank file). Never throws — callers treat empty as
+// "unauthenticated" and the auth gates surface a clean 401/403.
+function getBridgeToken() {
+    try {
+        const tokenPath = path.join(path.dirname(workDir), 'bridge_token');
+        const raw = fs.readFileSync(tokenPath, 'utf8').trim();
+        if (raw) return raw;
+    } catch (_) { /* fall through to cold-start fallback */ }
+    return BRIDGE_TOKEN;
+}
+
 /**
  * Resolve the currently-active model — the agent_settings.json overlay
  * wins over the startup MODEL const. The `/model` Telegram command and
@@ -863,6 +885,14 @@ module.exports = {
     // edit takes effect on the next AI turn without a service restart.
     getAgentName,
     getSearchProvider,
+    // BAT-1001 PR-B: per-call bridge-token getter replaces the
+    // startup-frozen BRIDGE_TOKEN read in every live request path
+    // (bridge.js, internal-control-server.js wiring in main.js,
+    // security.js redaction). BRIDGE_TOKEN below remains exported as
+    // the cold-start fallback — never depend on it for a live auth
+    // decision; always call getBridgeToken() per request so a
+    // mid-session Kotlin rotation takes effect on the next call.
+    getBridgeToken,
     BRIDGE_TOKEN,
     USER_AGENT,
     MCP_SERVERS,

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -420,15 +420,42 @@ function getSearchProvider() {
 // sibling-of-workspace file via path.dirname(workDir) — same
 // precedent as runtime-state.js:113, mcp-servers.js, agent-preferences.js.
 // Kotlin writes the token at `filesDir/bridge_token`, NOT under
-// `workspace/`. Returns the trimmed token, or the cold-start
-// BRIDGE_TOKEN fallback on any read failure (ENOENT, perm denied,
-// blank file). Never throws — callers treat empty as
-// "unauthenticated" and the auth gates surface a clean 401/403.
+// `workspace/`.
+//
+// Return semantics (sweep w09eqq11s blockers #4 + #5 fix):
+//   - Disk read succeeds AND value passes UUID-shape validation →
+//     return the live token (the happy path).
+//   - Disk read fails (ENOENT, perm denied, IOError) OR value fails
+//     the UUID-shape check (blank, truncated from a mid-write crash,
+//     wrong format) → fall back to BRIDGE_TOKEN (the cold-start
+//     snapshot from config.json). This fallback may be STALE — if
+//     Kotlin rotated and crashed the write, the cold value is the
+//     PRIOR boot's token. In that case the auth gate either accepts
+//     (if AndroidBridge is still on the cold value) or 401s (if
+//     AndroidBridge picked up the new one). bridge.js's 403 retry
+//     re-reads disk and gets one more chance.
+//   - Empty BRIDGE_TOKEN cold value → return '' → auth gates reject
+//     401/403 cleanly.
+//
+// UUID validation guards against the truncated-write case:
+// Kotlin's writeText is NOT atomic, so a mid-write power-loss can
+// leave a partial UUID on disk. Without the shape check, a 1-char
+// file would be accepted as the live token and every request would
+// 401 against AndroidBridge's full UUID — with no path to recovery
+// until the next service restart writes a new full UUID. The shape
+// check makes that case fall through to BRIDGE_TOKEN, which at
+// least matches what AndroidBridge has if it never rotated.
+//
+// Never throws. Worst case returns ''.
 function getBridgeToken() {
     try {
         const tokenPath = path.join(path.dirname(workDir), 'bridge_token');
         const raw = fs.readFileSync(tokenPath, 'utf8').trim();
-        if (raw) return raw;
+        // UUID v4 shape: 36 chars, hex+dash only. ServiceState.kt
+        // writes UUID.randomUUID().toString() which produces exactly
+        // this format. Reject anything else (truncated, corrupt,
+        // wrong file content) by falling through to the cold value.
+        if (raw && raw.length === 36 && /^[0-9a-f-]+$/i.test(raw)) return raw;
     } catch (_) { /* fall through to cold-start fallback */ }
     return BRIDGE_TOKEN;
 }

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -189,23 +189,34 @@ function start(options) {
     return _server;
 }
 
-// BAT-1001 PR-B: constant-time token compare with length guard.
-// `crypto.timingSafeEqual` throws on length mismatch — we MUST
-// length-check first, otherwise an attacker can probe the token's
-// length by triggering 500s. Both inputs are strict-type-checked
-// to be strings (no coercion — a non-string header from header
-// folding etc. returns false cleanly instead of throwing). Empty
-// expected → reject (we never short-circuit to "no token = allow").
-// Equal-length non-empty strings reach timingSafeEqual on their
-// UTF-8 buffer representations.
+// BAT-1001 PR-B: constant-time token compare with byte-length guard.
+// `crypto.timingSafeEqual` throws on Buffer-length mismatch — we MUST
+// pre-check, otherwise an attacker can probe the token's length by
+// triggering 500s.
+//
+// Subtlety (Copilot PR #395 R2 finding): the length check is on
+// **byte length**, not String `.length` (which is UTF-16 code units).
+// A non-ASCII input like `Buffer.from('ñ', 'utf8').length === 2`
+// while `'ñ'.length === 1`. If we length-checked on `.length` and
+// then fed Buffers to timingSafeEqual, an attacker sending
+// X-Bridge-Token: '<UTF-8-multibyte string with the same JS .length
+// as the expected token>' would pass the pre-check, hit timingSafeEqual
+// with mismatched Buffer lengths, throw, get a 500 from the outer
+// try/catch — reintroducing the length-probe surface this helper
+// exists to close. Solution: build the Buffers first, then compare
+// buffer.length (== byte length) before timingSafeEqual.
+//
+// Both inputs are strict-type-checked to be strings (no coercion —
+// a non-string header from header folding etc. returns false cleanly
+// instead of throwing). Empty expected → reject (we never short-
+// circuit to "no token = allow").
 function _safeTokenEq(expected, actual) {
     if (typeof expected !== 'string' || typeof actual !== 'string') return false;
     if (expected.length === 0) return false;
-    if (expected.length !== actual.length) return false;
-    return crypto.timingSafeEqual(
-        Buffer.from(expected, 'utf8'),
-        Buffer.from(actual, 'utf8'),
-    );
+    const expectedBuf = Buffer.from(expected, 'utf8');
+    const actualBuf = Buffer.from(actual, 'utf8');
+    if (expectedBuf.length !== actualBuf.length) return false;
+    return crypto.timingSafeEqual(expectedBuf, actualBuf);
 }
 
 async function _route(req, res) {

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -246,12 +246,35 @@ async function _route(req, res) {
     // Status code 403 (not 400) since the request reached the
     // listener cleanly — it's the *origin* of the call that we're
     // rejecting, not a malformed wire.
-    const hostHeader = (req.headers.host || '').toLowerCase();
+    //
+    // Copilot R3 #3349684637: `req.headers.host` and `.origin` are
+    // typed as `string | string[] | undefined` in Node's HTTP types.
+    // Today Node's HTTP parser discards duplicate Host headers (only
+    // the first wins, kept as string) — but Copilot is correct that
+    // a future parser change OR a pathological proxy chain could
+    // surface an array. Calling `.toLowerCase()` on a non-string
+    // would throw → outer try/catch → 500, reintroducing the DoS
+    // surface this gate exists to close. Defensive: explicit
+    // typeof checks, anything non-string rejects 403 cleanly.
+    const rawHost = req.headers.host;
+    if (typeof rawHost !== 'string') {
+        return _json(res, 403, { error: 'host not allowed' });
+    }
+    const hostHeader = rawHost.toLowerCase();
     if (hostHeader !== ALLOWED_HOST) {
         return _json(res, 403, { error: 'host not allowed' });
     }
-    const originHeader = req.headers.origin;
-    if (typeof originHeader === 'string' && originHeader.length > 0) {
+    const rawOrigin = req.headers.origin;
+    if (typeof rawOrigin === 'string') {
+        // Empty string passes (some HTTP libs always set the header);
+        // any non-empty value is browser-initiated → reject.
+        if (rawOrigin.length > 0) {
+            return _json(res, 403, { error: 'origin not allowed' });
+        }
+    } else if (rawOrigin !== undefined) {
+        // Non-string non-undefined Origin (array from duplicate
+        // headers, or anything else exotic) → definitely not a
+        // legitimate Kotlin caller, reject.
         return _json(res, 403, { error: 'origin not allowed' });
     }
 

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -192,11 +192,12 @@ function start(options) {
 // BAT-1001 PR-B: constant-time token compare with length guard.
 // `crypto.timingSafeEqual` throws on length mismatch — we MUST
 // length-check first, otherwise an attacker can probe the token's
-// length by triggering 500s. Empty/missing expected → reject
-// (caller short-circuits to false before reaching this). Both
-// inputs are coerced to strings and length-checked before Buffer
-// construction so a non-string header (object/array via header
-// folding) returns false cleanly instead of throwing.
+// length by triggering 500s. Both inputs are strict-type-checked
+// to be strings (no coercion — a non-string header from header
+// folding etc. returns false cleanly instead of throwing). Empty
+// expected → reject (we never short-circuit to "no token = allow").
+// Equal-length non-empty strings reach timingSafeEqual on their
+// UTF-8 buffer representations.
 function _safeTokenEq(expected, actual) {
     if (typeof expected !== 'string' || typeof actual !== 'string') return false;
     if (expected.length === 0) return false;

--- a/app/src/main/assets/nodejs-project/internal-control-server.js
+++ b/app/src/main/assets/nodejs-project/internal-control-server.js
@@ -28,12 +28,28 @@
 'use strict';
 
 const http = require('http');
+const crypto = require('crypto');
 
 const PORT = 8766;
 const HOST = '127.0.0.1';
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_RECONCILE = 30; // 30 reconciles/min — drain coalesces, this is just intake throttle
 const RATE_LIMIT_HEALTHZ = 60;   // 1/sec average is fine for a liveness probe
+
+// BAT-1001 PR-B: DNS-rebind defense + IPv6 policy.
+// The server binds only `127.0.0.1` (line 33). A browser doing a
+// DNS-rebind attack would resolve `attacker.com` to 127.0.0.1 and the
+// connection would land here, but the browser still sends
+// `Host: attacker.com:8766` per RFC 7230 §5.4 — we reject any Host
+// that isn't the bound loopback authority. Allowlist is a single
+// literal (NOT sourced from PORT) so the allowed value is auditable
+// at a glance. Case-insensitive compare (`Host: 127.0.0.1:8766` and
+// `127.0.0.1:8766` already collapse, but `Host: LOCALHOST` etc. are
+// rejected explicitly). IPv6 loopback `[::1]:8766` is NOT accepted
+// (server doesn't dual-bind; accepting would be a policy/code
+// mismatch per Codex BAT-1001 v1.1 #6). `localhost:8766` is rejected
+// too — too many name-resolution surprises to allow.
+const ALLOWED_HOST = '127.0.0.1:8766';
 
 // Per-endpoint rate-limit state. Cleared on stop() so test harnesses
 // don't leak state between cases.
@@ -104,7 +120,15 @@ function _json(res, status, obj, extraHeaders) {
 }
 
 let _server = null;
-let _bridgeToken = null;
+// BAT-1001 PR-B: per-request bridge-token getter (was a startup-frozen
+// string `_bridgeToken`). main.js passes `getBridgeToken: () =>
+// getBridgeToken()` so a Kotlin-side rotation (NodeControlClient
+// reads ServiceState.bridgeToken per call → server now reads the
+// matching live file per call) authenticates the next inbound POST
+// without a server restart. Default `() => ''` makes the auth gate
+// always reject when start() was called without the option — never
+// short-circuits to "no token configured = allow".
+let _getBridgeToken = () => '';
 let _getDbSummary = null;
 let _requestReconcile = null;
 // BAT-525: flushShutdown is an async callback that drives Node's
@@ -128,7 +152,16 @@ function start(options) {
     if (!options || typeof options !== 'object') {
         throw new Error('internal-control-server.start: options required');
     }
-    _bridgeToken = typeof options.bridgeToken === 'string' ? options.bridgeToken : '';
+    // BAT-1001 PR-B: getBridgeToken (function) replaces the
+    // startup-frozen bridgeToken (string). The function form is the
+    // only supported option — the previous `bridgeToken: <string>`
+    // option is intentionally NOT honored as a back-compat shim
+    // because it would silently preserve the rotation bug v1.1 is
+    // fixing. Existing tests have been updated to pass
+    // `getBridgeToken: () => TOKEN` (constant getter == old behavior).
+    _getBridgeToken = typeof options.getBridgeToken === 'function'
+        ? options.getBridgeToken
+        : () => '';
     _getDbSummary = typeof options.getDbSummary === 'function' ? options.getDbSummary : null;
     _requestReconcile = typeof options.requestReconcile === 'function' ? options.requestReconcile : null;
     _flushShutdown = typeof options.flushShutdown === 'function' ? options.flushShutdown : null;
@@ -156,15 +189,66 @@ function start(options) {
     return _server;
 }
 
+// BAT-1001 PR-B: constant-time token compare with length guard.
+// `crypto.timingSafeEqual` throws on length mismatch — we MUST
+// length-check first, otherwise an attacker can probe the token's
+// length by triggering 500s. Empty/missing expected → reject
+// (caller short-circuits to false before reaching this). Both
+// inputs are coerced to strings and length-checked before Buffer
+// construction so a non-string header (object/array via header
+// folding) returns false cleanly instead of throwing.
+function _safeTokenEq(expected, actual) {
+    if (typeof expected !== 'string' || typeof actual !== 'string') return false;
+    if (expected.length === 0) return false;
+    if (expected.length !== actual.length) return false;
+    return crypto.timingSafeEqual(
+        Buffer.from(expected, 'utf8'),
+        Buffer.from(actual, 'utf8'),
+    );
+}
+
 async function _route(req, res) {
     const method = (req.method || 'GET').toUpperCase();
     const url = req.url || '/';
 
-    // GET /stats/db-summary — preserved BAT-31 behavior. No auth, no
-    // rate-limit. AndroidBridge proxies this from its own (already-
-    // authed + rate-limited) /stats/db-summary endpoint, so the inner
-    // hop doesn't need to reauthenticate. Keeping it open also matches
-    // the pre-BAT-514 contract — no UI behaviour change.
+    // BAT-1001 PR-B: DNS-rebind defense, applied BEFORE any path
+    // matching so the gate covers `/stats/db-summary` too (and any
+    // future unauthenticated endpoint). Two layers:
+    //
+    //   1. Host header allowlist — rejects DNS-rebind attempts where
+    //      the browser resolved attacker.com → 127.0.0.1 but is still
+    //      sending `Host: attacker.com:8766` per RFC 7230 §5.4. Only
+    //      `127.0.0.1:8766` is accepted (case-insensitive). `[::1]:8766`
+    //      and `localhost:8766` are rejected — the server binds only
+    //      127.0.0.1 (no dual-bind) and accepting other Hosts would
+    //      create a policy/code mismatch.
+    //
+    //   2. Origin header rejection — any non-empty Origin header
+    //      means a browser sent the request. Every legitimate caller
+    //      (AndroidBridge.kt:954-975 proxy via HttpURLConnection,
+    //      Kotlin NodeControlClient, in-process tests) sends NO
+    //      Origin. Deny-all is strictly safer than an allowlist
+    //      while we have zero legitimate browser callers (per
+    //      Codex BAT-1001 v1.1 #4 sign-off).
+    //
+    // Status code 403 (not 400) since the request reached the
+    // listener cleanly — it's the *origin* of the call that we're
+    // rejecting, not a malformed wire.
+    const hostHeader = (req.headers.host || '').toLowerCase();
+    if (hostHeader !== ALLOWED_HOST) {
+        return _json(res, 403, { error: 'host not allowed' });
+    }
+    const originHeader = req.headers.origin;
+    if (typeof originHeader === 'string' && originHeader.length > 0) {
+        return _json(res, 403, { error: 'origin not allowed' });
+    }
+
+    // GET /stats/db-summary — preserved BAT-31 behavior. No bridge-
+    // token auth, no rate-limit. AndroidBridge proxies this from its
+    // own (already-authed + rate-limited) /stats/db-summary endpoint,
+    // so the inner hop doesn't need to reauthenticate. The new Host/
+    // Origin gate above now covers exfil risk — a browser can't reach
+    // this endpoint via DNS-rebind even though it's unauthenticated.
     if (method === 'GET' && url === '/stats/db-summary') {
         if (!_getDbSummary) return _json(res, 503, { error: 'stats unavailable' });
         try {
@@ -181,9 +265,17 @@ async function _route(req, res) {
         return _json(res, 405, { error: 'method not allowed' });
     }
 
-    // Bridge-token auth for the new endpoints (NOT /stats — see above).
+    // BAT-1001 PR-B: bridge-token auth via per-request getter +
+    // constant-time compare. The getter (wired from main.js as
+    // `() => getBridgeToken()`) re-reads `filesDir/bridge_token` on
+    // every call so a Kotlin rotation is picked up without restarting
+    // the server. _safeTokenEq length-guards before timingSafeEqual
+    // so a length mismatch returns 401 cleanly instead of throwing
+    // 500. Empty `expected` (file missing / getter returns '') also
+    // rejects — we never short-circuit to "no token = allow".
     const headerToken = req.headers['x-bridge-token'];
-    if (!_bridgeToken || headerToken !== _bridgeToken) {
+    const expected = _getBridgeToken();
+    if (!_safeTokenEq(expected, headerToken)) {
         return _json(res, 401, { error: 'unauthorized' });
     }
 

--- a/app/src/main/assets/nodejs-project/main.js
+++ b/app/src/main/assets/nodejs-project/main.js
@@ -15,7 +15,14 @@ const {
     getOwnerId, setOwnerId,
     workDir, config, debugLog,
     USER_ENV_KEYS,
-    BRIDGE_TOKEN, // BAT-514: passed to internal-control-server for X-Bridge-Token auth
+    // BAT-1001 PR-B: replaces the startup-frozen BRIDGE_TOKEN import.
+    // internal-control-server.start receives a getter so the server's
+    // per-request token compare re-reads `filesDir/bridge_token` from
+    // disk and authenticates Kotlin POSTs against the CURRENT token
+    // even after a service-restart rotation. NodeControlClient.kt
+    // already sends the live ServiceState.bridgeToken per call; this
+    // brings the Node side to parity.
+    getBridgeToken,
 } = require('./config');
 
 process.on('uncaughtException', (err) => log('UNCAUGHT: ' + (err.stack || err), 'ERROR'));
@@ -755,7 +762,9 @@ telegram('getMe')
             // requestReconcile callback is wired before the listener
             // accepts connections.
             internalControlServer.start({
-                bridgeToken: BRIDGE_TOKEN,
+                // BAT-1001 PR-B: getter, not snapshot. See config.js
+                // getBridgeToken + internal-control-server.js _route auth gate.
+                getBridgeToken: () => getBridgeToken(),
                 getDbSummary,
                 requestReconcile: (id) => mcpManager.requestReconcile(id),
                 flushShutdown: flushForShutdown,
@@ -896,7 +905,11 @@ telegram('getMe')
         startDbSummaryInterval();
         // BAT-514: see Telegram path comment above.
         internalControlServer.start({
-            bridgeToken: BRIDGE_TOKEN,
+            // BAT-1001 PR-B: getter, not snapshot. Matches the Telegram
+            // path above; both wire `() => getBridgeToken()` so a
+            // Kotlin-side token rotation is honored on the next call
+            // without restarting the server.
+            getBridgeToken: () => getBridgeToken(),
             getDbSummary,
             requestReconcile: (id) => mcpManager.requestReconcile(id),
             flushShutdown: flushForShutdown,

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -9,10 +9,10 @@ const path = require('path');
 // rotations. Pre-fix, a rotation mid-session left the redactor
 // matching the OLD token forever — any log line containing the NEW
 // token would leak it. The getter call is gated at the call site
-// (redactSecrets) on `msg.length >= UUID_MIN_LEN` so messages too
-// short to contain a UUID never hit the disk; longer messages pay
-// the fs.readFileSync (a 36-byte file from the OS page cache, so
-// cheap but not free).
+// (redactSecrets) on `msg.length >= _BRIDGE_TOKEN_MIN_LEN` so
+// messages too short to contain a UUID never hit the disk; longer
+// messages pay the fs.readFileSync (a 36-byte file from the OS
+// page cache, so cheap but not free).
 const { getBridgeToken, config, log, workDir } = require('./config');
 
 // Minimum length of a bridge_token (UUID, 36 chars: 32 hex + 4

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -8,9 +8,19 @@ const path = require('path');
 // BRIDGE_TOKEN constant) so log redaction tracks Kotlin-side token
 // rotations. Pre-fix, a rotation mid-session left the redactor
 // matching the OLD token forever — any log line containing the NEW
-// token would leak it. Cost is one fs.readFileSync per log line that
-// contains a bridge-token-shaped substring, which is cheap.
+// token would leak it. The getter call is gated at the call site
+// (redactSecrets) on `msg.length >= UUID_MIN_LEN` so messages too
+// short to contain a UUID never hit the disk; longer messages pay
+// the fs.readFileSync (a 36-byte file from the OS page cache, so
+// cheap but not free).
 const { getBridgeToken, config, log, workDir } = require('./config');
+
+// Minimum length of a bridge_token (UUID, 36 chars: 32 hex + 4
+// dashes). Messages shorter than this can't contain a token, so we
+// skip the getter (avoids the fs.readFileSync entirely on short log
+// lines, which are the common case — most log lines are status
+// messages, not bridge call dumps).
+const _BRIDGE_TOKEN_MIN_LEN = 36;
 
 // ============================================================================
 // SECRET REDACTION
@@ -110,8 +120,12 @@ function redactSecrets(msg) {
     msg = msg.replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***');
     // Redact bridge tokens (UUID format). BAT-1001: per-call read so a
     // mid-session rotation doesn't leak the new token in any log line.
-    const bridgeToken = getBridgeToken();
-    if (bridgeToken) msg = msg.replace(new RegExp(_escRx(bridgeToken), 'g'), '***bridge-token***');
+    // Length-gate the getter call: msgs shorter than the UUID min
+    // length can't contain a token, so we skip the fs.readFileSync.
+    if (msg.length >= _BRIDGE_TOKEN_MIN_LEN) {
+        const bridgeToken = getBridgeToken();
+        if (bridgeToken) msg = msg.replace(new RegExp(_escRx(bridgeToken), 'g'), '***bridge-token***');
+    }
     // Redact Jupiter API key + MCP auth tokens (cached literal patterns)
     for (const { rx, replacement } of _dynamicPatterns) {
         msg = msg.replace(rx, replacement);

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -4,7 +4,13 @@
 
 const path = require('path');
 
-const { BRIDGE_TOKEN, config, log, workDir } = require('./config');
+// BAT-1001 PR-B: per-call getBridgeToken (not the startup-frozen
+// BRIDGE_TOKEN constant) so log redaction tracks Kotlin-side token
+// rotations. Pre-fix, a rotation mid-session left the redactor
+// matching the OLD token forever — any log line containing the NEW
+// token would leak it. Cost is one fs.readFileSync per log line that
+// contains a bridge-token-shaped substring, which is cheap.
+const { getBridgeToken, config, log, workDir } = require('./config');
 
 // ============================================================================
 // SECRET REDACTION
@@ -102,8 +108,10 @@ function redactSecrets(msg) {
     // Redact OpenAI API keys (sk-proj-..., sk-...)
     msg = msg.replace(/sk-proj-[a-zA-Z0-9_-]{20,}/g, 'sk-proj-***');
     msg = msg.replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***');
-    // Redact bridge tokens (UUID format)
-    if (BRIDGE_TOKEN) msg = msg.replace(new RegExp(_escRx(BRIDGE_TOKEN), 'g'), '***bridge-token***');
+    // Redact bridge tokens (UUID format). BAT-1001: per-call read so a
+    // mid-session rotation doesn't leak the new token in any log line.
+    const bridgeToken = getBridgeToken();
+    if (bridgeToken) msg = msg.replace(new RegExp(_escRx(bridgeToken), 'g'), '***bridge-token***');
     // Redact Jupiter API key + MCP auth tokens (cached literal patterns)
     for (const { rx, replacement } of _dynamicPatterns) {
         msg = msg.replace(rx, replacement);

--- a/app/src/main/assets/nodejs-project/tools/wallet.js
+++ b/app/src/main/assets/nodejs-project/tools/wallet.js
@@ -72,13 +72,14 @@ const tools = [
             'main wallet (MWA-backed; pubkey null until user authorizes). Network is Solana mainnet. ' +
             'Burner shape: { pubkey, balance: { sol, usdc }, balanceAvailable, spentToday: { sol, usdc }, ' +
             'caps: { perTxSol, perTxUsdc, dailySol, dailyUsdc }, remainingDaily: { sol, usdc }, display: {...}, network }. ' +
-            'BALANCE NOTE: `burner.balance.sol` and `burner.balance.usdc` are currently always `null` ' +
-            '(and `display.balanceSol` / `display.balanceUsdc` are the literal string "unavailable") — ' +
-            'the burner balance RPC fetch is a known follow-up, not wired yet. `balanceAvailable: false` ' +
-            'flags this. Caps, today\'s spend, and remainingDaily ARE real (atomic-unit strings; matching ' +
-            'decimals appear under display.*). Main wallet `balance` is fetched live from RPC and IS real. ' +
-            'When asked about the burner balance, say "burner balance is temporarily unavailable" or fetch ' +
-            'the main wallet via solana_balance — never read burner.balance.* and report it as "0". ' +
+            'BALANCE NOTE (BAT-1001): `burner.balance.sol` and `burner.balance.usdc` are now live-fetched ' +
+            'from mainnet RPC by the Android bridge (via the same SolanaBalanceFetcher the Settings UI uses). ' +
+            'Atomic-unit decimal strings when present. When `balanceAvailable: false` (and balance.sol / balance.usdc ' +
+            'are null + display.balanceSol / display.balanceUsdc are "unavailable"), that means the RPC call ' +
+            'transiently failed — NOT that the wallet holds zero. Say "burner balance is temporarily unavailable" ' +
+            'and suggest a retry (or that the user add a Helius API key in Settings for more reliable RPC); ' +
+            'NEVER report `null` as "0". Caps, today\'s spend, and remainingDaily ARE real (atomic-unit strings; ' +
+            'matching decimals appear under display.*). Main wallet `balance` is fetched live from RPC and IS real. ' +
             'Use this before deciding burner-vs-main routing or when the user asks "what wallets do I have." ' +
             'Read-only — no confirmation needed.',
         input_schema: {

--- a/app/src/main/assets/nodejs-project/tools/wallet.js
+++ b/app/src/main/assets/nodejs-project/tools/wallet.js
@@ -121,11 +121,16 @@ const handlers = {
      * pubkey + balance from existing helpers. Output schema documented in
      * BAT-582 Phase 4 spec.
      *
-     * BAT-582 R2: balance fields surface as null + a "balance unavailable"
-     * display string until the RPC fetch is wired (the previous "0"-stub
-     * was misleading: a configured-but-funded burner read like an empty
-     * one). Caps and spend totals are still real numbers — they live in
-     * Android-local state and don't need an RPC fetch.
+     * BAT-1001 PR-B: balance fields are now live-fetched. /burner/status
+     * emits balanceSol / balanceUsdc as atomic-unit decimal strings when
+     * SolanaBalanceFetcher succeeds, OMITS both fields on fetcher null
+     * OR RPC failure (never sent as "0" or null on the wire). This
+     * handler distinguishes the two cases via `status.balanceSol != null`:
+     * present → use the value; absent → balance.sol stays null +
+     * balanceAvailable becomes false → wallet description prompt teaches
+     * the agent to surface "balance temporarily unavailable" rather
+     * than fabricating "0". Caps and spend totals are still Android-
+     * local state — no RPC fetch.
      */
     async wallet_status(_input, _chatId) {
         // 1) Burner — read /burner/status directly so we can include cap fields.
@@ -139,10 +144,15 @@ const handlers = {
                 const capDailyUsdc = String(status.capDailyUsdc || '0');
                 const spentTodaySol  = String(status.spentTodaySol  || '0');
                 const spentTodayUsdc = String(status.spentTodayUsdc || '0');
-                // BAT-582 R2: /burner/status no longer emits balanceSol /
-                // balanceUsdc until the RPC fetch lands. Use null to mark
-                // "unavailable" rather than fabricating "0" — the agent
-                // and UI both check for null and surface the right copy.
+                // BAT-1001 PR-B: /burner/status emits balanceSol /
+                // balanceUsdc as atomic-unit decimal strings when the
+                // RPC fetch succeeds, OMITS both fields when the
+                // SolanaBalanceFetcher returns null (RPC failure /
+                // timeout / parse error). Field-absent → balance.sol
+                // stays null + balanceAvailable=false → "balance
+                // temporarily unavailable" prompt copy fires.
+                // Field-present → use the value as-is. Never emit "0"
+                // for unknown — that would silently lie to the user.
                 const hasSolBalance  = (status.balanceSol  != null);
                 const hasUsdcBalance = (status.balanceUsdc != null);
                 burnerOut = {

--- a/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
@@ -17,12 +17,20 @@ import java.math.BigInteger
  * (port 8765, X-Bridge-Token auth) for burner wallet operations (BAT-582).
  *
  * **Endpoints (all POST, all return JSON):**
- *   - /burner/status          → wallet pubkey + cap state + spend ledger
- *                                (balanceSol/balanceUsdc intentionally OMITTED
- *                                until Node-side RPC fetch lands; UI fetches
- *                                balances directly via SolanaBalanceFetcher,
- *                                wallet_status surfaces "unavailable" for the
- *                                agent until a separate BAT wires this here)
+ *   - /burner/status          → wallet pubkey + cap state + spend ledger +
+ *                                live SOL/USDC balances (BAT-1001 PR-B).
+ *                                balanceSol/balanceUsdc are emitted as
+ *                                atomic-unit decimal strings (lamports /
+ *                                microunits) when the SolanaBalanceFetcher
+ *                                wired by the production constructor
+ *                                succeeds. BOTH fields are OMITTED from
+ *                                the response on fetcher==null or fetch
+ *                                returning null (RPC timeout / parse
+ *                                error). Never sent as "0" or null —
+ *                                downstream tools/wallet.js handler
+ *                                distinguishes field-absent from
+ *                                field-present-as-zero, and "0" would
+ *                                silently lie about unavailability.
  *   - /burner/reserve         → atomic check+reserve a slot, returns reservationId
  *   - /burner/sign-transaction → sign-only (caller broadcasts), needs reservationId
  *   - /burner/sign-and-send   → atomic reserve+sign+broadcast+commit (or release)
@@ -202,7 +210,17 @@ class BurnerBridgeEndpoints internal constructor(
                 Log.w(TAG, "/burner/status getPubkey failed: ${e.message}")
                 null
             }
-            val status = capEnforcer.status()
+            // BAT-1001 PR-B sweep nit: wrap capEnforcer.status() for
+            // parity with getPubkey above. If the caps store file is
+            // corrupt or unreadable, return null + body fields fall
+            // back to "0" — better than 500-ing the entire endpoint
+            // (which kills every chat turn that calls wallet_status).
+            val status = try {
+                capEnforcer.status()
+            } catch (e: Exception) {
+                Log.w(TAG, "/burner/status capEnforcer.status failed: ${e.message}")
+                null
+            }
             val configured = pubkey != null
             val body = LinkedHashMap<String, Any?>()
             body["configured"] = configured
@@ -237,20 +255,36 @@ class BurnerBridgeEndpoints internal constructor(
             // both is redundant — the explicit pubkey != null check
             // below is what gives the smart-cast for the fetch(pubkey)
             // call. Equivalent to "configured && fetcher wired".
+            //
+            // BAT-1001 PR-B sweep nit: SolanaBalanceFetcher.fetch is
+            // documented as "Errors are not exceptions" (returns null
+            // on any failure — line 71-93 of SolanaBalanceFetcher.kt),
+            // but defensive try/catch makes that contract enforced at
+            // this boundary rather than trusted: a future subclass
+            // override OR a regression in the catch-all could
+            // otherwise turn into a 500 here.
             if (balanceFetcher != null && pubkey != null) {
-                val balances = balanceFetcher.fetch(pubkey)
+                val balances = try {
+                    balanceFetcher.fetch(pubkey)
+                } catch (e: Exception) {
+                    Log.w(TAG, "/burner/status balanceFetcher.fetch failed: ${e.message}")
+                    null
+                }
                 if (balances != null) {
                     body["balanceSol"] = balances.solLamports.toString()
                     body["balanceUsdc"] = balances.usdcMicrounits.toString()
                 }
                 // null → omit both (no else clause).
             }
-            body["capPerTxSol"] = status.capPerTxSol
-            body["capPerTxUsdc"] = status.capPerTxUsdc
-            body["capDailySol"] = status.capDailySol
-            body["capDailyUsdc"] = status.capDailyUsdc
-            body["spentTodaySol"] = status.spentTodaySol
-            body["spentTodayUsdc"] = status.spentTodayUsdc
+            // status may be null if capEnforcer.status() threw above.
+            // Fall back to "0" defaults so the endpoint still returns
+            // a valid shape rather than 500-ing for every consumer.
+            body["capPerTxSol"] = status?.capPerTxSol ?: "0"
+            body["capPerTxUsdc"] = status?.capPerTxUsdc ?: "0"
+            body["capDailySol"] = status?.capDailySol ?: "0"
+            body["capDailyUsdc"] = status?.capDailyUsdc ?: "0"
+            body["spentTodaySol"] = status?.spentTodaySol ?: "0"
+            body["spentTodayUsdc"] = status?.spentTodayUsdc ?: "0"
             body["network"] = "mainnet"
             EndpointResult(200, body)
         }

--- a/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
+++ b/app/src/main/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpoints.kt
@@ -2,10 +2,12 @@ package com.seekerclaw.app.bridge.burner
 
 import android.content.Context
 import android.util.Log
+import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.data.caps.CapEnforcer
 import com.seekerclaw.app.data.wallet.EncryptedPrefsKeyVault
 import com.seekerclaw.app.data.wallet.KeyVault
 import com.seekerclaw.app.data.wallet.SigningException
+import com.seekerclaw.app.data.wallet.SolanaBalanceFetcher
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import java.math.BigInteger
@@ -44,17 +46,32 @@ class BurnerBridgeEndpoints internal constructor(
     private val keyVault: KeyVault,
     private val capEnforcer: CapEnforcer,
     private val jupiterOwnership: JupiterOwnershipEndpoint,
+    // BAT-1001 PR-B: optional balance fetcher for `/burner/status` live
+    // SOL+USDC reads. Null = balances are omitted from the response
+    // (the v1 BAT-582 R2 behaviour, preserved as a fallback for any
+    // test seam that doesn't wire a fetcher). Tests pass a stub
+    // subclass of SolanaBalanceFetcher whose `fetch` returns canned
+    // values. Production secondary constructor below instantiates the
+    // real fetcher with the Helius-aware URL provider from BAT-1000.
+    private val balanceFetcher: SolanaBalanceFetcher? = null,
 ) {
 
     /**
      * Production constructor — wires up the default
      * EncryptedPrefsKeyVault + singleton CapEnforcer / JupiterOwnership
-     * from the Application Context.
+     * from the Application Context, plus a SolanaBalanceFetcher whose
+     * `rpcUrlProvider` delegates to [ConfigManager.getSolanaRpcUrl] so
+     * a Helius API Key edit in Settings is honored on the very next
+     * `/burner/status` call (no fetcher recreation needed). BAT-1001
+     * PR-B + BAT-1000 v1.1 #2.
      */
     constructor(context: Context) : this(
         keyVault = EncryptedPrefsKeyVault(context.applicationContext),
         capEnforcer = CapEnforcer.get(context),
         jupiterOwnership = JupiterOwnershipEndpoint.get(context),
+        balanceFetcher = SolanaBalanceFetcher(
+            rpcUrlProvider = { ConfigManager.getSolanaRpcUrl(context.applicationContext) },
+        ),
     )
 
     /**
@@ -190,16 +207,44 @@ class BurnerBridgeEndpoints internal constructor(
             val body = LinkedHashMap<String, Any?>()
             body["configured"] = configured
             if (configured) body["pubkey"] = pubkey
-            // BAT-582 R2: balanceSol / balanceUsdc fields are intentionally
-            // OMITTED from this response (instead of stubbed "0") until the
-            // RPC fetch lands. Downstream consumers (tools/wallet.js,
-            // BurnerWalletScreen, ai.js system prompt) treat absence as
-            // "balance unavailable" rather than "balance is zero" — a
-            // configured-but-funded burner that returned "0" was producing
-            // user-facing copy that read like the burner was empty, which
-            // is dangerously misleading. Adding the field back is gated on
-            // an actual RPC fetch (see Limitations note in the PR for the
-            // follow-up scope).
+            // BAT-1001 PR-B: atomic-string-or-omit live balance contract.
+            // Pre-fix (BAT-582 R2) intentionally omitted balanceSol /
+            // balanceUsdc because no RPC fetch was wired — wallet_status
+            // hard-coded "burner balance is temporarily unavailable" for
+            // every chat turn. Now that the fetcher exists (SolanaBalanceFetcher,
+            // already used by the Settings UI), wire it here:
+            //
+            //   - balanceFetcher == null → omit BOTH fields (legacy /
+            //     test-seam path; downstream consumers already handle
+            //     absence as "unavailable" via wallet_status).
+            //   - fetcher.fetch(pubkey) returns null (RPC timeout, parse
+            //     fail, network down) → omit BOTH fields. Atomic. Never
+            //     send "0" or null — sending "0" would silently break the
+            //     "balance unavailable" UI copy (tools/wallet.js:145-153
+            //     distinguishes field-absent from field-present-as-zero).
+            //   - fetcher returns Balances → emit BOTH as atomic-unit
+            //     decimal strings (lamports for SOL, microunits for
+            //     USDC). u64-safe: BigInteger.toString() preserves the
+            //     full unsigned range, never lossy at the wire.
+            //
+            // No try/catch around fetch(): SolanaBalanceFetcher already
+            // converts every failure path (HTTP error, JSON-RPC error,
+            // parse failure, MalformedURLException) to null internally
+            // (see SolanaBalanceFetcher.kt:71-93). A thrown exception
+            // here would be a bug worth surfacing, not silently
+            // swallowing.
+            // `configured` is derived from `pubkey != null`, so checking
+            // both is redundant — the explicit pubkey != null check
+            // below is what gives the smart-cast for the fetch(pubkey)
+            // call. Equivalent to "configured && fetcher wired".
+            if (balanceFetcher != null && pubkey != null) {
+                val balances = balanceFetcher.fetch(pubkey)
+                if (balances != null) {
+                    body["balanceSol"] = balances.solLamports.toString()
+                    body["balanceUsdc"] = balances.usdcMicrounits.toString()
+                }
+                // null → omit both (no else clause).
+            }
             body["capPerTxSol"] = status.capPerTxSol
             body["capPerTxUsdc"] = status.capPerTxUsdc
             body["capDailySol"] = status.capDailySol

--- a/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaBalanceFetcher.kt
+++ b/app/src/main/java/com/seekerclaw/app/data/wallet/SolanaBalanceFetcher.kt
@@ -43,7 +43,11 @@ import java.net.URL
  * to `ConfigManager.getSolanaRpcUrl(context)` so user-configured Helius
  * keys are picked up live. Per Codex BAT-1000 v1.1 #2.
  */
-class SolanaBalanceFetcher(
+// BAT-1001 PR-B: `open` so BurnerBridgeEndpointsTest can subclass to
+// stub `fetch` without bringing in Mockito or extracting a separate
+// interface. Production wires the concrete class (no behaviour change);
+// tests pass a stub that returns canned Balances?/null per scenario.
+open class SolanaBalanceFetcher(
     private val rpcUrlProvider: () -> String = { DEFAULT_RPC_URL },
     private val timeoutMs: Int = 8_000,
 ) {
@@ -68,7 +72,7 @@ class SolanaBalanceFetcher(
      * (network failure, RPC error, malformed response) — UI treats null as
      * "balance unavailable".
      */
-    suspend fun fetch(pubkey: String): Balances? = withContext(Dispatchers.IO) {
+    open suspend fun fetch(pubkey: String): Balances? = withContext(Dispatchers.IO) {
         // BAT-582 R21: enforce IO dispatcher INTERNALLY rather than relying
         // on every caller to wrap with withContext(Dispatchers.IO) before
         // invoking. Pre-fix the suspend signature implied "safe to await

--- a/app/src/test/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpointsTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/bridge/burner/BurnerBridgeEndpointsTest.kt
@@ -1,11 +1,15 @@
 package com.seekerclaw.app.bridge.burner
 
 import com.seekerclaw.app.data.caps.CapEnforcer
+import com.seekerclaw.app.data.wallet.SolanaBalanceFetcher
 import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.math.BigInteger
 
@@ -308,6 +312,141 @@ class BurnerBridgeEndpointsTest {
         }
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // BAT-1001 PR-B: /burner/status live SOL+USDC balance wiring.
+    //
+    // Atomic-string-or-omit contract:
+    //   - balanceFetcher == null OR fetcher.fetch returns null →
+    //     balanceSol AND balanceUsdc are OMITTED from the response.
+    //     (Never sent as "0" or as null — downstream
+    //     wallet_status.handlers distinguishes field-absent from
+    //     field-present-as-zero via `status.balanceSol != null`.)
+    //   - fetcher.fetch returns Balances → BOTH fields present as
+    //     atomic-unit decimal strings (lamports for SOL, microunits
+    //     for USDC). u64-safe via BigInteger.toString().
+    //
+    // We test via dispatch("/burner/status", JSONObject()) because
+    // handleStatus is private; the public dispatch entry point gives
+    // us the same EndpointResult to assert on.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `handleStatus omits balance fields when fetcher returns null`() = runBlocking {
+        val ep = TestEndpointBuilder.buildForStatus(
+            balanceFetcher = TestEndpointBuilder.StubBalanceFetcher(result = null),
+            pubkey = "FakePubkey11111111111111111111111111111111",
+        )
+        val result = ep.dispatch("/burner/status", JSONObject())
+        assertEquals(200, result!!.httpStatus)
+        // The "unavailable" contract: fields ABSENT from the map,
+        // not present-as-null and not present-as-"0".
+        assertFalse(
+            "balanceSol must be OMITTED when fetcher returns null, not present-as-null",
+            result.body.containsKey("balanceSol"),
+        )
+        assertFalse(
+            "balanceUsdc must be OMITTED when fetcher returns null, not present-as-null",
+            result.body.containsKey("balanceUsdc"),
+        )
+        // Sanity: caps and spend ARE still present (they don't depend
+        // on the RPC fetcher).
+        assertTrue("capPerTxSol should still be present", result.body.containsKey("capPerTxSol"))
+    }
+
+    @Test
+    fun `handleStatus emits atomic-unit decimal strings when fetcher returns balances`() = runBlocking {
+        val ep = TestEndpointBuilder.buildForStatus(
+            balanceFetcher = TestEndpointBuilder.StubBalanceFetcher(
+                result = SolanaBalanceFetcher.Balances(
+                    solLamports = BigInteger("1234567890"),       // 1.234... SOL
+                    usdcMicrounits = BigInteger("9876543"),       // 9.876... USDC
+                ),
+            ),
+            pubkey = "FakePubkey11111111111111111111111111111111",
+        )
+        val result = ep.dispatch("/burner/status", JSONObject())
+        assertEquals(200, result!!.httpStatus)
+        // Atomic units, as STRINGS (not numbers, not decimals).
+        assertEquals("1234567890", result.body["balanceSol"])
+        assertEquals("9876543", result.body["balanceUsdc"])
+        // Type assertion: the wire shape MUST be String, not Long /
+        // BigInteger / decimal. JSON serialization would coerce
+        // BigInteger to scientific notation for large values; only
+        // String preserves the exact atomic-unit shape.
+        assertTrue("balanceSol must be a String", result.body["balanceSol"] is String)
+        assertTrue("balanceUsdc must be a String", result.body["balanceUsdc"] is String)
+    }
+
+    @Test
+    fun `handleStatus atomic strings are u64-safe at the upper bound`() = runBlocking {
+        // u64 max = 2^64 - 1 = 18446744073709551615. Java Long max is
+        // ~9.2e18, less than u64 max. Real Solana SOL supply is ~580M
+        // (far below either) and USDC is similar, but the Solana spec
+        // documents these fields as u64 — be correct against the spec
+        // rather than the current supply. BigInteger.toString()
+        // preserves the full unsigned range.
+        val u64Max = BigInteger("18446744073709551615")
+        val ep = TestEndpointBuilder.buildForStatus(
+            balanceFetcher = TestEndpointBuilder.StubBalanceFetcher(
+                result = SolanaBalanceFetcher.Balances(
+                    solLamports = u64Max,
+                    usdcMicrounits = u64Max,
+                ),
+            ),
+            pubkey = "FakePubkey11111111111111111111111111111111",
+        )
+        val result = ep.dispatch("/burner/status", JSONObject())
+        assertEquals(200, result!!.httpStatus)
+        // Round-trip: exact decimal-string representation preserved.
+        assertEquals("18446744073709551615", result.body["balanceSol"])
+        assertEquals("18446744073709551615", result.body["balanceUsdc"])
+    }
+
+    @Test
+    fun `handleStatus omits balance fields when fetcher is null (legacy path)`() = runBlocking {
+        // Back-compat: an endpoint built without a fetcher (e.g. via
+        // the 3-arg internal constructor in older tests) MUST omit
+        // balance fields rather than crash. This preserves the v1
+        // BAT-582 R2 behaviour for any code path that hasn't been
+        // migrated yet.
+        val ep = TestEndpointBuilder.buildForStatus(
+            balanceFetcher = null,
+            pubkey = "FakePubkey11111111111111111111111111111111",
+        )
+        val result = ep.dispatch("/burner/status", JSONObject())
+        assertEquals(200, result!!.httpStatus)
+        assertFalse(result.body.containsKey("balanceSol"))
+        assertFalse(result.body.containsKey("balanceUsdc"))
+    }
+
+    @Test
+    fun `handleStatus omits balance fields when burner is not configured (pubkey null)`() = runBlocking {
+        // The fetcher only fires when configured == true. An
+        // unconfigured burner (no pubkey) should never trigger an
+        // RPC call — even if a fetcher is wired. Verifies the
+        // configured-gate around the fetch.
+        val recordingFetcher = TestEndpointBuilder.StubBalanceFetcher(
+            result = SolanaBalanceFetcher.Balances(
+                solLamports = BigInteger("100"),
+                usdcMicrounits = BigInteger("200"),
+            ),
+        )
+        val ep = TestEndpointBuilder.buildForStatus(
+            balanceFetcher = recordingFetcher,
+            pubkey = null, // not configured
+        )
+        val result = ep.dispatch("/burner/status", JSONObject())
+        assertEquals(200, result!!.httpStatus)
+        assertEquals(false, result.body["configured"])
+        assertFalse("balanceSol must NOT appear for unconfigured burner", result.body.containsKey("balanceSol"))
+        assertFalse("balanceUsdc must NOT appear for unconfigured burner", result.body.containsKey("balanceUsdc"))
+        assertEquals(
+            "fetcher.fetch must NOT be invoked when pubkey is null",
+            0,
+            recordingFetcher.fetchCallCount,
+        )
+    }
+
     @Test
     fun `sign-transaction missing fields still fails before reservation lookup`() = runBlocking {
         val (ep, _, recorder) = TestEndpointBuilder.buildWithRealCapEnforcer()
@@ -400,6 +539,37 @@ private object TestEndpointBuilder {
         testClockMs += deltaMs
     }
 
+    /**
+     * BAT-1001 PR-B: build an endpoint instance for /burner/status
+     * balance-wiring tests. The KeyVault returns the given [pubkey]
+     * (so `configured` is true when non-null), the CapEnforcer is
+     * real with sensible defaults so status() returns valid cap
+     * fields, the JupiterOwnership is the noop seam, and the
+     * [balanceFetcher] is whatever the test passed (typically a
+     * StubBalanceFetcher returning a fixed Balances? value).
+     */
+    fun buildForStatus(
+        balanceFetcher: SolanaBalanceFetcher?,
+        pubkey: String?,
+    ): BurnerBridgeEndpoints {
+        val tmpCaps = newTempDir("status-caps")
+        val capStore = com.seekerclaw.app.util.CrossProcessStore(
+            filesDir = tmpCaps,
+            fileName = com.seekerclaw.app.data.caps.BurnerCapsState.FILE_NAME,
+            serializer = com.seekerclaw.app.data.caps.BurnerCapsState.serializer(),
+            initial = com.seekerclaw.app.data.caps.BurnerCapsState(),
+        )
+        val enforcer = com.seekerclaw.app.data.caps.CapEnforcer(
+            ledger = com.seekerclaw.app.data.caps.ReservationLedger(capStore),
+        )
+        return BurnerBridgeEndpoints(
+            keyVault = FixedPubkeyKeyVault(pubkey),
+            capEnforcer = enforcer,
+            jupiterOwnership = noopOwnership(),
+            balanceFetcher = balanceFetcher,
+        )
+    }
+
     fun cleanupTempDirs() {
         synchronized(tempDirs) {
             for (dir in tempDirs) {
@@ -427,6 +597,42 @@ private object TestEndpointBuilder {
             throw NotImplementedError()
         override suspend fun getPubkey(id: String): String? = null
         override suspend fun wipe(id: String) = Unit
+    }
+
+    /**
+     * BAT-1001 PR-B: KeyVault that returns a fixed pubkey (or null
+     * to simulate "burner not configured"). Used by [buildForStatus]
+     * so handleStatus can compute `configured = pubkey != null`
+     * without needing the real EncryptedPrefsKeyVault wiring (which
+     * requires a Context).
+     */
+    private class FixedPubkeyKeyVault(private val pubkey: String?) :
+        com.seekerclaw.app.data.wallet.KeyVault {
+        override suspend fun store(id: String, expanded64: ByteArray) = Unit
+        override suspend fun signTransaction(id: String, txBytes: ByteArray, allowPartiallySigned: Boolean): ByteArray =
+            throw NotImplementedError()
+        override suspend fun getPubkey(id: String): String? = pubkey
+        override suspend fun wipe(id: String) = Unit
+    }
+
+    /**
+     * BAT-1001 PR-B: SolanaBalanceFetcher subclass that returns a
+     * fixed Balances? result and counts fetch invocations. Used by
+     * the /burner/status balance-wiring tests to verify the atomic-
+     * string-or-omit contract without needing a real RPC server. The
+     * primary constructor's `rpcUrlProvider` default is preserved
+     * (we never reach the URL — fetch() is fully overridden).
+     */
+    class StubBalanceFetcher(
+        private val result: SolanaBalanceFetcher.Balances?,
+    ) : SolanaBalanceFetcher() {
+        @Volatile var fetchCallCount: Int = 0
+            private set
+
+        override suspend fun fetch(pubkey: String): SolanaBalanceFetcher.Balances? {
+            fetchCallCount++
+            return result
+        }
     }
 
     /**

--- a/tests/nodejs-project/bridge-token-reload.test.js
+++ b/tests/nodejs-project/bridge-token-reload.test.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// bridge-token-reload.test.js — BAT-1001 PR-B
+//
+// Proves the bridge.js → AndroidBridge 403 retry contract:
+//   1. androidBridgeCall reads getBridgeToken() per request (NOT
+//      cached at module-load time).
+//   2. On HTTP 403 from AndroidBridge, the call re-reads the token
+//      and retries EXACTLY ONCE. Persistent 403 surfaces cleanly.
+//   3. A second consecutive 403 returns the body as a hard error
+//      (no infinite loop).
+//
+// Test seam: we stub `./config` via require.cache BEFORE requiring
+// `bridge.js`, so the bridge module sees a fake getBridgeToken whose
+// value we mutate between calls. This is the same require-cache
+// stubbing pattern main-wallet-balance.test.js:51-85 establishes.
+// A fake AndroidBridge HTTP server bound to 127.0.0.1:8765 (the port
+// bridge.js hardcodes) returns 403/200 based on the current
+// "expected" token.
+//
+// Run:  node tests/nodejs-project/bridge-token-reload.test.js
+
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+
+const CONFIG_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'config.js');
+const BRIDGE_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'bridge.js');
+
+// --- stub config.js BEFORE requiring bridge.js ---
+// `bridge.js` destructures `getBridgeToken` at require-time. If we
+// later did `fakeConfig.getBridgeToken = newFn`, bridge.js would
+// keep using the OLD function reference. So the exported getter is
+// fixed at module load and reads from controllable closure state:
+//
+//   - `_stubbedToken` (string) — simple single-value tests mutate this
+//     to simulate a rotation. The exported getter just returns it.
+//   - `_tokenSequence` (string[]) + `_tokenSeqIdx` (number) — for the
+//     rotation-race test that needs DIFFERENT values across the two
+//     attempts in a single androidBridgeCall. When non-null, the
+//     sequence wins; each getter call returns the next entry (sticky
+//     on the last entry so over-reads return the final value).
+//
+// Tests reset both via the runner between cases.
+let _stubbedToken = 'initial-token-AAAAAAAAAA';
+let _tokenSequence = null;
+let _tokenSeqIdx = 0;
+
+const fakeConfig = {
+    getBridgeToken: () => {
+        if (_tokenSequence && _tokenSequence.length > 0) {
+            const idx = Math.min(_tokenSeqIdx, _tokenSequence.length - 1);
+            _tokenSeqIdx++;
+            return _tokenSequence[idx];
+        }
+        return _stubbedToken;
+    },
+    log: (_msg, _level) => {}, // silent
+};
+require.cache[require.resolve(CONFIG_JS)] = {
+    id: CONFIG_JS,
+    filename: CONFIG_JS,
+    loaded: true,
+    exports: fakeConfig,
+};
+
+const { androidBridgeCall } = require(BRIDGE_JS);
+
+// --- fake AndroidBridge on 127.0.0.1:8765 ---
+let _expectedToken = 'initial-token-AAAAAAAAAA';
+let _requestLog = [];
+let _bridgeServer = null;
+// When non-null, the fake bridge returns this status + body on every
+// request (regardless of auth) — used for the non-403 no-retry test.
+// Reset to null between tests by the runner.
+let _forcedResponse = null;
+
+function _startFakeBridge() {
+    return new Promise((resolve) => {
+        _bridgeServer = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', (c) => body += c);
+            req.on('end', () => {
+                const headerToken = req.headers['x-bridge-token'];
+                _requestLog.push({ path: req.url, token: headerToken });
+                if (_forcedResponse !== null) {
+                    res.writeHead(_forcedResponse.status, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify(_forcedResponse.body));
+                    return;
+                }
+                if (headerToken !== _expectedToken) {
+                    // Match AndroidBridge.kt:163 — 403, NOT 401.
+                    res.writeHead(403, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'bridge-token mismatch' }));
+                    return;
+                }
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true, echo: body }));
+            });
+        });
+        _bridgeServer.listen(8765, '127.0.0.1', () => resolve());
+    });
+}
+
+function _stopFakeBridge() {
+    return new Promise((resolve) => {
+        if (!_bridgeServer) return resolve();
+        _bridgeServer.close(() => resolve());
+    });
+}
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    await _startFakeBridge();
+    for (const { name, fn } of tests) {
+        try {
+            _requestLog = [];
+            // Reset rotation state each test.
+            _stubbedToken = 'initial-token-AAAAAAAAAA';
+            _expectedToken = 'initial-token-AAAAAAAAAA';
+            _tokenSequence = null;
+            _tokenSeqIdx = 0;
+            _forcedResponse = null;
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    await _stopFakeBridge();
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+// ── per-call getter contract ──────────────────────────────────────
+
+test('happy path: token matches → 200 with one request', async () => {
+    const result = await androidBridgeCall('/ping', { hello: 'world' });
+    assert.deepStrictEqual(result, { ok: true, echo: JSON.stringify({ hello: 'world' }) });
+    assert.strictEqual(_requestLog.length, 1, 'no retry on success');
+});
+
+test('per-call getter: stubbedToken change between calls is picked up immediately', async () => {
+    // Call 1: stubbedToken == expectedToken → 200.
+    const r1 = await androidBridgeCall('/ping', {});
+    assert.strictEqual(r1.ok, true);
+
+    // Mutate BOTH stubbed (Node side) and expected (fake bridge side)
+    // — simulates Kotlin rotating bridge_token on disk AND
+    // AndroidBridge picking up the new value.
+    _stubbedToken = 'token-B-XXXXXXXXXX';
+    _expectedToken = 'token-B-XXXXXXXXXX';
+
+    // Call 2: per-call getter MUST read the new value (not the
+    // cached initial-token-A from module load). If it used the
+    // cached value, the request would 403 and the retry would also
+    // fail (Node-side still has stale value).
+    const r2 = await androidBridgeCall('/ping', {});
+    assert.strictEqual(r2.ok, true);
+    assert.strictEqual(_requestLog.length, 2, 'no retry needed on second call');
+});
+
+// ── single-shot 403 retry contract ────────────────────────────────
+
+test('rotation race: Node sees stale token on first send, refreshes from disk on 403, retries once and succeeds', async () => {
+    // Setup the rotation race via the token-sequence mechanism: the
+    // getter returns 'token-A-OLD' on first read (request 1) and
+    // 'token-B-NEW' on the second (the post-403 retry). This mirrors
+    // "disk file changed between attempts" — exactly the production
+    // race the bridge.js retry exists to absorb.
+    _tokenSequence = ['token-A-OLD-PRE-ROTATION', 'token-B-NEW-POST-ROTATION'];
+    _expectedToken = 'token-B-NEW-POST-ROTATION';
+
+    const result = await androidBridgeCall('/ping', {});
+    // The 403-retry path MUST kick in: first send 403, refresh
+    // getter → token-B, retry → 200.
+    assert.strictEqual(result.ok, true, 'retry with refreshed token must succeed');
+    assert.strictEqual(_requestLog.length, 2, 'exactly one retry');
+    assert.strictEqual(_requestLog[0].token, 'token-A-OLD-PRE-ROTATION');
+    assert.strictEqual(_requestLog[1].token, 'token-B-NEW-POST-ROTATION');
+});
+
+test('persistent 403: both attempts fail → caller gets the second-response body (no infinite loop)', async () => {
+    // Both the initial token and the post-refresh token are wrong
+    // — simulates AndroidBridge genuinely rejecting this caller
+    // (Kotlin rotated to something we don't know about). The retry
+    // cap is 1; a third request MUST NOT fire.
+    _stubbedToken = 'genuinely-wrong-token';
+    _expectedToken = 'completely-different-token';
+
+    const result = await androidBridgeCall('/ping', {});
+    // Second 403's body is JSON `{error:"bridge-token mismatch"}`.
+    // bridge.js parses the body and returns it — the caller sees
+    // the error string and surfaces it as a hard failure.
+    assert.strictEqual(result.error, 'bridge-token mismatch', 'caller sees second 403 body');
+    assert.strictEqual(_requestLog.length, 2, 'capped at exactly 2 attempts (1 original + 1 retry)');
+});
+
+test('non-403 error response: no retry, body is returned directly', async () => {
+    // Simulate a 500 from AndroidBridge (e.g. an unrelated server
+    // error). The retry MUST only fire on 403 — other status codes
+    // pass through immediately so callers can react to them.
+    _forcedResponse = { status: 500, body: { error: 'internal' } };
+
+    const result = await androidBridgeCall('/ping', {});
+    assert.strictEqual(result.error, 'internal');
+    assert.strictEqual(_requestLog.length, 1, '500 must NOT trigger retry');
+});
+
+run();

--- a/tests/nodejs-project/internal-control-server-proxy-passthrough.test.js
+++ b/tests/nodejs-project/internal-control-server-proxy-passthrough.test.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// internal-control-server-proxy-passthrough.test.js — BAT-1001 PR-B
+//
+// Regression guard for the AndroidBridge → /stats/db-summary proxy.
+// AndroidBridge.kt:954-975 opens an HttpURLConnection to
+// http://127.0.0.1:8766/stats/db-summary and sets neither a custom
+// Host header (Java auto-fills 127.0.0.1:8766) nor an Origin header
+// (HttpURLConnection doesn't set Origin by default).
+//
+// The new Host/Origin gate in internal-control-server.js MUST let
+// this proxy shape through — pre-fix the gate didn't exist, the
+// proxy worked. Post-fix the proxy MUST still work or the Settings
+// "DB summary" screen breaks.
+//
+// Run:  node tests/nodejs-project/internal-control-server-proxy-passthrough.test.js
+
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+
+const SERVER_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'internal-control-server.js');
+const server = require(SERVER_JS);
+
+const HOST = '127.0.0.1';
+const PORT = server.PORT;
+const DB_SUMMARY = { messages: 42, tools: 7, mcpServers: 3 };
+
+function _request(method, path, headers) {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path,
+            method,
+            headers: headers || {},
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+        req.end();
+    });
+}
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    const httpServer = server.start({
+        getBridgeToken: () => 'unused-by-stats-endpoint',
+        getDbSummary: () => DB_SUMMARY,
+        requestReconcile: () => {},
+        logFn: () => {},
+    });
+    await new Promise((resolve) => {
+        if (httpServer.listening) resolve();
+        else httpServer.once('listening', resolve);
+    });
+    for (const { name, fn } of tests) {
+        try {
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    await server.stop();
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+// ── proxy-shape passthrough ────────────────────────────────────────
+
+test('AndroidBridge proxy shape (Host: 127.0.0.1:8766, no Origin) → 200', async () => {
+    // This is exactly what AndroidBridge.kt's HttpURLConnection sends:
+    // - Host header = the URL authority = 127.0.0.1:8766
+    // - No Origin header (Java HttpURLConnection doesn't set one)
+    // - No Bridge-Token (the inner /stats hop is unauthenticated by
+    //   contract; the outer AndroidBridge endpoint authed already).
+    const r = await _request('GET', '/stats/db-summary', {
+        Host: '127.0.0.1:8766',
+        // Intentionally NO Origin header.
+    });
+    assert.strictEqual(r.status, 200, 'proxy must still work after Host/Origin gate landed');
+    assert.deepStrictEqual(r.body, DB_SUMMARY);
+});
+
+test('proxy with Origin: https://attacker.example → 403 (DNS-rebind defense)', async () => {
+    // Even with the correct Host, an Origin-bearing request is
+    // browser-initiated and rejected.
+    const r = await _request('GET', '/stats/db-summary', {
+        Host: '127.0.0.1:8766',
+        Origin: 'https://attacker.example',
+    });
+    assert.strictEqual(r.status, 403);
+    assert.strictEqual(r.body.error, 'origin not allowed');
+});
+
+test('proxy with Host: localhost:8766 → 403 (case + variant rejection)', async () => {
+    // Codex v1.1 #4: localhost:8766 is rejected even though it
+    // resolves to the same IP. Single allowed Host literal keeps the
+    // gate auditable.
+    const r = await _request('GET', '/stats/db-summary', {
+        Host: 'localhost:8766',
+    });
+    assert.strictEqual(r.status, 403);
+});
+
+run();

--- a/tests/nodejs-project/internal-control-server-token-rotation.test.js
+++ b/tests/nodejs-project/internal-control-server-token-rotation.test.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// internal-control-server-token-rotation.test.js — BAT-1001 PR-B
+//
+// Proves the AC-3 rotation contract: after a Kotlin-side bridge_token
+// rotation, the very next inbound POST authenticates against the NEW
+// token without restarting the Node control server. Pre-fix, the
+// startup-frozen `_bridgeToken` rejected every POST after the rotation
+// until a process restart.
+//
+// We exercise this by passing a getter that we can mutate live — the
+// getter mirrors the production wiring `getBridgeToken: () =>
+// getBridgeToken()` (where getBridgeToken re-reads the file each
+// call). The test mutates what the getter returns BETWEEN requests
+// to simulate Kotlin writing a new token to disk.
+//
+// Run:  node tests/nodejs-project/internal-control-server-token-rotation.test.js
+// Exit: 0 = all pass, 1 = at least one failure.
+
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+
+const SERVER_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
+    'assets', 'nodejs-project', 'internal-control-server.js');
+const server = require(SERVER_JS);
+
+const HOST = '127.0.0.1';
+const PORT = server.PORT;
+
+// Mutable token — assigned by the getter wired into start(). Tests
+// reassign this between requests to simulate a Kotlin-side rotation.
+let _currentToken = 'token-A-1234567890';
+
+function _post(path, body, headers) {
+    return new Promise((resolve, reject) => {
+        const data = body == null ? '{}' : JSON.stringify(body);
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path,
+            method: 'POST',
+            headers: Object.assign({
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(data),
+            }, headers || {}),
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+// --- runner ---
+const tests = [];
+let pass = 0, fail = 0;
+function test(name, fn) { tests.push({ name, fn }); }
+async function run() {
+    const httpServer = server.start({
+        // Production wiring shape: a function that returns the
+        // current token. The getter closes over _currentToken so
+        // mutating it between requests is what the test exercises.
+        getBridgeToken: () => _currentToken,
+        getDbSummary: () => ({}),
+        requestReconcile: () => {},
+        logFn: () => {},
+    });
+    await new Promise((resolve) => {
+        if (httpServer.listening) resolve();
+        else httpServer.once('listening', resolve);
+    });
+    for (const { name, fn } of tests) {
+        try {
+            // Reset rotation state for each test so they don't bleed.
+            _currentToken = 'token-A-1234567890';
+            await fn();
+            pass++;
+            console.log(`PASS  ${name}`);
+        } catch (e) {
+            fail++;
+            console.log(`FAIL  ${name}`);
+            console.log(`  ${e.message}`);
+            if (e.stack) console.log(e.stack.split('\n').slice(1, 4).join('\n'));
+        }
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    await server.stop();
+    process.exit(fail === 0 ? 0 : 1);
+}
+
+// ── core rotation contract ─────────────────────────────────────────
+
+test('AC-3: initial token-A accepted, post-rotation token-A rejected, token-B accepted', async () => {
+    // Step 1: pre-rotation, token-A is the current token. Authed POST passes.
+    const r1 = await _post('/healthz', {}, { 'X-Bridge-Token': 'token-A-1234567890' });
+    assert.strictEqual(r1.status, 200, 'pre-rotation token-A should pass');
+
+    // Step 2: simulate Kotlin rotation — file on disk changed from
+    // token-A to token-B. With the per-request getter, the very next
+    // POST should use the new token for the auth compare.
+    _currentToken = 'token-B-9876543210';
+
+    // Step 3: an in-flight caller still sending the OLD token-A is
+    // now rejected. Pre-fix (startup-frozen _bridgeToken) this would
+    // have been accepted forever — the bug v1.1 fixes.
+    const r2 = await _post('/healthz', {}, { 'X-Bridge-Token': 'token-A-1234567890' });
+    assert.strictEqual(r2.status, 401, 'post-rotation old token must be rejected');
+
+    // Step 4: the new caller with token-B is accepted IMMEDIATELY,
+    // without a server restart. This is the load-bearing assertion.
+    const r3 = await _post('/healthz', {}, { 'X-Bridge-Token': 'token-B-9876543210' });
+    assert.strictEqual(r3.status, 200, 'post-rotation new token must be accepted without restart');
+});
+
+test('getter returning empty string → all POSTs reject 401 (never short-circuit to allow)', async () => {
+    // Simulates the file-missing case during a Kotlin restart — the
+    // getter returns ''. Auth gate MUST reject; we never short-circuit
+    // to "no token configured = allow".
+    _currentToken = '';
+    const r = await _post('/healthz', {}, { 'X-Bridge-Token': 'anything' });
+    assert.strictEqual(r.status, 401);
+});
+
+test('getter throwing → request still 401 (server is wrapped in try/catch)', async () => {
+    // If the getter itself throws (e.g. fs.readFileSync threw without
+    // the inner try-catch catching it for some odd reason), the
+    // server's outer try/catch on _route turns it into a 500. We
+    // expect either 500 OR the auth path to absorb it — what we
+    // MUST NOT see is a successful response (status 200).
+    // We assert the server doesn't crash by sending a follow-up
+    // request after restoring the getter.
+    const savedToken = _currentToken;
+    let throwOnce = true;
+    // Override the rotation getter mid-test by re-starting with a
+    // throwing wrapper... actually simpler: we can't easily replace
+    // the getter post-start in this test seam, but the behaviour is
+    // already covered by the "" case above and by the per-process
+    // outer try/catch in _route. Skip the runtime swap and just
+    // assert the explicit empty-string case is solid (above test).
+    // This test exists as a documentation marker for the safety
+    // boundary; pass it trivially since the throw path is
+    // structurally equivalent to the empty path (both reach `expected
+    // = ''` for the comparison).
+    assert.ok(throwOnce, 'safety: throw path equivalent to empty (see above)');
+    void savedToken;
+});
+
+run();

--- a/tests/nodejs-project/internal-control-server-token-rotation.test.js
+++ b/tests/nodejs-project/internal-control-server-token-rotation.test.js
@@ -83,7 +83,17 @@ async function run() {
     for (const { name, fn } of tests) {
         try {
             // Reset rotation state for each test so they don't bleed.
+            // Also re-bind the production-shape getter — the throwing-
+            // getter test swaps it via start() idempotency, and without
+            // this reset any test appended after it would inherit the
+            // throwing getter and see 500 on every call.
             _currentToken = 'token-A-1234567890';
+            server.start({
+                getBridgeToken: () => _currentToken,
+                getDbSummary: () => ({}),
+                requestReconcile: () => {},
+                logFn: () => {},
+            });
             await fn();
             pass++;
             console.log(`PASS  ${name}`);

--- a/tests/nodejs-project/internal-control-server-token-rotation.test.js
+++ b/tests/nodejs-project/internal-control-server-token-rotation.test.js
@@ -132,28 +132,39 @@ test('getter returning empty string → all POSTs reject 401 (never short-circui
     assert.strictEqual(r.status, 401);
 });
 
-test('getter throwing → request still 401 (server is wrapped in try/catch)', async () => {
-    // If the getter itself throws (e.g. fs.readFileSync threw without
-    // the inner try-catch catching it for some odd reason), the
-    // server's outer try/catch on _route turns it into a 500. We
-    // expect either 500 OR the auth path to absorb it — what we
-    // MUST NOT see is a successful response (status 200).
-    // We assert the server doesn't crash by sending a follow-up
-    // request after restoring the getter.
-    const savedToken = _currentToken;
-    let throwOnce = true;
-    // Override the rotation getter mid-test by re-starting with a
-    // throwing wrapper... actually simpler: we can't easily replace
-    // the getter post-start in this test seam, but the behaviour is
-    // already covered by the "" case above and by the per-process
-    // outer try/catch in _route. Skip the runtime swap and just
-    // assert the explicit empty-string case is solid (above test).
-    // This test exists as a documentation marker for the safety
-    // boundary; pass it trivially since the throw path is
-    // structurally equivalent to the empty path (both reach `expected
-    // = ''` for the comparison).
-    assert.ok(throwOnce, 'safety: throw path equivalent to empty (see above)');
-    void savedToken;
+test('throwing getter → server returns 500 cleanly, listener survives for next request', async () => {
+    // server.start() is idempotent for the listener but always
+    // rebinds _getBridgeToken — that lets us swap in a throwing
+    // getter mid-session without restarting the server. Production
+    // shouldn't ever see this (config.js getBridgeToken catches all
+    // fs errors and returns the cold-fallback), but a getter that
+    // genuinely threw would propagate up through _route's outer
+    // try/catch and surface as 500. We verify both:
+    //   (a) the request returns 500 (not a hang, not a 200, not a
+    //       socket reset),
+    //   (b) the server's listener is still alive for the next call
+    //       after the throw — proving the throw didn't crash the
+    //       handler.
+    server.start({
+        getBridgeToken: () => { throw new Error('simulated disk read failure'); },
+        getDbSummary: () => ({}),
+        requestReconcile: () => {},
+        logFn: () => {}, // suppress the [ControlServer] handler error log
+    });
+    const r1 = await _post('/healthz', {}, { 'X-Bridge-Token': 'anything' });
+    assert.strictEqual(r1.status, 500, 'throwing getter → outer try/catch → 500');
+
+    // Restore the rotation getter for any subsequent test AND prove
+    // the listener survived the throw — a successful POST after
+    // means the server didn't crash mid-handler.
+    server.start({
+        getBridgeToken: () => _currentToken,
+        getDbSummary: () => ({}),
+        requestReconcile: () => {},
+        logFn: () => {},
+    });
+    const r2 = await _post('/healthz', {}, { 'X-Bridge-Token': _currentToken });
+    assert.strictEqual(r2.status, 200, 'listener survived the throw — next request works');
 });
 
 run();

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -97,7 +97,12 @@ let pass = 0, fail = 0;
 function test(name, fn) { tests.push({ name, fn }); }
 async function run() {
     const httpServer = server.start({
-        bridgeToken: BRIDGE_TOKEN,
+        // BAT-1001 PR-B: getBridgeToken (function) replaces the old
+        // bridgeToken (string) option. For this test the getter
+        // returns a constant — equivalent to v1 behaviour. The
+        // rotation contract is covered by the separate
+        // internal-control-server-token-rotation.test.js.
+        getBridgeToken: () => BRIDGE_TOKEN,
         getDbSummary: () => _dbSummary,
         requestReconcile: (id) => { _reconcileCalls.push(id); },
         logFn: () => {}, // suppress
@@ -272,6 +277,148 @@ test('GET /mcp/reconcile returns 405', async () => {
 test('POST /unknown returns 404', async () => {
     const r = await _post('/unknown', {}, { 'X-Bridge-Token': BRIDGE_TOKEN });
     assert.strictEqual(r.status, 404);
+});
+
+// ============================================================================
+// BAT-1001 PR-B: Host allowlist, Origin rejection, length-guarded
+// timingSafeEqual. These tests cover the DNS-rebind defense + the
+// constant-time-compare hardening added in v1.1.
+// ============================================================================
+
+// Send a raw request with arbitrary Host / Origin headers. Node's
+// http.request normally auto-sets Host from hostname+port — passing
+// `headers.host` explicitly overrides it.
+function _send(method, path, headers, body) {
+    return new Promise((resolve, reject) => {
+        const data = body == null ? '' : JSON.stringify(body);
+        const req = http.request({
+            hostname: HOST,
+            port: PORT,
+            path,
+            method,
+            headers: Object.assign({
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(data),
+            }, headers || {}),
+            timeout: 2000,
+        }, (res) => {
+            let raw = '';
+            res.on('data', (c) => raw += c);
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(raw); } catch (_) { parsed = raw; }
+                resolve({ status: res.statusCode, body: parsed });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+// ── Host allowlist ─────────────────────────────────────────────────
+
+test('host gate: GET /stats/db-summary with Host: evil.com:8766 returns 403', async () => {
+    // DNS-rebind shape: the browser resolved evil.com → 127.0.0.1
+    // (so the socket lands here) but still sends Host: evil.com:8766
+    // per RFC 7230 §5.4.
+    const r = await _send('GET', '/stats/db-summary', { Host: 'evil.com:8766' });
+    assert.strictEqual(r.status, 403);
+    assert.strictEqual(r.body.error, 'host not allowed');
+});
+
+test('host gate: Host: localhost:8766 is rejected (server binds 127.0.0.1 only)', async () => {
+    // Codex v1.1 #4: explicitly do NOT accept `localhost:8766`.
+    // The server doesn't dual-bind; allowing localhost would invite
+    // name-resolution surprises.
+    const r = await _send('GET', '/stats/db-summary', { Host: 'localhost:8766' });
+    assert.strictEqual(r.status, 403);
+});
+
+test('host gate: Host: [::1]:8766 (IPv6 loopback) is rejected', async () => {
+    // Codex v1.1 #6: do NOT accept [::1]:8766 in v1.
+    const r = await _send('GET', '/stats/db-summary', { Host: '[::1]:8766' });
+    assert.strictEqual(r.status, 403);
+});
+
+test('host gate: wrong port (127.0.0.1:8765) is rejected', async () => {
+    const r = await _send('GET', '/stats/db-summary', { Host: '127.0.0.1:8765' });
+    assert.strictEqual(r.status, 403);
+});
+
+test('host gate: case-insensitive — 127.0.0.1:8766 (already lower) passes', async () => {
+    // The lowercased ALLOWED_HOST is '127.0.0.1:8766'. Verify the
+    // existing default request (which uses Node's auto-Host of the
+    // same value) still works after the gate landed.
+    const r = await _send('GET', '/stats/db-summary', { Host: '127.0.0.1:8766' });
+    assert.strictEqual(r.status, 200);
+});
+
+test('host gate also applies to POST endpoints (not just /stats/db-summary)', async () => {
+    // The gate is the FIRST check in _route, before path matching.
+    // POST /healthz with bad Host must 403 even though it would
+    // otherwise be a valid authed endpoint.
+    const r = await _send('POST', '/healthz', {
+        Host: 'evil.com:8766',
+        'X-Bridge-Token': BRIDGE_TOKEN,
+    }, {});
+    assert.strictEqual(r.status, 403);
+});
+
+// ── Origin rejection ───────────────────────────────────────────────
+
+test('origin gate: GET /stats/db-summary with Origin: https://evil.com returns 403', async () => {
+    // Any non-empty Origin means a browser sent the request.
+    // Legitimate Kotlin callers don't set Origin. Deny-all.
+    const r = await _send('GET', '/stats/db-summary', { Origin: 'https://evil.com' });
+    assert.strictEqual(r.status, 403);
+    assert.strictEqual(r.body.error, 'origin not allowed');
+});
+
+test('origin gate: empty Origin header is NOT rejected (we only reject non-empty)', async () => {
+    // Empty Origin happens in some HTTP libraries that always set the
+    // header. Per the v1.1 contract, only NON-empty Origin rejects.
+    const r = await _send('GET', '/stats/db-summary', { Origin: '' });
+    assert.strictEqual(r.status, 200);
+});
+
+test('origin gate also applies to POST endpoints', async () => {
+    const r = await _send('POST', '/healthz', {
+        Origin: 'https://attacker.test',
+        'X-Bridge-Token': BRIDGE_TOKEN,
+    }, {});
+    assert.strictEqual(r.status, 403);
+});
+
+// ── timingSafeEqual length-guard ───────────────────────────────────
+// These cases prove that a length-mismatch input does NOT crash the
+// server (timingSafeEqual throws on mismatched buffer lengths — the
+// _safeTokenEq helper MUST length-check first, otherwise length
+// probes turn into 500s instead of 401s).
+
+test('token compare: shorter-than-expected token returns 401 cleanly (no 500)', async () => {
+    const r = await _post('/healthz', {}, { 'X-Bridge-Token': 'short' });
+    assert.strictEqual(r.status, 401);
+    assert.strictEqual(r.body.error, 'unauthorized');
+});
+
+test('token compare: longer-than-expected token returns 401 cleanly (no 500)', async () => {
+    const r = await _post('/healthz', {}, {
+        'X-Bridge-Token': BRIDGE_TOKEN + 'extra-bytes-tacked-on',
+    });
+    assert.strictEqual(r.status, 401);
+    assert.strictEqual(r.body.error, 'unauthorized');
+});
+
+test('token compare: same-length-one-char-diff returns 401', async () => {
+    // Flip the first character. Keeps length identical so the
+    // length-guard passes and we exercise the actual timingSafeEqual
+    // comparison.
+    const flipped = (BRIDGE_TOKEN[0] === 'X' ? 'Y' : 'X') + BRIDGE_TOKEN.slice(1);
+    assert.strictEqual(flipped.length, BRIDGE_TOKEN.length);
+    const r = await _post('/healthz', {}, { 'X-Bridge-Token': flipped });
+    assert.strictEqual(r.status, 401);
 });
 
 run();

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -421,4 +421,32 @@ test('token compare: same-length-one-char-diff returns 401', async () => {
     assert.strictEqual(r.status, 401);
 });
 
+test('token compare: non-ASCII input with matching .length but different UTF-8 byte length returns 401 cleanly (Copilot R2 #3349626661)', async () => {
+    // The R1-fix used `.length` (UTF-16 code units) for the pre-check
+    // before calling timingSafeEqual on Buffers (UTF-8 bytes). A
+    // non-ASCII attacker can pass the .length check but trigger a
+    // Buffer-length-mismatch throw, yielding 500 — reintroducing
+    // the length-probe DoS surface. R2 fix: build Buffers first,
+    // compare buffer.length. This test locks that contract.
+    //
+    // Pick a string whose JS .length matches BRIDGE_TOKEN.length but
+    // whose UTF-8 byte length is larger. Each 'ñ' is 1 UTF-16 code
+    // unit (.length=1) but 2 UTF-8 bytes. So a string of all 'ñ' at
+    // BRIDGE_TOKEN.length chars has 2× the byte length.
+    const nonAscii = 'ñ'.repeat(BRIDGE_TOKEN.length);
+    assert.strictEqual(nonAscii.length, BRIDGE_TOKEN.length,
+        'pre-condition: JS .length matches');
+    assert.notStrictEqual(Buffer.byteLength(nonAscii, 'utf8'),
+        Buffer.byteLength(BRIDGE_TOKEN, 'utf8'),
+        'pre-condition: UTF-8 byte length differs — this is the attack vector');
+
+    const r = await _post('/healthz', {}, { 'X-Bridge-Token': nonAscii });
+    // MUST be 401 (clean rejection by the byte-length pre-check),
+    // NOT 500 (which would mean timingSafeEqual threw and the outer
+    // try/catch caught the throw — i.e. the byte-length pre-check
+    // is missing or broken).
+    assert.strictEqual(r.status, 401,
+        'non-ASCII token must reject 401 via byte-length pre-check, NOT 500 via timingSafeEqual throw');
+});
+
 run();

--- a/tests/nodejs-project/internal-control-server.test.js
+++ b/tests/nodejs-project/internal-control-server.test.js
@@ -24,6 +24,7 @@
 
 const assert = require('assert');
 const http = require('http');
+const net = require('net');
 const path = require('path');
 
 const SERVER_JS = path.join(__dirname, '..', '..', 'app', 'src', 'main',
@@ -419,6 +420,63 @@ test('token compare: same-length-one-char-diff returns 401', async () => {
     assert.strictEqual(flipped.length, BRIDGE_TOKEN.length);
     const r = await _post('/healthz', {}, { 'X-Bridge-Token': flipped });
     assert.strictEqual(r.status, 401);
+});
+
+// Raw-socket request: lets us send headers Node's http.request
+// client won't (duplicate Host) so we can prove the defensive
+// typeof guards don't crash into 500.
+function _rawSocketRequest(rawRequestText) {
+    return new Promise((resolve, reject) => {
+        const socket = net.createConnection(PORT, HOST);
+        socket.setTimeout(2000);
+        let raw = '';
+        socket.on('data', (chunk) => raw += chunk.toString('utf8'));
+        socket.on('end', () => {
+            // Parse just the status line — that's all we need to assert.
+            const m = raw.match(/^HTTP\/1\.[01]\s+(\d+)/);
+            resolve({ status: m ? parseInt(m[1], 10) : null, raw });
+        });
+        socket.on('error', (err) => resolve({ status: null, error: err.message }));
+        socket.on('timeout', () => { socket.destroy(); resolve({ status: null, error: 'socket-timeout' }); });
+        socket.on('connect', () => {
+            socket.write(rawRequestText);
+        });
+    });
+}
+
+test('host gate: duplicate Host headers do NOT crash the server with 500 (Copilot R3 #3349684637)', async () => {
+    // Send a request with TWO Host headers. Per Node's HTTP parser
+    // today, the first Host wins and the second is discarded — but
+    // the defensive typeof guard in _route() means even if a future
+    // parser change array-folded duplicates, the request would
+    // reject 403 cleanly instead of crashing into 500 via
+    // `.toLowerCase()` on an array.
+    //
+    // Acceptable outcomes (in order of likelihood):
+    //   - 200/401: parser kept only the first Host (the legitimate
+    //     one), gate passed, downstream handled normally.
+    //   - 403: parser surfaced the duplicate somehow, our typeof
+    //     guard caught it.
+    //   - 400: Node's parser itself rejected the duplicate.
+    //   - connection-close: parser rejected without a response.
+    // Forbidden: 500 (would mean the typeof guard is missing or
+    // broken and `.toLowerCase()` threw on a non-string value).
+    const raw =
+        'POST /healthz HTTP/1.1\r\n' +
+        'Host: 127.0.0.1:8766\r\n' +
+        'Host: evil.example.com:8766\r\n' +
+        `X-Bridge-Token: ${BRIDGE_TOKEN}\r\n` +
+        'Content-Type: application/json\r\n' +
+        'Content-Length: 2\r\n' +
+        'Connection: close\r\n' +
+        '\r\n' +
+        '{}';
+    const r = await _rawSocketRequest(raw);
+    // The load-bearing assertion: NEVER 500. (200, 401, 403, 400, or
+    // null-from-close all prove the typeof guard kept us safe from
+    // .toLowerCase() throwing.)
+    assert.notStrictEqual(r.status, 500,
+        `duplicate Host headers must not cause 500 (got status=${r.status})`);
 });
 
 test('token compare: non-ASCII input with matching .length but different UTF-8 byte length returns 401 cleanly (Copilot R2 #3349626661)', async () => {


### PR DESCRIPTION
## Summary

PR-B of the v2.1 foundation triad (BAT-1001 / BAT-1002 / BAT-1003). Three concrete defects bundled because each touches `bridge.js` / `config.js` / `internal-control-server.js` and splitting would churn the same review surface three times.

- **/burner/status now ships live SOL+USDC balances** via `SolanaBalanceFetcher` + atomic-string-or-omit contract. Pre-fix: every chat turn mentioning the burner returned "temporarily unavailable" (BAT-582 R2 deferred). The fetcher already existed with the BAT-1000 Helius-aware `rpcUrlProvider`; only the `handleStatus` wire was missing.
- **`bridge_token` hot-reload in BOTH directions** (`bridge.js` → AndroidBridge AND Kotlin `NodeControlClient` → `internal-control-server.js`). Per-call `getBridgeToken()` getter mirrors BAT-515 `getAgentName()`. Single-shot retry on AndroidBridge 403. Pre-fix: long-lived `:node` process that survived a service toggle held the stale token forever; every bridge call 403'd. Codex Q4 explicitly required migrating EVERY live request path — grep verifies no live site still reads the startup snapshot.
- **DNS-rebind defense on `127.0.0.1:8766`** — Host allowlist (`127.0.0.1:8766` only, case-insensitive; `[::1]:8766` and `localhost:8766` rejected per Codex v1.1 #4/#6), Origin reject (all non-empty Origin → 403), `crypto.timingSafeEqual` with explicit length-guard (turns length-probe attempts into clean 401s instead of 500s). Audit source: workflow `wg8q56ut5`.

Contract: BAT-1001 v1 + v1.1 addendum (Codex approved 2026-06-03).

## Implementation contract (cited from v1.1 addendum)

**A. Live balance wiring**
- `BurnerBridgeEndpoints` accepts optional `balanceFetcher: SolanaBalanceFetcher?`; production secondary constructor instantiates with `rpcUrlProvider = { ConfigManager.getSolanaRpcUrl(context) }` so a Helius API Key edit is honored on the next `/burner/status` call without recreating the endpoint.
- `handleStatus` atomic-string-or-omit: `balances == null` → both balance fields ABSENT from response; `balances != null` → both present as atomic-unit decimal strings (lamports / microunits). Never `"0"`, never `null`.
- `SolanaBalanceFetcher` class + `fetch` made `open` so tests can subclass without Mockito.
- `tools/wallet.js` `wallet_status` description updated to match (BAT-582 R2 "always null" copy → BAT-1001 live-fetch contract).

**B. Bridge-token hot-reload**
- `config.js getBridgeToken()` per-call read of `path.join(path.dirname(workDir), 'bridge_token')` (path verified against `runtime-state.js:113`, `mcp-servers.js:90-93`, `agent-preferences.js:73-80` precedent; Kotlin writer at `ServiceState.kt:185-201`). Cold-start `BRIDGE_TOKEN` fallback. Never throws.
- `bridge.js androidBridgeCall`: per-call `getBridgeToken()` + single-shot retry on HTTP 403 (NOT 401 — verified `AndroidBridge.kt:163`). Cap at exactly 1 retry; persistent 403 surfaces cleanly. No backoff (this is auth refresh, not transport retry).
- `security.js`: redaction uses live getter so mid-session rotations don't leak the new token via stale regex.
- `internal-control-server.js`: `_bridgeToken` (startup-frozen) → `_getBridgeToken` (function ref, default `() => ''`). `start({ getBridgeToken })` is the only supported option — the old `bridgeToken: <string>` string is intentionally NOT honored (would silently preserve the rotation bug).
- `main.js`: both Telegram and Discord startup paths pass `getBridgeToken: () => getBridgeToken()`.

**C. DNS-rebind + constant-time hardening**
- Host/Origin gate at top of `_route()`, BEFORE path matching, covers `/stats/db-summary` too. The BAT-31 no-auth contract on that endpoint is preserved for the inner AndroidBridge proxy hop; the new gate defeats DNS-rebind exfil at the HTTP layer.
- `_safeTokenEq(expected, actual)`: `typeof` checks + length-guard + `crypto.timingSafeEqual` on equal-length UTF-8 buffers. Empty `expected` (file missing) → 401, never short-circuits to "no token = allow."

## Test plan

- [x] `node --check`: 10/10 changed JS files parse cleanly.
- [x] `node tests/nodejs-project/internal-control-server.test.js`: **27/27 pass** (15 existing migrated + 12 new for Host/Origin/timingSafeEqual).
- [x] `node tests/nodejs-project/internal-control-server-token-rotation.test.js`: **3/3 pass** (AC-3 rotation contract).
- [x] `node tests/nodejs-project/internal-control-server-proxy-passthrough.test.js`: **3/3 pass** (regression guard for AndroidBridge → `/stats/db-summary` proxy).
- [x] `node tests/nodejs-project/bridge-token-reload.test.js`: **5/5 pass** (per-call getter + 403 single-shot retry + persistent-403 cap + non-403 no-retry).
- [x] `./gradlew :app:testDappStoreDebugUnitTest --tests BurnerBridgeEndpointsTest`: **20/20 pass** (5 new `handleStatus` cases + 15 existing).
- [x] `scripts/pre-push-check.sh`: **PASS** (4/4 phases — Node smoke 68 files, tool input_schema 63 tools, wallets prompt 4 scenarios, Kotlin compile BUILD SUCCESSFUL in 2m 58s).
- [x] Codex Q4 grep gate: live request paths use `getBridgeToken()` exclusively; remaining `BRIDGE_TOKEN` refs are `config.js` cold-fallback + comments.
- [ ] **Device test (deferred until Copilot clean per `feedback_copilot_before_device_tests`):** toggle service via Settings → next Kotlin POST authenticates without Node restart; outsider `curl` with `Origin: http://evil.example` against `127.0.0.1:8766/stats/db-summary` returns 403; burner balance shows live SOL+USDC in Settings.

## Known limitations / out of scope

- `getBridgeToken()` does a synchronous `fs.readFileSync` per request. No TTL cache in v1 — per Codex sign-off the correctness wins over the micro-cost on a 36-byte file (rotation path is cold).
- IPv6 loopback `[::1]:8766` rejected by design — server binds only `127.0.0.1`, dual-bind is out of scope for v1.
- AndroidBridge proxy (`AndroidBridge.kt:961` `String.equals` on bridge token) is NOT migrated to constant-time compare in this PR — Codex confirmed out of scope; follow-up if needed.
- Live balance latency on `/burner/status`: bounded by `SolanaBalanceFetcher.timeoutMs = 8_000`. On Helius slow / mainnet outage, `null` returned → balance fields omitted → UI shows "unavailable" instantly.

## Workflow references

- `wg8q56ut5` — BAT-1000 tool-observability security audit (DNS-rebind finding).
- `wdnpeytej` — parallel scope+draft+cross-check for v1 contracts.
- `wqflasi3v` — verify Codex feedback against repo + draft v1.1 addenda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)