### PR TITLE
fix(mwa): cache authToken to stop Phantom drop on sign (BAT-1021)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
@@ -378,14 +378,15 @@ object SolanaWalletManager {
     /**
      * Centralized stale-auth detection. Two paths:
      *
-     *  1. Typed exception: walks [TransactionResult.Failure.e] and up to
-     *     two `cause` links looking for a
+     *  1. Typed exception: walks [TransactionResult.Failure.e] (depth 0)
+     *     plus up to three `cause` links (depths 1–3) looking for a
      *     [JsonRpc20Client.JsonRpc20RemoteException] with
      *     `code == [ProtocolContract.ERROR_AUTHORIZATION_FAILED]` (-1).
      *     This is the canonical path — the SDK puts the
-     *     `JsonRpc20RemoteException` directly in [TransactionResult.Failure.e],
-     *     but we walk the cause chain defensively in case a wrapper is
-     *     introduced upstream.
+     *     `JsonRpc20RemoteException` directly in [TransactionResult.Failure.e]
+     *     (depth 0), but we walk the cause chain defensively in case an
+     *     upstream wrapper is introduced. The loop condition is
+     *     `depth < 4`, matching the implementation.
      *
      *  2. Message fallback: case-insensitive match against known stale-
      *     auth phrases the SDK pre-translates into the message field.

--- a/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
@@ -157,6 +157,7 @@ object SolanaWalletManager {
      * concurrently with an in-flight transact on another thread.
      */
     fun clearAuthToken() {
+        assertMainThread()
         val hadCached = cachedAuthToken != null
         cachedAuthToken = null
         core.authToken = null
@@ -303,15 +304,26 @@ object SolanaWalletManager {
             // Double-stale: the retry itself was rejected. The sentinel must
             // not leak — convert to a public-facing exception. This is the
             // user-revoked-during-retry / wallet-uninstalled scenario.
+            // Preserve the underlying root cause (typically the original
+            // JsonRpc20RemoteException) so crash reports + logs still see
+            // the real failure source.
             Log.e(TAG, "$op: stale auth retry also failed; surfacing caller-facing failure")
-            Result.failure(Exception("Authorization failed after retry (${retryError.message})"))
+            Result.failure(
+                Exception("Authorization failed after retry (${retryError.message})", retryError.cause)
+            )
         } else {
             retry
         }
     }
 
-    /** Sentinel exception used internally to flag "this failure was stale-auth, retry it". */
-    private class StaleAuthSignal(message: String) : Exception(message)
+    /**
+     * Sentinel exception used internally to flag "this failure was
+     * stale-auth, retry it". Carries the original wallet/SDK cause so
+     * diagnostics survive across the retry boundary if the retry also
+     * fails. The sentinel itself NEVER escapes to callers — see
+     * [runWithStaleRetry].
+     */
+    private class StaleAuthSignal(message: String, cause: Throwable?) : Exception(message, cause)
 
     private fun handlePubKeyResult(
         result: TransactionResult<Pair<String?, ByteArray?>>,
@@ -333,7 +345,7 @@ object SolanaWalletManager {
         }
         is TransactionResult.Failure -> {
             if (isStaleAuthError(result)) {
-                Result.failure(StaleAuthSignal(result.message))
+                Result.failure(StaleAuthSignal(result.message, result.e))
             } else {
                 Log.e(TAG, "MWA $op failed: ${result.message}")
                 Result.failure(Exception(result.message, result.e))
@@ -361,7 +373,7 @@ object SolanaWalletManager {
         }
         is TransactionResult.Failure -> {
             if (isStaleAuthError(result)) {
-                Result.failure(StaleAuthSignal(result.message))
+                Result.failure(StaleAuthSignal(result.message, result.e))
             } else {
                 Log.e(TAG, "MWA $op failed: ${result.message}")
                 Result.failure(Exception(result.message, result.e))

--- a/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.os.Looper
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import java.util.Locale
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import com.solana.mobilewalletadapter.clientlib.AdapterOperations
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
@@ -261,7 +262,18 @@ object SolanaWalletManager {
         } else {
             Log.i(TAG, "MWA call: fresh authorize path (no cached token; SDK handles)")
         }
-        return core.transact(sender, signInPayload = null, block = block)
+        return try {
+            core.transact(sender, signInPayload = null, block = block)
+        } catch (e: Exception) {
+            // Preserve the original error-contract: any throw from the SDK
+            // (or RealMwaCore.requireNotNull(sender), or main-thread
+            // registration failure, etc.) must surface as a
+            // TransactionResult.Failure so the downstream handlers can
+            // route it through stale-auth detection + the retry wrapper,
+            // instead of crashing the caller and bypassing the contract.
+            Log.e(TAG, "MWA transact threw; converting to Failure for unified handling", e)
+            TransactionResult.Failure(e.message ?: e.javaClass.simpleName, e)
+        }
     }
 
     /**
@@ -345,7 +357,7 @@ object SolanaWalletManager {
             }
         }
         is TransactionResult.NoWalletFound -> {
-            Result.failure(Exception("No MWA-compatible wallet found"))
+            Result.failure(Exception("No MWA-compatible wallet found. Install Phantom or Solflare."))
         }
         is TransactionResult.Failure -> {
             if (isStaleAuthError(result)) {
@@ -394,8 +406,11 @@ object SolanaWalletManager {
             t = t.cause
             depth++
         }
-        // Path 2: known SDK-translated messages
-        val msg = failure.message.lowercase()
+        // Path 2: known SDK-translated messages. Use locale-invariant
+        // lowercase so a device set to Turkish (where lowercase('I') is
+        // 'ı', not 'i') doesn't break the contains check on
+        // "auth token invalid" / "authorization failed".
+        val msg = failure.message.lowercase(Locale.ROOT)
         return STALE_AUTH_MESSAGE_HINTS.any { msg.contains(it) }
     }
 

--- a/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
+++ b/app/src/main/java/com/seekerclaw/app/solana/SolanaWalletManager.kt
@@ -1,17 +1,100 @@
 package com.seekerclaw.app.solana
 
 import android.net.Uri
+import android.os.Looper
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
+import com.solana.mobilewalletadapter.clientlib.AdapterOperations
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
 import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
+import com.solana.mobilewalletadapter.clientlib.protocol.JsonRpc20Client
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizationResult
+import com.solana.mobilewalletadapter.common.ProtocolContract
+import com.solana.mobilewalletadapter.common.signin.SignInWithSolana
 
+/**
+ * Wraps [MobileWalletAdapter] with an app-local auth-token cache so that
+ * subsequent transactions take the SDK's silent reauthorize path instead
+ * of bouncing the user back to the wallet picker on every signature.
+ *
+ * ## Threading
+ *
+ * Every public suspend function in this object MUST be invoked on
+ * `Dispatchers.Main`. MWA's `ActivityResultLauncher` registration is
+ * main-thread-only; calling from any other dispatcher will crash inside
+ * the SDK. The defensive [assertMainThread] guard at the top of each
+ * entry point enforces this at runtime — it is intentional belt-and-
+ * suspenders given that the singleton may be called from future ViewModel
+ * or service code paths that don't already pin to Main.
+ *
+ * ## Auth-token cache
+ *
+ * [cachedAuthToken] is the process-local memory of the last auth token
+ * returned by a successful authorize/reauthorize round-trip. It is
+ * `@Volatile` because the singleton is reachable from any thread (Node.js
+ * bridge calls, UI, services) — even though writes only happen from
+ * Main, reads from other threads (e.g. a future debug screen) must
+ * see the latest value without tearing or stale-cache surprises.
+ *
+ * The cache is intentionally process-only — it is NOT persisted across
+ * process death. nodejs-mobile + the foreground service keep the process
+ * alive in normal operation; on cold start the user signs once and the
+ * cache repopulates.
+ *
+ * ## Stale-token retry
+ *
+ * If the wallet has revoked the auth token on its side (user disconnect,
+ * wallet reinstall, time-out), the SDK surfaces a
+ * [JsonRpc20Client.JsonRpc20RemoteException] with code
+ * [ProtocolContract.ERROR_AUTHORIZATION_FAILED] (-1). When [isStaleAuthError]
+ * detects that, both caches are cleared and the operation is retried
+ * exactly ONCE so the user only sees a single wallet popup rather than
+ * an opaque failure.
+ */
 object SolanaWalletManager {
     private const val TAG = "SolanaWallet"
 
-    private val walletAdapter = MobileWalletAdapter(
+    /**
+     * Indirection over [MobileWalletAdapter] so unit tests can supply a
+     * fake. Production wiring is [RealMwaCore]; tests swap in a scripted
+     * fake before exercising [authorize] / [signTransaction] /
+     * [signAndSendTransaction].
+     */
+    internal interface MwaCore {
+        var authToken: String?
+        /**
+         * `sender` is nullable on the interface to let unit tests pass
+         * `null` (constructing a real [ActivityResultSender] requires a
+         * `ComponentActivity` which is unavailable in pure JVM tests).
+         * The production [RealMwaCore] enforces non-null at runtime.
+         */
+        suspend fun <T> transact(
+            sender: ActivityResultSender?,
+            signInPayload: SignInWithSolana.Payload? = null,
+            block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+        ): TransactionResult<T>
+    }
+
+    /** Default production [MwaCore] that delegates straight to the real SDK adapter. */
+    internal class RealMwaCore(private val adapter: MobileWalletAdapter) : MwaCore {
+        override var authToken: String?
+            get() = adapter.authToken
+            set(value) { adapter.authToken = value }
+
+        override suspend fun <T> transact(
+            sender: ActivityResultSender?,
+            signInPayload: SignInWithSolana.Payload?,
+            block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+        ): TransactionResult<T> {
+            val realSender = requireNotNull(sender) { "ActivityResultSender required for real MWA transact" }
+            return adapter.transact(realSender, signInPayload, block)
+        }
+    }
+
+    private fun buildAdapter(): MobileWalletAdapter = MobileWalletAdapter(
         connectionIdentity = ConnectionIdentity(
             identityUri = Uri.parse("https://seekerclaw.xyz"),
             iconUri = Uri.parse("favicon.ico"),
@@ -21,37 +104,85 @@ object SolanaWalletManager {
         blockchain = Solana.Mainnet
     }
 
-    // NOTE: Must be called from Dispatchers.Main — MWA's ActivityResultLauncher
-    // requires the main thread. The SDK handles its own IO threading internally.
+    /**
+     * Injectable seam. Constructed lazily so production `Uri.parse(...)`
+     * inside [buildAdapter] is not triggered during object init —
+     * important because (a) JVM unit tests never call into the real
+     * adapter, and (b) `Uri.parse` returns null under
+     * `unitTests.isReturnDefaultValues = true` which would crash
+     * `<clinit>` before tests get a chance to swap the seam.
+     *
+     * Tests assign [overrideCore] before invoking any public method.
+     */
+    private var overrideCore: MwaCore? = null
+    private val realCore: MwaCore by lazy { RealMwaCore(buildAdapter()) }
 
+    @VisibleForTesting
+    internal var core: MwaCore
+        get() = overrideCore ?: realCore
+        set(value) { overrideCore = value }
+
+    /**
+     * Process-local cached auth token. `null` means "no token yet —
+     * fall through to the fresh-authorize path". See class kdoc for
+     * the @Volatile rationale.
+     */
+    @Volatile
+    private var cachedAuthToken: String? = null
+
+    /** Test-only inspection of the cache. */
+    @VisibleForTesting
+    internal fun peekCachedAuthToken(): String? = cachedAuthToken
+
+    /** Test-only reset between tests. Clears cached token and the injected core override. */
+    @VisibleForTesting
+    internal fun resetForTest() {
+        cachedAuthToken = null
+        overrideCore = null
+    }
+
+    /**
+     * Explicit disconnect entry point — call this whenever the user
+     * disconnects, wipes the wallet, or the persisted wallet address
+     * is cleared. Drops both our process cache and the SDK's own copy
+     * so the next [authorize] call reliably triggers a fresh consent
+     * popup.
+     *
+     * **Threading:** call from the main thread. The function is non-
+     * suspend and runs synchronously; UI button `onClick` handlers
+     * already satisfy this. The `@Volatile cachedAuthToken` write is
+     * thread-safe regardless, but the SDK's `core.authToken` setter
+     * has no documented thread-safety guarantee, so do not call this
+     * concurrently with an in-flight transact on another thread.
+     */
+    fun clearAuthToken() {
+        val hadCached = cachedAuthToken != null
+        cachedAuthToken = null
+        core.authToken = null
+        if (hadCached) {
+            Log.i(TAG, "Clearing cached MWA authToken (explicit disconnect)")
+        }
+    }
+
+    /**
+     * Acquire / refresh an authorization. On a warm cache the SDK runs
+     * the silent reauthorize path and returns immediately with the same
+     * address; on a cold cache the user sees the wallet picker.
+     */
     suspend fun authorize(
         sender: ActivityResultSender,
+    ): Result<String> = authorizeInternal(sender)
+
+    @VisibleForTesting
+    internal suspend fun authorizeInternal(
+        sender: ActivityResultSender?,
     ): Result<String> {
-        return try {
-            val result = walletAdapter.transact(sender) { authResult ->
-                authResult.accounts.firstOrNull()?.publicKey
+        assertMainThread()
+        return runWithStaleRetry(op = "authorize") {
+            val result = primeAndTransact(sender) { authResult ->
+                Pair(authResult.authToken, authResult.accounts.firstOrNull()?.publicKey)
             }
-            when (result) {
-                is TransactionResult.Success -> {
-                    val pubKey = result.payload
-                    if (pubKey != null) {
-                        val base58 = org.sol4k.PublicKey(pubKey).toBase58()
-                        Log.i(TAG, "Wallet authorized: $base58")
-                        Result.success(base58)
-                    } else {
-                        Result.failure(Exception("No account returned from wallet"))
-                    }
-                }
-                is TransactionResult.NoWalletFound -> {
-                    Result.failure(Exception("No MWA-compatible wallet found. Install Phantom or Solflare."))
-                }
-                is TransactionResult.Failure -> {
-                    Result.failure(Exception(result.message))
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "MWA authorize failed", e)
-            Result.failure(e)
+            handlePubKeyResult(result, op = "authorize")
         }
     }
 
@@ -63,32 +194,21 @@ object SolanaWalletManager {
     suspend fun signAndSendTransaction(
         sender: ActivityResultSender,
         unsignedTransaction: ByteArray,
+    ): Result<ByteArray> = signAndSendTransactionInternal(sender, unsignedTransaction)
+
+    @VisibleForTesting
+    internal suspend fun signAndSendTransactionInternal(
+        sender: ActivityResultSender?,
+        unsignedTransaction: ByteArray,
     ): Result<ByteArray> {
-        return try {
-            val result = walletAdapter.transact(sender) { authResult ->
-                signAndSendTransactions(arrayOf(unsignedTransaction)).signatures.firstOrNull()
+        assertMainThread()
+        return runWithStaleRetry(op = "signAndSend") {
+            val result = primeAndTransact(sender) { authResult ->
+                val sig = signAndSendTransactions(arrayOf(unsignedTransaction))
+                    .signatures.firstOrNull()
+                Pair(authResult.authToken, sig)
             }
-            when (result) {
-                is TransactionResult.Success -> {
-                    val sig = result.payload
-                    if (sig != null) {
-                        Log.i(TAG, "Transaction signed and sent (${sig.size} bytes)")
-                        Result.success(sig)
-                    } else {
-                        Result.failure(Exception("No signature returned"))
-                    }
-                }
-                is TransactionResult.NoWalletFound -> {
-                    Result.failure(Exception("No MWA-compatible wallet found"))
-                }
-                is TransactionResult.Failure -> {
-                    Log.e(TAG, "MWA signAndSend failed: ${result.message}")
-                    Result.failure(Exception(result.message))
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "MWA signAndSend failed", e)
-            Result.failure(e)
+            handleByteArrayResult(result, op = "signAndSend", emptyLabel = "No signature returned")
         }
     }
 
@@ -100,32 +220,198 @@ object SolanaWalletManager {
     suspend fun signTransaction(
         sender: ActivityResultSender,
         unsignedTransaction: ByteArray,
+    ): Result<ByteArray> = signTransactionInternal(sender, unsignedTransaction)
+
+    @VisibleForTesting
+    internal suspend fun signTransactionInternal(
+        sender: ActivityResultSender?,
+        unsignedTransaction: ByteArray,
     ): Result<ByteArray> {
-        return try {
-            val result = walletAdapter.transact(sender) { authResult ->
-                signTransactions(arrayOf(unsignedTransaction)).signedPayloads.firstOrNull()
+        assertMainThread()
+        return runWithStaleRetry(op = "sign") {
+            val result = primeAndTransact(sender) { authResult ->
+                val signed = signTransactions(arrayOf(unsignedTransaction))
+                    .signedPayloads.firstOrNull()
+                Pair(authResult.authToken, signed)
             }
-            when (result) {
-                is TransactionResult.Success -> {
-                    val signed = result.payload
-                    if (signed != null) {
-                        Log.i(TAG, "Transaction signed (${signed.size} bytes)")
-                        Result.success(signed)
-                    } else {
-                        Result.failure(Exception("No signed transaction returned"))
-                    }
-                }
-                is TransactionResult.NoWalletFound -> {
-                    Result.failure(Exception("No MWA-compatible wallet found"))
-                }
-                is TransactionResult.Failure -> {
-                    Log.e(TAG, "MWA sign failed: ${result.message}")
-                    Result.failure(Exception(result.message))
-                }
+            handleByteArrayResult(result, op = "sign", emptyLabel = "No signed transaction returned")
+        }
+    }
+
+    // ── internal helpers ───────────────────────────────────────────────
+
+    /**
+     * Hands the cached auth token to the SDK ONLY when it is non-null —
+     * Codex amendment #2: do not stomp the SDK's internal state with a
+     * `null` because that prevents the SDK from running its own
+     * reauthorize-by-handle path on edge cases, and surfaces a noisier
+     * connect flow on cold start.
+     *
+     * Logs which path is being taken (cached vs fresh) but NEVER logs
+     * the token value itself.
+     */
+    private suspend fun <T> primeAndTransact(
+        sender: ActivityResultSender?,
+        block: suspend AdapterOperations.(authResult: AuthorizationResult) -> Pair<String?, T>,
+    ): TransactionResult<Pair<String?, T>> {
+        val cached = cachedAuthToken
+        if (cached != null) {
+            core.authToken = cached
+            Log.i(TAG, "MWA call: reauthorize path (cached token present)")
+        } else {
+            Log.i(TAG, "MWA call: fresh authorize path (no cached token; SDK handles)")
+        }
+        return core.transact(sender, signInPayload = null, block = block)
+    }
+
+    /**
+     * Single-retry wrapper: if [block] surfaces [StaleAuthSignal] in its
+     * `Result.failure`, clear both caches and retry exactly once. Any
+     * other failure (user rejection, network, etc.) propagates unchanged.
+     *
+     * The sentinel is internal-only — it is never allowed to escape to
+     * the caller. If the retry attempt ALSO reports stale-auth (cache
+     * was cleared but the wallet still refuses), we surface a real,
+     * caller-meaningful [Exception] instead so downstream code never
+     * sees the private [StaleAuthSignal] type.
+     */
+    private suspend fun <R> runWithStaleRetry(
+        op: String,
+        block: suspend () -> Result<R>,
+    ): Result<R> {
+        val first = block()
+        if (first.exceptionOrNull() !is StaleAuthSignal) return first
+
+        Log.w(TAG, "$op: stale auth token detected, clearing cache and retrying once")
+        cachedAuthToken = null
+        core.authToken = null
+        val retry = block()
+        val retryError = retry.exceptionOrNull()
+        return if (retryError is StaleAuthSignal) {
+            // Double-stale: the retry itself was rejected. The sentinel must
+            // not leak — convert to a public-facing exception. This is the
+            // user-revoked-during-retry / wallet-uninstalled scenario.
+            Log.e(TAG, "$op: stale auth retry also failed; surfacing caller-facing failure")
+            Result.failure(Exception("Authorization failed after retry (${retryError.message})"))
+        } else {
+            retry
+        }
+    }
+
+    /** Sentinel exception used internally to flag "this failure was stale-auth, retry it". */
+    private class StaleAuthSignal(message: String) : Exception(message)
+
+    private fun handlePubKeyResult(
+        result: TransactionResult<Pair<String?, ByteArray?>>,
+        op: String,
+    ): Result<String> = when (result) {
+        is TransactionResult.Success -> {
+            val (freshToken, pubKey) = result.payload!!
+            refreshCache(freshToken)
+            if (pubKey != null) {
+                val base58 = org.sol4k.PublicKey(pubKey).toBase58()
+                Log.i(TAG, "Wallet authorized: $base58")
+                Result.success(base58)
+            } else {
+                Result.failure(Exception("No account returned from wallet"))
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "MWA sign failed", e)
-            Result.failure(e)
+        }
+        is TransactionResult.NoWalletFound -> {
+            Result.failure(Exception("No MWA-compatible wallet found. Install Phantom or Solflare."))
+        }
+        is TransactionResult.Failure -> {
+            if (isStaleAuthError(result)) {
+                Result.failure(StaleAuthSignal(result.message))
+            } else {
+                Log.e(TAG, "MWA $op failed: ${result.message}")
+                Result.failure(Exception(result.message, result.e))
+            }
+        }
+    }
+
+    private fun handleByteArrayResult(
+        result: TransactionResult<Pair<String?, ByteArray?>>,
+        op: String,
+        emptyLabel: String,
+    ): Result<ByteArray> = when (result) {
+        is TransactionResult.Success -> {
+            val (freshToken, bytes) = result.payload!!
+            refreshCache(freshToken)
+            if (bytes != null) {
+                Log.i(TAG, "MWA $op: ${bytes.size} bytes")
+                Result.success(bytes)
+            } else {
+                Result.failure(Exception(emptyLabel))
+            }
+        }
+        is TransactionResult.NoWalletFound -> {
+            Result.failure(Exception("No MWA-compatible wallet found"))
+        }
+        is TransactionResult.Failure -> {
+            if (isStaleAuthError(result)) {
+                Result.failure(StaleAuthSignal(result.message))
+            } else {
+                Log.e(TAG, "MWA $op failed: ${result.message}")
+                Result.failure(Exception(result.message, result.e))
+            }
+        }
+    }
+
+    private fun refreshCache(freshToken: String?) {
+        if (freshToken != null) {
+            cachedAuthToken = freshToken
+        }
+    }
+
+    /**
+     * Centralized stale-auth detection. Two paths:
+     *
+     *  1. Typed exception: walks [TransactionResult.Failure.e] and up to
+     *     two `cause` links looking for a
+     *     [JsonRpc20Client.JsonRpc20RemoteException] with
+     *     `code == [ProtocolContract.ERROR_AUTHORIZATION_FAILED]` (-1).
+     *     This is the canonical path — the SDK puts the
+     *     `JsonRpc20RemoteException` directly in [TransactionResult.Failure.e],
+     *     but we walk the cause chain defensively in case a wrapper is
+     *     introduced upstream.
+     *
+     *  2. Message fallback: case-insensitive match against known stale-
+     *     auth phrases the SDK pre-translates into the message field.
+     *     This is a belt for the case where the typed shape changes in
+     *     a future SDK release.
+     */
+    @VisibleForTesting
+    internal fun isStaleAuthError(failure: TransactionResult.Failure<*>): Boolean {
+        // Path 1: typed JsonRpc20RemoteException (code -1) anywhere in the chain
+        var t: Throwable? = failure.e
+        var depth = 0
+        while (t != null && depth < 4) {
+            if (t is JsonRpc20Client.JsonRpc20RemoteException &&
+                t.code == ProtocolContract.ERROR_AUTHORIZATION_FAILED
+            ) {
+                return true
+            }
+            t = t.cause
+            depth++
+        }
+        // Path 2: known SDK-translated messages
+        val msg = failure.message.lowercase()
+        return STALE_AUTH_MESSAGE_HINTS.any { msg.contains(it) }
+    }
+
+    private val STALE_AUTH_MESSAGE_HINTS = listOf(
+        "auth token invalid",
+        "auth_token_not_valid",
+        "authorization failed",
+    )
+
+    private fun assertMainThread() {
+        // In pure JVM unit tests, Looper.getMainLooper() may return null
+        // (or its static stub may throw under default-values mode);
+        // skip the check then so tests don't have to fake the looper.
+        val main = try { Looper.getMainLooper() } catch (_: Throwable) { null } ?: return
+        check(Looper.myLooper() == main) {
+            "SolanaWalletManager must be called on Dispatchers.Main"
         }
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -94,6 +94,7 @@ import com.seekerclaw.app.config.searchProviderById
 import com.seekerclaw.app.qr.QrScannerActivity
 import com.seekerclaw.app.service.SeekerClawService
 import com.seekerclaw.app.solana.SolanaAuthActivity
+import com.seekerclaw.app.solana.SolanaWalletManager
 import com.seekerclaw.app.ui.theme.SeekerClawColors
 import com.seekerclaw.app.util.Analytics
 import com.seekerclaw.app.util.LogCollector
@@ -700,6 +701,12 @@ fun SettingsScreen(
                     Spacer(modifier = Modifier.height(12.dp))
                     OutlinedButton(
                         onClick = {
+                            // BAT-1021: clear the process-local MWA auth-token cache in
+                            // lockstep with the persisted wallet address so the next
+                            // connect attempt reliably triggers a fresh consent popup
+                            // (instead of silently reusing a stale token against a
+                            // wallet the user just disconnected from).
+                            SolanaWalletManager.clearAuthToken()
                             ConfigManager.clearWalletAddress(context)
                             walletAddress = null
                             walletError = null
@@ -1191,6 +1198,11 @@ fun SettingsScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
+                    // BAT-1021 same-class sweep: clearConfig clears the wallet
+                    // address as a side effect of clearing all prefs, so the
+                    // MWA auth-token cache must be cleared in lockstep — same
+                    // invariant as the Disconnect Wallet button.
+                    SolanaWalletManager.clearAuthToken()
                     SeekerClawService.stop(context)
                     ConfigManager.clearConfig(context)
                     Analytics.featureUsed("config_reset")

--- a/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
@@ -255,6 +255,56 @@ class SolanaWalletManagerTest {
     }
 
     @Test
+    fun `Copilot R-next-3 — double-stale preserves original JsonRpc cause through retry`() = runBlocking {
+        // Regression-catcher for Copilot R3 findings #3367468687/693/697/706:
+        // StaleAuthSignal used to drop the original cause (TransactionResult.Failure.e),
+        // and the double-stale conversion at runWithStaleRetry then surfaced a
+        // public Exception with NO cause attached. Crash reports / diagnostics
+        // lost the real JsonRpc20RemoteException. The fix carries the cause
+        // through the sentinel and reattaches it at the public-exception layer.
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        val baseline = fake.transactCalls
+
+        val staleA = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid (A)",
+            null,
+        )
+        val rootCauseB = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid (B)",
+            "root-cause-B-data",
+        )
+        fake.queueFailure(message = "Auth token invalid (A)", e = staleA)
+        fake.queueFailure(message = "Auth token invalid (B)", e = rootCauseB)
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue(result.isFailure)
+        val err = result.exceptionOrNull()
+        assertNotNull(err)
+        val errNonNull = err!!
+        // Public exception type — NOT the private sentinel:
+        assertFalse(
+            "must not leak StaleAuthSignal type",
+            errNonNull::class.java.simpleName == "StaleAuthSignal",
+        )
+        // The whole point of this fix: the JsonRpc20RemoteException from the
+        // retry attempt must be reachable via the cause chain so logs / crash
+        // reports see the real failure source.
+        assertEquals(
+            "public exception must carry the retry's underlying JsonRpc cause",
+            rootCauseB,
+            errNonNull.cause,
+        )
+        assertEquals(2, fake.transactCalls - baseline)
+    }
+
+    @Test
     fun `Copilot R-next-1 — transact throwing is converted to Failure not crash`() = runBlocking {
         // Regression-catcher for Copilot R1 finding #3367435964:
         // primeAndTransact used to call core.transact(...) without a try/catch,
@@ -567,10 +617,12 @@ class SolanaWalletManagerTest {
         val result = SolanaWalletManager.authorizeInternal(sender = null)
 
         assertTrue(result.isFailure)
-        val msg = result.exceptionOrNull()?.message ?: fail("expected error message")
+        val msg = result.exceptionOrNull()?.message
+        assertNotNull("expected error message", msg)
+        val msgNonNull = msg!!
         assertTrue(
-            "should mention installing a wallet, got: $msg",
-            (msg as String).contains("Phantom") || msg.contains("wallet"),
+            "should mention installing a wallet, got: $msgNonNull",
+            msgNonNull.contains("Phantom") || msgNonNull.contains("wallet"),
         )
     }
 }

--- a/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.util.ArrayDeque

--- a/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.util.ArrayDeque
+import java.util.Locale
 
 /**
  * Unit tests for [SolanaWalletManager]. Follow the project's no-mocking
@@ -244,13 +245,111 @@ class SolanaWalletManagerTest {
         // so diagnostics can still see what went wrong.
         assertTrue(
             "caller-facing exception should mention 'after retry'",
-            (errNonNull.message ?: "").lowercase().contains("after retry"),
+            (errNonNull.message ?: "").lowercase(Locale.ROOT).contains("after retry"),
         )
         // Exactly TWO transact calls: original + one retry (no recursion):
         assertEquals(2, fake.transactCalls - baseline)
         // Both caches cleared by the retry path:
         assertNull(SolanaWalletManager.peekCachedAuthToken())
         assertNull(fake.authToken)
+    }
+
+    @Test
+    fun `Copilot R-next-1 — transact throwing is converted to Failure not crash`() = runBlocking {
+        // Regression-catcher for Copilot R1 finding #3367435964:
+        // primeAndTransact used to call core.transact(...) without a try/catch,
+        // so any throw from the MWA SDK (or RealMwaCore's requireNotNull(sender),
+        // or main-thread registration failure) would bypass Result.failure AND
+        // the stale-retry wrapper. The fix wraps the call in try/catch and
+        // surfaces the throw as TransactionResult.Failure for uniform handling.
+        val throwingFake = object : SolanaWalletManager.MwaCore {
+            override var authToken: String? = null
+            override suspend fun <T> transact(
+                sender: ActivityResultSender?,
+                signInPayload: SignInWithSolana.Payload?,
+                block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+            ): TransactionResult<T> {
+                throw IllegalStateException("MWA SDK exploded")
+            }
+        }
+        SolanaWalletManager.core = throwingFake
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        // Must surface as a clean Result.failure, NOT a crash:
+        assertTrue("throwing transact must surface as failure", result.isFailure)
+        val err = result.exceptionOrNull()
+        assertNotNull(err)
+        assertTrue(
+            "error should preserve the original throw message",
+            (err!!.message ?: "").contains("MWA SDK exploded"),
+        )
+    }
+
+    @Test
+    fun `Copilot R-next-1 — signAndSend NoWalletFound message mentions Phantom-or-Solflare`() = runBlocking {
+        // Regression-catcher for Copilot R1 finding #3367435980:
+        // handleByteArrayResult used to surface "No MWA-compatible wallet found"
+        // while handlePubKeyResult said "...Install Phantom or Solflare." The
+        // user-facing strings are now aligned across all three entry points.
+        val noWalletFake = object : SolanaWalletManager.MwaCore {
+            override var authToken: String? = null
+            override suspend fun <T> transact(
+                sender: ActivityResultSender?,
+                signInPayload: SignInWithSolana.Payload?,
+                block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+            ): TransactionResult<T> = TransactionResult.NoWalletFound("none")
+        }
+        SolanaWalletManager.core = noWalletFake
+
+        val sendResult = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+        assertTrue(sendResult.isFailure)
+        val sendMsg = sendResult.exceptionOrNull()?.message ?: ""
+        assertTrue(
+            "signAndSend NoWalletFound must mention Phantom/Solflare like authorize does; got: $sendMsg",
+            sendMsg.contains("Phantom") || sendMsg.contains("Solflare"),
+        )
+
+        val signResult = SolanaWalletManager.signTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+        assertTrue(signResult.isFailure)
+        val signMsg = signResult.exceptionOrNull()?.message ?: ""
+        assertTrue(
+            "signTransaction NoWalletFound must mention Phantom/Solflare; got: $signMsg",
+            signMsg.contains("Phantom") || signMsg.contains("Solflare"),
+        )
+    }
+
+    @Test
+    fun `Copilot R-next-1 — isStaleAuthError uses Locale ROOT for Turkish-safe lowercase`() {
+        // Regression-catcher for Copilot R1 finding #3367435983:
+        // String.lowercase() is locale-dependent — in Turkish, lowercase('I')
+        // is 'ı' (dotless), so "AUTH TOKEN INVALID".lowercase() would
+        // produce "auth token ınvalıd" and miss the contains check. The fix
+        // pins lowercase(Locale.ROOT). Verify by temporarily setting the
+        // default locale to Turkish and confirming the helper still matches.
+        val savedLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale("tr", "TR"))
+            val failure = TransactionResult.Failure<Unit>(
+                "Wallet returned: AUTH TOKEN INVALID",
+                Exception("generic"),
+            )
+            assertTrue(
+                "isStaleAuthError must still detect stale-auth under Turkish locale",
+                SolanaWalletManager.isStaleAuthError(failure),
+            )
+        } finally {
+            Locale.setDefault(savedLocale)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
@@ -1,0 +1,477 @@
+package com.seekerclaw.app.solana
+
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
+import com.solana.mobilewalletadapter.clientlib.AdapterOperations
+import com.solana.mobilewalletadapter.clientlib.TransactionResult
+import com.solana.mobilewalletadapter.clientlib.protocol.JsonRpc20Client
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizationResult
+import com.solana.mobilewalletadapter.common.ProtocolContract
+import com.solana.mobilewalletadapter.common.signin.SignInWithSolana
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.util.ArrayDeque
+
+/**
+ * Unit tests for [SolanaWalletManager]. Follow the project's no-mocking
+ * convention — hand-rolled [FakeMwaCore] + the `core` injection seam +
+ * `resetForTest()`.
+ *
+ * Tests exercise the public [authorizeInternal] / [signTransactionInternal]
+ * / [signAndSendTransactionInternal] entry points (which accept a
+ * nullable [ActivityResultSender] so we don't need a [ComponentActivity]
+ * in pure JVM tests). The public non-nullable variants just delegate to
+ * these and are covered by the underlying logic tests.
+ */
+class SolanaWalletManagerTest {
+
+    /**
+     * Scriptable fake. Each call to [transact] pops the next result from
+     * [queued] and returns it (casting from `Pair<String?, Any?>` to the
+     * caller's `T`).
+     *
+     * Captures every write to [authToken] in [authTokenWrites] (ordered)
+     * AND records the value seen at the time of each `transact` call in
+     * [transactSeenTokens] so tests can assert the token was set BEFORE
+     * the call.
+     */
+    class FakeMwaCore : SolanaWalletManager.MwaCore {
+        private val storedAuthToken = arrayOfNulls<String?>(1)
+        val authTokenWrites = mutableListOf<String?>()
+        val transactSeenTokens = mutableListOf<String?>()
+        val queued: ArrayDeque<TransactionResult<Pair<String?, Any?>>> = ArrayDeque()
+        var transactCalls: Int = 0
+
+        override var authToken: String?
+            get() = storedAuthToken[0]
+            set(value) {
+                storedAuthToken[0] = value
+                authTokenWrites += value
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <T> transact(
+            sender: ActivityResultSender?,
+            signInPayload: SignInWithSolana.Payload?,
+            block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+        ): TransactionResult<T> {
+            transactCalls++
+            transactSeenTokens += storedAuthToken[0]
+            check(queued.isNotEmpty()) { "FakeMwaCore: no queued result for transact call #$transactCalls" }
+            return queued.removeFirst() as TransactionResult<T>
+        }
+
+        fun queueSuccess(token: String, payload: Any?) {
+            queued.addLast(TransactionResult.Success(Pair<String?, Any?>(token, payload)))
+        }
+
+        fun queueFailure(message: String, e: Exception) {
+            queued.addLast(TransactionResult.Failure<Pair<String?, Any?>>(message, e))
+        }
+    }
+
+    private lateinit var fake: FakeMwaCore
+
+    @Before
+    fun setUp() {
+        SolanaWalletManager.resetForTest()
+        fake = FakeMwaCore()
+        SolanaWalletManager.core = fake
+    }
+
+    @After
+    fun tearDown() {
+        SolanaWalletManager.resetForTest()
+    }
+
+    // ── authorize ──────────────────────────────────────────────────────
+
+    @Test
+    fun `authorize cold cache routes through fresh path and caches returned token`() = runBlocking {
+        // Cold start: no cached token. The fake returns Success with a fresh token "T1".
+        // (Pub key = empty byte array; we only care that the cache is updated to T1.)
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+
+        val result = SolanaWalletManager.authorizeInternal(sender = null)
+
+        // Result is a success (no JSON parse, just an address string from sol4k):
+        assertTrue("authorize should succeed on Success result", result.isSuccess)
+        // The fake's auth token was NOT pre-set (cold), so transact saw null:
+        assertEquals(listOf<String?>(null), fake.transactSeenTokens)
+        // Exactly one transact call happened:
+        assertEquals(1, fake.transactCalls)
+        // Cache now holds T1:
+        assertEquals("T1", SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    @Test
+    fun `authorize warm cache primes core authToken before transact (no null overwrite)`() = runBlocking {
+        // Pre-warm by running one successful authorize first:
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+
+        // Reset the fake's observation buffers but KEEP the cached token (T1):
+        fake.authTokenWrites.clear()
+        fake.transactSeenTokens.clear()
+        fake.transactCalls = 0
+
+        // Second call returns a NEW token T2 from the wallet:
+        fake.queueSuccess(token = "T2", payload = ByteArray(32))
+
+        val result = SolanaWalletManager.authorizeInternal(sender = null)
+
+        assertTrue(result.isSuccess)
+        // Critical: BEFORE the second transact call, core.authToken was set to T1
+        // (the cached value). It was NOT null. This is the Codex amendment #2
+        // guarantee — never null-overwrite the SDK state.
+        assertEquals(listOf<String?>("T1"), fake.transactSeenTokens)
+        // And the cache was refreshed to T2 on success:
+        assertEquals("T2", SolanaWalletManager.peekCachedAuthToken())
+        // The write log should contain T1 (we set it before transact) but no nulls
+        // injected by the wrapper code itself:
+        assertFalse(
+            "Wrapper must never null-overwrite the SDK's authToken on the warm path",
+            fake.authTokenWrites.contains(null)
+        )
+        assertTrue("T1 should have been written before the transact call", fake.authTokenWrites.contains("T1"))
+    }
+
+    // ── stale-token retry ──────────────────────────────────────────────
+
+    @Test
+    fun `signAndSend retries exactly once when SDK surfaces JsonRpc auth-failed exception`() = runBlocking {
+        // Warm up cache to T1:
+        SolanaWalletManager.core = fake
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+
+        // Reset counters:
+        val baseline = fake.transactCalls
+
+        // First signAndSend: Failure with typed JsonRpc20RemoteException, code = -1
+        val staleExc = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid",
+            null,
+        )
+        fake.queueFailure(message = "Auth token invalid", e = staleExc)
+        // Retry: Success with fresh token T2 and a signature payload
+        val sigPayload = ByteArray(64) { 0x7F }
+        fake.queueSuccess(token = "T2", payload = sigPayload)
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue("stale-auth retry should yield success", result.isSuccess)
+        assertEquals(sigPayload.toList(), result.getOrThrow().toList())
+        // Exactly TWO transact calls happened (original + retry):
+        assertEquals(2, fake.transactCalls - baseline)
+        // Cache was refreshed to T2 after retry success:
+        assertEquals("T2", SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    @Test
+    fun `signAndSend retries on plain message stale-auth signal (no typed exception)`() = runBlocking {
+        // Warm cache:
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        val baseline = fake.transactCalls
+
+        // No JsonRpc exception, just the SDK-translated message:
+        fake.queueFailure(message = "Auth token invalid", e = Exception("plain wrapper"))
+        // Retry returns success:
+        val sigPayload = ByteArray(64)
+        fake.queueSuccess(token = "T2", payload = sigPayload)
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, fake.transactCalls - baseline)
+        assertEquals("T2", SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    @Test
+    fun `signAndSend double-stale converts sentinel to caller-facing exception (never leaks StaleAuthSignal)`() = runBlocking {
+        // Pre-push code review found: when the retry attempt ALSO surfaces
+        // stale-auth, the previous implementation returned `block()` directly,
+        // which contained the private StaleAuthSignal sentinel — leaking an
+        // internal type to callers. Regression-catcher: BOTH attempts return
+        // stale-auth → result must be a plain Exception, NOT StaleAuthSignal.
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        val baseline = fake.transactCalls
+
+        val staleA = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid (A)",
+            null,
+        )
+        val staleB = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid (B)",
+            null,
+        )
+        fake.queueFailure(message = "Auth token invalid (A)", e = staleA)
+        fake.queueFailure(message = "Auth token invalid (B)", e = staleB)
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue("double-stale must surface as failure", result.isFailure)
+        val err = result.exceptionOrNull()
+        assertNotNull("expected non-null exception", err)
+        val errNonNull = err!!
+        // The whole point: the internal sentinel class must NOT leak.
+        assertFalse(
+            "double-stale must NOT surface the private StaleAuthSignal sentinel; got ${errNonNull::class.java}",
+            errNonNull::class.java.simpleName == "StaleAuthSignal",
+        )
+        // Must be a plain Exception, with the retry error's message threaded through
+        // so diagnostics can still see what went wrong.
+        assertTrue(
+            "caller-facing exception should mention 'after retry'",
+            (errNonNull.message ?: "").lowercase().contains("after retry"),
+        )
+        // Exactly TWO transact calls: original + one retry (no recursion):
+        assertEquals(2, fake.transactCalls - baseline)
+        // Both caches cleared by the retry path:
+        assertNull(SolanaWalletManager.peekCachedAuthToken())
+        assertNull(fake.authToken)
+    }
+
+    @Test
+    fun `signAndSend non-auth failure surfaces directly with no retry`() = runBlocking {
+        // Warm cache:
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        val baseline = fake.transactCalls
+
+        // User rejection is not stale-auth — must NOT retry:
+        fake.queueFailure(message = "User rejected", e = Exception("rejected"))
+
+        val result = SolanaWalletManager.signAndSendTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue("non-auth failure should propagate as failure", result.isFailure)
+        assertEquals("User rejected", result.exceptionOrNull()?.message)
+        // Only ONE transact call — no retry:
+        assertEquals(1, fake.transactCalls - baseline)
+        // And the cache is NOT cleared on a non-auth failure:
+        assertEquals("T1", SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    // ── clearAuthToken ─────────────────────────────────────────────────
+
+    @Test
+    fun `clearAuthToken nulls both the local cache and the SDK auth token`() = runBlocking {
+        // Two successful authorizes — second one triggers the warm path
+        // which calls fake.authToken = "T1" via primeAndTransact, so the
+        // SDK side actually holds a value to clear:
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        assertEquals("T1", SolanaWalletManager.peekCachedAuthToken())
+        assertEquals("warm path should have written T1 to the SDK", "T1", fake.authToken)
+
+        SolanaWalletManager.clearAuthToken()
+
+        assertNull("local cache must be cleared", SolanaWalletManager.peekCachedAuthToken())
+        // The fake's last authToken write should be null (from clearAuthToken's core.authToken = null):
+        assertEquals("SDK authToken must be reset", null, fake.authToken)
+    }
+
+    // ── isStaleAuthError (centralized helper) ──────────────────────────
+
+    @Test
+    fun `isStaleAuthError detects JsonRpc auth-failed code directly`() {
+        val failure = TransactionResult.Failure<Unit>(
+            "Auth token invalid",
+            JsonRpc20Client.JsonRpc20RemoteException(
+                ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+                "Auth token invalid",
+                null,
+            ),
+        )
+        assertTrue(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    @Test
+    fun `isStaleAuthError detects message-based stale signal (case-insensitive)`() {
+        val failure = TransactionResult.Failure<Unit>(
+            "AUTH TOKEN INVALID",
+            Exception("not a JsonRpc one"),
+        )
+        assertTrue(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    @Test
+    fun `isStaleAuthError walks cause chain to find JsonRpc auth-failed`() {
+        val inner = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "deep",
+            null,
+        )
+        // Wrap two deep — depth=2:
+        val wrapped = Exception("layer-1", Exception("layer-2", inner))
+        val failure = TransactionResult.Failure<Unit>("opaque message", wrapped)
+        assertTrue(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    @Test
+    fun `isStaleAuthError returns false on non-auth JsonRpc error code`() {
+        val failure = TransactionResult.Failure<Unit>(
+            "payload invalid",
+            JsonRpc20Client.JsonRpc20RemoteException(
+                -2, // ERROR_INVALID_PAYLOADS — not stale auth
+                "payload invalid",
+                null,
+            ),
+        )
+        assertFalse(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    @Test
+    fun `isStaleAuthError returns false on generic exception with unrelated message`() {
+        val failure = TransactionResult.Failure<Unit>(
+            "Network error",
+            Exception("timeout"),
+        )
+        assertFalse(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    @Test
+    fun `isStaleAuthError matches authorization failed phrase from message fallback`() {
+        val failure = TransactionResult.Failure<Unit>(
+            "Wallet returned: authorization failed",
+            Exception("generic"),
+        )
+        assertTrue(SolanaWalletManager.isStaleAuthError(failure))
+    }
+
+    // ── log-leak guard (defense-in-depth on Codex amendment) ───────────
+
+    @Test
+    fun `wrapper never writes the cached token value into android Log`() = runBlocking {
+        // android.util.Log no-ops in unit tests (isReturnDefaultValues=true)
+        // so we cannot intercept its output. We instead assert structurally:
+        // the wrapper's only contact with the token is via the `core.authToken`
+        // setter — there is no Log.* call that takes the cached value.
+        //
+        // FakeMwaCore captures every authToken write; we run a full
+        // warm-then-stale-retry sequence and verify that the only tokens
+        // ever observed by Log would have been read from
+        // `fake.authTokenWrites` — i.e. the test exercises every code path
+        // where a leak could happen, and we confirm via authTokenWrites
+        // capture that the wrapper's interaction with the token is
+        // confined to the setter contract.
+        //
+        // (Source review: see SolanaWalletManager.kt — every Log.i/Log.w/
+        // Log.e site logs a fixed message, a byte count, or a base58 pubkey
+        // — NEVER the raw cached token.)
+
+        fake.queueSuccess(token = "TOKEN_SECRET_A", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+
+        // stale retry round:
+        val stale = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid",
+            null,
+        )
+        fake.queueFailure("Auth token invalid", stale)
+        fake.queueSuccess(token = "TOKEN_SECRET_B", payload = ByteArray(64))
+        SolanaWalletManager.signAndSendTransactionInternal(null, ByteArray(10))
+
+        // Structural assertion: the wrapper only ever writes tokens it received
+        // back to core.authToken via the SDK contract. It never echoes them
+        // anywhere else. The set of values written to authToken is exactly:
+        //   TOKEN_SECRET_A (priming the second call with the cached token)
+        //   null           (stale-retry clears)
+        // TOKEN_SECRET_B is only written to the LOCAL cache (refreshCache),
+        // not to core.authToken — the SDK would do that itself on a real call.
+        val seen = fake.authTokenWrites.toSet()
+        assertTrue("primed token must hit the SDK", seen.contains("TOKEN_SECRET_A"))
+        assertTrue("stale-retry must clear core.authToken to null", seen.contains(null))
+        // Final cache value is TOKEN_SECRET_B (the most recent Success refresh):
+        assertEquals("TOKEN_SECRET_B", SolanaWalletManager.peekCachedAuthToken())
+
+        // No assertion can fully prove a negative ("token never logged") from
+        // unit tests because android.util.Log is stubbed. The real guarantee
+        // comes from source review — see the kdoc on primeAndTransact:
+        // Log.i takes a fixed-message literal, not the token value. This
+        // test guarantees the structural invariant; CSO review covers the
+        // string-literal invariant in source.
+        assertNotNull(SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    @Test
+    fun `signTransaction follows the same stale-retry contract as signAndSend`() = runBlocking {
+        // Warm cache:
+        fake.queueSuccess(token = "T1", payload = ByteArray(32))
+        SolanaWalletManager.authorizeInternal(sender = null)
+        val baseline = fake.transactCalls
+
+        val staleExc = JsonRpc20Client.JsonRpc20RemoteException(
+            ProtocolContract.ERROR_AUTHORIZATION_FAILED,
+            "Auth token invalid",
+            null,
+        )
+        fake.queueFailure("Auth token invalid", staleExc)
+        val signedBytes = ByteArray(200)
+        fake.queueSuccess(token = "T2", payload = signedBytes)
+
+        val result = SolanaWalletManager.signTransactionInternal(
+            sender = null,
+            unsignedTransaction = ByteArray(10),
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(signedBytes.size, result.getOrThrow().size)
+        assertEquals(2, fake.transactCalls - baseline)
+        assertEquals("T2", SolanaWalletManager.peekCachedAuthToken())
+    }
+
+    @Test
+    fun `authorize fails cleanly when wallet returns NoWalletFound`() = runBlocking {
+        // No fake.queueSuccess — instead inject a NoWalletFound result via a
+        // micro-extension of the fake (override transact for one shot):
+        val customFake = object : SolanaWalletManager.MwaCore {
+            override var authToken: String? = null
+            override suspend fun <T> transact(
+                sender: ActivityResultSender?,
+                signInPayload: SignInWithSolana.Payload?,
+                block: suspend AdapterOperations.(authResult: AuthorizationResult) -> T,
+            ): TransactionResult<T> {
+                @Suppress("UNCHECKED_CAST")
+                return TransactionResult.NoWalletFound<T>("No wallet installed")
+            }
+        }
+        SolanaWalletManager.core = customFake
+
+        val result = SolanaWalletManager.authorizeInternal(sender = null)
+
+        assertTrue(result.isFailure)
+        val msg = result.exceptionOrNull()?.message ?: fail("expected error message")
+        assertTrue(
+            "should mention installing a wallet, got: $msg",
+            (msg as String).contains("Phantom") || msg.contains("wallet"),
+        )
+    }
+}

--- a/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/solana/SolanaWalletManagerTest.kt
@@ -163,7 +163,7 @@ class SolanaWalletManagerTest {
         )
         fake.queueFailure(message = "Auth token invalid", e = staleExc)
         // Retry: Success with fresh token T2 and a signature payload
-        val sigPayload = ByteArray(64) { 0x7F }
+        val sigPayload = ByteArray(64) { 0x7F.toByte() }
         fake.queueSuccess(token = "T2", payload = sigPayload)
 
         val result = SolanaWalletManager.signAndSendTransactionInternal(


### PR DESCRIPTION
## Summary

Phantom silently drops MWA `sign_and_send` JSON-RPC calls when they arrive in a fresh MWA session shortly after a successful authorize — treating it as the same dApp re-asking for consent the user just granted. SeekerClaw previously did this on every signature: fresh authorize → fresh sign session, ~286ms apart. Result: 30s silent timeout, no sign sheet rendered, error "Local association was cancelled before connected".

This **blocks all BAT-1013 (PR #398) Phase 2-7 device tests** — every test path eventually routes through MWA.

**Fix:** Cache the `authToken` returned from successful `MobileWalletAdapter.transact()` in a process-local `@Volatile` field and pass it back before subsequent calls so the SDK uses its silent reauthorize path. On wallet-side revocation, detect via `JsonRpc20RemoteException.code == ERROR_AUTHORIZATION_FAILED` (with message-string fallback), clear both caches, and retry exactly ONCE — exposing a clean error if the retry also fails (no private sentinel leak).

Linear: [BAT-1021](https://linear.app/batcave/issue/BAT-1021)

## Codex sign-off

Approved with 7 amendments (all addressed). See ticket for the full review thread.

| # | Amendment | Status |
|---|---|---|
| 1 | Root cause framing — implicit SDK state, not "SDK doesn't cache" | ✅ |
| 2 | No null-overwrite of SDK state — conditional assignment only | ✅ enforced in `primeAndTransact` |
| 3 | Code-first stale detection — JsonRpc code, message fallback | ✅ `isStaleAuthError` walks Failure.e + cause chain |
| 4 | Real testing seam — interface + fake, not just helper tests | ✅ `MwaCore` + `FakeMwaCore` + `@VisibleForTesting var core` |
| 5 | Main-thread guard — explicit assertion at each public entry | ✅ `assertMainThread()` with JVM-test safety |
| 6 | Cross-process scope acknowledged — cache process-local | ✅ device test plan covers bridge-driven authorize → sign |
| 7 | Logs redacted — path-only labels, no token values | ✅ |

## Implementation contract

**Single file rewrite** (`SolanaWalletManager.kt`, 131 → 412 lines):

- `internal interface MwaCore` over `MobileWalletAdapter` surface. `RealMwaCore` delegates to the SDK; tests inject `FakeMwaCore`.
- `@Volatile private var cachedAuthToken: String?` — process-local, NOT persisted (encrypted-prefs persistence is a future BAT).
- `primeAndTransact` sets `core.authToken = cachedAuthToken` **only when non-null** (Codex amendment #2).
- `runWithStaleRetry` detects stale-auth, clears caches, retries once. If retry ALSO returns stale-auth, converts private `StaleAuthSignal` sentinel to public `Exception("Authorization failed after retry (...)")` so internal types never leak.
- `fun clearAuthToken()` for explicit disconnect — clears local cache AND `core.authToken`.
- Path-only logs ("reauthorize path" / "fresh authorize path"). No token values.
- Public method signatures unchanged → `SolanaAuthActivity` needs zero edits.

**Disconnect Wallet wiring** (`SettingsScreen.kt`):

- Disconnect Wallet button now calls `SolanaWalletManager.clearAuthToken()` before `ConfigManager.clearWalletAddress()`.
- Reset Config danger-zone button also calls `clearAuthToken()` before `ConfigManager.clearConfig()` (same-class sweep from R2 review — `clearConfig` does `.clear()` which removes wallet address as side effect).

## Test plan

### Unit tests (16 cases, all passing on JDK 21 / Gradle 8.13)

- [x] authorize cold cache → fresh path, caches T1
- [x] authorize warm cache → primes SDK with T1 BEFORE transact (FakeMwaCore asserts no-null-overwrite)
- [x] signAndSend stale-retry via typed `JsonRpc20RemoteException(code=-1)`
- [x] signAndSend stale-retry via plain message fallback
- [x] signAndSend **double-stale** → sentinel converts to caller-facing `Exception`, never escapes as `StaleAuthSignal`
- [x] signAndSend non-auth failure → no retry, cache preserved
- [x] clearAuthToken nulls both caches
- [x] isStaleAuthError parameterized: code-path, message case-insensitive, cause-chain depth 2, negative cases
- [x] log-leak guard (structural assertion)
- [x] signTransaction follows same stale-retry contract
- [x] NoWalletFound surfaces clean error mentioning Phantom/Solflare

Run via: `./gradlew :app:testDappStoreDebugUnitTest --tests com.seekerclaw.app.solana.SolanaWalletManagerTest`

### Validation

- [x] `bash scripts/pre-push-check.sh` → ALL CHECKS PASSED (Node smoke 68/68 + Kotlin `compileDappStoreDebugKotlin`)
- [x] Pre-push code review (feature-dev:code-reviewer) R1 found 2 blockers, fixed in same diff
- [x] Pre-push code review R2 found 1 same-class miss (Reset Config), fixed in same diff. Otherwise clean.
- [x] 5 pre-existing `CrossProcessStoreTest` failures verified unrelated via `git stash` baseline

### Device test (Seeker, after APK rebuild)

- [ ] Cold start → tap Connect Wallet → fresh authorize sheet renders, logcat `"fresh authorize path"`
- [ ] Warm cache → second Connect Wallet → NO sheet (or brief flash), logcat `"reauthorize path"`
- [ ] **PRIMARY REPRO** — Telegram `send 0.001 SOL from main to burner` → Phantom sign sheet renders + signature returns + NO 30s silent cancel
- [ ] Stale-token recovery: revoke connection in Phantom UI → retry swap → exactly 1 retry, fresh sheet, success
- [ ] Process-restart recovery: force-stop SeekerClaw → reopen → fresh authorize (cache is process-local)

## Known limitations

- Cache is process-local only — every cold start re-prompts the connect sheet once. Encrypted-prefs persistence is a follow-up BAT, deferred per Codex Q1 sign-off.
- Helper sentinel `StaleAuthSignal` is internal-only; double-stale converts to public `Exception` (test pins this contract).

## Blocks / blocked by

- **Blocks:** [BAT-1013](https://linear.app/batcave/issue/BAT-1013) Phase 2-7 device tests (PR #398).

## Self-Awareness Checklist (BAT-503)

- [x] N/A — pure infrastructure fix, no agent-visible capability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)