### PR TITLE
fix: keep Claude thinking-block signature on streamed replay + adaptive thinking (BAT-1033)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
             telegram-rich-send \
             rich-messages-default \
             truncate-tool-result \
+            claude-thinking-signature \
+            claude-adaptive-thinking \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-03
+
+> **Reasoning reliability hotfix for the latest Claude models.** Fixes two
+> failures that could surface with Claude Sonnet 5, Opus 4.8, and other current
+> models — one during tool use, one when Extended Thinking is turned on with a
+> personal Anthropic API key. Fully backward-compatible; no configuration or
+> data changes.
+
+### Fixed
+
+- Resolved an API error that could interrupt a Claude reply during tool use or
+  multi-step responses on the latest models (including Sonnet 5 and Opus 4.8):
+  a reasoning step from one turn could be rejected on the next. Reasoning is now
+  carried across turns intact.
+- Fixed Extended Thinking failing to start on current Claude models when
+  connected with a personal Anthropic API key. Reasoning now uses Anthropic's
+  adaptive thinking mode, which the newest models require.
+
 ## [2.1.0] - 2026-06-30
 
 > **Autonomous on-chain trading + richer chat.** v2.0 let the agent's burner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -904,7 +904,7 @@ if (bootstrap) { runRitual(/* resume: !!identity */); }
 
 **When assembling a streamed API response, handle every `*_delta` type the wire can send — a dropped delta silently corrupts the block.** The Claude SSE reducer in `http.js` (`applyClaudeStreamEvent`) accumulates `text_delta`, `input_json_delta`, `thinking_delta`, and `signature_delta`. Anthropic streams a thinking block as an empty shell followed by deltas:
 
-```
+```text
 content_block_start  { type:'thinking', thinking:'', signature:'' }
 content_block_delta  { thinking_delta:  <reasoning text> }
 content_block_delta  { signature_delta: <the signature> }   ← easy to forget
@@ -912,7 +912,7 @@ content_block_delta  { signature_delta: <the signature> }   ← easy to forget
 
 **The v2.1.0 bug (BAT-1033):** the reducer handled only `text_delta` + `input_json_delta`, so it dropped `signature_delta`. The assembled thinking block kept the empty signature from `content_block_start`. On the next tool-loop round the block was echoed back (Anthropic requires thinking blocks to be replayed **unchanged** on tool-use turns) and the API rejected the whole request:
 
-```
+```text
 API error (400): messages.N.content.0.thinking: each thinking block must contain thinking
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@
 
 | Version | Current | Location |
 |---------|---------|----------|
-| **App** | `2.1.0` (code 21) | `app/build.gradle.kts` → `versionName` / `versionCode` |
+| **App** | `2.1.1` (code 22) | `app/build.gradle.kts` → `versionName` / `versionCode` |
 | **OpenClaw** | `2026.4.10` | `app/build.gradle.kts` → `OPENCLAW_VERSION` buildConfigField |
 | **Node.js** | `18 LTS` | `app/build.gradle.kts` → `NODEJS_VERSION` buildConfigField |
 
