### PR TITLE
fix: harden bridge-token UUID validation + post-merge CodeRabbit nits (BAT-1071)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
             confirmation-policy \
             confirmation-policy-burner \
             confirmation-buttons-guard \
+            bridge-token-validation \
             system-prompt-wallets \
             wallet-registry \
             wallet-set-caps-errors \

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -929,10 +929,10 @@ The most common burner-policy `simulation_returned_error` after BAT-1013 ships i
 **With BAT-1024, the burner-policy reason string now decodes this case explicitly:**
 
 > SPL Token returned InsufficientFunds (code 1): Source account does not have enough tokens (or lamports for rent) to fund the transfer. — burner likely needs SOL top-up for rent (typical: ~0.01-0.02 SOL covers Order PDA + vault ATA). Suggest solana_send(source=main, to=<burner pubkey>, amount=0.02) and retry. (unitsConsumed=8421)
->   logs[-5..]:
->   Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
->   Program log: Error: insufficient funds
->   Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x1
+> logs[-5..]:
+> Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
+> Program log: Error: insufficient funds
+> Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x1
 
 **Agent recovery flow:**
 

--- a/app/src/main/assets/nodejs-project/bridge-token.js
+++ b/app/src/main/assets/nodejs-project/bridge-token.js
@@ -1,0 +1,21 @@
+// bridge-token.js — pure, dependency-free bridge-token validation (BAT-1071).
+//
+// Kept separate from config.js on purpose: config.js does heavy require-time
+// init (reads config.json, process.exit(1) on missing fields), so it can't be
+// imported in a unit test. This module is pure (no deps, no IO) — config.js and
+// the tests both import it.
+'use strict';
+
+// Canonical UUID shape (8-4-4-4-12 hex) — exactly what SeekerClawService writes
+// via UUID.randomUUID().toString() (SeekerClawService.kt:351). The old bridge-
+// token check (`length === 36 && /^[0-9a-f-]+$/`) accepted ANY 36 hex-or-dash
+// chars — even 36 dashes or misplaced dashes — so a corrupt file was used
+// instead of failing to the cold value. This enforces the real shape.
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** True iff `raw` (after trim) is a canonical UUID string. Non-strings → false. */
+function isCanonicalBridgeToken(raw) {
+    return typeof raw === 'string' && CANONICAL_UUID.test(raw.trim());
+}
+
+module.exports = { isCanonicalBridgeToken, CANONICAL_UUID };

--- a/app/src/main/assets/nodejs-project/config.js
+++ b/app/src/main/assets/nodejs-project/config.js
@@ -3,6 +3,8 @@
 
 const fs = require('fs');
 const path = require('path');
+// BAT-1071: pure, require-safe bridge-token validator (no config init).
+const { isCanonicalBridgeToken } = require('./bridge-token');
 
 // ============================================================================
 // WORKSPACE & LOG PATHS
