### PR TITLE
fix: strip runtime node_debug.log from packaged APK assets (BAT-1073)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,6 +237,30 @@ abstract class DownloadNodejsTask : DefaultTask() {
 tasks.register<DownloadNodejsTask>("downloadNodejs")
 tasks.named("preBuild") { dependsOn("downloadNodejs") }
 
+// --- Strip runtime log artifacts from packaged assets (BAT-1073) ---
+// config.js writes node_debug.log into its own directory (workDir defaults to
+// __dirname) whenever the Node smoke/tests run locally — and that directory is
+// src/main/assets/nodejs-project. Android packages everything under
+// src/main/assets/ into the APK regardless of .gitignore, so a stale dev log
+// (which embeds an absolute developer-machine path) would otherwise ship to
+// users and land on-device at files/nodejs-project/node_debug.log.
+//
+// Delete these runtime artifacts at the start of every asset-merge task. The
+// source-set assets filter is not honored by the asset merge, so we strip the
+// files instead. Paths are captured at configuration time (via layout) so the
+// task action touches no Project state — configuration-cache safe.
+val packagedAssetLogArtifacts = listOf(
+    "node_debug.log",
+    "node_debug.log.old",
+    "node_debug.log.bak",
+).map { layout.projectDirectory.file("src/main/assets/nodejs-project/$it").asFile }
+
+tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.configureEach {
+    doFirst {
+        packagedAssetLogArtifacts.forEach { artifact -> artifact.delete() }
+    }
+}
+
 // --- Dependencies ---
 
 dependencies {


### PR DESCRIPTION
## Summary
Running the Node smoke/tests locally makes `config.js` write `node_debug.log` into `app/src/main/assets/nodejs-project/` (its `workDir` defaults to `__dirname`). Android packages everything under `src/main/assets/` into the APK **regardless of `.gitignore`**, so a stale dev log — embedding an absolute developer-machine path (`E:\GIT\seekerclaw\...`) — shipped in locally-built APKs and landed on-device at `files/nodejs-project/node_debug.log`. Surfaced during BAT-1050 device testing.

Adds a `doFirst` on every `merge*Assets` task that deletes `node_debug.log` (+ `.old`/`.bak` rotation artifacts) from the assets dir right before the merge copies it. Pre-existing issue; not a BAT-1050 regression. Severity low (path disclosure, not a secret leak — config.js's pre-redaction startup lines are non-secret by design).

## Implementation contract
- **What:** strip `node_debug.log` / `.old` / `.bak` from `src/main/assets/nodejs-project/` before each variant's asset merge (all flavors × build types via `merge*Assets` match).
- **How:** task-graph `doFirst`; file paths captured at configuration time via `layout.projectDirectory` so the action touches no `Project` state — **configuration-cache safe**.
- **Why delete (not a source-set assets filter):** the source-set assets filter is not honored by the asset merge.
- **No runtime behavior change:** the device's live workspace log (`files/workspace/node_debug.log`) is untouched; only the never-should-ship build-time artifact is stripped.

## Test plan
- [x] `pre-push-check.sh` (Node smoke + tool-schema + wallets-prompt + Kotlin compile) — **passed**
- [x] `mergeDappStoreDebugAssets` with a planted stray `node_debug.log` — **passed**:
  - stray deleted from src by the `doFirst` (hook ran)
  - `node_debug.log` **absent** from `app/build/intermediates` merged assets
  - `config.js` still present in merged assets → asset merge intact

## Known limitations
- The strip targets only `node_debug.log{,.old,.bak}` (the artifacts `config.js` produces). Other ad-hoc files a dev might drop into `assets/` are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed runtime log files from packaged Android assets, preventing stale local-development log artifacts from being included in the app build.
  * Reduced the chance of shipping absolute-path debug logs inside the APK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->