### PR TITLE
feat: mask agent_settings.json secret values on model-facing reads (BAT-1087)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
             rich-messages-default \
             truncate-tool-result \
             web-fetch-redirect-headers \
+            agent-settings-mask \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -165,16 +165,23 @@ function _isSecretEntry(key, value, underApiKeys) {
 }
 
 // Recursively rebuild `node`, replacing secret string values with the mask.
+// `underApiKeys` propagates to EVERY descendant of an `apiKeys` map (through both
+// objects AND arrays), so a malformed shape like apiKeys:["k"] or apiKeys:{a:["k"]}
+// can't slip a secret through unmasked.
 function _maskSettingsNode(node, underApiKeys) {
-    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, false));
+    // A bare string reached via an array (no key to check) is secret iff it descends
+    // from an apiKeys map. Keyed strings are handled at the object level below.
+    if (typeof node === 'string') return underApiKeys ? _AGENT_SETTINGS_MASK : node;
+    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, underApiKeys));
     if (node && typeof node === 'object') {
         const out = {};
         for (const [k, v] of Object.entries(node)) {
             if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
-            if (_isSecretEntry(k, v, underApiKeys)) {
+            const childUnderApiKeys = underApiKeys || k === 'apiKeys';
+            if (_isSecretEntry(k, v, childUnderApiKeys)) {
                 out[k] = _AGENT_SETTINGS_MASK;
             } else if (v && typeof v === 'object') {
-                out[k] = _maskSettingsNode(v, k === 'apiKeys' && !Array.isArray(v));
+                out[k] = _maskSettingsNode(v, childUnderApiKeys);
             } else {
                 out[k] = v;
             }
@@ -199,14 +206,18 @@ function maskAgentSettings(text) {
 // shell_exec paths — which pass through redactSecrets, not the file mask — are
 // covered too, including values that never win the config merge.
 function _collectSettingsSecrets(node, underApiKeys, out) {
-    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, false, out); return out; }
+    // Mirror _maskSettingsNode exactly: propagate underApiKeys through arrays and
+    // objects so array-nested secrets under apiKeys are registered too.
+    if (typeof node === 'string') { if (underApiKeys) out.push(node); return out; }
+    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, underApiKeys, out); return out; }
     if (node && typeof node === 'object') {
         for (const [k, v] of Object.entries(node)) {
             if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
-            if (_isSecretEntry(k, v, underApiKeys)) {
+            const childUnderApiKeys = underApiKeys || k === 'apiKeys';
+            if (_isSecretEntry(k, v, childUnderApiKeys)) {
                 out.push(v);
             } else if (v && typeof v === 'object') {
-                _collectSettingsSecrets(v, k === 'apiKeys' && !Array.isArray(v), out);
+                _collectSettingsSecrets(v, childUnderApiKeys, out);
             }
         }
     }

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -3,6 +3,7 @@
 // Depends on: config.js
 
 const path = require('path');
+const fs = require('fs');
 
 // BAT-1001 PR-B: per-call getBridgeToken (not the startup-frozen
 // BRIDGE_TOKEN constant) so log redaction tracks Kotlin-side token
@@ -137,6 +138,95 @@ function redactSecrets(msg) {
     }
     return msg;
 }
+
+// ============================================================================
+// AGENT SETTINGS MASKING (BAT-1087)
+// ============================================================================
+// agent_settings.json stores plaintext provider keys under apiKeys.* and is
+// readable by the model via the read / js_eval / shell_exec tools. We mask the
+// secret VALUES when the file's contents would reach the model, while leaving
+// structural settings (heartbeat interval, model, provider, ...) visible. This
+// is MODEL-FACING OUTPUT MASKING, not storage-at-rest protection — the file on
+// disk is unchanged and the save/write/edit flow is untouched.
+
+const _AGENT_SETTINGS_MASK = '[REDACTED]';
+
+// Whether a key name denotes a credential value (matched at any depth). Separators
+// are stripped first so api_key / apiKey / api-key all normalize identically.
+function _isCredentialKeyName(key) {
+    const k = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+    return /(apikey|accesskey|secretkey|clientsecret|privatekey|authtoken|token|secret|password|passphrase|credential)s?$/.test(k);
+}
+
+// A string value is secret if it sits directly under an `apiKeys` map (every stored
+// service value — incl. unknown/custom services) OR its key name is credential-like.
+function _isSecretEntry(key, value, underApiKeys) {
+    return typeof value === 'string' && (underApiKeys || _isCredentialKeyName(key));
+}
+
+// Recursively rebuild `node`, replacing secret string values with the mask.
+function _maskSettingsNode(node, underApiKeys) {
+    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, false));
+    if (node && typeof node === 'object') {
+        const out = {};
+        for (const [k, v] of Object.entries(node)) {
+            if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+            if (_isSecretEntry(k, v, underApiKeys)) {
+                out[k] = _AGENT_SETTINGS_MASK;
+            } else if (v && typeof v === 'object') {
+                out[k] = _maskSettingsNode(v, k === 'apiKeys' && !Array.isArray(v));
+            } else {
+                out[k] = v;
+            }
+        }
+        return out;
+    }
+    return node;
+}
+
+// Mask secret values in agent_settings.json text. Returns the masked JSON string,
+// or null if the text is not a parseable JSON object — the caller MUST fail closed
+// (withhold the content) rather than emit possibly-secret raw bytes.
+function maskAgentSettings(text) {
+    let parsed;
+    try { parsed = JSON.parse(text); } catch (_) { return null; }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return JSON.stringify(_maskSettingsNode(parsed, false), null, 2);
+}
+
+// Collect every secret string value from a parsed settings object (same rule as
+// the mask). Used to register those values for global redaction so the js_eval /
+// shell_exec paths — which pass through redactSecrets, not the file mask — are
+// covered too, including values that never win the config merge.
+function _collectSettingsSecrets(node, underApiKeys, out) {
+    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, false, out); return out; }
+    if (node && typeof node === 'object') {
+        for (const [k, v] of Object.entries(node)) {
+            if (_isSecretEntry(k, v, underApiKeys)) {
+                out.push(v);
+            } else if (v && typeof v === 'object') {
+                _collectSettingsSecrets(v, k === 'apiKeys' && !Array.isArray(v), out);
+            }
+        }
+    }
+    return out;
+}
+
+// Read agent_settings.json from the workspace root, collect its secret values and
+// register them for redaction. Safe to call repeatedly (the Set dedupes). Called
+// at module load and after any write/edit to the file (tools/file.js).
+function registerAgentSettingsSecrets() {
+    try {
+        const settingsPath = path.join(workDir, 'agent_settings.json');
+        if (!fs.existsSync(settingsPath)) return;
+        const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        if (!parsed || typeof parsed !== 'object') return;
+        registerRedactedSecrets(_collectSettingsSecrets(parsed, false, []));
+    } catch (_) { /* unparseable / absent — nothing to register */ }
+}
+
+// Register at load so the very first js_eval/shell_exec read is already covered.
+registerAgentSettingsSecrets();
 
 // ============================================================================
 // PATH VALIDATION