@@ -447,15 +449,18 @@ function getSearchProvider() {
 // least matches what AndroidBridge has if it never rotated.
 //
 // Never throws. Worst case returns ''.
+//
+// BAT-1071: validate the EXACT canonical UUID shape via the pure `bridge-token`
+// module (8-4-4-4-12 hex — what SeekerClawService.kt writes). The old check
+// (`length === 36 && /^[0-9a-f-]+$/`) accepted ANY 36 hex-or-dash chars (even 36
+// dashes / misplaced dashes), so a corrupt file slipped through.
 function getBridgeToken() {
     try {
         const tokenPath = path.join(path.dirname(workDir), 'bridge_token');
         const raw = fs.readFileSync(tokenPath, 'utf8').trim();
-        // UUID v4 shape: 36 chars, hex+dash only. ServiceState.kt
-        // writes UUID.randomUUID().toString() which produces exactly
-        // this format. Reject anything else (truncated, corrupt,
-        // wrong file content) by falling through to the cold value.
-        if (raw && raw.length === 36 && /^[0-9a-f-]+$/i.test(raw)) return raw;
+        // Reject anything that isn't the real UUID shape by falling through to
+        // the cold BRIDGE_TOKEN (matches the function comment's stated intent).
+        if (isCanonicalBridgeToken(raw)) return raw;
     } catch (_) { /* fall through to cold-start fallback */ }
     return BRIDGE_TOKEN;
 }

--- a/tests/nodejs-project/bridge-token-validation.test.js
+++ b/tests/nodejs-project/bridge-token-validation.test.js
@@ -1,0 +1,51 @@
+'use strict';
+// BAT-1071 — bridge-token validation must accept ONLY the canonical UUID shape
+// (8-4-4-4-12 hex) and reject malformed content. The old check
+// (`length === 36 && /^[0-9a-f-]+$/`) accepted ANY 36 hex-or-dash chars — even
+// 36 dashes or misplaced dashes — so a corrupt bridge_token file was used
+// instead of failing to the cold value. We test the pure exported validator
+// `isCanonicalBridgeToken` (config.js loaded with DEFAULT argv, like smoke.js —
+// overriding workDir triggers config's init path and is not needed here).
+
+const assert = require('assert');
+const path = require('path');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+// Import the PURE validator module (config.js can't be required in a unit test —
+// it reads config.json + process.exit(1)s on missing fields). config.js uses
+// this same module, so this exercises the real production validator.
+const { isCanonicalBridgeToken } = require(path.join(BUNDLE, 'bridge-token.js'));
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); pass++; }
+    catch (e) { console.log('  ✗ ' + name + '\n    ' + (e && e.message)); fail++; }
+}
+
+assert.strictEqual(typeof isCanonicalBridgeToken, 'function', 'isCanonicalBridgeToken must be exported');
+
+const VALID = '3b241101-e2bb-4255-8caf-4136c566a962'; // canonical UUID shape
+
+// ── Accept: real UUIDs (what UUID.randomUUID().toString() produces) ──
+check('accepts a canonical lowercase UUID', () => assert.strictEqual(isCanonicalBridgeToken(VALID), true));
+check('accepts UPPERCASE hex (case-insensitive)', () => assert.strictEqual(isCanonicalBridgeToken(VALID.toUpperCase()), true));
+check('accepts with surrounding whitespace (trimmed)', () => assert.strictEqual(isCanonicalBridgeToken(`  ${VALID}\n`), true));
+
+// ── Reject: the bug class — all of these PASSED the old loose check ──
+check('rejects 36 dashes', () => assert.strictEqual(isCanonicalBridgeToken('-'.repeat(36)), false));
+check('rejects 36 chars with MISPLACED dashes (32 hex + 4 trailing dashes)', () => assert.strictEqual(isCanonicalBridgeToken('3b241101e2bb42558caf4136c566a962----'), false));
+check('rejects 36 hex chars with NO dashes', () => assert.strictEqual(isCanonicalBridgeToken('a'.repeat(36)), false));
+check('rejects truncated (35 chars)', () => assert.strictEqual(isCanonicalBridgeToken(VALID.slice(0, 35)), false));
+check('rejects too long (37 chars)', () => assert.strictEqual(isCanonicalBridgeToken(VALID + 'a'), false));
+check('rejects non-hex in a hex position', () => assert.strictEqual(isCanonicalBridgeToken('zzzzzzzz-e2bb-4255-8caf-4136c566a962'), false));
+check('rejects dashes in the wrong positions (right count, wrong places)', () => assert.strictEqual(isCanonicalBridgeToken('3b2411-01e2bb-4255-8caf-4136c566a962'), false));
+check('rejects empty string', () => assert.strictEqual(isCanonicalBridgeToken(''), false));
+check('rejects non-string (null / undefined / number)', () => {
+    assert.strictEqual(isCanonicalBridgeToken(null), false);
+    assert.strictEqual(isCanonicalBridgeToken(undefined), false);
+    assert.strictEqual(isCanonicalBridgeToken(36), false);
+});
+
+console.log('');
+if (fail > 0) { console.log(`FAIL: bridge-token-validation.test.js (${fail} failed, ${pass} passed)`); process.exit(1); }
+console.log(`PASS: bridge-token-validation.test.js (${pass} checks).`);

--- a/tests/nodejs-project/confirmation-buttons-guard.test.js
+++ b/tests/nodejs-project/confirmation-buttons-guard.test.js
@@ -42,7 +42,10 @@ async function runStatic() {
         // (up to the next lines.push) rather than a brittle fixed char window —
         // a magic 1400 could capture a later push's example or miss content.
         const next = aiSrc.indexOf('lines.push(', i + 1);
-        const door = aiSrc.slice(i, next === -1 ? undefined : next);
+        // Fail fast if the terminator is missing — otherwise the slice would run
+        // to EOF and unrelated later content could make this drift guard flaky.
+        assert.ok(next !== -1, 'door terminator missing (no lines.push after the inline-keyboard door)');
+        const door = aiSrc.slice(i, next);
         assert.ok(!/"callback_data":\s*"(yes|no)"/i.test(door), 'door still uses a yes/no confirm example');
         assert.ok(!(/✅\s*Confirm/.test(door) && /❌\s*Cancel/.test(door)), 'door still shows a Confirm/Cancel pair example');
     });

