### PR TITLE
fix: deliver interim/pre-tool assistant text, not just the final reply (BAT-1109)

### DIFF
--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -206,6 +206,19 @@ grep -i "OAuth refresh\|oauth_refresh\|invalid_grant" node_debug.log | tail -20
 2. Re-run with more targeted parameters (e.g., `grep` instead of `cat`, smaller page ranges)
 **Fix:** Use more targeted queries. For large files, use `head`/`tail`/`grep` instead of reading the whole file. For web content, extract specific sections.
 
+### Interim / Pre-Tool Narration Not Delivered (BAT-1109)
+**Symptoms:** The agent's brief narration written alongside a tool call (e.g. "Let me check…") didn't arrive as a message, but the final reply did.
+**How it works:** Text emitted in the same model turn as a `tool_use` block is delivered live — before the tool runs — as its own message (BAT-1109). Each such interim send is independent of tool execution and of the final reply.
+**Check:**
+```
+grep "\[Interim\]" node_debug.log | tail -5
+```
+**Diagnosis:**
+- `[Interim] send failed` / `[Interim] sendInterim threw` (WARN): a transient channel error (e.g. Telegram 429 / network) on the interim bubble only. The tool turn and the final reply are unaffected, and the text is still in conversation history, so the agent's transcript stays consistent.
+- `[Interim] Duplicate interim text suppressed` (DEBUG): the exact same narration was emitted twice in one turn (e.g. a reasoning-content-400 recovery replay) and the duplicate bubble was intentionally suppressed — not an error.
+- No `[Interim]` lines but narration still missing: the model didn't emit any text alongside the tool call (nothing to deliver), or the text was a protocol token (`[[SILENT_REPLY]]` / `HEARTBEAT_OK`) and was intentionally suppressed.
+**Fix:** Interim-send failures are transient and self-recovering — the final reply still arrives. If they recur, check the Telegram/Discord channel sections (rate limits or token issues). Only the interactive channel receives interim narration; cron/heartbeat turns deliver a single message by design.
+
 ---
 
 ## Web Search

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -830,6 +830,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     lines.push('Default: do not narrate routine, low-risk tool calls (just call the tool).');
     lines.push('Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.');
     lines.push('Keep narration brief and value-dense; avoid repeating obvious steps.');
+    lines.push('Text you write alongside a tool call is delivered to the user in real time (as its own message), so brief pre-tool narration reaches them immediately — not only in your final reply. Narrate intentionally, and don\'t repeat that same text verbatim in your final reply.');
     lines.push('Use plain human language for narration unless in a technical context.');
     lines.push('When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.');
     lines.push('For visual checks ("what do you see", "check my dog", "look at the room"), call android_camera_check.');
