### PR TITLE
feat: add Claude Sonnet 5 to the model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 
 - **Updated Claude model lineup** — added **Fable 5** (`claude-fable-5`, new top
-  tier) and **Opus 4.8** (`claude-opus-4-8`, new default). Opus 4.6 remains
-  available.
+  tier), **Opus 4.8** (`claude-opus-4-8`, new default), and **Sonnet 5**
+  (`claude-sonnet-5`, the speed/intelligence tier). Opus 4.6 remains available.
 
 ### Security
 

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2018,6 +2018,7 @@ const MODEL_CONTEXT_LIMITS = {
     'claude-opus-4-8':     200000,
     'claude-opus-4-7':     200000,
     'claude-opus-4-6':     200000,
+    'claude-sonnet-5':     200000, // 1M actual; conservative cap consistent with mobile memory limits
     'claude-sonnet-4-6':   200000,
     'claude-sonnet-4-5':   200000,
     'claude-haiku-4-5':    200000,

--- a/app/src/main/assets/nodejs-project/model-registry.json
+++ b/app/src/main/assets/nodejs-project/model-registry.json
@@ -38,6 +38,7 @@
         { "id": "claude-opus-4-8",   "displayName": "Opus 4.8",   "reasoningSupport": "yes" },
         { "id": "claude-opus-4-7",   "displayName": "Opus 4.7",   "reasoningSupport": "yes" },
         { "id": "claude-opus-4-6",   "displayName": "Opus 4.6",   "reasoningSupport": "yes" },
+        { "id": "claude-sonnet-5",   "displayName": "Sonnet 5",   "reasoningSupport": "yes" },
         { "id": "claude-sonnet-4-6", "displayName": "Sonnet 4.6", "reasoningSupport": "yes" },
         { "id": "claude-haiku-4-5",  "displayName": "Haiku 4.5",  "reasoningSupport": "no"  }
       ]

--- a/tests/nodejs-project/model-catalog.test.js
+++ b/tests/nodejs-project/model-catalog.test.js
@@ -337,6 +337,8 @@ check('claude/claude-opus-4-7 → yes',
     mc.reasoningSupportFor('claude', 'claude-opus-4-7', 'api_key'), 'yes');
 check('claude/claude-opus-4-6 → yes',
     mc.reasoningSupportFor('claude', 'claude-opus-4-6', 'api_key'), 'yes');
+check('claude/claude-sonnet-5 → yes',
+    mc.reasoningSupportFor('claude', 'claude-sonnet-5', 'api_key'), 'yes');
 check('claude/claude-sonnet-4-6 → yes',
     mc.reasoningSupportFor('claude', 'claude-sonnet-4-6', 'api_key'), 'yes');
 


### PR DESCRIPTION
## Summary
Adds **Claude Sonnet 5** (`claude-sonnet-5`) as a selectable Anthropic model for v2.1.0. Model ID + metadata verified against the official docs (`platform.claude.com`): 1M context, 128k max output, adaptive thinking (extended thinking = No), knowledge cutoff Jan 2026, "best combination of speed and intelligence."

## Changes (verified touchpoints)
- **`model-registry.json`** — add `claude-sonnet-5` (`reasoningSupport: yes`). This is the **single source** parsed by both Kotlin (`Providers.kt` → `assets.open(...)`, powers the Android picker) and Node (`model-catalog.js`). No duplicated list to update.
- **`ai.js`** — `MODEL_CONTEXT_LIMITS` entry (200000, tier-consistent; without it, unknown models fall back to a lower 128000 cap).
- **`CHANGELOG.md`** — extend the v2.1.0 "Updated Claude model lineup" line.
- **`tests/nodejs-project/model-catalog.test.js`** — regression check `claude/claude-sonnet-5 → yes` (reads the real registry).

**Default unchanged** — stays `claude-opus-4-8`. Sonnet 5 is available in the picker, not the default.

**Reasoning:** Sonnet 5 is adaptive-thinking (always-on, `effort` defaults to `high`), the same profile as Opus 4.8 / Fable 5 — hence `reasoningSupport: yes`, mirroring the Opus 4.8 entry. Claude reasoning is registry-driven (no per-model-ID branch in `claude.js`/`reasoning-gating.js`), so no adapter change is needed.

## Test plan
- [x] `bash scripts/pre-push-check.sh` — PASS (Node smoke, 64 tool schemas, wallets regression, Kotlin `BUILD SUCCESSFUL`)
- [x] `node tests/nodejs-project/model-catalog.test.js` — ALL PASS (incl. new sonnet-5 check)
- [x] `active-model.test.js`, `reasoning-gating.test.js` — pass
- [ ] **Device test (rc2)** — Sonnet 5 appears in the Android picker + a turn on it works + `/think` on Sonnet 5 (re **BAT-1033** extended-thinking-400, which affects the whole adaptive family) + memory preserved + new System SHA

## Notes
- **BAT-1033** (open): extended-thinking 400 on the adaptive-thinking family (Opus 4.8) — Sonnet 5 inherits the same known behavior; not a new regression. rc2 device test will confirm parity.
- Folds into **v2.1.0** (no version bump; still `2.1.0 / 21`). Supersedes rc1 → will cut **rc2**.

## Merge
Targets `main` (admin override). Merge only on explicit user go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Sonnet 5 model in the model catalog.
  * Updated release notes to include Sonnet 5 alongside the latest Claude lineup.
* **Bug Fixes**
  * Improved context-size handling and trimming behavior for Sonnet 5 to match other supported models.
* **Tests**
  * Added coverage to verify Sonnet 5 is recognized as reasoning-capable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->