### PR TITLE
feat(skills): BAT-1035 generic priority frontmatter + narrow paysh-catalog triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
             solana-dca-routing \
             tx-parser \
             public-rpc-shaper \
+            skills-priority \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
+++ b/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paysh-catalog
-description: "Catalog of pay.sh services payable via agent_pay (x402). OPT-IN ONLY — activate when the user explicitly invokes pay.sh / paysh / x402 / 'pay for' / 'pay with burner', or asks what they can pay for. Stay dormant otherwise; defer to free tools. Full keyword list and policy in SKILL.md body."
+description: "Catalog of pay.sh services payable via agent_pay (x402). OPT-IN ONLY — activate when the user explicitly invokes pay.sh / paysh / x402 / 'pay for' / 'pay with burner', or asks what they can pay for. Stay dormant otherwise; defer to free tools. Activation triggers are the frontmatter `triggers:` list (authoritative); policy + examples in the SKILL.md body."
 version: "1.9.0"
 priority: 10
 triggers:

--- a/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
+++ b/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
@@ -36,12 +36,15 @@ This skill activates ONLY when the user's message contains one of the explicit p
 
 ### Opt-in keywords (skill activates)
 
-- `pay.sh` / `paysh` / `pay sh` — naming the platform
+The authoritative activation contract is the `triggers:` list in this file's frontmatter (BAT-1035). The skill activates only when the user's message contains one of those exact phrases:
+
+- `pay.sh` / `paysh` — naming the platform
 - `x402` — naming the protocol
-- `pay for X` / `pay to X` / `pay <amount> to <service>` / `use pay` — explicit paying verb
-- `look this up paid` / `fetch this paid` / `buy data from <service>` — explicit paid-fetch verb
-- `use <service> to pay` / `pay <service> for X` — service-name + paying verb
+- `pay with burner` — explicit burner-pay intent
+- `pay for` — explicit paying verb
 - `what can you pay for` / `show me pay.sh services` / `list paid services` — capability question
+
+Intentionally NOT triggers: `pay to <person>` (that is a normal SOL/SPL transfer — use `solana_send`, not a paid API) and `pay with main` (`agent_pay` settles from the burner only, never the main wallet). If a message is ambiguous, prefer the free path — paid lookups cost USDC and the user did not authorize a charge implicitly.
 
 ### NOT opt-in (skill stays dormant)
 

--- a/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
+++ b/app/src/main/assets/default-skills/paysh-catalog/SKILL.md
@@ -1,7 +1,17 @@
 ---
 name: paysh-catalog
-description: "Catalog of pay.sh services payable via agent_pay (x402). OPT-IN ONLY — activate when the user explicitly invokes pay.sh / paysh / x402 / 'pay for'. Stay dormant otherwise; defer to free tools. Full keyword list and policy in SKILL.md body."
-version: "1.8.0"
+description: "Catalog of pay.sh services payable via agent_pay (x402). OPT-IN ONLY — activate when the user explicitly invokes pay.sh / paysh / x402 / 'pay for' / 'pay with burner', or asks what they can pay for. Stay dormant otherwise; defer to free tools. Full keyword list and policy in SKILL.md body."
+version: "1.9.0"
+priority: 10
+triggers:
+  - "pay.sh"
+  - "paysh"
+  - "x402"
+  - "pay with burner"
+  - "pay for"
+  - "what can you pay for"
+  - "show me pay.sh services"
+  - "list paid services"
 metadata:
   openclaw:
     emoji: "🛒"