--- a/tests/nodejs-project/confirmation-buttons-guard.test.js
+++ b/tests/nodejs-project/confirmation-buttons-guard.test.js
@@ -38,7 +38,11 @@ async function runStatic() {
     await check('drift: inline-keyboard door no longer demonstrates a ✅Confirm/❌Cancel pair', () => {
         const i = aiSrc.indexOf('Inline keyboard buttons');
         assert.ok(i !== -1, 'inline-keyboard door missing');
-        const door = aiSrc.slice(i, i + 1400);
+        // BAT-1071: bound the slice to the door's OWN lines.push(...) string
+        // (up to the next lines.push) rather than a brittle fixed char window —
+        // a magic 1400 could capture a later push's example or miss content.
+        const next = aiSrc.indexOf('lines.push(', i + 1);
+        const door = aiSrc.slice(i, next === -1 ? undefined : next);
         assert.ok(!/"callback_data":\s*"(yes|no)"/i.test(door), 'door still uses a yes/no confirm example');
         assert.ok(!(/✅\s*Confirm/.test(door) && /❌\s*Cancel/.test(door)), 'door still shows a Confirm/Cancel pair example');
     });

--- a/tests/nodejs-project/smoke.js
+++ b/tests/nodejs-project/smoke.js
@@ -110,6 +110,7 @@ const LOAD_TARGETS = [
     'confirmation/index.js',
     'tools/solana-send-guard.js',   // BAT-1037: pure native-SOL-only denomination guard (no config dep)
     'security-reject-block.js',   // BAT-1039: pure deterministic security-reject renderer (no config dep)
+    'bridge-token.js',   // BAT-1071: pure require-safe bridge-token UUID validator (no config dep)
 ];
 
 // Files skipped intentionally. Most modules depend on config.js (which


### PR DESCRIPTION
## Summary
Addresses the 3 findings CodeRabbit surfaced on #415's incremental review of the main merge — all pre-existing `main` code, **not BAT-1050**.

**Primary (security-adjacent):** `config.js getBridgeToken()` validated `bridge_token` with `length === 36 && /^[0-9a-f-]+$/i` — accepts ANY 36 hex/dash chars (even 36 dashes or misplaced dashes), so a corrupt file was accepted instead of failing to the cold value, contrary to the function's stated intent. Low exploitability (app writes the file itself), but the check didn't do its job.

**Fix (fail-MORE-closed, no new design):** new pure `bridge-token.js` → `isCanonicalBridgeToken()` enforces the exact UUID shape (8-4-4-4-12 hex). Kept separate from config.js so it's unit-testable (config.js `process.exit(1)`s at require-time). **No regression:** real `UUID.randomUUID()` tokens match old + new regex (verified `SeekerClawService.kt:351`); only malformed tokens change → they now fall to the cold `BRIDGE_TOKEN`.

**Bundled minor nits (same review):**
- `confirmation-buttons-guard.test.js`: brittle fixed `slice(i, i+1400)` → bound to the door's own `lines.push` string.
- `DIAGNOSTICS.md` MD027: `>` + 3 spaces → single space in a log example.

## Test plan
- [x] `bridge-token-validation.test.js` — 12 checks (accepts canonical/upper/whitespace; rejects 36-dashes / misplaced / no-dashes / truncated / too-long / non-hex / wrong-positions / empty / non-string). Exercises the real production validator.
- [x] Wired into smoke `PURE_MODULES` + `build.yml` + `ci-coverage-manifest`.
- [x] Full CI (37 files) + `scripts/pre-push-check.sh` (incl. Kotlin compile) green.
- [x] No cap/signing/gate logic touched — only the bridge-token validation regex.

## Notes
Done in an isolated git worktree off `main` (owner's local checkout was mid-test). Not a BAT-1050 / #415 blocker. Codex not required (fail-more-closed tightening of an existing check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened bridge token validation to accept only canonical UUIDs (strict segment formatting), improving reliability and reducing acceptance of malformed values.
  * Improved fallback behavior by using the default token when the saved on-disk value fails validation.

* **Tests**
  * Added dedicated unit tests for bridge token validation (valid/invalid cases).
  * Enhanced guard and smoke checks for better regression detection.
  * Expanded CI to run the new bridge-token-validation test script.

* **Documentation**
  * Updated a diagnostic example’s log snippet formatting for improved readability/consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->