@@ -899,3 +899,42 @@ if (bootstrap && !identity) { runRitual(); }
 // GOOD — trigger file is sole source of truth; add resume note if identity exists
 if (bootstrap) { runRitual(/* resume: !!identity */); }
 ```
+
+### SSE Streaming — Handle EVERY Delta Type (thinking signatures)
+
+**When assembling a streamed API response, handle every `*_delta` type the wire can send — a dropped delta silently corrupts the block.** The Claude SSE reducer in `http.js` (`applyClaudeStreamEvent`) accumulates `text_delta`, `input_json_delta`, `thinking_delta`, and `signature_delta`. Anthropic streams a thinking block as an empty shell followed by deltas:
+
+```
+content_block_start  { type:'thinking', thinking:'', signature:'' }
+content_block_delta  { thinking_delta:  <reasoning text> }
+content_block_delta  { signature_delta: <the signature> }   ← easy to forget
+```
+
+**The v2.1.0 bug (BAT-1033):** the reducer handled only `text_delta` + `input_json_delta`, so it dropped `signature_delta`. The assembled thinking block kept the empty signature from `content_block_start`. On the next tool-loop round the block was echoed back (Anthropic requires thinking blocks to be replayed **unchanged** on tool-use turns) and the API rejected the whole request:
+
+```
+API error (400): messages.N.content.0.thinking: each thinking block must contain thinking
+```
+
+**The message is misleading — the trigger is the empty SIGNATURE, not empty text.** Proven with a live probe (`testing/test-thinking-poison.js`): a signed *empty-text* thinking block replays 200; the *same* block with `signature:''` replays 400. So:
+
+- **Capture side:** never lose the signature. `signature_delta` MUST be accumulated.
+- **Replay guard (`claude.js:_collectClaudeWireBlocks`):** skip a thinking block whose `signature` is empty/whitespace — **key on the signature, not the text** (an empty-text signed block is valid and must still replay). This also recovers checkpoints poisoned by an older build after upgrade.
+- **Why only Sonnet 5 surfaced it:** with `/think` off, Sonnet 5 emits a thinking block by default while Opus 4.8 doesn't — and emission is stochastic, which is why it flapped ("works now" → "broke again"). Any model that emits a thinking block hits it on the first tool-using turn.
+
+### Adaptive Thinking — `budget_tokens` was removed (verify per auth path)
+
+**A second, distinct BAT-1033 bug:** with `/think` **ON**, `formatRequest` used to send `thinking:{type:'enabled', budget_tokens}` (extended thinking). Anthropic **removed** extended thinking from the current models — fable-5/opus-4-8/opus-4-7/sonnet-5 reject it with `400 "thinking.type.enabled is not supported for this model. Use thinking.type.adaptive"`. Fix: send `thinking:{type:'adaptive'}` uniformly (the model auto-sizes its budget; accepted by every reasoning model). This retired the BAT-558 budget clamp (no `budget_tokens` → no `budget_tokens < max_tokens` constraint).
+
+**The trap that nearly made us defer it — auth path matters.** The `cc_version` billing masquerade on the **setup_token** path still *tolerated* the deprecated `budget_tokens` (returned 200), so probing only that path made it look "latent." On the **raw API-key** path (the common dApp-Store user, QR `anthropic_api_key`), the same request **400s**. **Always verify a provider-shape claim on BOTH auth paths** — `testing/test-thinking-matrix.js` runs the per-model × extended/adaptive grid on the api-key path; `test-thinking-repro.js` covers setup_token.
+
+### Wire-Contract Bugs Need Live Probes, Not Just Mocks
+
+**A fully-mocked test cannot catch a bug in what the *live API* actually accepts.** BAT-1033 shipped even though `claude-reasoning-roundtrip.test.js` existed — its mocks only covered *missing*-signature/wrong-type blocks, never the *empty-string* signature the real stream produces. Two-layer defense:
+
+1. **Offline (CI/smoke):** extract wire-assembly into a pure exported reducer and feed it the EXACT bytes the API streams (`tests/nodejs-project/claude-thinking-signature.test.js` drives `http.js`'s real `assembleClaudeStreamMessage`). The test must fail if the fix is reverted — verify that.
+2. **Live (opt-in, `testing/`):** `test-thinking-repro.js` (per-model × reasoning on/off/extended/adaptive matrix) and `test-thinking-poison.js` (verbatim vs signature-stripped replay) hit the real endpoint with a setup_token. Run before any release that touches provider request/response shaping.
+
+### Verify External API Contracts via context7 (not training memory)
+
+**Before writing or changing any provider request/response shaping — Anthropic, OpenAI, OpenRouter — pull the CURRENT API contract via the context7 MCP first; do not rely on training memory.** Model APIs change faster than the training cutoff. In BAT-1033, context7 (`platform.claude.com`) is what surfaced that Anthropic **removed** `thinking:{type:'enabled', budget_tokens}` from the current models and requires `type:'adaptive'` — a fact no amount of code-reading or memory would have revealed, and which the fix hinged on. Pair it with a live probe (above): context7 tells you the documented contract, the probe tells you what the endpoint (and our specific auth path) actually enforces. Applies to any hardcoded external identifier — API params, model ids, header/beta tags, endpoint paths.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.seekerclaw.app"
         minSdk = 34
         targetSdk = 35
-        versionCode = 21
-        versionName = "2.1.0"
+        versionCode = 22
+        versionName = "2.1.1"
 
         // Keep these in sync when updating OpenClaw or nodejs-mobile
         buildConfigField("String", "OPENCLAW_VERSION", "\"2026.4.10\"")

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -82,6 +82,7 @@ function applyClaudeStreamEvent(state, eventType, parsed) {
             }
             break;
         case 'content_block_delta': {
+            if (typeof parsed.index !== 'number') break;
             const blk = blocks[parsed.index];
             if (!blk || !parsed.delta) break;
             if (parsed.delta.type === 'text_delta') {
@@ -100,6 +101,7 @@ function applyClaudeStreamEvent(state, eventType, parsed) {
             break;
         }
         case 'content_block_stop': {
+            if (typeof parsed.index !== 'number') break;
             const blk = blocks[parsed.index];
             if (blk?.type === 'tool_use' && blk._inputJson) {
                 try { blk.input = JSON.parse(blk._inputJson); } catch (_) { blk.input = {}; }
@@ -136,7 +138,11 @@ function finalizeClaudeStreamBlocks(blocks) {
 function assembleClaudeStreamMessage(events) {
     const state = newClaudeStreamState();
     let stopped = false;
-    for (const ev of events) { if (applyClaudeStreamEvent(state, ev.eventType, ev.data)) stopped = true; }
+    for (const ev of events) {
+        // Stop at the first message_stop, matching the live socket path (which
+        // settles and breaks) — trailing events must not mutate a finalized message.
+        if (applyClaudeStreamEvent(state, ev.eventType, ev.data)) { stopped = true; break; }
+    }
     if (!stopped) state.message.content = finalizeClaudeStreamBlocks(state.blocks);
     return state.message;
 }

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -244,6 +244,11 @@ function httpStreamingRequest(options, body = null) {
                     if (applyClaudeStreamEvent(state, eventType, parsed)) {
                         clearTimeout(hardTimer);
                         settle(resolve, { status: 200, data: message, headers: res.headers });
+                        // Stop the stream so any trailing bytes can't re-enter the
+                        // reducer and mutate the already-resolved message by
+                        // reference (mirrors the SSE-error path). settled=true
+                        // also no-ops the res.on('end') partial-flush below.
+                        res.destroy();
                         break;
                     }
                 }

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -33,6 +33,111 @@ function httpRequest(options, body = null) {
     });
 }
 
+// ── Claude SSE stream assembly (BAT-1033) ────────────────────────────────────
+// Pure reducer for Anthropic streaming events, extracted so the live socket
+// path AND offline regression tests run the EXACT same assembly logic.
+//
+// The v2.1.0 bug lived here: the content_block_delta arm handled only
+// text_delta + input_json_delta and silently dropped `thinking_delta` and
+// `signature_delta`. Anthropic streams a `thinking` block as
+//   content_block_start {type:'thinking', thinking:'', signature:''}
+//   content_block_delta {signature_delta: <the real signature>}
+//   content_block_delta {thinking_delta:  <the reasoning text>}
+// so dropping those two deltas left the block with the EMPTY signature from
+// content_block_start. Echoing that block back on the next tool-loop round →
+// API 400 "each thinking block must contain thinking" (the message is
+// misleading — the trigger is the empty *signature*, not empty text; a signed
+// empty-text block is accepted). Handling both delta types makes the assembled
+// block byte-complete so it replays cleanly.
+
+function newClaudeStreamState() {
+    return {
+        message: { id: null, type: 'message', role: 'assistant', content: [], model: null, stop_reason: null, usage: {} },
+        blocks: [], // indexed by content_block index
+    };
+}
+
+// Apply one parsed Anthropic SSE event to the accumulator. Content assembly
+// only — transport concerns (error events, settle, timers) stay in the caller.
+// Returns true when the event is `message_stop` (stream complete).
+function applyClaudeStreamEvent(state, eventType, parsed) {
+    const { message, blocks } = state;
+    switch (eventType) {
+        case 'message_start':
+            if (parsed.message) {
+                message.id = parsed.message.id;
+                message.model = parsed.message.model;
+                Object.assign(message.usage, parsed.message.usage || {});
+            }
+            break;
+        case 'content_block_start':
+            if (typeof parsed.index === 'number' && parsed.content_block) {
+                blocks[parsed.index] = parsed.content_block;
+                if (blocks[parsed.index].type === 'tool_use') {
+                    blocks[parsed.index]._inputJson = '';
+                }
+            }
+            break;
+        case 'content_block_delta': {
+            const blk = blocks[parsed.index];
+            if (!blk || !parsed.delta) break;
+            if (parsed.delta.type === 'text_delta') {
+                blk.text = (blk.text || '') + parsed.delta.text;
+            } else if (parsed.delta.type === 'input_json_delta') {
+                if (typeof blk._inputJson !== 'string') blk._inputJson = '';
+                blk._inputJson += parsed.delta.partial_json;
+            } else if (parsed.delta.type === 'thinking_delta') {
+                // BAT-1033: accumulate reasoning text (was silently dropped).
+                blk.thinking = (blk.thinking || '') + (parsed.delta.thinking || '');
+            } else if (parsed.delta.type === 'signature_delta') {
+                // BAT-1033: accumulate the thinking signature. Without this the
+                // block keeps content_block_start's empty signature → replay 400.
+                blk.signature = (blk.signature || '') + (parsed.delta.signature || '');
+            }
+            break;
+        }
+        case 'content_block_stop': {
+            const blk = blocks[parsed.index];
+            if (blk?.type === 'tool_use' && blk._inputJson) {
+                try { blk.input = JSON.parse(blk._inputJson); } catch (_) { blk.input = {}; }
+                delete blk._inputJson;
+            }
+            break;
+        }
+        case 'message_delta':
+            if (parsed.delta) {
+                message.stop_reason = parsed.delta.stop_reason ?? message.stop_reason;
+            }
+            Object.assign(message.usage, parsed.usage || {});
+            break;
+        case 'message_stop':
+            message.content = finalizeClaudeStreamBlocks(blocks);
+            return true;
+    }
+    return false;
+}
+
+// Map accumulated blocks to the non-streaming content[] shape. text/tool_use
+// are normalized; thinking/redacted_thinking pass through verbatim — now WITH
+// their assembled signature + text.
+function finalizeClaudeStreamBlocks(blocks) {
+    return blocks.filter(Boolean).map(b => {
+        if (b.type === 'text') return { type: 'text', text: b.text || '' };
+        if (b.type === 'tool_use') return { type: 'tool_use', id: b.id, name: b.name, input: b.input || {} };
+        return b;
+    });
+}
+
+// Assemble a full message from an ordered list of {eventType, data} events.
+// Test-only convenience; the live path drives applyClaudeStreamEvent directly.
+function assembleClaudeStreamMessage(events) {
+    const state = newClaudeStreamState();
+    let stopped = false;
+    for (const ev of events) { if (applyClaudeStreamEvent(state, ev.eventType, ev.data)) stopped = true; }
+    if (!stopped) state.message.content = finalizeClaudeStreamBlocks(state.blocks);
+    return state.message;
+}
+
 // BAT-259: Streaming HTTP request for Claude API — SSE parsing, same return shape as httpRequest.
 // Eliminates transport timeouts: SSE events reset the socket idle timer every few seconds,
 // so even 120s responses never trigger the 60s timeout.
@@ -78,8 +183,12 @@ function httpStreamingRequest(options, body = null) {
 
             // SSE streaming — accumulate content blocks into a non-streaming response shape
             res.setEncoding('utf8');
-            const message = { id: null, type: 'message', role: 'assistant', content: [], model: null, stop_reason: null, usage: {} };
-            const blocks = []; // indexed by content_block index
+            // BAT-1033: assembly runs through the shared pure reducer so the live
+            // socket path and offline regression tests stay in lockstep. message
+            // and blocks alias the state so the res.on('end') partial-flush below
+            // keeps working unchanged.
+            const state = newClaudeStreamState();
+            const { message, blocks } = state;
             let sseBuffer = '';
 
             res.on('data', chunk => {
@@ -120,56 +229,13 @@ function httpStreamingRequest(options, body = null) {
                     let parsed;
                     try { parsed = JSON.parse(eventData); } catch (_) { continue; }
 
-                    switch (eventType) {
-                        case 'message_start':
-                            if (parsed.message) {
-                                message.id = parsed.message.id;
-                                message.model = parsed.message.model;
-                                Object.assign(message.usage, parsed.message.usage || {});
-                            }
-                            break;
-                        case 'content_block_start':
-                            if (typeof parsed.index === 'number' && parsed.content_block) {
-                                blocks[parsed.index] = parsed.content_block;
-                                if (blocks[parsed.index].type === 'tool_use') {
-                                    blocks[parsed.index]._inputJson = '';
-                                }
-                            }
-                            break;
-                        case 'content_block_delta': {
-                            const blk = blocks[parsed.index];
-                            if (!blk || !parsed.delta) break;
-                            if (parsed.delta.type === 'text_delta') {
-                                blk.text = (blk.text || '') + parsed.delta.text;
-                            } else if (parsed.delta.type === 'input_json_delta') {
-                                if (typeof blk._inputJson !== 'string') blk._inputJson = '';
-                                blk._inputJson += parsed.delta.partial_json;
-                            }
-                            break;
-                        }
-                        case 'content_block_stop': {
-                            const blk = blocks[parsed.index];
-                            if (blk?.type === 'tool_use' && blk._inputJson) {
-                                try { blk.input = JSON.parse(blk._inputJson); } catch (_) { blk.input = {}; }
-                                delete blk._inputJson;
-                            }
-                            break;
-                        }
-                        case 'message_delta':
-                            if (parsed.delta) {
-                                message.stop_reason = parsed.delta.stop_reason ?? message.stop_reason;
-                            }
-                            Object.assign(message.usage, parsed.usage || {});
-                            break;
-                        case 'message_stop':
-                            clearTimeout(hardTimer);
-                            message.content = blocks.filter(Boolean).map(b => {
-                                if (b.type === 'text') return { type: 'text', text: b.text || '' };
-                                if (b.type === 'tool_use') return { type: 'tool_use', id: b.id, name: b.name, input: b.input || {} };
-                                return b;
-                            });
-                            settle(resolve, { status: 200, data: message, headers: res.headers });
-                            break;
+                    // Assemble via the shared pure reducer (BAT-1033). Returns
+                    // true on message_stop, at which point message.content is
+                    // finalized and we settle.
+                    if (applyClaudeStreamEvent(state, eventType, parsed)) {
+                        clearTimeout(hardTimer);
+                        settle(resolve, { status: 200, data: message, headers: res.headers });
+                        break;
                     }
                 }
             });
@@ -677,4 +743,9 @@ module.exports = {
     httpStreamingRequest,
     httpOpenAIStreamingRequest,
     httpChatCompletionsStreamingRequest,
+    // BAT-1033: exported for offline regression tests (Claude SSE assembly).
+    newClaudeStreamState,
+    applyClaudeStreamEvent,
+    finalizeClaudeStreamBlocks,
+    assembleClaudeStreamMessage,
 };

--- a/app/src/main/assets/nodejs-project/http.js
+++ b/app/src/main/assets/nodejs-project/http.js
@@ -39,10 +39,13 @@ function httpRequest(options, body = null) {
 //
 // The v2.1.0 bug lived here: the content_block_delta arm handled only
 // text_delta + input_json_delta and silently dropped `thinking_delta` and
-// `signature_delta`. Anthropic streams a `thinking` block as
+// `signature_delta`. Anthropic streams a `thinking` block as an empty shell
+// then interleaved deltas — typically the reasoning text first and the
+// signature last, but the order can vary. The reducer accumulates each delta
+// independently, so it does NOT depend on ordering (don't "fix" it to assume one):
 //   content_block_start {type:'thinking', thinking:'', signature:''}
-//   content_block_delta {signature_delta: <the real signature>}
 //   content_block_delta {thinking_delta:  <the reasoning text>}
+//   content_block_delta {signature_delta: <the signature, typically last>}
 // so dropping those two deltas left the block with the EMPTY signature from
 // content_block_start. Echoing that block back on the next tool-loop round →
 // API 400 "each thinking block must contain thinking" (the message is
@@ -248,7 +251,10 @@ function httpStreamingRequest(options, body = null) {
                     const err = new Error('Stream ended before message_stop');
                     err.timeoutSource = 'transport';
                     if (blocks.length > 0) {
-                        message.content = blocks.filter(Boolean);
+                        // BAT-1033: normalize via the shared finalizer so the
+                        // diagnostic partial message matches the real message
+                        // shape and doesn't leak internal fields (e.g. _inputJson).
+                        message.content = finalizeClaudeStreamBlocks(blocks);
                         err.partialMessage = message;
                     }
                     settle(reject, err);

--- a/app/src/main/assets/nodejs-project/providers/claude.js
+++ b/app/src/main/assets/nodejs-project/providers/claude.js
@@ -5,32 +5,29 @@
 const { log } = require('../config');
 const { logSuppression, SUPPRESSION_REASONS } = require('../reasoning-gating');
 
-// BAT-558 R1 — Claude extended-thinking clamp constants.
+// BAT-1033 — Claude adaptive thinking.
 //
-// Anthropic Messages API requires `thinking.budget_tokens < max_tokens`,
-// AND the thinking budget itself has a 1024-token floor. A naive
-// `min(DEFAULT, max_tokens - 1)` formula satisfies the validator but
-// can leave only single-digit tokens for the actual response on small
-// turns — useless. The `* 0.5` rule below splits the budget so every
-// emitted thinking turn has at least `ANTHROPIC_MIN_BUDGET` tokens for
-// thinking AND at least `MIN_THINKING_TURN - ANTHROPIC_MIN_BUDGET`
-// tokens left over for the final answer.
+// Anthropic REMOVED extended thinking (`thinking.type:'enabled'` +
+// `budget_tokens`) from the current models. fable-5, opus-4-8, opus-4-7,
+// and sonnet-5 reject it with HTTP 400 ("thinking.type.enabled is not
+// supported for this model. Use thinking.type.adaptive"); only the older
+// opus-4-6 / sonnet-4-6 still accept it. `thinking.type:'adaptive'` (the
+// model auto-sizes its own budget — no `budget_tokens`) is accepted by
+// EVERY reasoning model, so we send it uniformly.
 //
-// The `MIN_THINKING_TURN < 2048 → omit thinking` short-circuit is the
-// load-bearing piece. Without it, a `max_tokens=1100` turn would emit
-// `budget_tokens=1024` and have 76 tokens for the answer — technically
-// valid Anthropic API, useless to the user. Skipping thinking entirely
-// for these small turns is the contract Codex signed off on (v3
-// amendment 1, ratified into v4).
+// This also retires the BAT-558 budget clamp: with no `budget_tokens`
+// there is no `budget_tokens < max_tokens` constraint to satisfy, which
+// removes that entire 400 class (the reason BAT-558 existed).
 //
-// Practical sizing examples (max_tokens × 0.5, clamped to [1024, 16000]):
-//   1024 → omit (below MIN_THINKING_TURN floor)
-//   1536 → omit (below MIN_THINKING_TURN floor; v3 gap-case)
-//   2048 → 1024 budget, 1024 answer room
-//   4096 → 2048 budget, 2048 answer room (the heartbeat case)
-//   32000 → 16000 budget (DEFAULT_THINKING_BUDGET cap kicks in)
-const ANTHROPIC_MIN_BUDGET = 1024;
-const DEFAULT_THINKING_BUDGET = 16000;
+// Verified live on the RAW api-key path (testing/test-thinking-matrix.js):
+//   extended → fable-5/opus-4-8/opus-4-7/sonnet-5: 400 removed; opus-4-6/sonnet-4-6: 200
+//   adaptive → all six: 200
+// The 400 only surfaced for users on their own API key — setup_token's
+// `cc_version` billing lane still tolerated the deprecated extended shape.
+//
+// MIN_THINKING_TURN is retained purely as a UX guard: on a sub-2048
+// max_tokens turn, reasoning would eat most of the answer budget, so we
+// skip it. It is no longer an API constraint (adaptive has no budget floor).
 const MIN_THINKING_TURN = 2048;
 
 // ── Neutral ↔ Claude message translation ────────────────────────────────────
@@ -66,9 +63,21 @@ function _collectClaudeWireBlocks(msg) {
         const t = blk.wire.type;
         if (t !== 'thinking' && t !== 'redacted_thinking') continue;
         // Verify the shape minimally so a corrupted checkpoint can't
-        // submit nonsense: thinking needs string `thinking` + signature;
-        // redacted_thinking needs string `data`.
-        if (t === 'thinking' && (typeof blk.wire.thinking !== 'string' || typeof blk.wire.signature !== 'string')) continue;
+        // submit nonsense: thinking needs string `thinking` + a NON-EMPTY
+        // signature; redacted_thinking needs string `data`.
+        //
+        // BAT-1033: the signature — not the thinking text — is what Anthropic
+        // validates. A thinking block with an empty/whitespace signature is
+        // rejected with 400 "each thinking block must contain thinking" (the
+        // message is misleading); an empty-TEXT block WITH a valid signature is
+        // accepted. Pre-fix builds streamed thinking blocks with an empty
+        // signature (http.js dropped signature_delta), so guard on the signature
+        // being present. This also recovers already-poisoned v2.1.0 checkpoints
+        // after upgrade — skip the bad block rather than 400 the whole request.
+        // Do NOT reject on empty thinking text: a signed empty-text block is
+        // valid and must still be echoed back unchanged.
+        if (t === 'thinking' && (typeof blk.wire.thinking !== 'string'
+            || typeof blk.wire.signature !== 'string' || blk.wire.signature.trim() === '')) continue;
         if (t === 'redacted_thinking' && typeof blk.wire.data !== 'string') continue;
         out.push(blk.wire);
     }
@@ -186,6 +195,18 @@ function fromApiResponse(raw) {
     const sourceModel = (raw && typeof raw.model === 'string') ? raw.model : null;
     for (const c of content) {
         if (!c || (c.type !== 'thinking' && c.type !== 'redacted_thinking')) continue;
+        // BAT-1033: reject malformed blocks at the CAPTURE boundary too, not
+        // just on replay, so a poisoned block never enters a checkpoint in the
+        // first place. Mirror _collectClaudeWireBlocks exactly: a `thinking`
+        // block needs a string `thinking` + a NON-EMPTY string `signature`
+        // (empty TEXT is valid — an empty-signature block is the poison);
+        // `redacted_thinking` needs a string `data`. With the http.js delta
+        // fix the normal streamed path won't produce these, but a malformed
+        // block from any other source (older build, non-streaming edge) is
+        // dropped here instead of persisted.
+        if (c.type === 'thinking' && (typeof c.thinking !== 'string'
+            || typeof c.signature !== 'string' || c.signature.trim() === '')) continue;
+        if (c.type === 'redacted_thinking' && typeof c.data !== 'string') continue;
         reasoningBlocks.push({
             schemaVersion: 1,
             provider: 'anthropic',
@@ -252,31 +273,22 @@ function formatTools(tools) {
  *
  * BAT-549 Commit 3c gated `body.thinking` emission on the user toggle
  * (`reasoningEnabled === true`) AND registry confirmation
- * (`reasoningSupport === "yes"`). BAT-558 v4 R1 layered a request-level
- * BUDGET CLAMP on top of that: the budget must be `< max_tokens` per
- * Anthropic, and `>= 1024` per Anthropic's thinking-budget floor — so
- * the budget is sized as `floor(maxTokens * 0.5)` clamped to
- * `[ANTHROPIC_MIN_BUDGET, DEFAULT_THINKING_BUDGET]`, and turns with
- * `maxTokens < MIN_THINKING_TURN` (2048) skip thinking entirely so the
- * answer always has at least `ANTHROPIC_MIN_BUDGET` tokens of room.
+ * (`reasoningSupport === "yes"`). BAT-558 v4 R3 added the
+ * `reasoningMode: 'off'` short-circuit so heartbeats / synthetic turns
+ * opt out even when the user toggle is on.
  *
- * Pre-clamp, this code emitted `budget_tokens=16000` regardless of
- * `max_tokens`. ai.js calls `formatRequest(..., 4096, ...)` for normal
- * chat, which Anthropic rejects with HTTP 400 ("max_tokens must be
- * greater than thinking.budget_tokens"). The heartbeat path hit it
- * first because the watchdog made the 400s visible; real user chats
- * with Extended thinking on were silently failing too.
+ * BAT-1033 replaced the extended-thinking budget clamp with
+ * `thinking: { type: 'adaptive' }`. Anthropic removed extended thinking
+ * (`type:'enabled'` + `budget_tokens`) from the current models — they 400
+ * — while adaptive (model auto-sizes its own budget) is accepted by every
+ * reasoning model. Adaptive carries no `budget_tokens`, so the old
+ * `budget_tokens < max_tokens` clamp is gone; see the module header for
+ * the per-model matrix and the live-probe evidence.
  *
- * BAT-558 v4 R3 also adds `reasoningMode: 'off'` short-circuit — when
- * the caller (heartbeat / future synthetic turns) marks the request
- * as opted out of app-controlled reasoning, skip thinking even when
- * the user toggle is on. R2 documents this contract at the chat()
- * boundary; ai.js threads it through `requestOptions` per BAT-549's
- * existing pattern.
- *
- * Existing call sites (vision/summary) that pass small `maxTokens`
- * (256, 500) or no `requestOptions` continue to emit no `thinking` —
- * additive change.
+ * The `maxTokens < MIN_THINKING_TURN` (2048) skip is retained as a UX
+ * guard so a tiny answer budget isn't consumed by reasoning. Existing
+ * call sites (vision/summary) that pass small `maxTokens` (256, 500) or
+ * no `requestOptions` continue to emit no `thinking` — additive change.
  */
 function formatRequest(model, maxTokens, systemBlocks, messages, tools, requestOptions) {
     const body = {
@@ -301,10 +313,10 @@ function formatRequest(model, maxTokens, systemBlocks, messages, tools, requestO
         return JSON.stringify(body);
     }
 
-    // BAT-558 v4 R1 — small-turn skip. `max_tokens < 2048` doesn't have
-    // headroom for both the 1024-floor budget AND a usable answer, so
-    // thinking is skipped (rate-limited INFO log so the suppression is
-    // discoverable in field reports without flooding the Logs screen).
+    // Small-turn skip (retained from BAT-558 as a UX guard): a sub-2048
+    // max_tokens turn has no headroom for useful reasoning AND a usable
+    // answer, so thinking is skipped (rate-limited INFO log so the
+    // suppression is discoverable in field reports without flooding Logs).
     if (maxTokens < MIN_THINKING_TURN) {
         logSuppression(
             SUPPRESSION_REASONS.MAX_TOKENS_BELOW_FLOOR,
@@ -313,13 +325,10 @@ function formatRequest(model, maxTokens, systemBlocks, messages, tools, requestO
         return JSON.stringify(body);
     }
 
-    // BAT-558 v4 R1 — clamp budget to [ANTHROPIC_MIN_BUDGET,
-    // DEFAULT_THINKING_BUDGET], scaled at half of `maxTokens` so the
-    // final answer always has the other half. See module-level constant
-    // block for the worked-examples table.
-    const cap = Math.min(DEFAULT_THINKING_BUDGET, Math.floor(maxTokens * 0.5));
-    const budget = Math.max(ANTHROPIC_MIN_BUDGET, cap);
-    body.thinking = { type: 'enabled', budget_tokens: budget };
+    // BAT-1033 — adaptive thinking: the model auto-sizes its own budget.
+    // No `budget_tokens` (extended thinking was removed from the current
+    // models; adaptive is accepted by all). See module header for the matrix.
+    body.thinking = { type: 'adaptive' };
     return JSON.stringify(body);
 }
 

--- a/app/src/main/assets/nodejs-project/reasoning-gating.js
+++ b/app/src/main/assets/nodejs-project/reasoning-gating.js
@@ -165,8 +165,9 @@ function stripReasoningForCustomGating(messages, behavior) {
  * process, so adding a noisy reason will be visible in production logs.
  */
 const SUPPRESSION_REASONS = Object.freeze({
-    // R1 clamp — Claude turn's maxTokens leaves no headroom for both
-    // a thinking budget AND a final answer (< MIN_THINKING_TURN = 2048).
+    // Claude small-turn skip — maxTokens leaves no headroom for useful
+    // reasoning AND a final answer (< MIN_THINKING_TURN = 2048). Retained
+    // from BAT-558 as a UX guard after the BAT-1033 adaptive migration.
     MAX_TOKENS_BELOW_FLOOR: 'maxTokens-below-floor',
     // R2/R3 — heartbeat AI turn carries reasoningMode='off'; no app-
     // controlled optional reasoning emitted (heartbeats are liveness

--- a/testing/test-thinking-apikey.js
+++ b/testing/test-thinking-apikey.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// test-thinking-apikey.js — settles BAT-1033 open question #2 (the adaptive/
+// budget_tokens migration) on the RAW API-KEY path — the common dApp Store
+// user path (QR payload carries anthropic_api_key), which the setup_token
+// probes never covered.
+//
+// Replicates EXACTLY what SeekerClaw sends on api_key auth (claude.js
+// buildHeaders + formatSystemPrompt):
+//   - header:  x-api-key: <key>            (NOT Authorization: Bearer)
+//   - beta:    prompt-caching-2024-07-31,interleaved-thinking-2025-05-14
+//              (NO oauth-2025-04-20 — that's setup_token only)
+//   - system:  plain instruction, NO CC billing-header block (setup_token only)
+//
+// Question it answers, per model, for /think-ON:
+//   extended {type:'enabled', budget_tokens}  → 200 or 400?  (is the migration LIVE for api-key users?)
+//   adaptive {type:'adaptive'}                → 200?          (does the proposed fix work on api-key?)
+//
+// Setup: ANTHROPIC_API_KEY=sk-ant-api03-… in testing/.env
+// Run:   node testing/test-thinking-apikey.js
+'use strict';
+
+const https = require('https');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const MODELS = (process.env.TEST_MODELS && process.env.TEST_MODELS.trim() !== 'all')
+    ? process.env.TEST_MODELS.split(',').map((s) => s.trim()).filter(Boolean)
+    : ['claude-opus-4-8', 'claude-sonnet-5'];
+
+// api_key path betas — NO oauth. Mirrors claude.js:356.
+const BETA = 'prompt-caching-2024-07-31,interleaved-thinking-2025-05-14';
+
+const CONFIGS = [
+    { name: 'off      ', thinking: null },
+    { name: 'extended ', thinking: { type: 'enabled', budget_tokens: 2000 } },
+    { name: 'adaptive ', thinking: { type: 'adaptive' } },
+];
+
+const TOOL = { name: 'get_weather', description: 'Get the current weather for a city.', input_schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] } };
+const USER_MSG = 'What is the weather in Tbilisi right now? Use the get_weather tool, then tell me.';
+// api_key path: NO billing-header system block (formatSystemPrompt adds it only for setup_token).
+const sys = () => [{ type: 'text', text: 'You are a helpful assistant. Use tools when appropriate.' }];
+
+function httpPost(key, bodyObj) {
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'x-api-key': key },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } resolve({ status: res.statusCode, data: p }); }); });
+        req.on('error', reject); req.setTimeout(60000, () => req.destroy(new Error('timeout')));
+        req.write(JSON.stringify(bodyObj)); req.end();
+    });
+}
+
+async function probe(model, key, cfg) {
+    const base = { model, max_tokens: 4096, stream: false, system: sys(), tools: [TOOL] };
+    if (cfg.thinking) base.thinking = cfg.thinking;
+
+    const r1 = await httpPost(key, { ...base, messages: [{ role: 'user', content: USER_MSG }] });
+    if (r1.status !== 200) {
+        const msg = r1.data?.error?.message || JSON.stringify(r1.data);
+        const isBudget = /budget_tokens|thinking\.type|thinking\.budget/i.test(msg);
+        console.log(`  [${cfg.name}] R1 ❌ ${r1.status} ${isBudget ? '🎯 budget/thinking rejected' : ''}— ${msg.slice(0, 90)}`);
+        return;
+    }
+    const content = Array.isArray(r1.data.content) ? r1.data.content : [];
+    const thinking = content.filter((b) => b.type === 'thinking' || b.type === 'redacted_thinking');
+    const toolUse = content.find((b) => b.type === 'tool_use');
+    const tdesc = thinking.map((t) => t.type === 'thinking'
+        ? `thinking(len=${(t.thinking || '').trim().length},sig=${t.signature ? 'y' : 'n'})`
+        : `redacted(len=${(t.data || '').length})`).join('+') || 'none';
+
+    let r2 = 'n/a (no tool_use)';
+    if (toolUse) {
+        const rr = await httpPost(key, { ...base, messages: [
+            { role: 'user', content: USER_MSG },
+            { role: 'assistant', content },  // verbatim
+            { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUse.id, content: '{"temp_c":18,"condition":"clear"}' }] },
+        ] });
+        const m = rr.data?.error?.message || '';
+        r2 = rr.status === 200 ? '200 ✅'
+            : `${rr.status} ❌ ${/each thinking block must contain thinking/i.test(m) ? '🎯 THE BUG' : m.slice(0, 55)}`;
+    }
+    console.log(`  [${cfg.name}] R1 blocks=[${content.map((b) => b.type).join(',')}] thinking=${tdesc} | REPLAY=${r2}`);
+}
+
+(async () => {
+    const key = process.env.ANTHROPIC_API_KEY;
+    if (!key) { console.error('❌ Set ANTHROPIC_API_KEY in testing/.env'); process.exit(1); }
+    if (!/^sk-ant-/.test(key)) { console.error('❌ ANTHROPIC_API_KEY does not look like a raw sk-ant-… key'); process.exit(1); }
+    console.log('🧪 BAT-1033 #2 — RAW API-KEY path (x-api-key, no billing masquerade) — is budget_tokens live?');
+    for (const model of MODELS) {
+        console.log(`\n=== ${model} ===`);
+        for (const cfg of CONFIGS) { await probe(model, key, cfg); await new Promise((r) => setTimeout(r, 1200)); }
+    }
+    console.log('\nKey question: does [extended] 400 here? If yes → migration is LIVE for api-key users → v2.1.1.');
+})();

--- a/testing/test-thinking-matrix.js
+++ b/testing/test-thinking-matrix.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// test-thinking-matrix.js — definitive per-model thinking-shape matrix on the
+// RAW API-KEY path. One request per (model × shape); reports 200/400 so we get
+// the exact extended-vs-adaptive mapping straight from the API (no doc-trust).
+//
+// Setup: ANTHROPIC_API_KEY=sk-ant-api03-… in testing/.env
+// Run:   node testing/test-thinking-matrix.js
+'use strict';
+
+const https = require('https');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+// Registry reasoning models (haiku-4-5 is reasoningSupport:'no' → SeekerClaw
+// never sends a thinking param, so it's N/A here).
+const MODELS = ['claude-fable-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-5', 'claude-sonnet-4-6'];
+const BETA = 'prompt-caching-2024-07-31,interleaved-thinking-2025-05-14'; // api_key path
+const SHAPES = [
+    { name: 'extended', thinking: { type: 'enabled', budget_tokens: 2000 } },
+    { name: 'adaptive', thinking: { type: 'adaptive' } },
+];
+
+function httpPost(key, bodyObj) {
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'x-api-key': key },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } resolve({ status: res.statusCode, data: p }); }); });
+        req.on('error', reject); req.setTimeout(60000, () => req.destroy(new Error('timeout')));
+        req.write(JSON.stringify(bodyObj)); req.end();
+    });
+}
+
+(async () => {
+    const key = process.env.ANTHROPIC_API_KEY;
+    if (!key) { console.error('❌ Set ANTHROPIC_API_KEY in testing/.env'); process.exit(1); }
+    console.log('🧪 Per-model thinking-shape matrix (raw api-key path)\n');
+    console.log('model'.padEnd(20) + 'extended'.padEnd(14) + 'adaptive');
+    console.log('─'.repeat(48));
+    for (const model of MODELS) {
+        const cells = [];
+        for (const shape of SHAPES) {
+            const r = await httpPost(key, { model, max_tokens: 1024, thinking: shape.thinking, messages: [{ role: 'user', content: 'Say hi in one word.' }] });
+            if (r.status === 200) cells.push('200 ✅');
+            else {
+                const m = r.data?.error?.message || JSON.stringify(r.data);
+                cells.push(`${r.status} ${/not supported/i.test(m) ? '❌ removed' : '❌ ' + m.slice(0, 24)}`);
+            }
+            await new Promise((res) => setTimeout(res, 900));
+        }
+        console.log(model.padEnd(20) + cells[0].padEnd(14) + cells[1]);
+    }
+    console.log('\n→ "extended 400 / adaptive 200" = must migrate to adaptive.  "extended 200" = keep as-is.');
+})();

--- a/testing/test-thinking-poison.js
+++ b/testing/test-thinking-poison.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// test-thinking-poison.js — ISOLATES the exact BAT-1033 trigger.
+//
+// The main repro probe (test-thinking-repro.js) replays each thinking block
+// VERBATIM (real signature) → always 200, even when the thinking TEXT is empty.
+// That proves empty-text is NOT the trigger. This script isolates the real one:
+// the EMPTY SIGNATURE that http.js produces by dropping `signature_delta`.
+//
+// It fetches one real thinking block (sonnet-5, extended), then replays it 3 ways
+// on a tool-loop turn:
+//   A. verbatim            (real signature)      → control, expect 200
+//   B. signature: ''       (http.js poison)      → expect 400 "must contain thinking"
+//   C. signature stripped  (field deleted)       → expect 400
+//
+// Run: node testing/test-thinking-poison.js
+'use strict';
+
+const https = require('https');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
+loadEnv();
+
+// Default to opus-4-8: it reliably emits the empty-text thinking block, and the
+// signature trigger we're isolating is model-agnostic. Sonnet-5's thinking-block
+// emission is stochastic (the very reason prod flaps), so it's a poor R1 source.
+const MODEL = process.env.TEST_MODELS && process.env.TEST_MODELS.trim() && process.env.TEST_MODELS.trim() !== 'all'
+    ? process.env.TEST_MODELS.split(',')[0].trim()
+    : 'claude-opus-4-8';
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+const TOOL = { name: 'get_weather', description: 'Get the current weather for a city.', input_schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] } };
+const USER_MSG = 'What is the weather in Tbilisi right now? Use the get_weather tool, then tell me.';
+const sys = () => [{ type: 'text', text: CC_BILLING_HEADER }, { type: 'text', text: 'You are a helpful assistant. Use tools when appropriate.' }];
+
+function httpPost(token, bodyObj) {
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${token}` },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } resolve({ status: res.statusCode, data: p }); }); });
+        req.on('error', reject); req.setTimeout(60000, () => req.destroy(new Error('timeout')));
+        req.write(JSON.stringify(bodyObj)); req.end();
+    });
+}
+
+function classify(rr) {
+    const m = rr.data?.error?.message || '';
+    if (rr.status === 200) return '200 ✅';
+    const tag = /each thinking block must contain thinking/i.test(m) ? '🎯 THE BUG (must contain thinking)' : m.slice(0, 70);
+    return `${rr.status} ❌ ${tag}`;
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ Set SETUP_TOKEN in testing/.env'); process.exit(1); }
+    console.log(`🧪 BAT-1033 poison isolation — ${MODEL}\n`);
+
+    // 1) Get a real assistant turn with a thinking block + tool_use.
+    //    Thinking-block emission is stochastic, so retry until we get one.
+    const base = { model: MODEL, max_tokens: 4096, stream: false, system: sys(), tools: [TOOL], thinking: { type: 'enabled', budget_tokens: 2000 } };
+    let content = [];
+    let thinkingBlock;
+    let toolUse;
+    for (let attempt = 1; attempt <= 6; attempt++) {
+        const r1 = await httpPost(token, { ...base, messages: [{ role: 'user', content: USER_MSG }] });
+        if (r1.status !== 200) { console.error(`R1 failed: ${r1.status} ${JSON.stringify(r1.data).slice(0, 120)}`); process.exit(1); }
+        content = Array.isArray(r1.data.content) ? r1.data.content : [];
+        thinkingBlock = content.find((b) => b.type === 'thinking');
+        toolUse = content.find((b) => b.type === 'tool_use');
+        if (thinkingBlock && toolUse) break;
+        console.log(`  (attempt ${attempt}: got [${content.map((b) => b.type).join(',')}], retrying for thinking+tool_use…)`);
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    if (!thinkingBlock || !toolUse) { console.error('Could not obtain a thinking+tool_use turn after 6 attempts.'); process.exit(1); }
+    console.log(`R1 block: thinking(len=${(thinkingBlock.thinking || '').length}, sig=${thinkingBlock.signature ? `${thinkingBlock.signature.length} chars` : 'MISSING'})`);
+    console.log(`         → the API returned an empty-TEXT thinking block WITH a real signature.\n`);
+
+    const replay = (blk) => httpPost(token, { ...base, messages: [
+        { role: 'user', content: USER_MSG },
+        { role: 'assistant', content: content.map((b) => (b.type === 'thinking' ? blk : b)) },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUse.id, content: '{"temp_c":18,"condition":"clear"}' }] },
+    ] });
+
+    // A) verbatim — control
+    const A = await replay({ ...thinkingBlock });
+    console.log(`A. verbatim (real signature)      → ${classify(A)}`);
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // B) signature: '' — EXACTLY what http.js stores when it drops signature_delta
+    const B = await replay({ ...thinkingBlock, signature: '' });
+    console.log(`B. signature:'' (http.js poison)  → ${classify(B)}`);
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // C) signature field removed entirely
+    const cNoSig = { ...thinkingBlock }; delete cNoSig.signature;
+    const C = await replay(cNoSig);
+    console.log(`C. signature removed              → ${classify(C)}`);
+
+    console.log('\nExpected: A=200 (verbatim OK), B & C = 400 "must contain thinking" (empty/missing sig = the bug).');
+})();

