### PR TITLE
fix: harden web_fetch SSRF guard against IPv6/private literals (BAT-1088)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
             truncate-tool-result \
             web-fetch-redirect-headers \
             agent-settings-mask \
+            web-fetch-ssrf-guard \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/app/src/main/assets/nodejs-project/telegram.js
+++ b/app/src/main/assets/nodejs-project/telegram.js
@@ -11,6 +11,7 @@ const { BOT_TOKEN, log, workDir, getOwnerId, RICH_MESSAGES_ENABLED } = require('
 const { redactSecrets } = require('./security');
 const { httpRequest } = require('./http');
 const { sanitizeRichMarkdown } = require('./rich-markdown');
+const { isBlockedAddress } = require('./web'); // BAT-1088: shared SSRF host classifier
 
 // ============================================================================
 // TELEGRAM API
@@ -315,15 +316,13 @@ async function downloadFileByUrl(url, fileName, maxSize) {
         throw new Error('Unsupported URL protocol: ' + parsedUrl.protocol + ' (only https: allowed)');
     }
 
-    // SSRF guard: block private/local/reserved addresses by hostname string.
-    // Known limitation: DNS rebinding attacks are not prevented here because we check
-    // the hostname string before DNS resolution. Full protection would require async DNS
-    // lookup and IP validation, which adds latency and complexity.
-    // Accepted trade-off: Discord CDN URLs come from cdn.discordapp.com (validated by
-    // the Discord API) — this hostname check is a first-pass defense against obvious
-    // SSRF attempts (localhost, RFC1918, link-local). Prompt-injection-sourced URLs
-    // arriving through normal message flow are a lower risk given the owner-only gate.
-    if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.|localhost|\[::1\]|\[fe80:)/i.test(parsedUrl.hostname)) {
+    // SSRF guard: shared canonical classifier (BAT-1088) — blocks private/loopback/
+    // link-local literals incl. IPv6 (ULA / IPv4-mapped / IPv4-compatible / zone-id),
+    // so this path can't drift from web_fetch's guard.
+    // Known limitation: DNS rebinding (a public hostname resolving to a private IP) is
+    // NOT prevented here — that needs resolve-and-pin (tracked as BAT-1093). Discord CDN
+    // URLs come from cdn.discordapp.com; the owner-only message flow keeps injection risk low.
+    if (isBlockedAddress(parsedUrl.hostname)) {
         throw new Error('Blocked: private/local address');
     }
 

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -342,13 +342,15 @@ function _ipv6ToBytes(str) {
 function _isBlockedIPv6(str) {
     const b = _ipv6ToBytes(str);
     if (!b) return true; // fail closed on anything we can't classify
-    if (b.every((x) => x === 0)) return true;                              // :: unspecified
-    if (b.slice(0, 15).every((x) => x === 0) && b[15] === 1) return true;  // ::1 loopback
-    if ((b[0] & 0xfe) === 0xfc) return true;                               // fc00::/7 ULA
-    if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true;              // fe80::/10 link-local
-    if (b.slice(0, 10).every((x) => x === 0) && b[10] === 0xff && b[11] === 0xff) {
-        return _isBlockedIPv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);      // ::ffff:0:0/96 IPv4-mapped
-    }
+    if ((b[0] & 0xfe) === 0xfc) return true;                  // fc00::/7 ULA
+    if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true; // fe80::/10 link-local
+    const embeddedV4 = () => _isBlockedIPv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);
+    // IPv4-mapped ::ffff:0:0/96 → classify by embedded IPv4.
+    if (b.slice(0, 10).every((x) => x === 0) && b[10] === 0xff && b[11] === 0xff) return embeddedV4();
+    // First 96 bits zero covers :: (unspecified → 0.0.0.0), ::1 (loopback → 0.0.0.1),
+    // and the deprecated IPv4-compatible form ::w.x.y.z (::7f00:1 etc.) that some
+    // stacks route as IPv4 — classify by the embedded IPv4 (0/8 catches :: and ::1).
+    if (b.slice(0, 12).every((x) => x === 0)) return embeddedV4();
     return false;
 }
 

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -2,6 +2,7 @@
 // Web cache, HTML-to-markdown, search providers, web fetch.
 // Depends on: config.js, http.js
 