--- a/app/src/main/assets/nodejs-project/skills.js
+++ b/app/src/main/assets/nodejs-project/skills.js
@@ -237,9 +237,10 @@ function parseSkillFile(content, skillDir) {
             if (frontmatter.name) skill.name = frontmatter.name;
             if (frontmatter.description) skill.description = frontmatter.description;
             if (frontmatter.version) skill.version = frontmatter.version;
-            // BAT-1035: optional generic `priority` — a finite integer clamped
-            // to [-100, 100]; invalid / non-numeric / out-of-range collapse to
-            // the documented default. Drives the two-skill-cap selection in
+            // BAT-1035: optional generic `priority` — a finite integer. Absent
+            // / non-numeric / NaN / ±Infinity → 0 (the default); in-range
+            // fractional values truncate toward zero; out-of-range values clamp
+            // to [-100, 100]. Drives the two-skill-cap selection in
             // findMatchingSkills so an explicitly-authorized skill can outrank
             // directory load order without hard-coding any skill name.
             skill.priority = parseSkillPriority(frontmatter.priority);

--- a/app/src/main/assets/nodejs-project/skills.js
+++ b/app/src/main/assets/nodejs-project/skills.js
@@ -32,6 +32,11 @@ const { SKILLS_DIR, log, config, SHELL_ALLOWLIST } = require('./config');
  * ---
  * name: skill-name
  * description: "What it does"
+ * priority: 0        # optional: integer -100..100 (default 0). When more than
+ *                    # two skills match a message, the matcher keeps the two
+ *                    # highest-priority (ties broken by load order). Use a
+ *                    # higher value only for narrow, explicitly-authorized
+ *                    # triggers so a skill is not dropped by the 2-skill cap.
  * metadata:
  *   openclaw:
  *     emoji: "🔧"
@@ -186,6 +191,22 @@ function parseYamlLines(lines, parentIndent) {
 // SKILL FILE PARSING
 // ============================================================================
 
+// BAT-1035: parse the optional `priority` frontmatter field. Public frontmatter,
+// so the contract is explicit and stable: a finite integer clamped to
+// [-100, 100]; anything non-finite / non-numeric / absent → 0. We truncate
+// (not round) toward zero so "10.9" and "10" behave the same.
+const SKILL_PRIORITY_MIN = -100;
+const SKILL_PRIORITY_MAX = 100;
+function parseSkillPriority(raw) {
+    if (raw === undefined || raw === null) return 0;
+    const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+    if (!Number.isFinite(n)) return 0;
+    const i = Math.trunc(n);
+    if (i < SKILL_PRIORITY_MIN) return SKILL_PRIORITY_MIN;
+    if (i > SKILL_PRIORITY_MAX) return SKILL_PRIORITY_MAX;
+    return i;
+}
+
 function parseSkillFile(content, skillDir) {
     const skill = {
         name: '',
@@ -193,6 +214,7 @@ function parseSkillFile(content, skillDir) {
         description: '',
         instructions: '',
         version: '',
+        priority: 0,        // BAT-1035: generic matcher priority (-100..100); default 0
         tools: [],
         emoji: '',
         image: '',
@@ -215,6 +237,12 @@ function parseSkillFile(content, skillDir) {
             if (frontmatter.name) skill.name = frontmatter.name;
             if (frontmatter.description) skill.description = frontmatter.description;
             if (frontmatter.version) skill.version = frontmatter.version;
+            // BAT-1035: optional generic `priority` — a finite integer clamped
+            // to [-100, 100]; invalid / non-numeric / out-of-range collapse to
+            // the documented default. Drives the two-skill-cap selection in
+            // findMatchingSkills so an explicitly-authorized skill can outrank
+            // directory load order without hard-coding any skill name.
+            skill.priority = parseSkillPriority(frontmatter.priority);
             if (frontmatter.triggers) {
                 const parsed = toArray(frontmatter.triggers)
                     .map(t => String(t).trim().toLowerCase())
@@ -546,13 +574,26 @@ function loadSkills() {
 // ============================================================================
 
 function findMatchingSkills(message) {
-    const skills = loadSkills();
+    return selectMatchingSkills(loadSkills(), message);
+}
+
+// BAT-1035: pure collect-sort-slice over a given skills array — kept separate
+// from loadSkills() so the priority + 2-skill-cap behavior is unit-testable
+// with synthetic skills.
+//
+// Collect ALL trigger-matched skills (no early break), then sort by priority
+// DESC and load order ASC, and cap at 2. The previous early break at
+// `matched.length >= 2` made it impossible for an explicitly-authorized
+// higher-priority skill (e.g. paysh-catalog on a pay request) to survive the
+// cap when two other skills happened to match first by directory order —
+// dropping the payment skill on an authorized paid request, the original bug
+// class. loadIndex is recorded EXPLICITLY (not relying on Array.sort
+// stability) so the tiebreak is deterministic across engines.
+function selectMatchingSkills(skills, message) {
     const lowerMsg = message.toLowerCase();
-
     const matched = [];
-    for (const skill of skills) {
-        if (matched.length >= 2) break;
-
+    for (let i = 0; i < skills.length; i++) {
+        const skill = skills[i];
         const hasTrigger = skill.triggers.some(trigger => {
             // Multi-word triggers: substring match is fine
             if (trigger.includes(' ')) return lowerMsg.includes(trigger);
@@ -561,10 +602,17 @@ function findMatchingSkills(message) {
             return regex.test(message);
         });
 
-        if (hasTrigger) matched.push(skill);
+        if (hasTrigger) matched.push({ skill, loadIndex: i });
     }
 
-    return matched;
+    matched.sort((a, b) => {
+        const pa = Number.isFinite(a.skill.priority) ? a.skill.priority : 0;
+        const pb = Number.isFinite(b.skill.priority) ? b.skill.priority : 0;
+        if (pb !== pa) return pb - pa;          // higher priority first
+        return a.loadIndex - b.loadIndex;       // stable: earlier load order first
+    });
+
+    return matched.slice(0, 2).map(m => m.skill);
 }
 
 function buildSkillsSection(skills) {
@@ -601,5 +649,7 @@ function buildSkillsSection(skills) {
 module.exports = {
     loadSkills,
     findMatchingSkills,
+    selectMatchingSkills,   // BAT-1035: pure matcher (priority + 2-cap), test surface
     parseSkillFile,
+    parseSkillPriority,     // BAT-1035: priority frontmatter parser, test surface
 };

--- a/tests/nodejs-project/skills-priority.test.js
+++ b/tests/nodejs-project/skills-priority.test.js
@@ -36,7 +36,10 @@ require.cache[configPath] = {
         SKILLS_DIR: path.join(BUNDLE, '..', 'default-skills'),
         log: () => {},
         config: {},
-        SHELL_ALLOWLIST: [],
+        // skills.js uses SHELL_ALLOWLIST.has(...) in requirements gating —
+        // keep the stub shape accurate (a Set, not an Array) even though the
+        // functions under test do not exercise that path.
+        SHELL_ALLOWLIST: new Set(),
     },
 };
 

--- a/tests/nodejs-project/skills-priority.test.js
+++ b/tests/nodejs-project/skills-priority.test.js
@@ -1,0 +1,138 @@
+// tests/nodejs-project/skills-priority.test.js
+//
+// BAT-1035: generic skill `priority` frontmatter + the two-skill-cap selection
+// (collect → sort by priority DESC, load order ASC → slice 2).
+//
+// Covers:
+//   - parseSkillPriority: default 0, integer parse, non-numeric/NaN/Infinity→0,
+//     clamp to [-100,100], truncate toward zero.
+//   - selectMatchingSkills: backward-compat (two priority-0 skills unchanged),
+//     3-match retention (an authorized higher-priority skill survives the cap
+//     REGARDLESS of directory load order — the original bug class), and
+//     deterministic tie order (equal priority → load order ASC).
+//   - paysh-catalog drift guard: exact 8 narrow triggers + priority 10 +
+//     version 1.9.0, and no service-name / dropped-phrase triggers.
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// config.js calls process.exit(1) at module load when no runtime config file is
+// present (and again if API keys / owner are missing), so skills.js — which
+// `require('./config')` at the top — cannot be loaded directly in a bare-node
+// unit test. Stub config in the require cache BEFORE loading skills.js. The
+// functions under test (parseSkillFile / parseSkillPriority /
+// selectMatchingSkills) are pure and never read config at runtime.
+const configPath = require.resolve(path.join(BUNDLE, 'config.js'));
+require.cache[configPath] = {
+    id: configPath,
+    filename: configPath,
+    loaded: true,
+    exports: {
+        SKILLS_DIR: path.join(BUNDLE, '..', 'default-skills'),
+        log: () => {},
+        config: {},
+        SHELL_ALLOWLIST: [],
+    },
+};
+
+const skills = require(path.join(BUNDLE, 'skills.js'));
+const { parseSkillFile, parseSkillPriority, selectMatchingSkills } = skills;
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+// A SKILL.md string with an optional `priority:` frontmatter line.
+function skillMd({ name = 'x', priority, triggers = ['zzz'] }) {
+    const pr = priority === undefined ? '' : `priority: ${priority}\n`;
+    const tr = triggers.map(t => `  - "${t}"`).join('\n');
+    return `---\nname: ${name}\ndescription: "d"\nversion: "1.0.0"\n${pr}triggers:\n${tr}\n---\n\n# ${name}\n\n## Instructions\nx\n`;
+}
+// A synthetic in-memory skill (the shape selectMatchingSkills consumes).
+function mkSkill(name, priority, triggers) {
+    return { name, priority, triggers, description: '', instructions: '' };
+}
+
+console.log('skills-priority.test.js — BAT-1035 generic priority + 2-skill cap');
+console.log();
+
+check('priority defaults to 0 when frontmatter omits it', () => {
+    const s = parseSkillFile(skillMd({ name: 'a' }), '/tmp/a');
+    assert.strictEqual(s.priority, 0);
+});
+
+check('priority parsed as integer when present', () => {
+    const s = parseSkillFile(skillMd({ name: 'a', priority: 10 }), '/tmp/a');
+    assert.strictEqual(s.priority, 10);
+});
+
+check('non-numeric / NaN / Infinity / null priority → 0', () => {
+    assert.strictEqual(parseSkillPriority('abc'), 0);
+    assert.strictEqual(parseSkillPriority(NaN), 0);
+    assert.strictEqual(parseSkillPriority(Infinity), 0);
+    assert.strictEqual(parseSkillPriority(-Infinity), 0);
+    assert.strictEqual(parseSkillPriority(undefined), 0);
+    assert.strictEqual(parseSkillPriority(null), 0);
+    const s = parseSkillFile(skillMd({ name: 'a', priority: 'notanumber' }), '/tmp/a');
+    assert.strictEqual(s.priority, 0);
+});
+
+check('priority clamps to [-100, 100] and truncates toward zero', () => {
+    assert.strictEqual(parseSkillPriority(1000), 100);
+    assert.strictEqual(parseSkillPriority(-1000), -100);
+    assert.strictEqual(parseSkillPriority(100), 100);
+    assert.strictEqual(parseSkillPriority(-100), -100);
+    assert.strictEqual(parseSkillPriority(10.9), 10);
+    assert.strictEqual(parseSkillPriority(-10.9), -10);
+    assert.strictEqual(parseSkillPriority('50'), 50);
+});
+
+check('backward-compat: two priority-0 skills → kept in load order, capped at 2', () => {
+    const list = [mkSkill('a', 0, ['alpha']), mkSkill('b', 0, ['alpha']), mkSkill('c', 0, ['alpha'])];
+    const r = selectMatchingSkills(list, 'please alpha now');
+    assert.deepStrictEqual(r.map(s => s.name), ['a', 'b'], 'unchanged 2-cap by load order when no priority set');
+});
+
+check('3-match retention: priority-10 skill survives the cap REGARDLESS of load order', () => {
+    const high = mkSkill('high', 10, ['alpha']);
+    const lo1 = mkSkill('lo1', 0, ['alpha']);
+    const lo2 = mkSkill('lo2', 0, ['alpha']);
+    // high LAST in load order — the old early-break dropped it; new code keeps it.
+    const rA = selectMatchingSkills([lo1, lo2, high], 'alpha');
+    assert.deepStrictEqual(rA.map(s => s.name), ['high', 'lo1'],
+        'high-priority skill kept at index 0; earliest priority-0 skill takes the 2nd slot');
+    // high FIRST — still kept (proves it is priority, not luck).
+    const rB = selectMatchingSkills([high, lo1, lo2], 'alpha');
+    assert.deepStrictEqual(rB.map(s => s.name), ['high', 'lo1']);
+});
+
+check('equal-priority skills keep load order (deterministic tie)', () => {
+    const list = [mkSkill('first', 5, ['alpha']), mkSkill('second', 5, ['alpha']), mkSkill('third', 5, ['alpha'])];
+    const r = selectMatchingSkills(list, 'alpha');
+    assert.deepStrictEqual(r.map(s => s.name), ['first', 'second']);
+});
+
+check('paysh-catalog SKILL.md drift: exact 8 triggers + priority 10 + version 1.9.0, no service-name/dropped triggers', () => {
+    const p = path.join(BUNDLE, '..', 'default-skills', 'paysh-catalog', 'SKILL.md');
+    const content = fs.readFileSync(p, 'utf8');
+    const s = parseSkillFile(content, path.dirname(p));
+    assert.strictEqual(s.priority, 10, 'paysh-catalog priority must be 10');
+    assert.strictEqual(s.version, '1.9.0', 'paysh-catalog version must be 1.9.0');
+    const expected = ['pay.sh', 'paysh', 'x402', 'pay with burner', 'pay for', 'what can you pay for', 'show me pay.sh services', 'list paid services'];
+    assert.deepStrictEqual(s.triggers, expected, `triggers must be exactly the 8 narrow set; got ${JSON.stringify(s.triggers)}`);
+    for (const bad of ['purch', 'tripadvisor', 'perplexity', 'reducto', 'rentcast', '2captcha', 'pay with main', 'pay to']) {
+        assert.ok(!s.triggers.includes(bad), `forbidden/service trigger "${bad}" must NOT be present`);
+    }
+});
+
+console.log();
+console.log(`Result: ${pass} passed, ${fail} failed`);
+if (fail > 0) { console.error('FAIL: skills-priority.test.js'); process.exit(1); }
+console.log('PASS: skills-priority.test.js');


### PR DESCRIPTION
## Summary
Fixes paysh-catalog (Purch) being dropped at runtime. `findMatchingSkills` hard-capped at 2 with an **early break**, so an explicitly-authorized paid request could lose the payment skill to two skills that matched first by directory order. Adds a **generic** `priority` frontmatter field + collect/sort/slice so an authorized skill survives the cap — without hard-coding any skill name.

## Implementation contract
- **`parseSkillPriority`**: finite integer, clamped `[-100,100]`, truncate toward zero; invalid/non-numeric/absent → `0`. Every skill defaults to `0`.
- **`selectMatchingSkills(skills, message)`** (pure, extracted from `findMatchingSkills` for testability): collect ALL matches, sort by **priority DESC, loadIndex ASC** (loadIndex recorded explicitly — not relying on `Array.sort` stability), `slice(0,2)`. Backward-compatible: all-priority-0 ⇒ identical 2-cap by load order.
- **paysh-catalog SKILL.md**: 8 final triggers (dropped `pay with main` [burner-only] + `pay to` [person-to-person send]); `priority: 10`; `v1.9.0`.
- `priority` documented in the skill-format frontmatter contract.

## Test plan
- [x] `node tests/nodejs-project/skills-priority.test.js` — **8 / 0** (default/int/clamp/non-numeric; backward-compat; **3-match retention regardless of load order**; deterministic ties; paysh drift guard)
- [x] `node tests/nodejs-project/ci-coverage-manifest.test.js` — 5/5 (new test wired into the build.yml allowlist)
- [x] `node tests/nodejs-project/smoke.js` — 23/23
- [x] `bash scripts/pre-push-check.sh` — **ALL CHECKS PASSED** (exit 0)
- [ ] Purch end-to-end execution probe + service-only negatives (`pay with main`, `pay to Alice`) — SAB/device probes, **pending hardware**

## Notes
- Zero Kotlin. `skills.js` change is backward-compatible (priority defaults 0); asset SKILL.md replaced on install (v1.8.0→1.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)