--- a/testing/test-thinking-repro.js
+++ b/testing/test-thinking-repro.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// test-thinking-repro.js — LIVE recreation of the BAT-1033 / v2.1.1 bug.
+// test-thinking-repro.js — LIVE recreation of the BAT-1033 bug (shipped in
+// v2.1.0, fixed in v2.1.1).
 //
 // Replicates SeekerClaw's production request (setup_token + interleaved-thinking
 // beta + a tool) across 3 thinking configs per model, then a REPLAY round to

--- a/testing/test-thinking-repro.js
+++ b/testing/test-thinking-repro.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// test-thinking-repro.js — LIVE recreation of the BAT-1033 / v2.1.1 bug.
+//
+// Replicates SeekerClaw's production request (setup_token + interleaved-thinking
+// beta + a tool) across 3 thinking configs per model, then a REPLAY round to
+// detect the "each thinking block must contain thinking" 400:
+//   - off      : no thinking param            (/think OFF)
+//   - extended : {type:enabled, budget_tokens}(/think ON — what SeekerClaw sends today)
+//   - adaptive : {type:adaptive}              (the proposed fix)
+//
+// Run for claude-opus-4-8 (works in prod) + claude-sonnet-5 (breaks).
+// Setup: SETUP_TOKEN=sk-ant-oat01-… in testing/.env    Run: node testing/test-thinking-repro.js
+'use strict';
+
+const https = require('https');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
+loadEnv();
+
+const MODELS = (process.env.TEST_MODELS && process.env.TEST_MODELS.trim() !== 'all')
+    ? process.env.TEST_MODELS.split(',').map((s) => s.trim()).filter(Boolean)
+    : ['claude-opus-4-8', 'claude-sonnet-5'];
+
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+
+const CONFIGS = [
+    { name: 'off      ', thinking: null },
+    { name: 'extended ', thinking: { type: 'enabled', budget_tokens: 2000 } },
+    { name: 'adaptive ', thinking: { type: 'adaptive' } },
+];
+
+const TOOL = { name: 'get_weather', description: 'Get the current weather for a city.', input_schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] } };
+const USER_MSG = 'What is the weather in Tbilisi right now? Use the get_weather tool, then tell me.';
+
+function httpPost(token, bodyObj) {
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${token}` },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } resolve({ status: res.statusCode, data: p }); }); });
+        req.on('error', reject); req.setTimeout(60000, () => req.destroy(new Error('timeout')));
+        req.write(JSON.stringify(bodyObj)); req.end();
+    });
+}
+
+const sys = () => [{ type: 'text', text: CC_BILLING_HEADER }, { type: 'text', text: 'You are a helpful assistant. Use tools when appropriate.' }];
+
+async function probe(model, token, cfg) {
+    const base = { model, max_tokens: 4096, stream: false, system: sys(), tools: [TOOL] };
+    if (cfg.thinking) base.thinking = cfg.thinking;
+
+    const r1 = await httpPost(token, { ...base, messages: [{ role: 'user', content: USER_MSG }] });
+    if (r1.status !== 200) {
+        console.log(`  [${cfg.name}] R1 ❌ ${r1.status} — ${(r1.data?.error?.message || JSON.stringify(r1.data)).slice(0, 90)}`);
+        return;
+    }
+    const content = Array.isArray(r1.data.content) ? r1.data.content : [];
+    const thinking = content.filter((b) => b.type === 'thinking' || b.type === 'redacted_thinking');
+    const toolUse = content.find((b) => b.type === 'tool_use');
+    const emptyT = content.some((b) => b.type === 'thinking' && (b.thinking || '').trim() === '');
+    const tdesc = thinking.map((t) => t.type === 'thinking'
+        ? `thinking(len=${(t.thinking || '').trim().length}${emptyT ? ' ⚠️EMPTY' : ''},sig=${t.signature ? 'y' : 'n'})`
+        : `redacted(len=${(t.data || '').length})`).join('+') || 'none';
+
+    let r2 = 'n/a (no tool_use)';
+    if (toolUse) {
+        const rr = await httpPost(token, { ...base, messages: [
+            { role: 'user', content: USER_MSG },
+            { role: 'assistant', content },  // verbatim (per API "must be unchanged")
+            { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUse.id, content: '{"temp_c":18,"condition":"clear"}' }] },
+        ] });
+        const m = rr.data?.error?.message || '';
+        r2 = rr.status === 200 ? '200 ✅'
+            : `${rr.status} ❌ ${/each thinking block must contain thinking/i.test(m) ? '🎯 THE BUG' : m.slice(0, 55)}`;
+    }
+    console.log(`  [${cfg.name}] R1 blocks=[${content.map((b) => b.type).join(',')}] thinking=${tdesc} | REPLAY=${r2}`);
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ Set SETUP_TOKEN in testing/.env'); process.exit(1); }
+    console.log('🧪 BAT-1033 live recreation — setup_token + interleaved-thinking beta + tool');
+    for (const model of MODELS) {
+        console.log(`\n=== ${model} ===`);
+        for (const cfg of CONFIGS) { await probe(model, token, cfg); await new Promise((r) => setTimeout(r, 1200)); }
+    }
+    console.log('\nDone.');
+})();

--- a/tests/nodejs-project/claude-adaptive-thinking.test.js
+++ b/tests/nodejs-project/claude-adaptive-thinking.test.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// claude-adaptive-thinking.test.js — BAT-1033 request-shape guard.
+//
+// Anthropic REMOVED extended thinking (`thinking.type:'enabled'` +
+// `budget_tokens`) from the current models — fable-5/opus-4-8/opus-4-7/sonnet-5
+// reject it with 400 "thinking.type.enabled is not supported for this model.
+// Use thinking.type.adaptive". Verified live (testing/test-thinking-matrix.js):
+// adaptive is accepted by every reasoning model. So formatRequest now emits
+// `thinking: { type: 'adaptive' }` uniformly (no budget_tokens).
+//
+// This pins that shape and guards against `budget_tokens` ever coming back
+// (which would re-break every current model on the raw api-key path). It also
+// re-verifies the BAT-549/BAT-558 gates survive the migration.
+//
+// Run:  node tests/nodejs-project/claude-adaptive-thinking.test.js
+'use strict';
+
+const path = require('path');
+const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, API_TIMEOUT_MS: 60000 },
+};
+const claude = require('../../app/src/main/assets/nodejs-project/providers/claude');
+
+let failures = 0;
+function ok(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+
+const SYS = [{ type: 'text', text: 'sys' }];
+const MSGS = [{ role: 'user', content: 'hi' }];
+const ON = { reasoningEnabled: true, reasoningSupport: 'yes' };
+const bodyOf = (maxTokens, opts, model = 'claude-sonnet-5') =>
+    JSON.parse(claude.formatRequest(model, maxTokens, SYS, MSGS, [], opts));
+
+console.log('── BAT-1033: request emits adaptive thinking, never budget_tokens ──');
+
+// 1) reasoning ON + supported + big turn → adaptive, NO budget_tokens.
+const t = bodyOf(4096, ON).thinking;
+ok('(1) reasoning on → thinking.type === "adaptive"', !!t && t.type === 'adaptive', `got ${JSON.stringify(t)}`);
+ok('(2) adaptive carries NO budget_tokens', !!t && t.budget_tokens === undefined, `got ${JSON.stringify(t)}`);
+
+// 3–7) the BAT-549/BAT-558 gates must still suppress thinking.
+ok('(3) reasoning off → no thinking',
+    bodyOf(4096, { reasoningEnabled: false, reasoningSupport: 'yes' }).thinking === undefined);
+ok('(4) reasoningSupport!=="yes" → no thinking',
+    bodyOf(4096, { reasoningEnabled: true, reasoningSupport: 'no' }).thinking === undefined);
+ok('(5) reasoningMode:"off" (heartbeat) → no thinking',
+    bodyOf(4096, { ...ON, reasoningMode: 'off' }).thinking === undefined);
+ok('(6) small turn (maxTokens<2048) → no thinking',
+    bodyOf(1024, ON).thinking === undefined);
+ok('(7) no requestOptions → no thinking',
+    bodyOf(4096, undefined).thinking === undefined);
+
+// 8) HARD regression guard: no reasoning model may ever emit budget_tokens.
+const MODELS = ['claude-fable-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-5', 'claude-sonnet-4-6'];
+const offenders = MODELS.filter((m) => /"budget_tokens"/.test(claude.formatRequest(m, 4096, SYS, MSGS, [], ON)));
+ok('(8) no reasoning model emits budget_tokens (would 400 on api-key path)',
+    offenders.length === 0, `offenders: ${offenders.join(', ')}`);
+// …and every one of them emits adaptive.
+const allAdaptive = MODELS.every((m) => bodyOf(4096, ON, m).thinking?.type === 'adaptive');
+ok('(9) every reasoning model emits adaptive', allAdaptive);
+
+console.log();
+if (failures === 0) { console.log('ALL TESTS PASS'); process.exit(0); }
+else { console.log(`${failures} TEST(S) FAILED`); process.exit(1); }

--- a/tests/nodejs-project/claude-thinking-signature.test.js
+++ b/tests/nodejs-project/claude-thinking-signature.test.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// claude-thinking-signature.test.js — regression guard for BAT-1033.
+//
+// THE BUG (shipped in v2.1.0): Anthropic streams a `thinking` block as
+//   content_block_start {type:'thinking', thinking:'', signature:''}
+//   content_block_delta {thinking_delta:  <reasoning text>}
+//   content_block_delta {signature_delta: <the real signature>}
+// but http.js's SSE reducer only handled text_delta + input_json_delta, so it
+// DROPPED thinking_delta + signature_delta. The assembled block kept the empty
+// signature from content_block_start. Echoing that block back on the next
+// tool-loop round → API 400 "each thinking block must contain thinking".
+//
+// PROVEN via live setup_token probe (testing/test-thinking-poison.js):
+//   - a signed EMPTY-TEXT thinking block replays 200 (empty text is fine)
+//   - the SAME block with signature:'' replays 400 (the exact prod error)
+// → the invariant is the SIGNATURE, not the text.
+//
+// This test pins two layers, offline + deterministic:
+//   1. http.js reducer assembles the FULL signature + text (would FAIL pre-fix).
+//   2. claude.js replay guard skips an empty-signature block but keeps a signed
+//      one (even with empty text) — recovers poisoned checkpoints on upgrade.
+//
+// Run:  node tests/nodejs-project/claude-thinking-signature.test.js
+'use strict';
+
+const path = require('path');
+
+// Stub config.js (shared by http.js + claude.js) BEFORE requiring either.
+const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, API_TIMEOUT_MS: 60000 },
+};
+
+const http = require('../../app/src/main/assets/nodejs-project/http');
+const claude = require('../../app/src/main/assets/nodejs-project/providers/claude');
+
+let failures = 0;
+function ok(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+
+const SIG = 'EvoBCmMIDxgCKkBd1zSf-EXAMPLE-thinking-signature-bytes-abc123==';
+
+console.log('── BAT-1033: streamed thinking block must retain its signature ──');
+
+// ── Layer 1: http.js SSE reducer ────────────────────────────────────────────
+// Feed the EXACT event sequence Anthropic streams (start-shell → thinking_delta
+// → signature_delta), plus a tool_use block, through the real reducer.
+const events = [
+    { eventType: 'message_start', data: { message: { id: 'msg_1', model: 'claude-sonnet-5', usage: { input_tokens: 10 } } } },
+    { eventType: 'content_block_start', data: { index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } } },
+    { eventType: 'content_block_delta', data: { index: 0, delta: { type: 'thinking_delta', thinking: 'Let me ' } } },
+    { eventType: 'content_block_delta', data: { index: 0, delta: { type: 'thinking_delta', thinking: 'check the logs.' } } },
+    { eventType: 'content_block_delta', data: { index: 0, delta: { type: 'signature_delta', signature: SIG } } },
+    { eventType: 'content_block_stop', data: { index: 0 } },
+    { eventType: 'content_block_start', data: { index: 1, content_block: { type: 'tool_use', id: 'tu_1', name: 'read', input: {} } } },
+    { eventType: 'content_block_delta', data: { index: 1, delta: { type: 'input_json_delta', partial_json: '{"path":' } } },
+    { eventType: 'content_block_delta', data: { index: 1, delta: { type: 'input_json_delta', partial_json: '"/logs"}' } } },
+    { eventType: 'content_block_stop', data: { index: 1 } },
+    { eventType: 'message_delta', data: { delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 20 } } },
+    { eventType: 'message_stop', data: {} },
+];
+
+const msg = http.assembleClaudeStreamMessage(events);
+const think = Array.isArray(msg.content) ? msg.content.find((b) => b.type === 'thinking') : null;
+const tool = Array.isArray(msg.content) ? msg.content.find((b) => b.type === 'tool_use') : null;
+
+ok('(1) reducer preserves the streamed signature (the fix)',
+    !!think && think.signature === SIG,
+    `got signature=${JSON.stringify(think && think.signature)}`);
+ok('(2) reducer preserves the streamed thinking text',
+    !!think && think.thinking === 'Let me check the logs.',
+    `got thinking=${JSON.stringify(think && think.thinking)}`);
+ok('(3) tool_use block still assembles from input_json_delta (refactor regression guard)',
+    !!tool && tool.id === 'tu_1' && tool.input && tool.input.path === '/logs',
+    `got tool=${JSON.stringify(tool)}`);
+ok('(4) message_stop propagates stop_reason', msg.stop_reason === 'tool_use');
+
+// ── Layer 1b: capture side stores the good signature ─────────────────────────
+const captured = claude.fromApiResponse(msg).reasoningBlocks;
+ok('(5) fromApiResponse captures the thinking block WITH its signature',
+    captured.length === 1 && captured[0].wire && captured[0].wire.signature === SIG,
+    `captured=${JSON.stringify(captured)}`);
+
+// ── Layer 1c: capture-side guard (BAT-1033) — poison never enters a checkpoint.
+// Mirror the replay guard at the fromApiResponse boundary: a blank-signature
+// thinking block must be dropped on capture; signed (even empty-text) thinking
+// and redacted_thinking must be kept.
+const mixedResp = {
+    id: 'msg_mixed', model: 'claude-sonnet-5', stop_reason: 'end_turn', usage: {},
+    content: [
+        { type: 'thinking', thinking: '', signature: '' },          // poison → drop
+        { type: 'thinking', thinking: '  ', signature: '   ' },     // whitespace sig → drop
+        { type: 'thinking', thinking: '', signature: SIG },         // signed empty-text → keep
+        { type: 'thinking', thinking: 'real reasoning', signature: SIG }, // normal → keep
+        { type: 'redacted_thinking', data: 'AAAA' },                // keep
+    ],
+};
+const capMixed = claude.fromApiResponse(mixedResp).reasoningBlocks;
+ok('(5b) blank/whitespace-signature thinking blocks are NOT captured',
+    !capMixed.some((b) => b.wire.type === 'thinking' && (b.wire.signature || '').trim() === ''),
+    `captured=${JSON.stringify(capMixed.map((b) => b.wire))}`);
+ok('(5c) signed thinking (incl. empty-text) + redacted_thinking ARE captured',
+    capMixed.filter((b) => b.wire.type === 'thinking').length === 2
+    && capMixed.some((b) => b.wire.type === 'redacted_thinking'),
+    `captured=${JSON.stringify(capMixed.map((b) => b.wire))}`);
+
+// ── Layer 2: claude.js replay guard (defense-in-depth) ───────────────────────
+function replaysThinking(reasoningBlocks) {
+    const asst = claude.toApiMessages([
+        { role: 'user', content: 'check logs' },
+        { role: 'assistant', content: 'ok', toolCalls: [{ id: 'tc1', name: 'read', input: {} }], reasoningBlocks },
+        { role: 'tool', toolCallId: 'tc1', content: '{"ok":true}' },
+    ]).find((m) => m.role === 'assistant');
+    return (asst && Array.isArray(asst.content))
+        ? asst.content.filter((b) => b.type === 'thinking')
+        : [];
+}
+const mkBlock = (wire) => ({ schemaVersion: 1, provider: 'anthropic', sourceAdapter: 'claude', sourceModel: 'claude-sonnet-5', turnId: 't', wire });
+
+// Poisoned block (empty signature) — the v2.1.0 shape — must be skipped, not replayed.
+ok('(6) empty-signature thinking block is NOT replayed (would 400)',
+    replaysThinking([mkBlock({ type: 'thinking', thinking: '', signature: '' })]).length === 0);
+// Whitespace-only signature — equally invalid.
+ok('(7) whitespace-signature thinking block is NOT replayed',
+    replaysThinking([mkBlock({ type: 'thinking', thinking: 'x', signature: '   ' })]).length === 0);
+// Signed but EMPTY-TEXT block — valid per live probe — MUST still replay.
+const emptyTextSigned = replaysThinking([mkBlock({ type: 'thinking', thinking: '', signature: SIG })]);
+ok('(8) signed empty-TEXT thinking block IS replayed (empty text is valid)',
+    emptyTextSigned.length === 1 && emptyTextSigned[0].signature === SIG);
+// Signed non-empty block — the normal case — replayed unchanged.
+const signed = replaysThinking([mkBlock({ type: 'thinking', thinking: 'real reasoning', signature: SIG })]);
+ok('(9) signed non-empty thinking block IS replayed unchanged',
+    signed.length === 1 && signed[0].thinking === 'real reasoning' && signed[0].signature === SIG);
+
+console.log();
+if (failures === 0) { console.log('ALL TESTS PASS'); process.exit(0); }
+else { console.log(`${failures} TEST(S) FAILED`); process.exit(1); }


### PR DESCRIPTION
## Summary
Two proven-live production bugs in Claude reasoning, both shipped in v2.1.0 — fixed together as the **v2.1.1** hotfix:

1. **Signature drop (/think OFF):** the `http.js` SSE assembler handled only `text_delta` + `input_json_delta`, dropping `thinking_delta` + `signature_delta`. A streamed thinking block kept `content_block_start`'s empty signature and 400'd on tool-loop replay (`each thinking block must contain thinking`). Extracted the assembler into a pure exported reducer that accumulates both deltas; `claude.js` now rejects blank/whitespace-signature thinking blocks on **both** capture (`fromApiResponse`) and replay (`_collectClaudeWireBlocks`) — keyed on the signature, not the text (a signed empty-text block is valid and must still replay).
2. **Adaptive migration (/think ON):** `formatRequest` sent `thinking:{type:'enabled', budget_tokens}`, which the current models (fable-5/opus-4-8/opus-4-7/sonnet-5) reject with 400 on the raw API-key path (`thinking.type.enabled is not supported ... Use adaptive`). Now sends `thinking:{type:'adaptive'}` uniformly (accepted by every reasoning model), retiring the BAT-558 budget clamp.

## Root cause & evidence
- Live `setup_token` + raw API-key probes; A/B/C signature-poison isolation; per-model extended-vs-adaptive matrix (full detail on BAT-1033).
- Verified the trigger is the empty **signature**, not empty text (signed empty-text replays 200).
- Codex-approved (capture + replay guards on both boundaries; R1 resolved).

## Test plan
- [x] `node tests/nodejs-project/claude-thinking-signature.test.js` — passed (drives the real SSE reducer; **proven to FAIL if the fix is reverted**)
- [x] `node tests/nodejs-project/claude-adaptive-thinking.test.js` — passed (emits adaptive, never `budget_tokens`, all 6 reasoning models)
- [x] `node tests/nodejs-project/claude-reasoning-roundtrip.test.js` — passed
- [x] `node tests/nodejs-project/ci-coverage-manifest.test.js` — passed
- [x] `bash scripts/pre-push-check.sh` — ALL CHECKS PASSED (78/78 parse, 27/27 load, 64 tools, wallets, Kotlin BUILD SUCCESSFUL)
- [x] Live probes (opt-in, `testing/`): matrix + apikey + poison + repro — ran against the real endpoint
- [ ] Device test (/think OFF & ON on Sonnet 5 + Opus 4.8; poisoned-checkpoint recovery) — pending on Seeker

## Known limitations
- opus-4-6 / sonnet-4-6 still *accept* extended thinking but are moved to adaptive too (uniform, forward-compatible, non-breaking — both return 200, still reason). Flagged for review; per-model preservation is the alternative.
- OpenRouter/Custom have a same-**class** streaming gap (drop `delta.reasoning*`) — separate, lower-severity (no crash), filed as **BAT-1110**, deferred to after v2.1.1.

## Self-Awareness Checklist
- [x] **N/A** — does not touch `buildSystemBlocks()`, `DIAGNOSTICS.md`, add ERROR/WARN log sites, or ship a new user-visible AI capability (fixes existing reasoning request/response shaping only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adaptive thinking in Claude requests and responses, improving compatibility with newer models and API-key flows.
  * Updated version to 2.1.1.

* **Bug Fixes**
  * Fixed reasoning content replay so streamed thinking blocks keep their signatures and multi-turn tool use works reliably.
  * Prevented invalid empty or whitespace-only thinking signatures from causing request failures.

* **Documentation**
  * Added a new release note entry describing the reasoning reliability hotfix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->