+const net = require('net');
 const { config, log, USER_AGENT } = require('./config');
 const { httpRequest } = require('./http');
 
@@ -275,6 +276,95 @@ function computeOutboundHeaders(customHeaders, url, originUrl, options = {}, cur
     return headers;
 }
 
+// --- SSRF guard: block private / loopback / link-local literals (BAT-1088) ---
+//
+// LITERAL / canonical-host screening only — NOT DNS-rebind protection. `new URL()`
+// already canonicalizes IPv4 decimal/octal/hex forms to dotted-quad before we see
+// url.hostname, so the live gap this closes over the old prefix regex is IPv6
+// (loopback/mapped/ULA/link-local). A public hostname that RESOLVES to a private IP
+// is out of scope (needs resolve-and-pin — tracked separately as BAT-1093).
+//
+// V1 blocks: IPv4 loopback 127/8, private 10/8 + 172.16/12 + 192.168/16, link-local
+// 169.254/16, unspecified 0/8; IPv6 :: , ::1, ULA fc00::/7, link-local fe80::/10,
+// IPv4-mapped ::ffff:0:0/96 (classified by embedded IPv4); localhost / *.localhost.
+// Deliberately NOT blocked (per BAT-1088 decision): CGNAT 100.64/10, benchmark
+// 198.18/15, multicast, reserved-future — asserted allowed in tests.
+
+function _isBlockedIPv4(ip) {
+    const p = ip.split('.');
+    if (p.length !== 4) return true; // net.isIPv4 validated the shape; be safe
+    const a = Number(p[0]), b = Number(p[1]);
+    if (a === 127) return true;                       // loopback 127/8
+    if (a === 10) return true;                        // private 10/8
+    if (a === 0) return true;                         // "this host" 0/8
+    if (a === 169 && b === 254) return true;          // link-local 169.254/16
+    if (a === 192 && b === 168) return true;          // private 192.168/16
+    if (a === 172 && b >= 16 && b <= 31) return true; // private 172.16/12
+    return false;
+}
+
+// Parse a (net.isIPv6-validated) IPv6 string into 16 bytes, or null if unparseable.
+function _ipv6ToBytes(str) {
+    const halves = str.split('::');
+    if (halves.length > 2) return null;
+    const parseGroups = (part) => {
+        if (part === '') return [];
+        const out = [];
+        for (const t of part.split(':')) {
+            if (t.includes('.')) { // embedded IPv4 tail → two 16-bit groups
+                const q = t.split('.').map(Number);
+                if (q.length !== 4 || q.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+                out.push(((q[0] << 8) | q[1]) & 0xffff, ((q[2] << 8) | q[3]) & 0xffff);
+            } else {
+                if (!/^[0-9a-f]{1,4}$/i.test(t)) return null;
+                out.push(parseInt(t, 16));
+            }
+        }
+        return out;
+    };
+    const head = parseGroups(halves[0]);
+    const tail = halves.length === 2 ? parseGroups(halves[1]) : [];
+    if (head === null || tail === null) return null;
+    let g;
+    if (halves.length === 2) {
+        const missing = 8 - head.length - tail.length;
+        if (missing < 0) return null;
+        g = [...head, ...Array(missing).fill(0), ...tail];
+    } else {
+        g = head;
+    }
+    if (g.length !== 8) return null;
+    const bytes = new Uint8Array(16);
+    for (let i = 0; i < 8; i++) { bytes[2 * i] = (g[i] >> 8) & 0xff; bytes[2 * i + 1] = g[i] & 0xff; }
+    return bytes;
+}
+
+function _isBlockedIPv6(str) {
+    const b = _ipv6ToBytes(str);
+    if (!b) return true; // fail closed on anything we can't classify
+    if (b.every((x) => x === 0)) return true;                              // :: unspecified
+    if (b.slice(0, 15).every((x) => x === 0) && b[15] === 1) return true;  // ::1 loopback
+    if ((b[0] & 0xfe) === 0xfc) return true;                               // fc00::/7 ULA
+    if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true;              // fe80::/10 link-local
+    if (b.slice(0, 10).every((x) => x === 0) && b[10] === 0xff && b[11] === 0xff) {
+        return _isBlockedIPv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);      // ::ffff:0:0/96 IPv4-mapped
+    }
+    return false;
+}
+
+// Is this host a private/loopback/link-local literal that web_fetch must not reach?
+// Pure + exported for unit testing. Called per redirect hop before any socket opens.
+function isBlockedAddress(hostname) {
+    if (typeof hostname !== 'string') return true; // fail closed on junk
+    let host = hostname.trim().toLowerCase();
+    if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1); // strip IPv6 brackets
+    if (!host) return true; // empty / whitespace-only / "[]" → fail closed
+    const v = net.isIP(host);
+    if (v === 0) return host === 'localhost' || host.endsWith('.localhost'); // hostname, not an IP literal
+    if (v === 4) return _isBlockedIPv4(host);
+    return _isBlockedIPv6(host);
+}
+
 async function webFetch(urlString, options = {}) {
     const maxRedirects = options.maxRedirects || 5;
     const timeout = options.timeout || 30000;
@@ -293,8 +383,9 @@ async function webFetch(urlString, options = {}) {
             throw new Error('Unsupported URL protocol: ' + url.protocol);
         }
 
-        // SSRF guard: block private/local/reserved addresses
-        if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.|localhost)/i.test(url.hostname)) {
+        // SSRF guard: block private/local/link-local literals (BAT-1088).
+        // Per-hop + before any socket, so redirect targets are covered too.
+        if (isBlockedAddress(url.hostname)) {
             throw new Error('Blocked: private/local address');
         }
 
@@ -355,4 +446,5 @@ module.exports = {
     searchFirecrawl,
     webFetch,
     computeOutboundHeaders,
+    isBlockedAddress,
 };

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -358,7 +358,12 @@ function isBlockedAddress(hostname) {
     if (typeof hostname !== 'string') return true; // fail closed on junk
     let host = hostname.trim().toLowerCase();
     if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1); // strip IPv6 brackets
-    if (!host) return true; // empty / whitespace-only / "[]" → fail closed
+    // Strip trailing dot(s): the FQDN root form (localhost. / api.localhost.) resolves
+    // identically to the un-dotted name, so it must classify the same — otherwise it's
+    // a localhost SSRF bypass. (new URL() drops the dot on IP literals but keeps it on
+    // names.)
+    host = host.replace(/\.+$/, '');
+    if (!host) return true; // empty / whitespace-only / "[]" / "." → fail closed
     const v = net.isIP(host);
     if (v === 0) return host === 'localhost' || host.endsWith('.localhost'); // hostname, not an IP literal
     if (v === 4) return _isBlockedIPv4(host);

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -358,6 +358,12 @@ function isBlockedAddress(hostname) {
     if (typeof hostname !== 'string') return true; // fail closed on junk
     let host = hostname.trim().toLowerCase();
     if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1); // strip IPv6 brackets
+    // Strip an IPv6 zone identifier (RFC 6874: fe80::1%eth0). Classify the address
+    // itself so a zoned link-local literal is caught as link-local, not treated as a
+    // hostname. (new URL() actually rejects zoned IPv6 URLs, so this mainly hardens
+    // direct callers of this exported helper.)
+    const pct = host.indexOf('%');
+    if (pct !== -1) host = host.slice(0, pct);
     // Strip trailing dot(s): the FQDN root form (localhost. / api.localhost.) resolves
     // identically to the un-dotted name, so it must classify the same — otherwise it's
     // a localhost SSRF bypass. (new URL() drops the dot on IP literals but keeps it on

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -37,6 +37,7 @@ let calls = 0;
 httpMod.httpRequest = async () => { calls++; return { status: 200, headers: {}, data: 'ok' }; };
 
 const { isBlockedAddress, webFetch } = require(path.join(BUNDLE, 'web.js'));
+const tg = require(path.join(BUNDLE, 'telegram.js')); // BAT-1088: shares the same SSRF guard
 
 let pass = 0, fail = 0;
 function check(name, fn) {
@@ -128,6 +129,14 @@ console.log();
         const res = await webFetch('https://example.com/');
         assert.strictEqual(calls, 1, 'public host must reach the transport');
         assert.strictEqual(res.status, 200);
+    });
+
+    // Same-class sweep: telegram.js downloadFileByUrl shares the same classifier, so it
+    // gets the same IPv6/private coverage. Drift-guard that it actually calls the guard.
+    await checkAsync('telegram downloadFileByUrl rejects private hosts via the shared guard', async () => {
+        for (const u of ['https://127.0.0.1/x', 'https://[::1]/x', 'https://[::ffff:127.0.0.1]/x', 'https://localhost./x']) {
+            await assert.rejects(() => tg.downloadFileByUrl(u, 'f', 100), /Blocked: private\/local address/, `should block ${u}`);
+        }
     });
 
     console.log();

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -59,6 +59,8 @@ const BLOCK = [
     '[::1]', '::1', '[::]', '[::ffff:127.0.0.1]', '[::ffff:7f00:1]', '[fd00::1]', 'fd00::1', '[fe80::1]', 'fe80::1',
     // IPv6 zone identifiers (RFC 6874) — classify the address, ignore the zone
     'fe80::1%eth0', '[fe80::1%eth0]', '::1%lo0',
+    // Deprecated IPv4-compatible IPv6 (::w.x.y.z / ::7f00:1) embedding private/loopback IPv4
+    '::127.0.0.1', '::7f00:1', '[::127.0.0.1]', '::10.0.0.1', '::192.168.1.1',
     // IPv4 private / loopback / link-local / this-host
     '127.0.0.1', '127.255.255.254', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0',
     // hostnames — incl. FQDN-root trailing-dot forms (resolve like the un-dotted name)
@@ -68,6 +70,7 @@ const BLOCK = [
 const ALLOW = [
     '8.8.8.8', '1.1.1.1', '9.9.9.9',
     '[2606:4700::1111]', '2606:4700::1111',
+    '::8.8.8.8', // IPv4-compatible embedding a PUBLIC IPv4 → allowed (consistent with 8.8.8.8)
     'example.com', 'api.example.com', 'example.com.', // trailing-dot public FQDN stays allowed
     // Boundaries just outside the private ranges
     '172.15.0.1', '172.32.0.1',

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// tests/nodejs-project/web-fetch-ssrf-guard.test.js
+//
+// BAT-1088: web_fetch's SSRF guard is a pure canonical-host classifier,
+// isBlockedAddress(hostname), that rejects private/loopback/link-local literals
+// before any socket opens (per redirect hop). This is LITERAL screening only —
+// NOT DNS-rebind protection (that's BAT-1093).
+//
+// `new URL()` already canonicalizes IPv4 decimal/octal/hex to dotted-quad, so those
+// are regression cases (blocked today); the live add over the old prefix regex is
+// IPv6 (loopback / IPv4-mapped / ULA / link-local). Per the BAT-1088 decision, CGNAT
+// (100.64/10) and benchmark (198.18/15) are deliberately NOT blocked.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1088-ssrf-'));
+fs.writeFileSync(path.join(workDir, 'config.json'), JSON.stringify({
+    botToken: 'placeholder-not-a-real-bot-token',
+    anthropicApiKey: 'placeholder-not-a-real-api-key',
+    ownerId: '111',
+    channel: 'telegram',
+}), 'utf8');
+process.argv[2] = workDir;
+process.on('exit', () => { try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {} });
+
+// Stub the transport before loading web.js so we can assert the guard fires BEFORE
+// any socket (the stub must never be called for a blocked host).
+const httpMod = require(path.join(BUNDLE, 'http.js'));
+let calls = 0;
+httpMod.httpRequest = async () => { calls++; return { status: 200, headers: {}, data: 'ok' }; };
+
+const { isBlockedAddress, webFetch } = require(path.join(BUNDLE, 'web.js'));
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+console.log('web-fetch-ssrf-guard.test.js — BAT-1088 private/loopback literal screening');
+console.log();
+
+// ---------------------------------------------------------------------------
+// isBlockedAddress — pure classifier
+// ---------------------------------------------------------------------------
+const BLOCK = [
+    // IPv6 (the live gap): loopback, unspecified, IPv4-mapped, ULA, link-local
+    '[::1]', '::1', '[::]', '[::ffff:127.0.0.1]', '[::ffff:7f00:1]', '[fd00::1]', 'fd00::1', '[fe80::1]', 'fe80::1',
+    // IPv4 private / loopback / link-local / this-host
+    '127.0.0.1', '127.255.255.254', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0',
+    // hostnames
+    'localhost', 'api.localhost',
+];
+const ALLOW = [
+    '8.8.8.8', '1.1.1.1', '9.9.9.9',
+    '[2606:4700::1111]', '2606:4700::1111',
+    'example.com', 'api.example.com',
+    // Boundaries just outside the private ranges
+    '172.15.0.1', '172.32.0.1',
+    // Deliberately allowed in V1 (per BAT-1088 decision)
+    '100.64.0.1',  // CGNAT
+    '198.18.0.1',  // benchmark
+];
+
+check('blocks every private/loopback/link-local literal (IPv4 + IPv6)', () => {
+    for (const h of BLOCK) assert.strictEqual(isBlockedAddress(h), true, `should BLOCK ${h}`);
+});
+
+check('allows public IPs, hostnames, boundaries, and the V1-excluded CGNAT/benchmark ranges', () => {
+    for (const h of ALLOW) assert.strictEqual(isBlockedAddress(h), false, `should ALLOW ${h}`);
+});
+
+check('IPv4 alt-radix literals: canonicalized by new URL() then blocked (regression)', () => {
+    for (const u of ['https://2130706433/', 'https://0x7f000001/', 'https://0177.0.0.1/', 'https://0/']) {
+        const hostname = new URL(u).hostname;
+        assert.strictEqual(isBlockedAddress(hostname), true, `${u} -> ${hostname} should block`);
+    }
+});
+
+check('userinfo confusion: host is the PUBLIC part, so allowed (not private-host SSRF)', () => {
+    // https://127.0.0.1@api.example.com/ -> hostname is api.example.com (public)
+    const hostname = new URL('https://127.0.0.1@api.example.com/').hostname;
+    assert.strictEqual(hostname, 'api.example.com');
+    assert.strictEqual(isBlockedAddress(hostname), false);
+});
+
+check('fails closed on junk input', () => {
+    for (const h of ['', null, undefined, '   ']) assert.strictEqual(isBlockedAddress(h), true, `junk ${JSON.stringify(h)} should block`);
+});
+
+// ---------------------------------------------------------------------------
+// webFetch integration — guard fires before any socket
+// ---------------------------------------------------------------------------
+console.log();
+
+(async () => {
+    await checkAsync('webFetch to a blocked host throws BEFORE any socket opens', async () => {
+        calls = 0;
+        await assert.rejects(() => webFetch('https://[::1]/'), /Blocked: private\/local address/);
+        assert.strictEqual(calls, 0, 'transport must not be called for a blocked host');
+    });
+
+    await checkAsync('webFetch to an alt-radix loopback literal is blocked before socket', async () => {
+        calls = 0;
+        await assert.rejects(() => webFetch('https://2130706433/'), /Blocked: private\/local address/);
+        assert.strictEqual(calls, 0);
+    });
+
+    await checkAsync('webFetch to a public host still reaches the transport (no regression)', async () => {
+        calls = 0;
+        const res = await webFetch('https://example.com/');
+        assert.strictEqual(calls, 1, 'public host must reach the transport');
+        assert.strictEqual(res.status, 200);
+    });
+
+    console.log();
+    console.log(`Result: ${pass} passed, ${fail} failed`);
+    if (fail > 0) { console.error('FAIL: web-fetch-ssrf-guard.test.js'); process.exit(1); }
+    console.log('PASS: web-fetch-ssrf-guard.test.js');
+})();

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -57,6 +57,8 @@ console.log();
 const BLOCK = [
     // IPv6 (the live gap): loopback, unspecified, IPv4-mapped, ULA, link-local
     '[::1]', '::1', '[::]', '[::ffff:127.0.0.1]', '[::ffff:7f00:1]', '[fd00::1]', 'fd00::1', '[fe80::1]', 'fe80::1',
+    // IPv6 zone identifiers (RFC 6874) — classify the address, ignore the zone
+    'fe80::1%eth0', '[fe80::1%eth0]', '::1%lo0',
     // IPv4 private / loopback / link-local / this-host
     '127.0.0.1', '127.255.255.254', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0',
     // hostnames — incl. FQDN-root trailing-dot forms (resolve like the un-dotted name)

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -59,13 +59,14 @@ const BLOCK = [
     '[::1]', '::1', '[::]', '[::ffff:127.0.0.1]', '[::ffff:7f00:1]', '[fd00::1]', 'fd00::1', '[fe80::1]', 'fe80::1',
     // IPv4 private / loopback / link-local / this-host
     '127.0.0.1', '127.255.255.254', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0',
-    // hostnames
-    'localhost', 'api.localhost',
+    // hostnames — incl. FQDN-root trailing-dot forms (resolve like the un-dotted name)
+    'localhost', 'api.localhost', 'localhost.', 'api.localhost.', 'localhost..',
+    '127.0.0.1.', // trailing-dot IP literal (belt-and-suspenders; new URL also strips this)
 ];
 const ALLOW = [
     '8.8.8.8', '1.1.1.1', '9.9.9.9',
     '[2606:4700::1111]', '2606:4700::1111',
-    'example.com', 'api.example.com',
+    'example.com', 'api.example.com', 'example.com.', // trailing-dot public FQDN stays allowed
     // Boundaries just outside the private ranges
     '172.15.0.1', '172.32.0.1',
     // Deliberately allowed in V1 (per BAT-1088 decision)


### PR DESCRIPTION
## Summary
Replaces `web_fetch`'s hostname-prefix SSRF regex with a pure canonical-host classifier. My empirical check confirmed `new URL()` already canonicalizes IPv4 decimal/octal/hex (`2130706433`, `0x7f000001`, `0177.0.0.1` → `127.0.0.1`), so those were already blocked — the **live gap was IPv6** (loopback / IPv4-mapped / ULA / link-local), which the old regex missed.

Base: **`integration/security-hardening`** (3rd of 3; BAT-1086 ✅ + BAT-1087 ✅ merged).

## Implementation (per BAT-1088 v2 contract, PM/Codex signed off)
- **`isBlockedAddress(hostname)`** — new pure, exported classifier. **Literal/canonical-host screening only — NOT DNS-rebind protection.**
  - IPv4: `127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `0/8`.
  - IPv6: `::`, `::1`, `fc00::/7` (ULA), `fe80::/10` (link-local), `::ffff:0:0/96` IPv4-mapped (classified by the embedded IPv4, parsed from the 16-byte form).
  - `localhost` / `*.localhost`. Fails closed on junk/empty.
- Guard swapped to `isBlockedAddress(url.hostname)` — runs **per redirect hop, before any socket**, so redirect targets are covered.
- **Deliberately NOT blocked** (per the BAT-1088 decision): CGNAT `100.64/10`, benchmark `198.18/15`, multicast, reserved-future — this is host-literal screening, not network policy. Asserted allowed in tests.
- **Out of scope:** DNS-rebind (public hostname resolving to a private IP) → tracked as **BAT-1093** (resolve-and-pin).

## Test plan
- [x] `node tests/nodejs-project/web-fetch-ssrf-guard.test.js` — **8/8**: block matrix (v4+v6 incl. `[::1]`, `[::ffff:127.0.0.1]`/`[::ffff:7f00:1]`, `[fd00::1]`, `[fe80::1]`), allow matrix (publics + CGNAT/benchmark + `172.15`/`172.32` boundaries + userinfo-allowed `127.0.0.1@api.example.com`), URL-canonicalized alt-radix regression, fail-closed on junk, and `webFetch` **block-before-socket** (asserts the stubbed transport is never called).
- [x] `node tests/nodejs-project/web-fetch-redirect-headers.test.js` — **12/12** (BAT-1086 regression, no interaction).
- [x] `node tests/nodejs-project/ci-coverage-manifest.test.js` — registered `web-fetch-ssrf-guard` in the allowlist.
- [x] `bash scripts/pre-push-check.sh` — **PASS** (Node smoke, schemas, wallets, Kotlin `compileDappStoreDebugKotlin` BUILD SUCCESSFUL).

## Self-awareness (SAB)
N/A — no `buildSystemBlocks()` / prompt-text / user-visible capability change (internal guard hardening; error string unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)