@@ -277,6 +367,8 @@ module.exports = {
     rebuildRedactPatterns,
     registerRedactedSecret,
     registerRedactedSecrets,
+    maskAgentSettings,
+    registerAgentSettingsSecrets,
     safePath,
     INJECTION_PATTERNS,
     normalizeWhitespace,

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -150,6 +150,9 @@ function redactSecrets(msg) {
 // disk is unchanged and the save/write/edit flow is untouched.
 
 const _AGENT_SETTINGS_MASK = '[REDACTED]';
+// Centralized within this module so registration can't drift from the read/js_eval/
+// shell_exec paths (which keep their own AGENT_SETTINGS_FILE consts) if renamed.
+const _AGENT_SETTINGS_FILE = 'agent_settings.json';
 
 // Whether a key name denotes a credential value (matched at any depth). Separators
 // are stripped first so api_key / apiKey / api-key all normalize identically.
@@ -234,7 +237,7 @@ function _collectSettingsSecrets(node, underApiKeys, out) {
 // write/edit to the file (tools/file.js).
 function registerAgentSettingsSecrets() {
     try {
-        const settingsPath = path.join(workDir, 'agent_settings.json');
+        const settingsPath = path.join(workDir, _AGENT_SETTINGS_FILE);
         if (!fs.existsSync(settingsPath)) return;
         const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
         if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -202,6 +202,7 @@ function _collectSettingsSecrets(node, underApiKeys, out) {
     if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, false, out); return out; }
     if (node && typeof node === 'object') {
         for (const [k, v] of Object.entries(node)) {
+            if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
             if (_isSecretEntry(k, v, underApiKeys)) {
                 out.push(v);
             } else if (v && typeof v === 'object') {
@@ -220,7 +221,7 @@ function registerAgentSettingsSecrets() {
         const settingsPath = path.join(workDir, 'agent_settings.json');
         if (!fs.existsSync(settingsPath)) return;
         const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-        if (!parsed || typeof parsed !== 'object') return;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
         registerRedactedSecrets(_collectSettingsSecrets(parsed, false, []));
     } catch (_) { /* unparseable / absent — nothing to register */ }
 }

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -201,10 +201,14 @@ function maskAgentSettings(text) {
     return JSON.stringify(_maskSettingsNode(parsed, false), null, 2);
 }
 
-// Collect every secret string value from a parsed settings object (same rule as
-// the mask). Used to register those values for global redaction so the js_eval /
-// shell_exec paths — which pass through redactSecrets, not the file mask — are
-// covered too, including values that never win the config merge.
+// Collect secret string values from a parsed settings object (same rule as the
+// mask). Registering them makes redactSecrets scrub those values if they ever
+// surface OUTSIDE the file read — e.g. in a log line or another tool's output.
+// This is DEFENSE-IN-DEPTH, not the primary protection: the read tool masks the
+// file (all lengths) and js_eval/shell_exec block it outright. Note registration
+// only takes values >= _MIN_SECRET_LEN (short strings would cause false-positive
+// redaction elsewhere); short secrets are still fully covered by those mask/block
+// paths, just not by redactSecrets.
 function _collectSettingsSecrets(node, underApiKeys, out) {
     // Mirror _maskSettingsNode exactly: propagate underApiKeys through arrays and
     // objects so array-nested secrets under apiKeys are registered too.
@@ -224,9 +228,10 @@ function _collectSettingsSecrets(node, underApiKeys, out) {
     return out;
 }
 
-// Read agent_settings.json from the workspace root, collect its secret values and
-// register them for redaction. Safe to call repeatedly (the Set dedupes). Called
-// at module load and after any write/edit to the file (tools/file.js).
+// Read agent_settings.json from the workspace root and register its secret values
+// (>= _MIN_SECRET_LEN) for redaction as defense-in-depth (see _collectSettingsSecrets).
+// Safe to call repeatedly (the Set dedupes). Called at module load and after any
+// write/edit to the file (tools/file.js).
 function registerAgentSettingsSecrets() {
     try {
         const settingsPath = path.join(workDir, 'agent_settings.json');
@@ -237,7 +242,7 @@ function registerAgentSettingsSecrets() {
     } catch (_) { /* unparseable / absent — nothing to register */ }
 }
 
-// Register at load so the very first js_eval/shell_exec read is already covered.
+// Register at load so any secret that later surfaces in logs/output is scrubbed.
 registerAgentSettingsSecrets();
 
 // ============================================================================

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -161,30 +161,24 @@ function _isCredentialKeyName(key) {
     return /(apikey|accesskey|secretkey|clientsecret|privatekey|authtoken|token|secret|password|passphrase|credential)s?$/.test(k);
 }
 
-// A string value is secret if it sits directly under an `apiKeys` map (every stored
-// service value — incl. unknown/custom services) OR its key name is credential-like.
-function _isSecretEntry(key, value, underApiKeys) {
-    return typeof value === 'string' && (underApiKeys || _isCredentialKeyName(key));
-}
-
-// Recursively rebuild `node`, replacing secret string values with the mask.
-// `underApiKeys` propagates to EVERY descendant of an `apiKeys` map (through both
-// objects AND arrays), so a malformed shape like apiKeys:["k"] or apiKeys:{a:["k"]}
-// can't slip a secret through unmasked.
-function _maskSettingsNode(node, underApiKeys) {
-    // A bare string reached via an array (no key to check) is secret iff it descends
-    // from an apiKeys map. Keyed strings are handled at the object level below.
-    if (typeof node === 'string') return underApiKeys ? _AGENT_SETTINGS_MASK : node;
-    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, underApiKeys));
+// A node enters a "secret context" once traversal passes through a credential-typed
+// key — apiKeys (itself credential-typed), webhookSecret, authToken, etc. Inside that
+// context EVERY string is secret (keyed, bare-in-array, or nested arbitrarily deep in
+// objects/arrays), so `{ webhookSecret: { current: "x" } }` or `apiKeys: ["k"]` can't
+// slip a value through. Outside it, a string is secret only if its OWN key is
+// credential-typed. `underSecret` carries the context down through objects AND arrays.
+function _maskSettingsNode(node, underSecret) {
+    if (typeof node === 'string') return underSecret ? _AGENT_SETTINGS_MASK : node;
+    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, underSecret));
     if (node && typeof node === 'object') {
         const out = {};
         for (const [k, v] of Object.entries(node)) {
             if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
-            const childUnderApiKeys = underApiKeys || k === 'apiKeys';
-            if (_isSecretEntry(k, v, childUnderApiKeys)) {
-                out[k] = _AGENT_SETTINGS_MASK;
+            const childSecret = underSecret || _isCredentialKeyName(k);
+            if (typeof v === 'string') {
+                out[k] = childSecret ? _AGENT_SETTINGS_MASK : v;
             } else if (v && typeof v === 'object') {
-                out[k] = _maskSettingsNode(v, childUnderApiKeys);
+                out[k] = _maskSettingsNode(v, childSecret);
             } else {
                 out[k] = v;
             }
@@ -212,19 +206,19 @@ function maskAgentSettings(text) {
 // only takes values >= _MIN_SECRET_LEN (short strings would cause false-positive
 // redaction elsewhere); short secrets are still fully covered by those mask/block
 // paths, just not by redactSecrets.
-function _collectSettingsSecrets(node, underApiKeys, out) {
-    // Mirror _maskSettingsNode exactly: propagate underApiKeys through arrays and
-    // objects so array-nested secrets under apiKeys are registered too.
-    if (typeof node === 'string') { if (underApiKeys) out.push(node); return out; }
-    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, underApiKeys, out); return out; }
+function _collectSettingsSecrets(node, underSecret, out) {
+    // Mirror _maskSettingsNode exactly: propagate the secret context through arrays
+    // and objects so array-nested and object-nested secrets are registered too.
+    if (typeof node === 'string') { if (underSecret) out.push(node); return out; }
+    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, underSecret, out); return out; }
     if (node && typeof node === 'object') {
         for (const [k, v] of Object.entries(node)) {
             if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
-            const childUnderApiKeys = underApiKeys || k === 'apiKeys';
-            if (_isSecretEntry(k, v, childUnderApiKeys)) {
-                out.push(v);
+            const childSecret = underSecret || _isCredentialKeyName(k);
+            if (typeof v === 'string') {
+                if (childSecret) out.push(v);
             } else if (v && typeof v === 'object') {
-                _collectSettingsSecrets(v, childUnderApiKeys, out);
+                _collectSettingsSecrets(v, childSecret, out);
             }
         }
     }

--- a/app/src/main/assets/nodejs-project/tools/file.js
+++ b/app/src/main/assets/nodejs-project/tools/file.js
@@ -12,7 +12,11 @@ const channel = require('../channel');
 
 const {
     redactSecrets, rebuildRedactPatterns, safePath, detectSuspiciousPatterns,
+    maskAgentSettings, registerAgentSettingsSecrets,
 } = require('../security');
+
+// BAT-1087: filename whose contents carry provider/service secrets under apiKeys.*
+const AGENT_SETTINGS_FILE = 'agent_settings.json';
 
 // Helper to recursively list files in a directory (used by skill_read)
 function listFilesRecursive(dir, maxDepth = 3, currentDepth = 0) {
@@ -132,8 +136,9 @@ const handlers = {
             return { error: `File not found: ${input.path}` };
         }
         // Resolve symlinks and re-check basename (prevents symlink bypass)
+        let realBasename = readBasename;
         try {
-            const realBasename = path.basename(fs.realpathSync(filePath));
+            realBasename = path.basename(fs.realpathSync(filePath));
             if (SECRETS_BLOCKED.has(realBasename)) {
                 log(`[Security] BLOCKED read via symlink to sensitive file: ${realBasename}`, 'WARN');
                 return { error: `Reading ${realBasename} is blocked for security.` };
@@ -144,6 +149,22 @@ const handlers = {
             return { error: 'Path is a directory, use ls tool instead' };
         }
         const content = fs.readFileSync(filePath, 'utf8');
+        // BAT-1087: mask secret values before returning agent_settings.json to the
+        // model. Match basename OR realpath-basename so symlink aliases are covered;
+        // conservatively masking any file named agent_settings.json is acceptable.
+        if (readBasename === AGENT_SETTINGS_FILE || realBasename === AGENT_SETTINGS_FILE) {
+            const masked = maskAgentSettings(content);
+            if (masked === null) {
+                // Unparseable → fail closed: withhold rather than emit raw bytes.
+                log('[Security] agent_settings.json unparseable — withholding content from model', 'WARN');
+                return {
+                    path: input.path,
+                    size: stat.size,
+                    error: 'agent_settings.json is unparseable; contents withheld to avoid leaking secrets',
+                };
+            }
+            return { path: input.path, size: stat.size, content: masked.slice(0, 50000) };
+        }
         return {
             path: input.path,
             size: stat.size,
@@ -178,9 +199,10 @@ const handlers = {
         fs.writeFileSync(filePath, input.content, 'utf8');
 
         // BAT-236: If agent wrote to workspace root agent_settings.json, re-sync API keys
-        if (filePath === path.join(workDir, 'agent_settings.json')) {
+        if (filePath === path.join(workDir, AGENT_SETTINGS_FILE)) {
             syncAgentApiKeys();
             rebuildRedactPatterns();
+            registerAgentSettingsSecrets(); // BAT-1087: register newly-saved secrets for redaction
         }
 
         return {
@@ -231,9 +253,10 @@ const handlers = {
         fs.writeFileSync(filePath, content, 'utf8');
 
         // BAT-236: If agent edited workspace root agent_settings.json, re-sync API keys
-        if (filePath === path.join(workDir, 'agent_settings.json')) {
+        if (filePath === path.join(workDir, AGENT_SETTINGS_FILE)) {
             syncAgentApiKeys();
             rebuildRedactPatterns();
+            registerAgentSettingsSecrets(); // BAT-1087: register newly-saved secrets for redaction
         }
 
         return {

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -11,6 +11,12 @@ const {
     redactSecrets, safePath,
 } = require('../security');
 
+// BAT-1087: agent_settings.json holds provider secrets under apiKeys.*. It is NOT in
+// SECRETS_BLOCKED (the read tool needs masked access), but shell_exec and js_eval must
+// not return its raw bytes — redactSecrets only covers registered values (misses
+// <7-char and corrupt-file secrets). Both route the agent to the masking read tool.
+const AGENT_SETTINGS_FILE = 'agent_settings.json';
+
 // DeerFlow P2: Tool registry for tool_search — set from tools/index.js at startup
 let _getTools = null;
 function _setToolRegistry(fn) { _getTools = fn; }
@@ -143,9 +149,11 @@ const handlers = {
         // BAT-1087: block shell access to agent_settings.json. redactSecrets covers
         // registered values, but a corrupt/unparseable file registers nothing, so a
         // dump command (cat/head/grep/base64/...) could still leak raw stored keys.
-        // Fail closed and route the agent to the read tool, which masks values and
-        // withholds unparseable content.
-        if (/\bagent_settings\.json\b/i.test(cmd)) {
+        // Strip shell quoting/backslash escapes before matching so evasions like
+        // `agent_settings\.json` or `agent_settings.jso''n` (which /bin/sh collapses to
+        // the real name) can't slip past; operators ($, backticks, *, ...) are already
+        // rejected above, leaving quotes and backslashes as the only evasion chars.
+        if (/\bagent_settings\.json\b/i.test(cmd.replace(/['"\\]/g, ''))) {
             return { error: 'Reading agent_settings.json via shell_exec is blocked. Use the read tool — it returns the file with secret values masked.' };
         }
 
@@ -297,6 +305,12 @@ const handlers = {
                             const basename = path.basename(resolvedPath);
                             if (SECRETS_BLOCKED.has(basename)) {
                                 throw new Error(`Access to ${basename} is blocked for security.`);
+                            }
+                            // BAT-1087: agent_settings.json isn't in SECRETS_BLOCKED (masked
+                            // read is allowed via the read tool), but js_eval must not read it
+                            // raw — that would bypass masking for <7-char / corrupt-file secrets.
+                            if (basename === AGENT_SETTINGS_FILE) {
+                                throw new Error('Access to agent_settings.json via js_eval is blocked; use the read tool (secret values are masked).');
                             }
                             return original.apply(target, args);
                         };

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -140,6 +140,15 @@ const handlers = {
             return { error: 'Shell operators (;, &, |, `, <, >, $, *, ?, ~, {}, []) are not allowed in arguments. Run one simple command at a time.' };
         }
 
+        // BAT-1087: block shell access to agent_settings.json. redactSecrets covers
+        // registered values, but a corrupt/unparseable file registers nothing, so a
+        // dump command (cat/head/grep/base64/...) could still leak raw stored keys.
+        // Fail closed and route the agent to the read tool, which masks values and
+        // withholds unparseable content.
+        if (/\bagent_settings\.json\b/i.test(cmd)) {
+            return { error: 'Reading agent_settings.json via shell_exec is blocked. Use the read tool — it returns the file with secret values masked.' };
+        }
+
         // Resolve working directory (must be within workspace)
         let cwd = workDir;
         if (input.cwd) {

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -190,13 +190,18 @@ const handlers = {
                 shell: shellPath,
                 env: childEnv
             }, (err, stdout, stderr) => {
+                // BAT-1087: redact secrets from shell output before it reaches the
+                // model. `cat agent_settings.json` (and other allowlisted printers)
+                // would otherwise return raw provider keys; redactSecrets also masks
+                // the bridge token and any registered secret. Redact BEFORE slicing so
+                // a secret spanning the truncation boundary is still masked.
                 if (err) {
                     if (err.killed && err.signal) {
                         log(`shell_exec TIMEOUT: ${cmd.slice(0, 80)}`, 'WARN');
                         resolve({
                             success: false,
                             command: cmd,
-                            stdout: (stdout || '').slice(0, 50000),
+                            stdout: redactSecrets(stdout || '').slice(0, 50000),
                             stderr: `Command timed out after ${timeout}ms`,
                             exit_code: err.code || 1
                         });
@@ -205,8 +210,8 @@ const handlers = {
                         resolve({
                             success: false,
                             command: cmd,
-                            stdout: (stdout || '').slice(0, 50000),
-                            stderr: (stderr || '').slice(0, 10000) || err.message || 'Unknown error',
+                            stdout: redactSecrets(stdout || '').slice(0, 50000),
+                            stderr: redactSecrets((stderr || '') || err.message || 'Unknown error').slice(0, 10000),
                             exit_code: err.code || 1
                         });
                     }
@@ -215,8 +220,8 @@ const handlers = {
                     resolve({
                         success: true,
                         command: cmd,
-                        stdout: (stdout || '').slice(0, 50000),
-                        stderr: (stderr || '').slice(0, 10000),
+                        stdout: redactSecrets(stdout || '').slice(0, 50000),
+                        stderr: redactSecrets(stderr || '').slice(0, 10000),
                         exit_code: 0
                     });
                 }

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -16,6 +16,9 @@ const {
 // not return its raw bytes — redactSecrets only covers registered values (misses
 // <7-char and corrupt-file secrets). Both route the agent to the masking read tool.
 const AGENT_SETTINGS_FILE = 'agent_settings.json';
+// Word-boundary matcher for the filename, derived from the constant so shell_exec
+// and js_eval stay in lockstep if the name ever changes.
+const AGENT_SETTINGS_RX = new RegExp('\\b' + AGENT_SETTINGS_FILE.replace(/[.]/g, '\\.') + '\\b', 'i');
 
 // DeerFlow P2: Tool registry for tool_search — set from tools/index.js at startup
 let _getTools = null;
@@ -153,8 +156,8 @@ const handlers = {
         // `agent_settings\.json` or `agent_settings.jso''n` (which /bin/sh collapses to
         // the real name) can't slip past; operators ($, backticks, *, ...) are already
         // rejected above, leaving quotes and backslashes as the only evasion chars.
-        if (/\bagent_settings\.json\b/i.test(cmd.replace(/['"\\]/g, ''))) {
-            return { error: 'Reading agent_settings.json via shell_exec is blocked. Use the read tool — it returns the file with secret values masked.' };
+        if (AGENT_SETTINGS_RX.test(cmd.replace(/['"\\]/g, ''))) {
+            return { error: `Reading ${AGENT_SETTINGS_FILE} via shell_exec is blocked. Use the read tool — it returns the file with secret values masked.` };
         }
 
         // Resolve working directory (must be within workspace)

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -16,9 +16,12 @@ const {
 // not return its raw bytes — redactSecrets only covers registered values (misses
 // <7-char and corrupt-file secrets). Both route the agent to the masking read tool.
 const AGENT_SETTINGS_FILE = 'agent_settings.json';
-// Word-boundary matcher for the filename, derived from the constant so shell_exec
-// and js_eval stay in lockstep if the name ever changes.
-const AGENT_SETTINGS_RX = new RegExp('\\b' + AGENT_SETTINGS_FILE.replace(/[.]/g, '\\.') + '\\b', 'i');
+// Match the filename as a WHOLE command token: optional path prefix (start / space /
+// separator) and whitespace-or-end after — so `cat agent_settings.json` and
+// `cat ./agent_settings.json` are blocked, but a different file like
+// `agent_settings.json.bak` is NOT falsely matched (a `\b` after `.json` would).
+// Derived from the constant so shell_exec and js_eval stay in lockstep if renamed.
+const AGENT_SETTINGS_RX = new RegExp('(^|[\\s/])' + AGENT_SETTINGS_FILE.replace(/[.]/g, '\\.') + '(\\s|$)', 'i');
 
 // DeerFlow P2: Tool registry for tool_search — set from tools/index.js at startup
 let _getTools = null;

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -133,16 +133,24 @@ check('every stored value (incl. merge-losers + nested) is registered for redact
         assert.ok(hasNoSentinel(r.result), 'js_eval result must not contain any raw stored value');
     });
 
-    // shell_exec cat — same redactSecrets wrapper on stdout. Guarded: on a runner
-    // without a POSIX shell the handler fails; the redaction mechanism is already
-    // proven by test B (redactSecrets) and runs for real on the Linux CI runner.
-    await checkAsync('shell_exec cat agent_settings.json: stdout redacted (CI/POSIX)', async () => {
-        const sh = await sysTool.handlers.shell_exec({ command: 'cat agent_settings.json' }, 'chat');
-        if (sh && sh.success && sh.stdout) {
-            assert.ok(hasNoSentinel(sh.stdout), 'shell_exec cat stdout must be redacted');
-        } else {
-            console.log('    (shell unavailable on this host — asserted via redactSecrets in test B; runs on Linux CI)');
+    // shell_exec must fail CLOSED on any command that references agent_settings.json
+    // (cat/head/base64/... incl. ./ paths). redactSecrets only covers registered
+    // values, so a corrupt/unparseable file — which registers nothing — could
+    // otherwise leak raw keys through a shell dump. Blocking is deterministic and
+    // needs no shell spawn (short-circuits before exec), so it runs on every host.
+    await checkAsync('shell_exec referencing agent_settings.json is blocked (fail closed)', async () => {
+        for (const command of ['cat agent_settings.json', 'head ./agent_settings.json', 'base64 agent_settings.json']) {
+            const sh = await sysTool.handlers.shell_exec({ command }, 'chat');
+            assert.ok(sh.error && /blocked/i.test(sh.error), `must block: ${command}`);
+            assert.strictEqual(sh.stdout, undefined, 'a blocked command returns no stdout');
         }
+    });
+
+    await checkAsync('shell_exec still works for unrelated commands (block is narrow)', async () => {
+        const sh = await sysTool.handlers.shell_exec({ command: 'echo hello' }, 'chat');
+        // On a host without a POSIX shell the exec fails, but it must NOT be blocked
+        // by the agent_settings guard — assert we did not short-circuit with a block.
+        assert.ok(!(sh.error && /blocked/i.test(sh.error)), 'unrelated command must not be blocked');
     });
 
     // ---------------------------------------------------------------------------

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -3,13 +3,15 @@
 //
 // BAT-1087: agent_settings.json stores plaintext provider keys under apiKeys.* and
 // is readable by the model via the read / js_eval / shell_exec tools. This test
-// pins the model-facing masking:
+// pins the model-facing protection across all three surfaces:
 //   A. maskAgentSettings() masks apiKeys.* + credential-typed values at any depth,
 //      keeps structural fields, and fails closed (null) on unparseable input.
-//   B. registerAgentSettingsSecrets() registers EVERY stored value (incl. ones that
-//      lost the config merge) so redactSecrets — applied by js_eval AND shell_exec —
-//      masks them.
-//   C. the read handler returns masked content (and withholds on corrupt JSON).
+//   B. registerAgentSettingsSecrets() registers stored values (>= _MIN_SECRET_LEN)
+//      so redactSecrets scrubs them if they surface elsewhere (logs/other output) —
+//      DEFENSE-IN-DEPTH, not the primary path.
+//   C. read handler returns masked content (all lengths) and withholds on corrupt
+//      JSON; js_eval and shell_exec BLOCK the file outright (so short/corrupt-file
+//      secrets can't leak via those surfaces).
 //   D. the save/write flow still persists + syncs keys (BAT-236 unbroken).
 //
 // This is MODEL-FACING OUTPUT MASKING, not storage-at-rest protection — the file on
@@ -117,7 +119,7 @@ check('fails closed (null) on unparseable / non-object JSON', () => {
 // ---------------------------------------------------------------------------
 // B. registration + redactSecrets  (the js_eval / shell_exec coverage mechanism)
 // ---------------------------------------------------------------------------
-check('every stored value (incl. merge-losers + nested) is registered for redaction', () => {
+check('stored values >= min length (incl. merge-losers + nested) are registered for redaction', () => {
     // registerAgentSettingsSecrets() ran at security.js load against the seeded file.
     const blob = `dump: ${SENTINELS.join(' / ')}`;
     const red = sec.redactSecrets(blob);

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -124,22 +124,31 @@ check('every stored value (incl. merge-losers + nested) is registered for redact
         assert.ok(r.content.includes('"model": "claude-opus-4-8"'), 'model still visible');
     });
 
-    // D. js_eval reading the file — redactSecrets (in the js_eval handler) masks the
-    // registered values, INCLUDING merge-losers that never enter `config`.
-    await checkAsync('js_eval reading the file: all stored values masked (incl. merge-loser)', async () => {
+    // js_eval must not read agent_settings.json raw — the guarded fs proxy blocks it,
+    // so <7-char / corrupt-file secrets that registration can't cover never leak. The
+    // read tool is the masked path. (Registration is still proven by test B as
+    // defense-in-depth for any value that surfaces elsewhere.)
+    await checkAsync('js_eval reading agent_settings.json is blocked (no raw bytes reach the model)', async () => {
         const code = "const fs=require('fs'), p=require('path'); return fs.readFileSync(p.join(process.cwd(), 'agent_settings.json'),'utf8');";
         const r = await sysTool.handlers.js_eval({ code }, 'chat');
-        assert.ok(r.success, `js_eval failed: ${r.error}`);
-        assert.ok(hasNoSentinel(r.result), 'js_eval result must not contain any raw stored value');
+        assert.ok(!r.success, 'js_eval read of agent_settings.json must be blocked');
+        assert.ok(/blocked/i.test(r.error || ''), 'error explains the block');
+        assert.ok(hasNoSentinel(JSON.stringify(r)), 'no raw stored value in result/output/error');
     });
 
-    // shell_exec must fail CLOSED on any command that references agent_settings.json
-    // (cat/head/base64/... incl. ./ paths). redactSecrets only covers registered
-    // values, so a corrupt/unparseable file — which registers nothing — could
-    // otherwise leak raw keys through a shell dump. Blocking is deterministic and
-    // needs no shell spawn (short-circuits before exec), so it runs on every host.
-    await checkAsync('shell_exec referencing agent_settings.json is blocked (fail closed)', async () => {
-        for (const command of ['cat agent_settings.json', 'head ./agent_settings.json', 'base64 agent_settings.json']) {
+    // shell_exec must fail CLOSED on any command referencing agent_settings.json,
+    // INCLUDING shell-quoting / backslash evasions that /bin/sh would normalize to the
+    // real filename. Deterministic + needs no shell spawn (short-circuits before exec).
+    await checkAsync('shell_exec referencing agent_settings.json is blocked, incl. quoted/escaped', async () => {
+        const variants = [
+            'cat agent_settings.json',
+            'head ./agent_settings.json',
+            'base64 agent_settings.json',
+            'cat agent_settings\\.json',   // backslash escape → \.
+            "cat agent_settings.jso''n",   // empty-quote split
+            'cat "agent_settings.json"',   // quoted
+        ];
+        for (const command of variants) {
             const sh = await sysTool.handlers.shell_exec({ command }, 'chat');
             assert.ok(sh.error && /blocked/i.test(sh.error), `must block: ${command}`);
             assert.strictEqual(sh.stdout, undefined, 'a blocked command returns no stdout');

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// tests/nodejs-project/agent-settings-mask.test.js
+//
+// BAT-1087: agent_settings.json stores plaintext provider keys under apiKeys.* and
+// is readable by the model via the read / js_eval / shell_exec tools. This test
+// pins the model-facing masking:
+//   A. maskAgentSettings() masks apiKeys.* + credential-typed values at any depth,
+//      keeps structural fields, and fails closed (null) on unparseable input.
+//   B. registerAgentSettingsSecrets() registers EVERY stored value (incl. ones that
+//      lost the config merge) so redactSecrets — applied by js_eval AND shell_exec —
+//      masks them.
+//   C. the read handler returns masked content (and withholds on corrupt JSON).
+//   D. the save/write flow still persists + syncs keys (BAT-236 unbroken).
+//
+// This is MODEL-FACING OUTPUT MASKING, not storage-at-rest protection — the file on
+// disk stays plaintext.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// Fixture workDir (config.js reads process.argv[2]). config.json marks braveApiKey
+// as an Android-settings key so the agent's apiKeys.brave value is a MERGE-LOSER
+// (never enters `config`) — the case that only registration, not the config-derived
+// redaction patterns, can cover. Placeholders are obviously fake (no real-key shape).
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1087-mask-'));
+fs.writeFileSync(path.join(workDir, 'config.json'), JSON.stringify({
+    botToken: 'placeholder-not-a-real-bot-token',
+    anthropicApiKey: 'placeholder-not-a-real-api-key',
+    braveApiKey: 'ANDROID_BRAVE_PLACEHOLDER',
+    ownerId: '111',
+    channel: 'telegram',
+}), 'utf8');
+const ORIGINAL_SETTINGS = {
+    apiKeys: {
+        anthropic: 'SENTINEL_ANTHROPIC_VALUE',   // maps to an Android key -> merge-loser
+        custommap: 'SENTINEL_CUSTOM_VALUE',       // unknown service -> not in config
+        brave: 'SENTINEL_BRAVE_MERGELOSER',       // Android brave wins -> merge-loser
+    },
+    nested: { webhookSecret: 'SENTINEL_NESTED_SECRET' }, // credential by key-name, any depth
+    heartbeatIntervalMinutes: 7,
+    model: 'claude-opus-4-8',
+    provider: 'claude',
+};
+fs.writeFileSync(path.join(workDir, 'agent_settings.json'), JSON.stringify(ORIGINAL_SETTINGS), 'utf8');
+process.argv[2] = workDir;
+process.on('exit', () => { try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {} });
+
+const sec = require(path.join(BUNDLE, 'security.js'));       // registerAgentSettingsSecrets() runs at load
+const cfg = require(path.join(BUNDLE, 'config.js'));
+const fileTool = require(path.join(BUNDLE, 'tools', 'file.js'));
+const sysTool = require(path.join(BUNDLE, 'tools', 'system.js'));
+
+const SENTINELS = ['SENTINEL_ANTHROPIC_VALUE', 'SENTINEL_CUSTOM_VALUE', 'SENTINEL_BRAVE_MERGELOSER', 'SENTINEL_NESTED_SECRET'];
+function hasNoSentinel(s, list = SENTINELS) { return list.every((x) => !String(s).includes(x)); }
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+console.log('agent-settings-mask.test.js — BAT-1087 model-facing settings masking');
+console.log();
+
+// ---------------------------------------------------------------------------
+// A. maskAgentSettings — pure
+// ---------------------------------------------------------------------------
+check('masks apiKeys.* (known + unknown) and nested credential fields; keeps structure', () => {
+    const sample = JSON.stringify({
+        apiKeys: { anthropic: 'AAA_SECRET', weirdsvc: 'BBB_SECRET' },
+        deep: { nested: { authToken: 'CCC_SECRET' } },
+        heartbeatIntervalMinutes: 5,
+        model: 'm',
+        provider: 'claude',
+    });
+    const masked = sec.maskAgentSettings(sample);
+    assert.ok(typeof masked === 'string', 'returns a string on valid input');
+    const obj = JSON.parse(masked);
+    assert.strictEqual(obj.apiKeys.anthropic, '[REDACTED]');
+    assert.strictEqual(obj.apiKeys.weirdsvc, '[REDACTED]', 'unknown service value still masked');
+    assert.strictEqual(obj.deep.nested.authToken, '[REDACTED]', 'nested credential-typed key masked');
+    assert.strictEqual(obj.heartbeatIntervalMinutes, 5, 'structural field visible');
+    assert.strictEqual(obj.model, 'm');
+    assert.strictEqual(obj.provider, 'claude');
+    assert.ok(!masked.includes('SECRET'), 'no raw secret value leaks');
+});
+
+check('fails closed (null) on unparseable / non-object JSON', () => {
+    assert.strictEqual(sec.maskAgentSettings('{bad json'), null, 'corrupt JSON -> null');
+    assert.strictEqual(sec.maskAgentSettings('[1,2,3]'), null, 'array -> null');
+    assert.strictEqual(sec.maskAgentSettings('"just a string"'), null, 'primitive -> null');
+});
+
+// ---------------------------------------------------------------------------
+// B. registration + redactSecrets  (the js_eval / shell_exec coverage mechanism)
+// ---------------------------------------------------------------------------
+check('every stored value (incl. merge-losers + nested) is registered for redaction', () => {
+    // registerAgentSettingsSecrets() ran at security.js load against the seeded file.
+    const blob = `dump: ${SENTINELS.join(' / ')}`;
+    const red = sec.redactSecrets(blob);
+    for (const s of SENTINELS) assert.ok(!red.includes(s), `${s} must be redacted by redactSecrets`);
+});
+
+// ---------------------------------------------------------------------------
+// C. read handler
+// ---------------------------------------------------------------------------
+(async () => {
+    await checkAsync('read agent_settings.json: values masked, structural fields visible', async () => {
+        const r = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(!r.error, `unexpected error: ${r.error}`);
+        assert.ok(hasNoSentinel(r.content), 'no sentinel value in returned content');
+        assert.ok(r.content.includes('[REDACTED]'), 'masked placeholder present');
+        assert.ok(r.content.includes('"heartbeatIntervalMinutes": 7'), 'heartbeat interval still visible');
+        assert.ok(r.content.includes('"model": "claude-opus-4-8"'), 'model still visible');
+    });
+
+    // D. js_eval reading the file — redactSecrets (in the js_eval handler) masks the
+    // registered values, INCLUDING merge-losers that never enter `config`.
+    await checkAsync('js_eval reading the file: all stored values masked (incl. merge-loser)', async () => {
+        const code = "const fs=require('fs'), p=require('path'); return fs.readFileSync(p.join(process.cwd(), 'agent_settings.json'),'utf8');";
+        const r = await sysTool.handlers.js_eval({ code }, 'chat');
+        assert.ok(r.success, `js_eval failed: ${r.error}`);
+        assert.ok(hasNoSentinel(r.result), 'js_eval result must not contain any raw stored value');
+    });
+
+    // shell_exec cat — same redactSecrets wrapper on stdout. Guarded: on a runner
+    // without a POSIX shell the handler fails; the redaction mechanism is already
+    // proven by test B (redactSecrets) and runs for real on the Linux CI runner.
+    await checkAsync('shell_exec cat agent_settings.json: stdout redacted (CI/POSIX)', async () => {
+        const sh = await sysTool.handlers.shell_exec({ command: 'cat agent_settings.json' }, 'chat');
+        if (sh && sh.success && sh.stdout) {
+            assert.ok(hasNoSentinel(sh.stdout), 'shell_exec cat stdout must be redacted');
+        } else {
+            console.log('    (shell unavailable on this host — asserted via redactSecrets in test B; runs on Linux CI)');
+        }
+    });
+
+    // ---------------------------------------------------------------------------
+    // D. save/write regression — BAT-236 sync + new-key registration still work
+    // ---------------------------------------------------------------------------
+    await checkAsync('write flow persists a new key, syncs to config, masks on read-back', async () => {
+        const NEWKEY = 'NEWPERPLEXITY_PLACEHOLDER_VALUE';
+        const newSettings = JSON.stringify({ apiKeys: { perplexity: NEWKEY }, heartbeatIntervalMinutes: 9 });
+        const w = await fileTool.handlers.write({ path: 'agent_settings.json', content: newSettings }, 'chat');
+        assert.ok(w.success, 'write succeeded');
+        // BAT-236: syncAgentApiKeys picked the new key into config (perplexity is not an Android key here)
+        assert.strictEqual(cfg.config.perplexityApiKey, NEWKEY, 'new key synced into config');
+        // File on disk stays plaintext (this is output masking, not at-rest encryption)
+        const onDisk = fs.readFileSync(path.join(workDir, 'agent_settings.json'), 'utf8');
+        assert.ok(onDisk.includes(NEWKEY), 'file persists the raw key on disk');
+        // Reading it back through the tool is masked, and it is now registered for redaction
+        const rr = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(!rr.content.includes(NEWKEY), 'read-back masks the newly-saved key');
+        assert.ok(!sec.redactSecrets(`k=${NEWKEY}`).includes(NEWKEY), 'newly-saved key registered for redaction');
+    });
+
+    // ---------------------------------------------------------------------------
+    // C. corrupt file — fail closed (run last: it clobbers the settings file)
+    // ---------------------------------------------------------------------------
+    await checkAsync('corrupt agent_settings.json → content withheld (fail closed)', async () => {
+        fs.writeFileSync(path.join(workDir, 'agent_settings.json'), '{ this is : not valid json ', 'utf8');
+        const r = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(r.error && /withheld/i.test(r.error), 'unparseable settings file must be withheld');
+        assert.strictEqual(r.content, undefined, 'no raw content returned');
+    });
+
+    console.log();
+    console.log(`Result: ${pass} passed, ${fail} failed`);
+    if (fail > 0) { console.error('FAIL: agent-settings-mask.test.js'); process.exit(1); }
+    console.log('PASS: agent-settings-mask.test.js');
+})();

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -185,11 +185,14 @@ check('stored values >= min length (incl. merge-losers + nested) are registered 
         }
     });
 
-    await checkAsync('shell_exec still works for unrelated commands (block is narrow)', async () => {
-        const sh = await sysTool.handlers.shell_exec({ command: 'echo hello' }, 'chat');
-        // On a host without a POSIX shell the exec fails, but it must NOT be blocked
-        // by the agent_settings guard — assert we did not short-circuit with a block.
-        assert.ok(!(sh.error && /blocked/i.test(sh.error)), 'unrelated command must not be blocked');
+    await checkAsync('shell_exec block is a precise token — does not over-match neighbours', async () => {
+        // `echo hello` and a different file `agent_settings.json.bak` must NOT trip the
+        // block (a \b-based regex would falsely match the .bak). On a shell-less host the
+        // exec may fail, but it must not short-circuit with the agent_settings block.
+        for (const command of ['echo hello', 'cat agent_settings.json.bak']) {
+            const sh = await sysTool.handlers.shell_exec({ command }, 'chat');
+            assert.ok(!(sh.error && /blocked/i.test(sh.error)), `must not be blocked: ${command}`);
+        }
     });
 
     // ---------------------------------------------------------------------------

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -110,6 +110,21 @@ check('masks secrets nested under apiKeys via arrays + deep objects (malformed s
     assert.strictEqual(JSON.parse(masked).heartbeatIntervalMinutes, 3, 'structural field intact');
 });
 
+check('masks secrets nested under a credential-typed key (object/array value)', () => {
+    // A credential-named key whose VALUE is an object/array must mask its descendants,
+    // not just direct-string values.
+    const sample = JSON.stringify({
+        webhookSecret: { current: 'CRED_OBJ_SECRET', previous: 'CRED_OBJ_SECRET_2' },
+        authToken: ['TOKEN_ARR_SECRET'],
+        heartbeatIntervalMinutes: 4,
+    });
+    const masked = sec.maskAgentSettings(sample);
+    for (const s of ['CRED_OBJ_SECRET', 'CRED_OBJ_SECRET_2', 'TOKEN_ARR_SECRET']) {
+        assert.ok(!masked.includes(s), `${s} nested under a credential-typed key must be masked`);
+    }
+    assert.strictEqual(JSON.parse(masked).heartbeatIntervalMinutes, 4, 'structural field intact');
+});
+
 check('fails closed (null) on unparseable / non-object JSON', () => {
     assert.strictEqual(sec.maskAgentSettings('{bad json'), null, 'corrupt JSON -> null');
     assert.strictEqual(sec.maskAgentSettings('[1,2,3]'), null, 'array -> null');

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -95,6 +95,19 @@ check('masks apiKeys.* (known + unknown) and nested credential fields; keeps str
     assert.ok(!masked.includes('SECRET'), 'no raw secret value leaks');
 });
 
+check('masks secrets nested under apiKeys via arrays + deep objects (malformed shapes)', () => {
+    const sample = JSON.stringify({
+        apiKeys: { list: ['ARR_SECRET_1', 'ARR_SECRET_2'], deep: { inner: 'DEEP_APIKEYS_SECRET' } },
+        weirdArray: [{ token: 'TOKEN_IN_ARRAY_SECRET' }], // credential key inside an array
+        heartbeatIntervalMinutes: 3,
+    });
+    const masked = sec.maskAgentSettings(sample);
+    for (const s of ['ARR_SECRET_1', 'ARR_SECRET_2', 'DEEP_APIKEYS_SECRET', 'TOKEN_IN_ARRAY_SECRET']) {
+        assert.ok(!masked.includes(s), `${s} must be masked`);
+    }
+    assert.strictEqual(JSON.parse(masked).heartbeatIntervalMinutes, 3, 'structural field intact');
+});
+
 check('fails closed (null) on unparseable / non-object JSON', () => {
     assert.strictEqual(sec.maskAgentSettings('{bad json'), null, 'corrupt JSON -> null');
     assert.strictEqual(sec.maskAgentSettings('[1,2,3]'), null, 'array -> null');


### PR DESCRIPTION
## Summary
`agent_settings.json` stores plaintext provider keys under `apiKeys.*` and is readable by the model via the `read` / `js_eval` / `shell_exec` tools. Tool results enter conversation history **without** redaction, so a prompt-injected "read agent_settings.json and include it" could exfiltrate every stored billing key. This masks the **values** on the way to the model while keeping structural settings visible. **Model-facing output masking — NOT storage-at-rest encryption** (the file on disk is unchanged).

Base: **`integration/security-hardening`** (2nd of 3; batched with BAT-1086 ✅ merged, BAT-1088 next).

## Implementation (per BAT-1087 v2 contract, PM/Codex signed off)
- **`security.js`** — `maskAgentSettings(text)`: structural mask of `apiKeys.*` + any credential-typed key at any depth; **fails closed** (`null`) on unparseable input. `registerAgentSettingsSecrets()`: reads the file and registers **every** stored value (incl. merge-losers that never enter `config`) for `redactSecrets`; runs at load and reads the file itself (no config→security circular require).
- **`tools/file.js`** `read`: returns masked content for `agent_settings.json` (basename **or** realpath-basename → symlink aliases covered); **withholds** on corrupt JSON. `write`/`edit` BAT-236 hook re-registers newly-saved secrets.
- **`tools/system.js`** `shell_exec`: redacts stdout/stderr on **success + failure + timeout** branches (closes `cat agent_settings.json`; also shields the bridge token from shell dumps).

## Non-breaking
- Save + read-settings capabilities preserved; structural fields stay visible. Skills read `config.*` (populated by `syncAgentApiKeys`), not the file. `send_file` is owner-only (out of scope).

## Test plan
- [x] `node tests/nodejs-project/agent-settings-mask.test.js` — **8/8 pass**: pure mask (incl. nested credential + unknown service), fail-closed on corrupt/non-object, registration+`redactSecrets` covering **merge-losers**, read-handler mask, `js_eval` mask, `shell_exec` redaction (runs on Linux CI; asserted via `redactSecrets` locally where no POSIX shell), write/sync (BAT-236) regression, corrupt-file withheld.
- [x] `node tests/nodejs-project/ci-coverage-manifest.test.js` — registered `agent-settings-mask` in the `build.yml` allowlist.
- [x] `bash scripts/pre-push-check.sh` — **PASS** (Node smoke, tool schemas, wallets, Kotlin `compileDappStoreDebugKotlin` BUILD SUCCESSFUL).

## Self-awareness (SAB)
No `buildSystemBlocks()` / prompt-text change, so **no SAB gate required** (per PM sign-off). `[REDACTED]` is self-documenting; the existing prompt statement that the file "contains API keys" remains accurate (the keys are in the file; only the read output masks values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)