@@ -2951,12 +2952,20 @@ async function chat(chatId, userMessage, options = {}) {
             // sendInterim is wired ONLY from the interactive message-handler; other
             // callers (cron/heartbeat/auto-resume) pass none, so `?.` no-ops for them
             // (keeping their ack/HEARTBEAT_OK suppression + plain-only routing intact).
-            // The callback owns its own delivery errors (the message-handler wrapper
-            // logs + swallows), so a failed interim send never aborts the tool turn.
             // Empty / SILENT_REPLY-only interim text is suppressed by the shared
             // sanitizer inside the callback — not merely when parsed.text is falsy.
+            // Defense-in-depth (Copilot R1): the interactive wrapper already logs +
+            // swallows its own delivery errors, but the loop ALSO guards here so that
+            // NO sendInterim implementation (a future caller, or a wrapper regression)
+            // can throw and abort the tool round — which would reintroduce the
+            // dropped-text bug as a HARD failure. A delivery bubble must never fail the
+            // tool turn.
             if (parsed.text) {
-                await options.sendInterim?.(parsed.text);
+                try {
+                    await options.sendInterim?.(parsed.text);
+                } catch (interimErr) {
+                    log(`[Interim] sendInterim threw (continuing tool turn): ${interimErr && interimErr.message ? interimErr.message : String(interimErr)}`, 'WARN');
+                }
             }
 
             // Execute each tool and collect results

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -2936,6 +2936,29 @@ async function chat(chatId, userMessage, options = {}) {
                 break; // Model didn't listen — force exit with text response
             }
 
+            // BAT-1109: deliver interim/pre-tool assistant text — the text the model
+            // emits in the SAME message as a tool_use — to the interactive channel in
+            // real time. Without this, only the final text-only response is ever sent,
+            // and any text the agent "says" alongside a tool call is silently dropped
+            // (the trust-damaging "it insists it said X" bug). Delivery-only: this text
+            // is already in `messages` (pushed just above) and replayed to the model on
+            // the next turn, so conversation history is unchanged. Placement is
+            // deliberate:
+            //   - AFTER the _loopFinalIteration guard, so the forced-final text (which
+            //     is RETURNED as the final answer) is never ALSO interim-sent;
+            //   - only reached for rounds whose tools actually execute — a text-only
+            //     response already broke out at the top of the loop (toolCalls === 0).
+            // sendInterim is wired ONLY from the interactive message-handler; other
+            // callers (cron/heartbeat/auto-resume) pass none, so `?.` no-ops for them
+            // (keeping their ack/HEARTBEAT_OK suppression + plain-only routing intact).
+            // The callback owns its own delivery errors (the message-handler wrapper
+            // logs + swallows), so a failed interim send never aborts the tool turn.
+            // Empty / SILENT_REPLY-only interim text is suppressed by the shared
+            // sanitizer inside the callback — not merely when parsed.text is falsy.
+            if (parsed.text) {
+                await options.sendInterim?.(parsed.text);
+            }
+
             // Execute each tool and collect results
             // BAT-246: Each tool execution is individually guarded — if one tool throws,
             // the others still run and ALL tool calls get matching tool result entries.

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -50,6 +50,7 @@ function assertInit() {
 //                     reasoning-content-400 recovery replay (chat() re-emits the same
 //                     pre-tool text after quarantine + retry). The final send passes none.
 async function deliverAgentText(chatId, rawText, messageId, replyToDefault, dedupSet = null) {
+    assertInit();
     if (typeof rawText !== 'string') return false;
     if (containsSilentReply(rawText)) deps.log('[Audit] Agent sent SILENT_REPLY', 'DEBUG');
     let text = stripSilentReply(
@@ -68,15 +69,19 @@ async function deliverAgentText(chatId, rawText, messageId, replyToDefault, dedu
     // Dedup AFTER sanitizing so an exact-duplicate delivered string (the recovery
     // replay) is suppressed regardless of protocol-token noise. Exact-match only —
     // near-identical re-emits are rare and low-harm (BAT-1109 contract decision).
-    if (dedupSet) {
-        if (dedupSet.has(text)) {
-            deps.log('[Interim] Duplicate interim text suppressed (recovery replay)', 'DEBUG');
-            return false;
-        }
-        dedupSet.add(text);
+    // Record the text as delivered ONLY AFTER a successful send (not before): a
+    // FAILED send must leave the text un-recorded so a later retry — e.g. the
+    // reasoning-content-400 recovery replay this guard exists for — can still
+    // deliver it, instead of being silently suppressed as a phantom "duplicate"
+    // (CodeRabbit R1: dedup state must reflect a confirmed outcome, not an
+    // optimistic pre-send mark).
+    if (dedupSet && dedupSet.has(text)) {
+        deps.log('[Interim] Duplicate interim text suppressed (recovery replay)', 'DEBUG');
+        return false;
     }
 
     await deps.sendMessage(chatId, text, replyTo);
+    if (dedupSet) dedupSet.add(text);
     return true;
 }
 

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -1290,6 +1290,16 @@ async function handleMessage(normalized) {
 
         let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction, resumedFromTaskId, sendInterim });
 
+        // chat() is contracted to return a STRING (assistant text, a budget/fallback
+        // string, or the SILENT_REPLY sentinel). A non-string here is a programming
+        // error / adapter regression — surface it LOUDLY via the catch → error-reply
+        // path (as the pre-BAT-1109 `response.trim()` did) rather than letting
+        // deliverAgentText's non-string guard treat it as a protocol-token-only reply
+        // and silently drop the final response (Copilot R2).
+        if (typeof response !== 'string') {
+            throw new Error(`chat() returned a non-string response (${typeof response})`);
+        }
+
         // Final reply — routed through the SAME shared sanitizer/sender as interim text
         // (BAT-1109). replyToDefault = messageId preserves the prior behavior of always
         // quote-replying the triggering message; no dedup on the final send. A false

--- a/app/src/main/assets/nodejs-project/message-handler.js
+++ b/app/src/main/assets/nodejs-project/message-handler.js
@@ -33,6 +33,53 @@ function assertInit() {
     if (!initialized) throw new Error('message-handler.js: init() must be called before use');
 }
 
+// BAT-1109: Shared delivery for agent text — used for BOTH the final reply and
+// interim/pre-tool text (the text the model emits alongside a tool_use). Applies the
+// SAME protocol-token handling as the final reply always has (SILENT_REPLY audit +
+// strip, HEARTBEAT_OK strip), the SAME [[reply_to_current]] handling, and the SAME
+// rich / HTML / plain-fallback + long-message split (all inside deps.sendMessage).
+// Returns true if a message was actually sent, false if suppressed (empty after
+// sanitizing) — the caller owns statusReaction / stats side-effects.
+//
+//   messageId       — the triggering user message (target for [[reply_to_current]]).
+//   replyToDefault  — reply target when NO [[reply_to_current]] tag is present:
+//                       final   → messageId (preserves the prior always-quote-reply)
+//                       interim → null      (interim bubbles don't quote by default)
+//   dedupSet        — optional per-turn Set; when provided, an identical SANITIZED
+//                     string already delivered this turn is suppressed. Guards the
+//                     reasoning-content-400 recovery replay (chat() re-emits the same
+//                     pre-tool text after quarantine + retry). The final send passes none.
+async function deliverAgentText(chatId, rawText, messageId, replyToDefault, dedupSet = null) {
+    if (typeof rawText !== 'string') return false;
+    if (containsSilentReply(rawText)) deps.log('[Audit] Agent sent SILENT_REPLY', 'DEBUG');
+    let text = stripSilentReply(
+        rawText.trim()
+            .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
+    );
+    if (!text) return false;
+
+    let replyTo = replyToDefault;
+    if (text.startsWith('[[reply_to_current]]')) {
+        text = text.replace('[[reply_to_current]]', '').trim();
+        replyTo = messageId;
+        if (!text) return false; // tag-only content after strip → nothing to send
+    }
+
+    // Dedup AFTER sanitizing so an exact-duplicate delivered string (the recovery
+    // replay) is suppressed regardless of protocol-token noise. Exact-match only —
+    // near-identical re-emits are rare and low-harm (BAT-1109 contract decision).
+    if (dedupSet) {
+        if (dedupSet.has(text)) {
+            deps.log('[Interim] Duplicate interim text suppressed (recovery replay)', 'DEBUG');
+            return false;
+        }
+        dedupSet.add(text);
+    }
+
+    await deps.sendMessage(chatId, text, replyTo);
+    return true;
+}
+
 // ============================================================================
 // COMMAND HANDLERS
 // ============================================================================
@@ -1216,30 +1263,39 @@ async function handleMessage(normalized) {
             }
         }
 
-        let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction, resumedFromTaskId });
+        // BAT-1109: interim/pre-tool text delivery. sendInterim routes text the model
+        // emits alongside a tool_use through the SAME sanitize + rich-send path as the
+        // final reply (deliverAgentText), so it is no longer silently dropped. Wired
+        // ONLY here (the interactive path); cron/heartbeat/auto-resume callers of chat()
+        // pass no sendInterim, so their ack/HEARTBEAT_OK suppression + plain-only
+        // routing are never bypassed. The dedup Set is per-turn (this closure): it
+        // survives chat()'s internal reasoning-content-400 recovery `continue` — which
+        // re-emits the same pre-tool text after quarantine — but resets on the next user
+        // turn (a fresh Set per handleMessage call). Interim send failures are logged and
+        // swallowed here so a delivery error never aborts the tool turn or the final
+        // reply. Interim sends don't quote-reply (replyToDefault = null).
+        const seenInterim = new Set();
+        const sendInterim = async (rawText) => {
+            try {
+                await deliverAgentText(chatId, rawText, messageId, null, seenInterim);
+            } catch (e) {
+                deps.log(`[Interim] send failed (continuing): ${e && e.message ? e.message : String(e)}`, 'WARN');
+            }
+        };
 
-        // Strip protocol tokens the agent may have mixed into content (BAT-279)
-        // Uses centralized silent-reply.js helper (BAT-488) that also handles
-        // leading-attached cases like "SILENT_REPLYhello" + JSON envelope form.
-        if (containsSilentReply(response)) deps.log('[Audit] Agent sent SILENT_REPLY', 'DEBUG');
-        response = stripSilentReply(
-            response.trim()
-                .replace(/(?:^|\s+|\*+)HEARTBEAT_OK\s*$/gi, '').replace(/\bHEARTBEAT_OK\b/gi, '')
-        );
-        if (!response) {
+        let response = await deps.chat(chatId, userContent, { isResume, originalGoal: resumeGoal, statusReaction, resumedFromTaskId, sendInterim });
+
+        // Final reply — routed through the SAME shared sanitizer/sender as interim text
+        // (BAT-1109). replyToDefault = messageId preserves the prior behavior of always
+        // quote-replying the triggering message; no dedup on the final send. A false
+        // return means the response was only protocol tokens (SILENT_REPLY / HEARTBEAT_OK
+        // / empty / a bare [[reply_to_current]]) → nothing to deliver.
+        const finalSent = await deliverAgentText(chatId, response, messageId, messageId);
+        if (!finalSent) {
             deps.log('Agent returned protocol-token-only response, discarding', 'DEBUG');
             await statusReaction.clear();
             return;
         }
-
-        // [[reply_to_current]] - quote reply to the current message
-        let replyToId = null;
-        if (response.startsWith('[[reply_to_current]]')) {
-            response = response.replace('[[reply_to_current]]', '').trim();
-            replyToId = messageId;
-        }
-
-        await deps.sendMessage(chatId, response, replyToId || messageId);
         await statusReaction.setDone();
 
         // Report message to Android for stats tracking
@@ -1440,4 +1496,4 @@ async function handleThinkCommand(chatId, args) {
     return `✓ ${action} Takes effect on your next message.`;
 }
 
-module.exports = { init, handleCommand, handleMessage, handleReactionUpdate };
+module.exports = { init, handleCommand, handleMessage, handleReactionUpdate, deliverAgentText };

--- a/docs/internal/audits/SAB-AUDIT-v41.md
+++ b/docs/internal/audits/SAB-AUDIT-v41.md
@@ -1,0 +1,80 @@
+# SAB-AUDIT-v41 — SeekerClaw Agent Self-Knowledge Audit
+
+> **Date:** 2026-07-03
+> **SAB Version:** v3
+> **Scope:** Delta audit for PR #432 / BAT-1109 — interim (pre-tool) assistant text delivery. Text emitted alongside a `tool_use` block is now delivered to the interactive user in real time (was silently dropped). Adds two new `[Interim]` WARN log sites.
+> **Method:** Delta audit — score only the items this PR affects; carry forward the v40 post-fix baseline (100%) for untouched subsystems (tools, providers, channels, search, memory, cron, MCP, skills, reasoning). This PR adds no tools/providers/channels, so Sections C and D are unchanged by construction.
+> **Baseline:** SAB-AUDIT-v40.md (240/246 = 97.6% pre-fix, 246/246 = 100% post-fix)
+
+## Scores
+
+| Section | Pre-fix | Post-fix | Max |
+|---------|---------|----------|-----|
+| A: Knowledge & Doors (30 baseline + 1 new: interim delivery) | 91 | 93 | 93 |
+| B: Diagnostics (35 baseline + 1 new: interim delivery) | 106 | 108 | 108 |
+| C: Tool Consistency (7 fixed + 5 rotated) — unchanged, no tools added | 36 | 36 | 36 |
+| D: Behavioral Probes (2 fixed + 3 rotated) — unchanged | 15 | 15 | 15 |
+| **Combined** | **248 (98.4%)** | **252 (100%)** | **252** |
+
+Pre-fix **98.4% is above the 95% drift threshold** → no drift incident. The feature shipped with most self-awareness already in place (the existing "Tool Call Style" narration guidance in `buildSystemBlocks()` already instructs the agent to narrate alongside tool calls — this fix makes that narration actually reach the user, aligning delivery with the prompt's existing assumption). Two small delta items needed filling and were fixed in this same PR.
+
+## Pre-fix Trend
+| Audit | Pre-fix % | Post-fix % |
+|-------|-----------|------------|
+| v38 (BAT-1067) | ~ | 100 |
+| v39 (BAT-1050) | ~ | 100 |
+| v40 (holistic v2.1.0) | 97.6 | 100 |
+| **v41 (BAT-1109 interim delivery)** | **98.4** | **100** |
+
+## Section A — Knowledge & Doors (delta)
+
+**New item: "Interim / pre-tool text delivery."**
+Apply the 3-part new-door test:
+1. Meaningfully changes how it works? **Yes** — narration written alongside a tool call now reaches the user live (previously dropped).
+2. Users likely to ask / notice? **Yes** — they now see a pre-tool "let me check…" bubble, and could ask "why two messages?" or "I didn't get your first message."
+3. Wrong/incomplete answer without coverage? **Yes (pre-fix ⚠️)** — the "Tool Call Style" section told the agent to narrate but never stated that pre-tool narration is delivered in real time, so the agent couldn't narrate intentionally and might repeat the same text verbatim in its final reply.
+
+- **Pre-fix:** ⚠️ (1/3) — narration guidance present but silent on live delivery.
+- **Fix:** one door line added to the "Tool Call Style" section of `buildSystemBlocks()` (ai.js): *"Text you write alongside a tool call is delivered to the user in real time (as its own message)… Narrate intentionally, and don't repeat that same text verbatim in your final reply."* The "don't repeat verbatim" clause also steers the agent away from the one known limitation (the final reply is not deduped against interim text — see PR #432).
+- **Post-fix:** ✅ (3/3).
+
+All 30 baseline items carry forward from v40 post-fix (90/90) unchanged — this PR touches none of them.
+
+## Section B — Diagnostic Coverage (delta)
+
+**New diagnostic mode: interim / pre-tool narration delivery.** Two new WARN log sites:
+- `[Interim] send failed (continuing): …` — `message-handler.js` sendInterim wrapper (interactive channel send error).
+- `[Interim] sendInterim threw (continuing tool turn): …` — `ai.js` tool-loop defensive guard.
+- (plus `[Interim] Duplicate interim text suppressed` at DEBUG — recovery-replay dedup, not an error.)
+
+- **Pre-fix:** ⚠️ (1/3) — the WARN sites are visible in `node_debug.log` but had no `DIAGNOSTICS.md` diagnosis path; a user reporting "your first message never arrived" had no guided answer.
+- **Fix:** new `DIAGNOSTICS.md` entry under **Tools** → *"Interim / Pre-Tool Narration Not Delivered (BAT-1109)"* — symptoms, `grep "[Interim]"` check, per-line diagnosis (transient send error vs. dedup suppression vs. nothing-to-deliver), and fix (transient/self-recovering; final reply unaffected; interactive-channel-only by design).
+- **Post-fix:** ✅ (3/3).
+
+All 35 baseline modes carry forward from v40 post-fix (105/105) unchanged.
+
+## Section C — Tool Consistency
+
+Unchanged. This PR adds no tools and changes no tool descriptions, confirmation gates, or safety semantics. v40 result (36/36) carries forward.
+
+## Section D — Behavioral Probes
+
+Unchanged. No new user-facing troubleshooting scenario is introduced beyond the Section B entry above (which is itself the door→target path for "my pre-tool narration didn't arrive"). v40 result (15/15) carries forward.
+
+## Negative Knowledge
+
+Unchanged (6/6) — this PR introduces no new capability boundary.
+
+## Gaps Found (Pre-fix)
+1. **Section A** — no door stating pre-tool narration is delivered live (⚠️).
+2. **Section B** — two new `[Interim]` WARN sites without a `DIAGNOSTICS.md` diagnosis path (⚠️).
+
+## Fixes Applied (same PR)
+1. `ai.js` `buildSystemBlocks()` — one door line in "Tool Call Style".
+2. `DIAGNOSTICS.md` — "Interim / Pre-Tool Narration Not Delivered (BAT-1109)" entry.
+
+## Code Issues Found
+None (the delivery-correctness findings from Copilot/CodeRabbit were fixed in the same PR before this audit; see PR #432).
+
+## Remaining Gaps
+None. Post-fix 252/252 = 100%.

--- a/tests/nodejs-project/ci-coverage-manifest.test.js
+++ b/tests/nodejs-project/ci-coverage-manifest.test.js
@@ -73,6 +73,7 @@ const SKIP_REASONS = {
     'env-list.test.js': 'fixture-only — needs env scaffold',
     'env-merge.test.js': 'fixture-only — needs env scaffold',
     'idle-summary-timers.test.js': 'fixture-only — timer-based, flaky in CI',
+    'interim-delivery.test.js': 'fixture-only — message-handler.js depends on main.js globals + config require-cache stubs (run via node locally / pre-push)',
     'jupiter-trigger-v2.test.js': 'fixture-only — live Jupiter Trigger V2 API roundtrip',
     'main-wallet-balance.test.js': 'fixture-only — live MWA + RPC roundtrip',
     'mcp-servers.test.js': 'fixture-only — needs workDir scaffold',

--- a/tests/nodejs-project/interim-delivery.test.js
+++ b/tests/nodejs-project/interim-delivery.test.js
@@ -262,6 +262,22 @@ async function turn(text, chat) {
     await turn('silent final', async () => '[[SILENT_REPLY]]');
     ok('B6 SILENT_REPLY-only final delivers nothing', sent.length === 0);
 
+    // B7: a FAILED interim send is NOT recorded in the dedup Set (CodeRabbit R1) — a
+    // later retry of the SAME text still delivers instead of being suppressed as a
+    // phantom duplicate. Without the after-send record fix, the first (failed) send
+    // would mark 'RETRY' seen and the retry would be dropped — permanently losing it
+    // in exactly the reasoning-400-recovery case the dedup guard exists for.
+    await turn('failed-then-retry', async (chatId, content, opts) => {
+        throwOnText = 'RETRY';
+        await opts.sendInterim('RETRY');   // fails → must NOT be marked delivered
+        throwOnText = null;
+        await opts.sendInterim('RETRY');   // retry → must deliver (not suppressed)
+        return 'final';
+    });
+    ok('B7 failed interim not marked seen; retry delivers',
+        sent.filter(s => s.text === 'RETRY').length === 1 && sent.some(s => s.text === 'final'),
+        JSON.stringify(sent));
+
     // Cleanup
     try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
 

--- a/tests/nodejs-project/interim-delivery.test.js
+++ b/tests/nodejs-project/interim-delivery.test.js
@@ -278,6 +278,14 @@ async function turn(text, chat) {
         sent.filter(s => s.text === 'RETRY').length === 1 && sent.some(s => s.text === 'final'),
         JSON.stringify(sent));
 
+    // B8: a non-string chat() return is surfaced LOUDLY as an error reply, NOT silently
+    // dropped as a phantom "protocol-token-only" response (Copilot R2). Guards against an
+    // adapter regression turning a dropped final reply into a silent no-op.
+    await turn('nonstring-return', async () => undefined);
+    ok('B8 non-string chat() return surfaces an error (not a silent drop)',
+        sent.length === 1 && /^Error:/.test(sent[0].text),
+        JSON.stringify(sent));
+
     // Cleanup
     try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
 

--- a/tests/nodejs-project/interim-delivery.test.js
+++ b/tests/nodejs-project/interim-delivery.test.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+// interim-delivery.test.js — BAT-1109: interim/pre-tool assistant text delivery.
+//
+// The bug: when the model returns an assistant message with BOTH text and a
+// tool_use block, the ai.js tool loop executed the tool and dropped the text —
+// only the final text-only response reached the user. The fix threads a
+// sendInterim callback into chat() and routes both interim and final text
+// through a shared deliverAgentText sanitizer/sender.
+//
+// This pins the message-handler half (deliverAgentText + the sendInterim
+// wiring). The ai.js insertion point (interim only on tool-executing rounds,
+// after the _loopFinalIteration guard, never double-sent) is covered by the
+// contract's exhaustive per-exit-path analysis + on-device testing — the full
+// chat() loop is too coupled to mock deterministically here.
+//
+// Pins:
+//   deliverAgentText (shared sanitizer/sender):
+//     - plain text sent; returns true
+//     - final replyToDefault = messageId; interim replyToDefault = null
+//     - [[reply_to_current]] honored (interim quote-replies the message)
+//     - SILENT_REPLY (canonical + legacy bare) suppressed → returns false, no send
+//     - HEARTBEAT_OK stripped; HEARTBEAT_OK-only suppressed
+//     - empty / whitespace-only suppressed
+//     - dedup: exact repeat suppressed, distinct sent, resets with a fresh Set
+//   handleMessage wiring:
+//     - interim text delivered BEFORE the final reply, in order
+//     - interim uses no quote-reply; final quote-replies the message
+//     - dedup within a turn (recovery replay of the same text → sent once)
+//     - dedup resets on the next user turn (fresh Set per handleMessage call)
+//     - interim send failure is logged + swallowed → final reply still delivered
+//     - the interactive path wires a real sendInterim function into chat()
+//
+// Run:  node tests/nodejs-project/interim-delivery.test.js
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// ── Stub config.js + main.js dependencies BEFORE requiring message-handler ──
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1109-interim-'));
+const workDir = path.join(tmpRoot, 'workspace');
+fs.mkdirSync(workDir, { recursive: true });
+
+const configPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = {
+    id: configPath, filename: configPath, loaded: true,
+    exports: {
+        log: () => {},
+        CHANNEL: 'telegram',
+        workDir,
+        PROVIDER: 'claude',
+        AUTH_TYPE: 'api_key',
+        OPENAI_AUTH_TYPE: 'api_key',
+        resolveActiveModel: () => 'claude-opus-4-7',
+        runtimeState: { read: () => ({}), write: () => {} },
+        config: {},
+    },
+};
+
+const stubModule = (relPath, exports) => {
+    const fullPath = path.resolve(__dirname, '../../app/src/main/assets/nodejs-project', relPath);
+    require.cache[fullPath] = { id: fullPath, filename: fullPath, loaded: true, exports };
+};
+stubModule('telegram.js', { sendTyping: async () => {}, sentMessageCache: new Map(), SENT_CACHE_TTL: 60000 });
+stubModule('discord.js', {});
+stubModule('channel.js', { sendMessage: async () => {} });
+stubModule('skills.js', { findRelevantSkill: () => null });
+stubModule('mcp-client.js', { MCPManager: class {} });
+stubModule('database.js', { getDb: () => null });
+stubModule('memory.js', {});
+stubModule('cron.js', {});
+stubModule('quick-actions.js', {});
+stubModule('repetition-detector.js', {});
+stubModule('task-store.js', { listOpenCheckpoints: () => [] });
+stubModule('security.js', { redactSecrets: (s) => s });
+stubModule('bridge.js', { androidBridgeCall: async () => ({}) });
+stubModule('http.js', {});
+
+const mh = require('../../app/src/main/assets/nodejs-project/message-handler');
+
+// ── Recording sinks (reset per test) ──
+let sent = [];                 // { chatId, text, replyTo }
+let logs = [];                 // { msg, level }
+let chatImpl = async () => ''; // per-test chat() behavior
+let throwOnText = null;        // when set, deps.sendMessage throws for this exact text
+
+const OWNER = '42';
+mh.init({
+    log: (msg, level) => logs.push({ msg, level }),
+    androidBridgeCall: async () => ({}),
+    sendMessage: async (chatId, text, replyTo) => {
+        if (throwOnText !== null && text === throwOnText) throw new Error('simulated telegram failure');
+        sent.push({ chatId, text, replyTo });
+    },
+    sendTyping: async () => {},
+    getOwnerId: () => OWNER,
+    setOwnerId: () => {},
+    createStatusReactionController: () => ({
+        setQueued: () => {}, setThinking: () => {}, setTool: () => {},
+        setDone: async () => {}, clear: async () => {}, setError: async () => {},
+    }),
+    lastIncomingMessages: new Map(),
+    chat: (...a) => chatImpl(...a),
+    redactSecrets: (s) => s,
+    MAX_FILE_SIZE: 20 * 1024 * 1024,
+    MAX_IMAGE_SIZE: 5 * 1024 * 1024,
+});
+
+let failures = 0;
+function ok(label, cond, hint = '') {
+    if (cond) console.log(`PASS: ${label}`);
+    else { console.log(`FAIL: ${label}${hint ? ' — ' + hint : ''}`); failures++; }
+}
+function reset() { sent = []; logs = []; throwOnText = null; }
+
+// Drive one plain-text interactive turn through the real handleMessage.
+async function turn(text, chat) {
+    reset();
+    chatImpl = chat;
+    await mh.handleMessage({ chatId: '123', senderId: OWNER, text, messageId: 7, media: null });
+}
+
+(async () => {
+    // ─────────────────────────────────────────────────────────────
+    // Part A — deliverAgentText (shared sanitizer + dedup), direct
+    // ─────────────────────────────────────────────────────────────
+
+    reset();
+    let r = await mh.deliverAgentText('c', 'hello world', 9, 9);
+    ok('A1 plain text sent + returns true',
+        r === true && sent.length === 1 && sent[0].text === 'hello world' && sent[0].replyTo === 9);
+
+    reset();
+    r = await mh.deliverAgentText('c', 'BANANA', 9, null);
+    ok('A2 interim: replyToDefault=null → no quote-reply',
+        r === true && sent.length === 1 && sent[0].text === 'BANANA' && sent[0].replyTo === null);
+
+    reset();
+    r = await mh.deliverAgentText('c', '[[reply_to_current]]hi there', 9, null);
+    ok('A3 [[reply_to_current]] honored for interim (quote-replies message, tag stripped)',
+        r === true && sent.length === 1 && sent[0].text === 'hi there' && sent[0].replyTo === 9);
+
+    reset();
+    r = await mh.deliverAgentText('c', '[[SILENT_REPLY]]', 9, 9);
+    ok('A4 canonical [[SILENT_REPLY]] suppressed', r === false && sent.length === 0);
+
+    reset();
+    r = await mh.deliverAgentText('c', 'SILENT_REPLY', 9, 9);
+    ok('A5 legacy bare SILENT_REPLY (whole message) suppressed', r === false && sent.length === 0);
+
+    reset();
+    r = await mh.deliverAgentText('c', 'Hello [[SILENT_REPLY]] world', 9, null);
+    ok('A6 mixed-content SILENT_REPLY stripped, remainder sent',
+        r === true && sent.length === 1 && sent[0].text === 'Hello world');
+
+    reset();
+    r = await mh.deliverAgentText('c', 'done HEARTBEAT_OK', 9, 9);
+    ok('A7 HEARTBEAT_OK stripped from mixed content',
+        r === true && sent.length === 1 && sent[0].text === 'done');
+
+    reset();
+    r = await mh.deliverAgentText('c', 'HEARTBEAT_OK', 9, 9);
+    ok('A8 HEARTBEAT_OK-only suppressed', r === false && sent.length === 0);
+
+    reset();
+    r = await mh.deliverAgentText('c', '   ', 9, 9);
+    ok('A9 whitespace-only suppressed', r === false && sent.length === 0);
+
+    reset();
+    r = await mh.deliverAgentText('c', 12345, 9, 9);
+    ok('A10 non-string suppressed (no throw)', r === false && sent.length === 0);
+
+    // dedup semantics
+    reset();
+    const set = new Set();
+    const d1 = await mh.deliverAgentText('c', 'X', 9, null, set);
+    const d2 = await mh.deliverAgentText('c', 'X', 9, null, set);
+    const d3 = await mh.deliverAgentText('c', 'Y', 9, null, set);
+    ok('A11 dedup: exact repeat suppressed, distinct sent',
+        d1 === true && d2 === false && d3 === true
+        && sent.length === 2 && sent[0].text === 'X' && sent[1].text === 'Y');
+
+    reset();
+    const freshSet = new Set();
+    const e1 = await mh.deliverAgentText('c', 'X', 9, null, freshSet);
+    ok('A12 dedup resets with a fresh Set', e1 === true && sent.length === 1 && sent[0].text === 'X');
+
+    // dedup keys on SANITIZED text: "X" vs "X HEARTBEAT_OK" both sanitize to "X"
+    reset();
+    const set2 = new Set();
+    const f1 = await mh.deliverAgentText('c', 'X', 9, null, set2);
+    const f2 = await mh.deliverAgentText('c', 'X HEARTBEAT_OK', 9, null, set2);
+    ok('A13 dedup keys on sanitized text (X vs "X HEARTBEAT_OK")',
+        f1 === true && f2 === false && sent.length === 1);
+
+    // ─────────────────────────────────────────────────────────────
+    // Part B — handleMessage wiring (end-to-end interactive turn)
+    // ─────────────────────────────────────────────────────────────
+
+    // B1: interim delivered before final, in order; interim no quote-reply, final quotes.
+    let sawSendInterimFn = false;
+    await turn('say BANANA, then use a tool', async (chatId, content, opts) => {
+        sawSendInterimFn = typeof opts.sendInterim === 'function';
+        await opts.sendInterim('BANANA');
+        return 'Your heartbeat interval is 30 minutes';
+    });
+    ok('B1a interactive path wires a real sendInterim function', sawSendInterimFn);
+    ok('B1b interim before final, in order',
+        sent.length === 2
+        && sent[0].text === 'BANANA' && sent[0].replyTo === null
+        && sent[1].text === 'Your heartbeat interval is 30 minutes' && sent[1].replyTo === 7,
+        JSON.stringify(sent));
+
+    // B2: multiple DISTINCT interim strings across tool rounds are all delivered, in order.
+    await turn('multi', async (chatId, content, opts) => {
+        await opts.sendInterim('Let me check X');
+        await opts.sendInterim('Now checking Y');
+        return 'done';
+    });
+    ok('B2 distinct interims all delivered in order + final',
+        sent.length === 3
+        && sent[0].text === 'Let me check X'
+        && sent[1].text === 'Now checking Y'
+        && sent[2].text === 'done',
+        JSON.stringify(sent));
+
+    // B3: recovery replay — the SAME interim text emitted twice in one turn is sent once.
+    await turn('recovery', async (chatId, content, opts) => {
+        await opts.sendInterim('BANANA');   // round 1
+        await opts.sendInterim('BANANA');   // reasoning-400 recovery re-emit
+        return 'final';
+    });
+    ok('B3 duplicate interim (recovery replay) sent once',
+        sent.length === 2 && sent[0].text === 'BANANA' && sent[1].text === 'final',
+        JSON.stringify(sent));
+
+    // B4: dedup resets on the next user turn (fresh Set per handleMessage call).
+    await turn('turn-one', async (chatId, content, opts) => { await opts.sendInterim('SAME'); return 'a'; });
+    const turnOneSent = sent.map(s => s.text);
+    await turn('turn-two', async (chatId, content, opts) => { await opts.sendInterim('SAME'); return 'b'; });
+    const turnTwoSent = sent.map(s => s.text);
+    ok('B4 dedup resets across turns (SAME delivered in both turns)',
+        turnOneSent[0] === 'SAME' && turnTwoSent[0] === 'SAME',
+        JSON.stringify({ turnOneSent, turnTwoSent }));
+
+    // B5: interim send FAILURE is logged + swallowed; the final reply still delivers.
+    await turn('failing interim', async (chatId, content, opts) => {
+        throwOnText = 'boom';               // deps.sendMessage throws for this exact text
+        await opts.sendInterim('boom');     // must NOT abort the turn
+        throwOnText = null;
+        return 'final after failed interim';
+    });
+    ok('B5a interim failure did not abort → final reply delivered',
+        sent.length === 1 && sent[0].text === 'final after failed interim' && sent[0].replyTo === 7,
+        JSON.stringify(sent));
+    ok('B5b interim failure logged (WARN)',
+        logs.some(l => l.level === 'WARN' && /\[Interim\] send failed/.test(l.msg)));
+
+    // B6: SILENT_REPLY-only final → nothing delivered (final path suppression via shared sanitizer).
+    await turn('silent final', async () => '[[SILENT_REPLY]]');
+    ok('B6 SILENT_REPLY-only final delivers nothing', sent.length === 0);
+
+    // Cleanup
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
+
+    console.log('');
+    if (failures === 0) {
+        console.log('ALL TESTS PASS');
+        process.exit(0);
+    } else {
+        console.log(`${failures} TEST(S) FAILED`);
+        process.exit(1);
+    }
+})().catch((e) => {
+    console.error('UNEXPECTED ERROR:', e && e.stack ? e.stack : e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes **BAT-1109**: when the model returned an assistant message containing **both** text and a `tool_use` block, the `ai.js` tool loop ran the tool and **dropped the accompanying text** — only a final text-only response ever reached the user. Any text the agent "said" alongside a tool call was silently lost, so the agent appeared to skip content, then (from its own transcript) insisted it *did* say it — trust-damaging. Pre-existing on `main` (v2.1.0); affects all providers (the drop is at the neutral `parsed.text` layer).

Contract-first, **Codex-signed** (see the ticket for the full contract + amendments): https://linear.app/batcave/issue/BAT-1109

## Implementation

- **`ai.js`** — thread an optional `options.sendInterim(text)` callback into `chat()`; call it for tool-executing rounds at the verified insertion point (**after** the `_loopFinalIteration` guard, **before** tool execution) so the forced-final text is never *also* interim-sent and text-only finals never reach it. **Delivery-only** — the text is already in `messages` and replayed to the model next turn, so conversation history is unchanged.
- **`message-handler.js`** — extract a shared `deliverAgentText()` used by **both** interim and final delivery, so interim text gets the same `SILENT_REPLY`/`HEARTBEAT_OK` stripping, `[[reply_to_current]]` handling, and rich/HTML/plain-fallback + 4096-split (via `deps.sendMessage`) as the final reply. `sendInterim` is wired **only** from the interactive path; cron/heartbeat/auto-resume callers pass none, so their ack/`HEARTBEAT_OK` suppression + plain-only routing are never bypassed (a safety boundary, not just scope).
- **Per-turn exact-match dedup `Set`** guards the reasoning-content-400 recovery replay (chat() re-emits the same pre-tool text after quarantine) from double-sending. Interim send failures are logged + swallowed so a delivery error never aborts the tool turn or the final reply.
- **Latent bug also fixed:** a bare `[[reply_to_current]]`-only response is now suppressed instead of sending an empty message.

## No-double-send analysis (verified across all 6 loop-exit paths)

| Exit path | Interim sent? | Final return | Dup? |
|---|---|---|---|
| text-only final (break before push) | no | that text | ✓ none |
| `_loopFinalIteration` break | no (insertion is after the guard) | that text | ✓ none |
| MAX_STEPS | last round yes | budget fallback string | ✓ different |
| security short-circuit | that round yes | deterministic security block | ✓ different |
| summary-fallback | prior rounds only | summary (fires only when final had no text) | ✓ none |

## Test plan (all passed)

- [x] `node tests/nodejs-project/interim-delivery.test.js` — **21/21** (deliverAgentText: SILENT_REPLY/HEARTBEAT_OK/empty/`[[reply_to_current]]`/dedup; handleMessage wiring: interim-before-final ordering, dedup within turn, dedup reset across turns, interim-failure-doesn't-abort)
- [x] `node tests/nodejs-project/smoke.js` — 78/78 parse, 27/27 load
- [x] `think-command` / `thinking-status` / `telegram-commands` / `ci-coverage-manifest` — green
- [x] `scripts/pre-push-check.sh` — all 4 phases, Kotlin **BUILD SUCCESSFUL**
- [x] Adversarial pre-push code review — 0 correctness/regression findings; all 5 contract invariants verified
- [ ] **Device test** (BANANA repro + normal single-message + multi-tool + one blocked/fallback path) — pending

## Known limitations (transparent)

- **Final reply is not deduped against interims** (by design — Codex ruled "the final send passes none"). If the model emits verbatim-identical text as interim in one round *and* as the final in a later round, it's delivered twice. Deduping the final would risk suppressing the authoritative final reply, so this is deliberately not done. Rare; arguably correct (the agent did say it twice).
- **Recovery/trim context-drop (pre-existing, low severity):** a reasoning-content-400 recovery / long-turn trim can drop already-delivered interim text from the model's *later* context. Pre-existing (interim text was always stored + subject to these paths); this fix only makes it user-visible. Not a blocker; documented for a possible future follow-up (no ticket filed per Codex).

## Self-awareness

New `WARN` log site (`[Interim] send failed`) + user-visible delivery change → **SAB audit will run before merge** (not skipped).

## Test file CI note

`interim-delivery.test.js` is registered in the CI coverage manifest `SKIP_REASONS` (message-handler tests run locally via node/pre-push, consistent with `think-command`/`thinking-status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interim assistant text delivery during interactive chat, showing partial narration before tool execution.
  * Improved system guidance so narration near tool calls is delivered immediately without being redundantly repeated.
* **Bug Fixes**
  * Sanitizes interim/final outputs to suppress `SILENT_REPLY` and `HEARTBEAT_OK`, and ignores empty/whitespace/non-string content.
  * Correctly handles `[[reply_to_current]]` for interim messages and applies per-turn deduplication while allowing retries after failed interim sends.
* **Tests**
  * Added `interim-delivery` coverage (dedup, filtering, reply targeting, failure tolerance) and documented a CI skip reason.
* **Documentation**
  * Added diagnostics describing why interim/pre-tool narration may not appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->