### PR TITLE
Security hardening: web_fetch header/body + agent_settings masking + SSRF (BAT-1086/1087/1088)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
             telegram-rich-send \
             rich-messages-default \
             truncate-tool-result \
+            web-fetch-redirect-headers \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
             rich-messages-default \
             truncate-tool-result \
             web-fetch-redirect-headers \
+            agent-settings-mask \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
             truncate-tool-result \
             web-fetch-redirect-headers \
             agent-settings-mask \
+            web-fetch-ssrf-guard \
             ci-coverage-manifest
           do
             echo "── $t ──"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+
+- Hardened `web_fetch` against credential exfiltration on cross-origin redirects: caller-supplied headers (API keys, bearer tokens) are now dropped when a request redirects to a different origin, and a cross-origin `307`/`308` can no longer forward the request body to the new host. Same-origin flows are unchanged. (BAT-1086)
+- API-key values stored in `agent_settings.json` are now masked before they reach the AI model. The agent can still read its settings and save keys, but raw key values are never exposed to the model or the chat — the read tool returns them masked, and the `js_eval`/`shell_exec` paths are blocked for that file. Protects provider billing keys even against prompt injection. This is model-facing output masking; the file on disk and the save flow are unchanged. (BAT-1087)
+- Strengthened `web_fetch`'s SSRF guard to block private/loopback/link-local addresses across all IPv4 and IPv6 encodings — including IPv6 loopback, IPv4-mapped, ULA, link-local, zone-identifier, and decimal/hex/octal literal forms — and applied the same guard to the file-download path. Only requests to internal addresses are affected. (BAT-1088)
+
 ## [2.1.1] - 2026-07-03
 
 > **Reasoning & message-delivery reliability hotfix for the latest Claude

--- a/app/src/main/assets/nodejs-project/security.js
+++ b/app/src/main/assets/nodejs-project/security.js
@@ -3,6 +3,7 @@
 // Depends on: config.js
 
 const path = require('path');
+const fs = require('fs');
 
 // BAT-1001 PR-B: per-call getBridgeToken (not the startup-frozen
 // BRIDGE_TOKEN constant) so log redaction tracks Kotlin-side token
@@ -137,6 +138,109 @@ function redactSecrets(msg) {
     }
     return msg;
 }
+
+// ============================================================================
+// AGENT SETTINGS MASKING (BAT-1087)
+// ============================================================================
+// agent_settings.json stores plaintext provider keys under apiKeys.* and is
+// readable by the model via the read / js_eval / shell_exec tools. We mask the
+// secret VALUES when the file's contents would reach the model, while leaving
+// structural settings (heartbeat interval, model, provider, ...) visible. This
+// is MODEL-FACING OUTPUT MASKING, not storage-at-rest protection — the file on
+// disk is unchanged and the save/write/edit flow is untouched.
+
+const _AGENT_SETTINGS_MASK = '[REDACTED]';
+// Centralized within this module so registration can't drift from the read/js_eval/
+// shell_exec paths (which keep their own AGENT_SETTINGS_FILE consts) if renamed.
+const _AGENT_SETTINGS_FILE = 'agent_settings.json';
+
+// Whether a key name denotes a credential value (matched at any depth). Separators
+// are stripped first so api_key / apiKey / api-key all normalize identically.
+function _isCredentialKeyName(key) {
+    const k = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+    return /(apikey|accesskey|secretkey|clientsecret|privatekey|authtoken|token|secret|password|passphrase|credential)s?$/.test(k);
+}
+
+// A node enters a "secret context" once traversal passes through a credential-typed
+// key — apiKeys (itself credential-typed), webhookSecret, authToken, etc. Inside that
+// context EVERY string is secret (keyed, bare-in-array, or nested arbitrarily deep in
+// objects/arrays), so `{ webhookSecret: { current: "x" } }` or `apiKeys: ["k"]` can't
+// slip a value through. Outside it, a string is secret only if its OWN key is
+// credential-typed. `underSecret` carries the context down through objects AND arrays.
+function _maskSettingsNode(node, underSecret) {
+    if (typeof node === 'string') return underSecret ? _AGENT_SETTINGS_MASK : node;
+    if (Array.isArray(node)) return node.map((v) => _maskSettingsNode(v, underSecret));
+    if (node && typeof node === 'object') {
+        const out = {};
+        for (const [k, v] of Object.entries(node)) {
+            if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+            const childSecret = underSecret || _isCredentialKeyName(k);
+            if (typeof v === 'string') {
+                out[k] = childSecret ? _AGENT_SETTINGS_MASK : v;
+            } else if (v && typeof v === 'object') {
+                out[k] = _maskSettingsNode(v, childSecret);
+            } else {
+                out[k] = v;
+            }
+        }
+        return out;
+    }
+    return node;
+}
+
+// Mask secret values in agent_settings.json text. Returns the masked JSON string,
+// or null if the text is not a parseable JSON object — the caller MUST fail closed
+// (withhold the content) rather than emit possibly-secret raw bytes.
+function maskAgentSettings(text) {
+    let parsed;
+    try { parsed = JSON.parse(text); } catch (_) { return null; }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return JSON.stringify(_maskSettingsNode(parsed, false), null, 2);
+}
+
+// Collect secret string values from a parsed settings object (same rule as the
+// mask). Registering them makes redactSecrets scrub those values if they ever
+// surface OUTSIDE the file read — e.g. in a log line or another tool's output.
+// This is DEFENSE-IN-DEPTH, not the primary protection: the read tool masks the
+// file (all lengths) and js_eval/shell_exec block it outright. Note registration
+// only takes values >= _MIN_SECRET_LEN (short strings would cause false-positive
+// redaction elsewhere); short secrets are still fully covered by those mask/block
+// paths, just not by redactSecrets.
+function _collectSettingsSecrets(node, underSecret, out) {
+    // Mirror _maskSettingsNode exactly: propagate the secret context through arrays
+    // and objects so array-nested and object-nested secrets are registered too.
+    if (typeof node === 'string') { if (underSecret) out.push(node); return out; }
+    if (Array.isArray(node)) { for (const v of node) _collectSettingsSecrets(v, underSecret, out); return out; }
+    if (node && typeof node === 'object') {
+        for (const [k, v] of Object.entries(node)) {
+            if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+            const childSecret = underSecret || _isCredentialKeyName(k);
+            if (typeof v === 'string') {
+                if (childSecret) out.push(v);
+            } else if (v && typeof v === 'object') {
+                _collectSettingsSecrets(v, childSecret, out);
+            }
+        }
+    }
+    return out;
+}
+
+// Read agent_settings.json from the workspace root and register its secret values
+// (>= _MIN_SECRET_LEN) for redaction as defense-in-depth (see _collectSettingsSecrets).
+// Safe to call repeatedly (the Set dedupes). Called at module load and after any
+// write/edit to the file (tools/file.js).
+function registerAgentSettingsSecrets() {
+    try {
+        const settingsPath = path.join(workDir, _AGENT_SETTINGS_FILE);
+        if (!fs.existsSync(settingsPath)) return;
+        const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+        registerRedactedSecrets(_collectSettingsSecrets(parsed, false, []));
+    } catch (_) { /* unparseable / absent — nothing to register */ }
+}
+
+// Register at load so any secret that later surfaces in logs/output is scrubbed.
+registerAgentSettingsSecrets();
 
 // ============================================================================
 // PATH VALIDATION
@@ -277,6 +381,8 @@ module.exports = {
     rebuildRedactPatterns,
     registerRedactedSecret,
     registerRedactedSecrets,
+    maskAgentSettings,
+    registerAgentSettingsSecrets,
     safePath,
     INJECTION_PATTERNS,
     normalizeWhitespace,

--- a/app/src/main/assets/nodejs-project/telegram.js
+++ b/app/src/main/assets/nodejs-project/telegram.js
@@ -11,6 +11,7 @@ const { BOT_TOKEN, log, workDir, getOwnerId, RICH_MESSAGES_ENABLED } = require('
 const { redactSecrets } = require('./security');
 const { httpRequest } = require('./http');
 const { sanitizeRichMarkdown } = require('./rich-markdown');
+const { isBlockedAddress } = require('./web'); // BAT-1088: shared SSRF host classifier
 
 // ============================================================================
 // TELEGRAM API
@@ -315,15 +316,13 @@ async function downloadFileByUrl(url, fileName, maxSize) {
         throw new Error('Unsupported URL protocol: ' + parsedUrl.protocol + ' (only https: allowed)');
     }
 
-    // SSRF guard: block private/local/reserved addresses by hostname string.
-    // Known limitation: DNS rebinding attacks are not prevented here because we check
-    // the hostname string before DNS resolution. Full protection would require async DNS
-    // lookup and IP validation, which adds latency and complexity.
-    // Accepted trade-off: Discord CDN URLs come from cdn.discordapp.com (validated by
-    // the Discord API) — this hostname check is a first-pass defense against obvious
-    // SSRF attempts (localhost, RFC1918, link-local). Prompt-injection-sourced URLs
-    // arriving through normal message flow are a lower risk given the owner-only gate.
-    if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.|localhost|\[::1\]|\[fe80:)/i.test(parsedUrl.hostname)) {
+    // SSRF guard: shared canonical classifier (BAT-1088) — blocks private/loopback/
+    // link-local literals incl. IPv6 (ULA / IPv4-mapped / IPv4-compatible / zone-id),
+    // so this path can't drift from web_fetch's guard.
+    // Known limitation: DNS rebinding (a public hostname resolving to a private IP) is
+    // NOT prevented here — that needs resolve-and-pin (tracked as BAT-1093). Discord CDN
+    // URLs come from cdn.discordapp.com; the owner-only message flow keeps injection risk low.
+    if (isBlockedAddress(parsedUrl.hostname)) {
         throw new Error('Blocked: private/local address');
     }
 

--- a/app/src/main/assets/nodejs-project/tools/file.js
+++ b/app/src/main/assets/nodejs-project/tools/file.js
@@ -12,7 +12,11 @@ const channel = require('../channel');
 
 const {
     redactSecrets, rebuildRedactPatterns, safePath, detectSuspiciousPatterns,
+    maskAgentSettings, registerAgentSettingsSecrets,
 } = require('../security');
+
+// BAT-1087: filename whose contents carry provider/service secrets under apiKeys.*
+const AGENT_SETTINGS_FILE = 'agent_settings.json';
 
 // Helper to recursively list files in a directory (used by skill_read)
 function listFilesRecursive(dir, maxDepth = 3, currentDepth = 0) {
@@ -132,8 +136,9 @@ const handlers = {
             return { error: `File not found: ${input.path}` };
         }
         // Resolve symlinks and re-check basename (prevents symlink bypass)
+        let realBasename = readBasename;
         try {
-            const realBasename = path.basename(fs.realpathSync(filePath));
+            realBasename = path.basename(fs.realpathSync(filePath));
             if (SECRETS_BLOCKED.has(realBasename)) {
                 log(`[Security] BLOCKED read via symlink to sensitive file: ${realBasename}`, 'WARN');
                 return { error: `Reading ${realBasename} is blocked for security.` };
@@ -144,6 +149,22 @@ const handlers = {
             return { error: 'Path is a directory, use ls tool instead' };
         }
         const content = fs.readFileSync(filePath, 'utf8');
+        // BAT-1087: mask secret values before returning agent_settings.json to the
+        // model. Match basename OR realpath-basename so symlink aliases are covered;
+        // conservatively masking any file named agent_settings.json is acceptable.
+        if (readBasename === AGENT_SETTINGS_FILE || realBasename === AGENT_SETTINGS_FILE) {
+            const masked = maskAgentSettings(content);
+            if (masked === null) {
+                // Unparseable → fail closed: withhold rather than emit raw bytes.
+                log('[Security] agent_settings.json unparseable — withholding content from model', 'WARN');
+                return {
+                    path: input.path,
+                    size: stat.size,
+                    error: 'agent_settings.json is unparseable; contents withheld to avoid leaking secrets',
+                };
+            }
+            return { path: input.path, size: stat.size, content: masked.slice(0, 50000) };
+        }
         return {
             path: input.path,
             size: stat.size,
@@ -178,9 +199,10 @@ const handlers = {
         fs.writeFileSync(filePath, input.content, 'utf8');
 
         // BAT-236: If agent wrote to workspace root agent_settings.json, re-sync API keys
-        if (filePath === path.join(workDir, 'agent_settings.json')) {
+        if (filePath === path.join(workDir, AGENT_SETTINGS_FILE)) {
             syncAgentApiKeys();
             rebuildRedactPatterns();
+            registerAgentSettingsSecrets(); // BAT-1087: register newly-saved secrets for redaction
         }
 
         return {
@@ -231,9 +253,10 @@ const handlers = {
         fs.writeFileSync(filePath, content, 'utf8');
 
         // BAT-236: If agent edited workspace root agent_settings.json, re-sync API keys
-        if (filePath === path.join(workDir, 'agent_settings.json')) {
+        if (filePath === path.join(workDir, AGENT_SETTINGS_FILE)) {
             syncAgentApiKeys();
             rebuildRedactPatterns();
+            registerAgentSettingsSecrets(); // BAT-1087: register newly-saved secrets for redaction
         }
 
         return {

--- a/app/src/main/assets/nodejs-project/tools/system.js
+++ b/app/src/main/assets/nodejs-project/tools/system.js
@@ -11,6 +11,18 @@ const {
     redactSecrets, safePath,
 } = require('../security');
 
+// BAT-1087: agent_settings.json holds provider secrets under apiKeys.*. It is NOT in
+// SECRETS_BLOCKED (the read tool needs masked access), but shell_exec and js_eval must
+// not return its raw bytes — redactSecrets only covers registered values (misses
+// <7-char and corrupt-file secrets). Both route the agent to the masking read tool.
+const AGENT_SETTINGS_FILE = 'agent_settings.json';
+// Match the filename as a WHOLE command token: optional path prefix (start / space /
+// separator) and whitespace-or-end after — so `cat agent_settings.json` and
+// `cat ./agent_settings.json` are blocked, but a different file like
+// `agent_settings.json.bak` is NOT falsely matched (a `\b` after `.json` would).
+// Derived from the constant so shell_exec and js_eval stay in lockstep if renamed.
+const AGENT_SETTINGS_RX = new RegExp('(^|[\\s/])' + AGENT_SETTINGS_FILE.replace(/[.]/g, '\\.') + '(\\s|$)', 'i');
+
 // DeerFlow P2: Tool registry for tool_search — set from tools/index.js at startup
 let _getTools = null;
 function _setToolRegistry(fn) { _getTools = fn; }
@@ -140,6 +152,17 @@ const handlers = {
             return { error: 'Shell operators (;, &, |, `, <, >, $, *, ?, ~, {}, []) are not allowed in arguments. Run one simple command at a time.' };
         }
 
+        // BAT-1087: block shell access to agent_settings.json. redactSecrets covers
+        // registered values, but a corrupt/unparseable file registers nothing, so a
+        // dump command (cat/head/grep/base64/...) could still leak raw stored keys.
+        // Strip shell quoting/backslash escapes before matching so evasions like
+        // `agent_settings\.json` or `agent_settings.jso''n` (which /bin/sh collapses to
+        // the real name) can't slip past; operators ($, backticks, *, ...) are already
+        // rejected above, leaving quotes and backslashes as the only evasion chars.
+        if (AGENT_SETTINGS_RX.test(cmd.replace(/['"\\]/g, ''))) {
+            return { error: `Reading ${AGENT_SETTINGS_FILE} via shell_exec is blocked. Use the read tool — it returns the file with secret values masked.` };
+        }
+
         // Resolve working directory (must be within workspace)
         let cwd = workDir;
         if (input.cwd) {
@@ -190,13 +213,18 @@ const handlers = {
                 shell: shellPath,
                 env: childEnv
             }, (err, stdout, stderr) => {
+                // BAT-1087: redact secrets from shell output before it reaches the
+                // model. `cat agent_settings.json` (and other allowlisted printers)
+                // would otherwise return raw provider keys; redactSecrets also masks
+                // the bridge token and any registered secret. Redact BEFORE slicing so
+                // a secret spanning the truncation boundary is still masked.
                 if (err) {
                     if (err.killed && err.signal) {
                         log(`shell_exec TIMEOUT: ${cmd.slice(0, 80)}`, 'WARN');
                         resolve({
                             success: false,
                             command: cmd,
-                            stdout: (stdout || '').slice(0, 50000),
+                            stdout: redactSecrets(stdout || '').slice(0, 50000),
                             stderr: `Command timed out after ${timeout}ms`,
                             exit_code: err.code || 1
                         });
@@ -205,8 +233,8 @@ const handlers = {
                         resolve({
                             success: false,
                             command: cmd,
-                            stdout: (stdout || '').slice(0, 50000),
-                            stderr: (stderr || '').slice(0, 10000) || err.message || 'Unknown error',
+                            stdout: redactSecrets(stdout || '').slice(0, 50000),
+                            stderr: redactSecrets((stderr || '') || err.message || 'Unknown error').slice(0, 10000),
                             exit_code: err.code || 1
                         });
                     }
@@ -215,8 +243,8 @@ const handlers = {
                     resolve({
                         success: true,
                         command: cmd,
-                        stdout: (stdout || '').slice(0, 50000),
-                        stderr: (stderr || '').slice(0, 10000),
+                        stdout: redactSecrets(stdout || '').slice(0, 50000),
+                        stderr: redactSecrets(stderr || '').slice(0, 10000),
                         exit_code: 0
                     });
                 }
@@ -283,6 +311,12 @@ const handlers = {
                             const basename = path.basename(resolvedPath);
                             if (SECRETS_BLOCKED.has(basename)) {
                                 throw new Error(`Access to ${basename} is blocked for security.`);
+                            }
+                            // BAT-1087: agent_settings.json isn't in SECRETS_BLOCKED (masked
+                            // read is allowed via the read tool), but js_eval must not read it
+                            // raw — that would bypass masking for <7-char / corrupt-file secrets.
+                            if (basename === AGENT_SETTINGS_FILE) {
+                                throw new Error('Access to agent_settings.json via js_eval is blocked; use the read tool (secret values are masked).');
                             }
                             return original.apply(target, args);
                         };

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -2,6 +2,7 @@
 // Web cache, HTML-to-markdown, search providers, web fetch.
 // Depends on: config.js, http.js
 
+const net = require('net');
 const { config, log, USER_AGENT } = require('./config');
 const { httpRequest } = require('./http');
 
@@ -275,6 +276,108 @@ function computeOutboundHeaders(customHeaders, url, originUrl, options = {}, cur
     return headers;
 }
 
+// --- SSRF guard: block private / loopback / link-local literals (BAT-1088) ---
+//
+// LITERAL / canonical-host screening only — NOT DNS-rebind protection. `new URL()`
+// already canonicalizes IPv4 decimal/octal/hex forms to dotted-quad before we see
+// url.hostname, so the live gap this closes over the old prefix regex is IPv6
+// (loopback/mapped/ULA/link-local). A public hostname that RESOLVES to a private IP
+// is out of scope (needs resolve-and-pin — tracked separately as BAT-1093).
+//
+// V1 blocks: IPv4 loopback 127/8, private 10/8 + 172.16/12 + 192.168/16, link-local
+// 169.254/16, unspecified 0/8; IPv6 :: , ::1, ULA fc00::/7, link-local fe80::/10,
+// IPv4-mapped ::ffff:0:0/96 (classified by embedded IPv4); localhost / *.localhost.
+// Deliberately NOT blocked (per BAT-1088 decision): CGNAT 100.64/10, benchmark
+// 198.18/15, multicast, reserved-future — asserted allowed in tests.
+
+function _isBlockedIPv4(ip) {
+    const p = ip.split('.');
+    if (p.length !== 4) return true; // net.isIPv4 validated the shape; be safe
+    const a = Number(p[0]), b = Number(p[1]);
+    if (a === 127) return true;                       // loopback 127/8
+    if (a === 10) return true;                        // private 10/8
+    if (a === 0) return true;                         // "this host" 0/8
+    if (a === 169 && b === 254) return true;          // link-local 169.254/16
+    if (a === 192 && b === 168) return true;          // private 192.168/16
+    if (a === 172 && b >= 16 && b <= 31) return true; // private 172.16/12
+    return false;
+}
+
+// Parse a (net.isIPv6-validated) IPv6 string into 16 bytes, or null if unparseable.
+function _ipv6ToBytes(str) {
+    const halves = str.split('::');
+    if (halves.length > 2) return null;
+    const parseGroups = (part) => {
+        if (part === '') return [];
+        const out = [];
+        for (const t of part.split(':')) {
+            if (t.includes('.')) { // embedded IPv4 tail → two 16-bit groups
+                const q = t.split('.').map(Number);
+                if (q.length !== 4 || q.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+                out.push(((q[0] << 8) | q[1]) & 0xffff, ((q[2] << 8) | q[3]) & 0xffff);
+            } else {
+                if (!/^[0-9a-f]{1,4}$/i.test(t)) return null;
+                out.push(parseInt(t, 16));
+            }
+        }
+        return out;
+    };
+    const head = parseGroups(halves[0]);
+    const tail = halves.length === 2 ? parseGroups(halves[1]) : [];
+    if (head === null || tail === null) return null;
+    let g;
+    if (halves.length === 2) {
+        const missing = 8 - head.length - tail.length;
+        if (missing < 0) return null;
+        g = [...head, ...Array(missing).fill(0), ...tail];
+    } else {
+        g = head;
+    }
+    if (g.length !== 8) return null;
+    const bytes = new Uint8Array(16);
+    for (let i = 0; i < 8; i++) { bytes[2 * i] = (g[i] >> 8) & 0xff; bytes[2 * i + 1] = g[i] & 0xff; }
+    return bytes;
+}
+
+function _isBlockedIPv6(str) {
+    const b = _ipv6ToBytes(str);
+    if (!b) return true; // fail closed on anything we can't classify
+    if ((b[0] & 0xfe) === 0xfc) return true;                  // fc00::/7 ULA
+    if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true; // fe80::/10 link-local
+    const embeddedV4 = () => _isBlockedIPv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);
+    // IPv4-mapped ::ffff:0:0/96 → classify by embedded IPv4.
+    if (b.slice(0, 10).every((x) => x === 0) && b[10] === 0xff && b[11] === 0xff) return embeddedV4();
+    // First 96 bits zero covers :: (unspecified → 0.0.0.0), ::1 (loopback → 0.0.0.1),
+    // and the deprecated IPv4-compatible form ::w.x.y.z (::7f00:1 etc.) that some
+    // stacks route as IPv4 — classify by the embedded IPv4 (0/8 catches :: and ::1).
+    if (b.slice(0, 12).every((x) => x === 0)) return embeddedV4();
+    return false;
+}
+
+// Is this host a private/loopback/link-local literal that web_fetch must not reach?
+// Pure + exported for unit testing. Called per redirect hop before any socket opens.
+function isBlockedAddress(hostname) {
+    if (typeof hostname !== 'string') return true; // fail closed on junk
+    let host = hostname.trim().toLowerCase();
+    if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1); // strip IPv6 brackets
+    // Strip an IPv6 zone identifier (RFC 6874: fe80::1%eth0). Classify the address
+    // itself so a zoned link-local literal is caught as link-local, not treated as a
+    // hostname. (new URL() actually rejects zoned IPv6 URLs, so this mainly hardens
+    // direct callers of this exported helper.)
+    const pct = host.indexOf('%');
+    if (pct !== -1) host = host.slice(0, pct);
+    // Strip trailing dot(s): the FQDN root form (localhost. / api.localhost.) resolves
+    // identically to the un-dotted name, so it must classify the same — otherwise it's
+    // a localhost SSRF bypass. (new URL() drops the dot on IP literals but keeps it on
+    // names.)
+    host = host.replace(/\.+$/, '');
+    if (!host) return true; // empty / whitespace-only / "[]" / "." → fail closed
+    const v = net.isIP(host);
+    if (v === 0) return host === 'localhost' || host.endsWith('.localhost'); // hostname, not an IP literal
+    if (v === 4) return _isBlockedIPv4(host);
+    return _isBlockedIPv6(host);
+}
+
 async function webFetch(urlString, options = {}) {
     const maxRedirects = options.maxRedirects || 5;
     const timeout = options.timeout || 30000;
@@ -293,8 +396,9 @@ async function webFetch(urlString, options = {}) {
             throw new Error('Unsupported URL protocol: ' + url.protocol);
         }
 
-        // SSRF guard: block private/local/reserved addresses
-        if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.|localhost)/i.test(url.hostname)) {
+        // SSRF guard: block private/local/link-local literals (BAT-1088).
+        // Per-hop + before any socket, so redirect targets are covered too.
+        if (isBlockedAddress(url.hostname)) {
             throw new Error('Blocked: private/local address');
         }
 
@@ -355,4 +459,5 @@ module.exports = {
     searchFirecrawl,
     webFetch,
     computeOutboundHeaders,
+    isBlockedAddress,
 };

--- a/app/src/main/assets/nodejs-project/web.js
+++ b/app/src/main/assets/nodejs-project/web.js
@@ -236,6 +236,45 @@ async function searchFirecrawl(query, count = 5) {
 
 // --- Enhanced HTTP fetch with redirects + SSRF protection ---
 
+// Build the outbound headers for a single hop of a (possibly redirected) web_fetch.
+//
+// Security (BAT-1086): caller-supplied headers ride along ONLY when this hop is
+// same-origin as the ORIGINAL request. On any cross-origin hop we send just the
+// framework defaults (User-Agent, Accept), so secret auth headers — Authorization,
+// Cookie, x-api-key, a bearer token placed in a custom header, etc. — never follow
+// a redirect to a different host. Comparing against the ORIGINAL origin (not the
+// previous hop) means that once the chain leaves the trusted origin the headers
+// stay stripped, while a hop back to the original origin (A->B->A) re-attaches them.
+//
+// Content-Type is re-derived here (never carried across origins) and only when a
+// body is actually being sent. Pure and deterministic — exported for unit testing.
+function computeOutboundHeaders(customHeaders, url, originUrl, options = {}, currentBody = null) {
+    const headers = {
+        'User-Agent': USER_AGENT,
+        'Accept': (options && options.accept) || 'text/markdown, text/html;q=0.9, */*;q=0.1',
+    };
+    // Caller headers AND a body-derived Content-Type ride along ONLY on same-origin
+    // hops. A cross-origin hop gets nothing but the two framework defaults above.
+    // (webFetch also blocks cross-origin body-preserving redirects, so a body is
+    // only ever sent same-origin anyway.)
+    if (url.origin === originUrl.origin) {
+        if (customHeaders && typeof customHeaders === 'object') {
+            for (const [k, v] of Object.entries(customHeaders)) {
+                // Filter prototype-pollution keys — this helper is exported, so a
+                // direct caller could pass unsanitized headers (tools/web.js already
+                // strips these at the input boundary; mirror it here defensively).
+                if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+                headers[k] = v;
+            }
+        }
+        const hasContentType = Object.keys(headers).some(k => k.toLowerCase() === 'content-type');
+        if (currentBody != null && typeof currentBody === 'object' && !hasContentType) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+    return headers;
+}
+
 async function webFetch(urlString, options = {}) {
     const maxRedirects = options.maxRedirects || 5;
     const timeout = options.timeout || 30000;
@@ -262,21 +301,9 @@ async function webFetch(urlString, options = {}) {
         const remaining = deadline - Date.now();
         if (remaining <= 0) throw new Error('Request timeout (redirect chain)');
 
-        // Strip sensitive headers on cross-origin redirect
-        const reqHeaders = {
-            'User-Agent': USER_AGENT,
-            'Accept': options.accept || 'text/markdown, text/html;q=0.9, */*;q=0.1'
-        };
-        for (const [k, v] of Object.entries(customHeaders)) {
-            const lower = k.toLowerCase();
-            // Strip auth headers on cross-origin redirects
-            if (url.origin !== originUrl.origin && (lower === 'authorization' || lower === 'cookie')) continue;
-            reqHeaders[k] = v;
-        }
-        const hasContentType = Object.keys(reqHeaders).some(k => k.toLowerCase() === 'content-type');
-        if (currentBody && typeof currentBody === 'object' && !hasContentType) {
-            reqHeaders['Content-Type'] = 'application/json';
-        }
+        // Build outbound headers: caller headers only on same-origin hops,
+        // safe framework defaults otherwise (BAT-1086 — see computeOutboundHeaders).
+        const reqHeaders = computeOutboundHeaders(customHeaders, url, originUrl, options, currentBody);
 
         const res = await httpRequest({
             hostname: url.hostname,
@@ -289,14 +316,21 @@ async function webFetch(urlString, options = {}) {
 
         // Follow redirects
         if ([301, 302, 303, 307, 308].includes(res.status) && res.headers?.location) {
-            currentUrl = new URL(res.headers.location, currentUrl).toString();
+            const nextUrl = new URL(res.headers.location, currentUrl);
             if (res.status === 307 || res.status === 308) {
-                // Preserve method + body
+                // 307/308 preserve method + body. Block cross-origin body-preserving
+                // redirects (BAT-1086): forwarding a caller POST/PUT body to a
+                // different origin is a data-exfil path even after headers are
+                // stripped. Same-origin 307/308 keep method + body as before.
+                if (nextUrl.origin !== originUrl.origin && currentBody != null) {
+                    throw new Error('Blocked: cross-origin redirect with request body');
+                }
             } else {
                 // 301/302/303 → downgrade to GET, drop body
                 currentMethod = 'GET';
                 currentBody = null;
             }
+            currentUrl = nextUrl.toString();
             continue;
         }
 
@@ -320,4 +354,5 @@ module.exports = {
     searchTavily,
     searchFirecrawl,
     webFetch,
+    computeOutboundHeaders,
 };

--- a/tests/nodejs-project/agent-settings-mask.test.js
+++ b/tests/nodejs-project/agent-settings-mask.test.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// tests/nodejs-project/agent-settings-mask.test.js
+//
+// BAT-1087: agent_settings.json stores plaintext provider keys under apiKeys.* and
+// is readable by the model via the read / js_eval / shell_exec tools. This test
+// pins the model-facing protection across all three surfaces:
+//   A. maskAgentSettings() masks apiKeys.* + credential-typed values at any depth,
+//      keeps structural fields, and fails closed (null) on unparseable input.
+//   B. registerAgentSettingsSecrets() registers stored values (>= _MIN_SECRET_LEN)
+//      so redactSecrets scrubs them if they surface elsewhere (logs/other output) —
+//      DEFENSE-IN-DEPTH, not the primary path.
+//   C. read handler returns masked content (all lengths) and withholds on corrupt
+//      JSON; js_eval and shell_exec BLOCK the file outright (so short/corrupt-file
+//      secrets can't leak via those surfaces).
+//   D. the save/write flow still persists + syncs keys (BAT-236 unbroken).
+//
+// This is MODEL-FACING OUTPUT MASKING, not storage-at-rest protection — the file on
+// disk stays plaintext.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// Fixture workDir (config.js reads process.argv[2]). config.json marks braveApiKey
+// as an Android-settings key so the agent's apiKeys.brave value is a MERGE-LOSER
+// (never enters `config`) — the case that only registration, not the config-derived
+// redaction patterns, can cover. Placeholders are obviously fake (no real-key shape).
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1087-mask-'));
+fs.writeFileSync(path.join(workDir, 'config.json'), JSON.stringify({
+    botToken: 'placeholder-not-a-real-bot-token',
+    anthropicApiKey: 'placeholder-not-a-real-api-key',
+    braveApiKey: 'ANDROID_BRAVE_PLACEHOLDER',
+    ownerId: '111',
+    channel: 'telegram',
+}), 'utf8');
+const ORIGINAL_SETTINGS = {
+    apiKeys: {
+        anthropic: 'SENTINEL_ANTHROPIC_VALUE',   // maps to an Android key -> merge-loser
+        custommap: 'SENTINEL_CUSTOM_VALUE',       // unknown service -> not in config
+        brave: 'SENTINEL_BRAVE_MERGELOSER',       // Android brave wins -> merge-loser
+    },
+    nested: { webhookSecret: 'SENTINEL_NESTED_SECRET' }, // credential by key-name, any depth
+    heartbeatIntervalMinutes: 7,
+    model: 'claude-opus-4-8',
+    provider: 'claude',
+};
+fs.writeFileSync(path.join(workDir, 'agent_settings.json'), JSON.stringify(ORIGINAL_SETTINGS), 'utf8');
+process.argv[2] = workDir;
+process.on('exit', () => { try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {} });
+
+const sec = require(path.join(BUNDLE, 'security.js'));       // registerAgentSettingsSecrets() runs at load
+const cfg = require(path.join(BUNDLE, 'config.js'));
+const fileTool = require(path.join(BUNDLE, 'tools', 'file.js'));
+const sysTool = require(path.join(BUNDLE, 'tools', 'system.js'));
+
+const SENTINELS = ['SENTINEL_ANTHROPIC_VALUE', 'SENTINEL_CUSTOM_VALUE', 'SENTINEL_BRAVE_MERGELOSER', 'SENTINEL_NESTED_SECRET'];
+function hasNoSentinel(s, list = SENTINELS) { return list.every((x) => !String(s).includes(x)); }
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+console.log('agent-settings-mask.test.js — BAT-1087 model-facing settings masking');
+console.log();
+
+// ---------------------------------------------------------------------------
+// A. maskAgentSettings — pure
+// ---------------------------------------------------------------------------
+check('masks apiKeys.* (known + unknown) and nested credential fields; keeps structure', () => {
+    const sample = JSON.stringify({
+        apiKeys: { anthropic: 'AAA_SECRET', weirdsvc: 'BBB_SECRET' },
+        deep: { nested: { authToken: 'CCC_SECRET' } },
+        heartbeatIntervalMinutes: 5,
+        model: 'm',
+        provider: 'claude',
+    });
+    const masked = sec.maskAgentSettings(sample);
+    assert.ok(typeof masked === 'string', 'returns a string on valid input');
+    const obj = JSON.parse(masked);
+    assert.strictEqual(obj.apiKeys.anthropic, '[REDACTED]');
+    assert.strictEqual(obj.apiKeys.weirdsvc, '[REDACTED]', 'unknown service value still masked');
+    assert.strictEqual(obj.deep.nested.authToken, '[REDACTED]', 'nested credential-typed key masked');
+    assert.strictEqual(obj.heartbeatIntervalMinutes, 5, 'structural field visible');
+    assert.strictEqual(obj.model, 'm');
+    assert.strictEqual(obj.provider, 'claude');
+    assert.ok(!masked.includes('SECRET'), 'no raw secret value leaks');
+});
+
+check('masks secrets nested under apiKeys via arrays + deep objects (malformed shapes)', () => {
+    const sample = JSON.stringify({
+        apiKeys: { list: ['ARR_SECRET_1', 'ARR_SECRET_2'], deep: { inner: 'DEEP_APIKEYS_SECRET' } },
+        weirdArray: [{ token: 'TOKEN_IN_ARRAY_SECRET' }], // credential key inside an array
+        heartbeatIntervalMinutes: 3,
+    });
+    const masked = sec.maskAgentSettings(sample);
+    for (const s of ['ARR_SECRET_1', 'ARR_SECRET_2', 'DEEP_APIKEYS_SECRET', 'TOKEN_IN_ARRAY_SECRET']) {
+        assert.ok(!masked.includes(s), `${s} must be masked`);
+    }
+    assert.strictEqual(JSON.parse(masked).heartbeatIntervalMinutes, 3, 'structural field intact');
+});
+
+check('masks secrets nested under a credential-typed key (object/array value)', () => {
+    // A credential-named key whose VALUE is an object/array must mask its descendants,
+    // not just direct-string values.
+    const sample = JSON.stringify({
+        webhookSecret: { current: 'CRED_OBJ_SECRET', previous: 'CRED_OBJ_SECRET_2' },
+        authToken: ['TOKEN_ARR_SECRET'],
+        heartbeatIntervalMinutes: 4,
+    });
+    const masked = sec.maskAgentSettings(sample);
+    for (const s of ['CRED_OBJ_SECRET', 'CRED_OBJ_SECRET_2', 'TOKEN_ARR_SECRET']) {
+        assert.ok(!masked.includes(s), `${s} nested under a credential-typed key must be masked`);
+    }
+    assert.strictEqual(JSON.parse(masked).heartbeatIntervalMinutes, 4, 'structural field intact');
+});
+
+check('fails closed (null) on unparseable / non-object JSON', () => {
+    assert.strictEqual(sec.maskAgentSettings('{bad json'), null, 'corrupt JSON -> null');
+    assert.strictEqual(sec.maskAgentSettings('[1,2,3]'), null, 'array -> null');
+    assert.strictEqual(sec.maskAgentSettings('"just a string"'), null, 'primitive -> null');
+});
+
+// ---------------------------------------------------------------------------
+// B. registration + redactSecrets  (the js_eval / shell_exec coverage mechanism)
+// ---------------------------------------------------------------------------
+check('stored values >= min length (incl. merge-losers + nested) are registered for redaction', () => {
+    // registerAgentSettingsSecrets() ran at security.js load against the seeded file.
+    const blob = `dump: ${SENTINELS.join(' / ')}`;
+    const red = sec.redactSecrets(blob);
+    for (const s of SENTINELS) assert.ok(!red.includes(s), `${s} must be redacted by redactSecrets`);
+});
+
+// ---------------------------------------------------------------------------
+// C. read handler
+// ---------------------------------------------------------------------------
+(async () => {
+    await checkAsync('read agent_settings.json: values masked, structural fields visible', async () => {
+        const r = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(!r.error, `unexpected error: ${r.error}`);
+        assert.ok(hasNoSentinel(r.content), 'no sentinel value in returned content');
+        assert.ok(r.content.includes('[REDACTED]'), 'masked placeholder present');
+        assert.ok(r.content.includes('"heartbeatIntervalMinutes": 7'), 'heartbeat interval still visible');
+        assert.ok(r.content.includes('"model": "claude-opus-4-8"'), 'model still visible');
+    });
+
+    // js_eval must not read agent_settings.json raw — the guarded fs proxy blocks it,
+    // so <7-char / corrupt-file secrets that registration can't cover never leak. The
+    // read tool is the masked path. (Registration is still proven by test B as
+    // defense-in-depth for any value that surfaces elsewhere.)
+    await checkAsync('js_eval reading agent_settings.json is blocked (no raw bytes reach the model)', async () => {
+        const code = "const fs=require('fs'), p=require('path'); return fs.readFileSync(p.join(process.cwd(), 'agent_settings.json'),'utf8');";
+        const r = await sysTool.handlers.js_eval({ code }, 'chat');
+        assert.ok(!r.success, 'js_eval read of agent_settings.json must be blocked');
+        assert.ok(/blocked/i.test(r.error || ''), 'error explains the block');
+        assert.ok(hasNoSentinel(JSON.stringify(r)), 'no raw stored value in result/output/error');
+    });
+
+    // shell_exec must fail CLOSED on any command referencing agent_settings.json,
+    // INCLUDING shell-quoting / backslash evasions that /bin/sh would normalize to the
+    // real filename. Deterministic + needs no shell spawn (short-circuits before exec).
+    await checkAsync('shell_exec referencing agent_settings.json is blocked, incl. quoted/escaped', async () => {
+        const variants = [
+            'cat agent_settings.json',
+            'head ./agent_settings.json',
+            'base64 agent_settings.json',
+            'cat agent_settings\\.json',   // backslash escape → \.
+            "cat agent_settings.jso''n",   // empty-quote split
+            'cat "agent_settings.json"',   // quoted
+        ];
+        for (const command of variants) {
+            const sh = await sysTool.handlers.shell_exec({ command }, 'chat');
+            assert.ok(sh.error && /blocked/i.test(sh.error), `must block: ${command}`);
+            assert.strictEqual(sh.stdout, undefined, 'a blocked command returns no stdout');
+        }
+    });
+
+    await checkAsync('shell_exec block is a precise token — does not over-match neighbours', async () => {
+        // `echo hello` and a different file `agent_settings.json.bak` must NOT trip the
+        // block (a \b-based regex would falsely match the .bak). On a shell-less host the
+        // exec may fail, but it must not short-circuit with the agent_settings block.
+        for (const command of ['echo hello', 'cat agent_settings.json.bak']) {
+            const sh = await sysTool.handlers.shell_exec({ command }, 'chat');
+            assert.ok(!(sh.error && /blocked/i.test(sh.error)), `must not be blocked: ${command}`);
+        }
+    });
+
+    // ---------------------------------------------------------------------------
+    // D. save/write regression — BAT-236 sync + new-key registration still work
+    // ---------------------------------------------------------------------------
+    await checkAsync('write flow persists a new key, syncs to config, masks on read-back', async () => {
+        const NEWKEY = 'NEWPERPLEXITY_PLACEHOLDER_VALUE';
+        const newSettings = JSON.stringify({ apiKeys: { perplexity: NEWKEY }, heartbeatIntervalMinutes: 9 });
+        const w = await fileTool.handlers.write({ path: 'agent_settings.json', content: newSettings }, 'chat');
+        assert.ok(w.success, 'write succeeded');
+        // BAT-236: syncAgentApiKeys picked the new key into config (perplexity is not an Android key here)
+        assert.strictEqual(cfg.config.perplexityApiKey, NEWKEY, 'new key synced into config');
+        // File on disk stays plaintext (this is output masking, not at-rest encryption)
+        const onDisk = fs.readFileSync(path.join(workDir, 'agent_settings.json'), 'utf8');
+        assert.ok(onDisk.includes(NEWKEY), 'file persists the raw key on disk');
+        // Reading it back through the tool is masked, and it is now registered for redaction
+        const rr = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(!rr.content.includes(NEWKEY), 'read-back masks the newly-saved key');
+        assert.ok(!sec.redactSecrets(`k=${NEWKEY}`).includes(NEWKEY), 'newly-saved key registered for redaction');
+    });
+
+    // ---------------------------------------------------------------------------
+    // C. corrupt file — fail closed (run last: it clobbers the settings file)
+    // ---------------------------------------------------------------------------
+    await checkAsync('corrupt agent_settings.json → content withheld (fail closed)', async () => {
+        fs.writeFileSync(path.join(workDir, 'agent_settings.json'), '{ this is : not valid json ', 'utf8');
+        const r = await fileTool.handlers.read({ path: 'agent_settings.json' }, 'chat');
+        assert.ok(r.error && /withheld/i.test(r.error), 'unparseable settings file must be withheld');
+        assert.strictEqual(r.content, undefined, 'no raw content returned');
+    });
+
+    console.log();
+    console.log(`Result: ${pass} passed, ${fail} failed`);
+    if (fail > 0) { console.error('FAIL: agent-settings-mask.test.js'); process.exit(1); }
+    console.log('PASS: agent-settings-mask.test.js');
+})();

--- a/tests/nodejs-project/web-fetch-redirect-headers.test.js
+++ b/tests/nodejs-project/web-fetch-redirect-headers.test.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// tests/nodejs-project/web-fetch-redirect-headers.test.js
+//
+// BAT-1086: on a CROSS-ORIGIN redirect hop, web_fetch must
+//   (1) drop ALL caller-supplied headers — only SAME-ORIGIN hops carry them, so
+//       secret auth headers (Authorization, Cookie, x-api-key, bearer-in-custom-
+//       header, ...) never follow a redirect to another host; and
+//   (2) fail closed on a cross-origin 307/308 that would forward the request BODY
+//       to a different origin (data-exfil path even after headers are stripped).
+// Same-origin redirects preserve headers + method + body as before.
+//
+// Two layers: computeOutboundHeaders() is exercised as a pure function, and the
+// body-block + per-hop stripping are exercised through the real webFetch redirect
+// loop with a stubbed transport that records every outbound request.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+// config.js (required transitively by http.js/web.js) reads its workDir from
+// process.argv[2] and process.exit(1)s without a valid config.json. Point it at a
+// throwaway fixture workDir BEFORE any bundle require so the real modules load.
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1086-webfetch-'));
+// Fixtures use obviously-fake, non-credential-shaped placeholders (config.js only
+// requires these to be non-empty) so secret scanners don't flag the test file.
+fs.writeFileSync(path.join(workDir, 'config.json'), JSON.stringify({
+    botToken: 'placeholder-not-a-real-bot-token',
+    anthropicApiKey: 'placeholder-not-a-real-api-key',
+    ownerId: '111',
+    channel: 'telegram',
+}), 'utf8');
+process.argv[2] = workDir;
+process.on('exit', () => { try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {} });
+
+// Stub the transport BEFORE loading web.js so its `const { httpRequest } = require('./http')`
+// destructure captures our stub. `calls` records every outbound hop; `responses` is the
+// scripted response queue (one entry consumed per hop).
+const httpMod = require(path.join(BUNDLE, 'http.js'));
+let responses = [];
+let calls = [];
+httpMod.httpRequest = async (opts, body) => {
+    calls.push({ opts, body });
+    if (responses.length === 0) throw new Error('stub: no scripted response for this hop');
+    return responses.shift();
+};
+
+const { webFetch, computeOutboundHeaders } = require(path.join(BUNDLE, 'web.js'));
+const { USER_AGENT } = require(path.join(BUNDLE, 'config.js'));
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+function reset() { responses = []; calls = []; }
+function redirect(status, location) { return { status, headers: { location }, data: '' }; }
+function ok() { return { status: 200, headers: {}, data: 'done' }; }
+function headerKeys(h) { return Object.keys(h).map(k => k.toLowerCase()); }
+
+console.log('web-fetch-redirect-headers.test.js — BAT-1086 cross-origin header + body strip');
+console.log();
+
+// ---------------------------------------------------------------------------
+// computeOutboundHeaders — pure
+// ---------------------------------------------------------------------------
+const ORIGIN = new URL('https://api.example.com/start');
+
+check('same-origin hop carries caller headers + framework defaults', () => {
+    const url = new URL('https://api.example.com/next');
+    const h = computeOutboundHeaders({ 'X-Api-Key': 'SECRET', Authorization: 'Bearer T' }, url, ORIGIN, {}, null);
+    assert.strictEqual(h['X-Api-Key'], 'SECRET');
+    assert.strictEqual(h['Authorization'], 'Bearer T');
+    assert.strictEqual(h['User-Agent'], USER_AGENT);
+    assert.ok(h['Accept']);
+});
+
+check('cross-origin hop drops ALL caller headers, keeps only defaults', () => {
+    const url = new URL('https://evil.example.com/collect');
+    const h = computeOutboundHeaders(
+        { 'X-Api-Key': 'SECRET', Authorization: 'Bearer T', Cookie: 'sid=1', 'X-Goog-Api-Key': 'G', 'X-Foo': 'bar' },
+        url, ORIGIN, {}, null);
+    const keys = headerKeys(h);
+    for (const leaked of ['x-api-key', 'authorization', 'cookie', 'x-goog-api-key', 'x-foo']) {
+        assert.ok(!keys.includes(leaked), `header ${leaked} must be absent cross-origin`);
+    }
+    assert.strictEqual(h['User-Agent'], USER_AGENT);
+    assert.ok(h['Accept']);
+});
+
+check('same-origin object body derives Content-Type when caller omits it', () => {
+    const url = new URL('https://api.example.com/next');
+    const h = computeOutboundHeaders({}, url, ORIGIN, {}, { a: 1 });
+    assert.strictEqual(h['Content-Type'], 'application/json');
+});
+
+check('same-origin caller Content-Type is preserved (not overwritten)', () => {
+    const url = new URL('https://api.example.com/next');
+    const h = computeOutboundHeaders({ 'Content-Type': 'text/plain' }, url, ORIGIN, {}, { a: 1 });
+    assert.strictEqual(h['Content-Type'], 'text/plain');
+});
+
+check('same-origin: prototype-pollution header keys are filtered out', () => {
+    const url = new URL('https://api.example.com/next');
+    // JSON.parse (not an object literal) yields REAL own "__proto__"/"constructor"
+    // properties that Object.entries enumerates — the shape an attacker would send.
+    const malicious = JSON.parse('{"__proto__":"x","constructor":"y","prototype":"z","X-Ok":"v"}');
+    const h = computeOutboundHeaders(malicious, url, ORIGIN, {}, null);
+    const keys = headerKeys(h);
+    for (const bad of ['__proto__', 'constructor', 'prototype']) {
+        assert.ok(!keys.includes(bad), `dangerous key ${bad} must be filtered`);
+    }
+    assert.strictEqual(h['X-Ok'], 'v', 'safe caller header still passes through');
+    assert.strictEqual(({}).polluted, undefined, 'Object.prototype must be untouched');
+});
+
+check('cross-origin never derives Content-Type from a (would-be) body', () => {
+    // Guards the invariant even though webFetch blocks cross-origin bodies upstream.
+    const url = new URL('https://evil.example.com/x');
+    const h = computeOutboundHeaders({}, url, ORIGIN, {}, { a: 1 });
+    assert.ok(!headerKeys(h).includes('content-type'));
+});
+
+// ---------------------------------------------------------------------------
+// webFetch redirect loop — stubbed transport
+// ---------------------------------------------------------------------------
+console.log();
+
+(async () => {
+    await checkAsync('cross-origin 302: secret headers absent on 2nd hop, present on 1st', async () => {
+        reset();
+        responses = [redirect(302, 'https://evil.example.com/collect'), ok()];
+        await webFetch('https://api.example.com/start', {
+            headers: { 'X-Api-Key': 'SECRET', Authorization: 'Bearer T', Cookie: 'sid=1' },
+        });
+        assert.strictEqual(calls.length, 2, 'expected 2 hops');
+        // hop 0 = original (same-origin) → headers present
+        assert.strictEqual(calls[0].opts.headers['X-Api-Key'], 'SECRET');
+        // hop 1 = cross-origin → headers stripped
+        const k2 = headerKeys(calls[1].opts.headers);
+        for (const leaked of ['x-api-key', 'authorization', 'cookie']) {
+            assert.ok(!k2.includes(leaked), `hop2 must not carry ${leaked}`);
+        }
+        assert.strictEqual(calls[1].opts.headers['User-Agent'], USER_AGENT);
+    });
+
+    await checkAsync('same-origin 302: custom header preserved on 2nd hop', async () => {
+        reset();
+        responses = [redirect(302, 'https://api.example.com/other'), ok()];
+        await webFetch('https://api.example.com/start', { headers: { 'X-Api-Key': 'SECRET' } });
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(calls[1].opts.headers['X-Api-Key'], 'SECRET');
+    });
+
+    await checkAsync('A->B->A: header stripped on B, re-attached on the final A hop', async () => {
+        reset();
+        responses = [
+            redirect(302, 'https://b.example.com/hop'),   // A -> B (cross-origin)
+            redirect(302, 'https://api.example.com/back'), // B -> A (back to original origin)
+            ok(),
+        ];
+        await webFetch('https://api.example.com/start', { headers: { 'X-Api-Key': 'SECRET' } });
+        assert.strictEqual(calls.length, 3);
+        assert.ok(!headerKeys(calls[1].opts.headers).includes('x-api-key'), 'B hop must be stripped');
+        assert.strictEqual(calls[2].opts.headers['X-Api-Key'], 'SECRET', 'final A hop must re-attach');
+    });
+
+    await checkAsync('cross-origin 307 WITH body: blocked before the 2nd hop is sent', async () => {
+        reset();
+        responses = [redirect(307, 'https://evil.example.com/collect'), ok()];
+        await assert.rejects(
+            () => webFetch('https://api.example.com/start', { method: 'POST', body: { secret: 'payload' } }),
+            /Blocked: cross-origin redirect with request body/,
+        );
+        assert.strictEqual(calls.length, 1, 'only the initial request may be sent; body must not reach the 2nd host');
+    });
+
+    await checkAsync('same-origin 307 WITH body: method + body preserved on 2nd hop', async () => {
+        reset();
+        responses = [redirect(307, 'https://api.example.com/other'), ok()];
+        await webFetch('https://api.example.com/start', { method: 'POST', body: { a: 1 } });
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(calls[1].opts.method, 'POST', 'method preserved on same-origin 307');
+        assert.deepStrictEqual(calls[1].body, { a: 1 }, 'body preserved on same-origin 307');
+    });
+
+    await checkAsync('cross-origin 303 (GET, no body): allowed, headers stripped', async () => {
+        // 303 downgrades to GET and drops body, so cross-origin is fine — only headers strip.
+        reset();
+        responses = [redirect(303, 'https://evil.example.com/x'), ok()];
+        const res = await webFetch('https://api.example.com/start', {
+            method: 'POST', body: { a: 1 }, headers: { Authorization: 'Bearer T' },
+        });
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(calls[1].opts.method, 'GET', '303 downgrades to GET');
+        assert.strictEqual(calls[1].body, null, '303 drops body');
+        assert.ok(!headerKeys(calls[1].opts.headers).includes('authorization'));
+        assert.strictEqual(res.finalUrl, 'https://evil.example.com/x');
+    });
+
+    console.log();
+    console.log(`Result: ${pass} passed, ${fail} failed`);
+    if (fail > 0) { console.error('FAIL: web-fetch-redirect-headers.test.js'); process.exit(1); }
+    console.log('PASS: web-fetch-redirect-headers.test.js');
+})();

--- a/tests/nodejs-project/web-fetch-ssrf-guard.test.js
+++ b/tests/nodejs-project/web-fetch-ssrf-guard.test.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// tests/nodejs-project/web-fetch-ssrf-guard.test.js
+//
+// BAT-1088: web_fetch's SSRF guard is a pure canonical-host classifier,
+// isBlockedAddress(hostname), that rejects private/loopback/link-local literals
+// before any socket opens (per redirect hop). This is LITERAL screening only —
+// NOT DNS-rebind protection (that's BAT-1093).
+//
+// `new URL()` already canonicalizes IPv4 decimal/octal/hex to dotted-quad, so those
+// are regression cases (blocked today); the live add over the old prefix regex is
+// IPv6 (loopback / IPv4-mapped / ULA / link-local). Per the BAT-1088 decision, CGNAT
+// (100.64/10) and benchmark (198.18/15) are deliberately NOT blocked.
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bat1088-ssrf-'));
+fs.writeFileSync(path.join(workDir, 'config.json'), JSON.stringify({
+    botToken: 'placeholder-not-a-real-bot-token',
+    anthropicApiKey: 'placeholder-not-a-real-api-key',
+    ownerId: '111',
+    channel: 'telegram',
+}), 'utf8');
+process.argv[2] = workDir;
+process.on('exit', () => { try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {} });
+
+// Stub the transport before loading web.js so we can assert the guard fires BEFORE
+// any socket (the stub must never be called for a blocked host).
+const httpMod = require(path.join(BUNDLE, 'http.js'));
+let calls = 0;
+httpMod.httpRequest = async () => { calls++; return { status: 200, headers: {}, data: 'ok' }; };
+
+const { isBlockedAddress, webFetch } = require(path.join(BUNDLE, 'web.js'));
+const tg = require(path.join(BUNDLE, 'telegram.js')); // BAT-1088: shares the same SSRF guard
+
+let pass = 0, fail = 0;
+function check(name, fn) {
+    try { fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); pass++; console.log(`  ✓ ${name}`); }
+    catch (e) { fail++; console.error(`  ✗ ${name}: ${e.message}`); if (process.env.VERBOSE) console.error(e.stack); }
+}
+
+console.log('web-fetch-ssrf-guard.test.js — BAT-1088 private/loopback literal screening');
+console.log();
+
+// ---------------------------------------------------------------------------
+// isBlockedAddress — pure classifier
+// ---------------------------------------------------------------------------
+const BLOCK = [
+    // IPv6 (the live gap): loopback, unspecified, IPv4-mapped, ULA, link-local
+    '[::1]', '::1', '[::]', '[::ffff:127.0.0.1]', '[::ffff:7f00:1]', '[fd00::1]', 'fd00::1', '[fe80::1]', 'fe80::1',
+    // IPv6 zone identifiers (RFC 6874) — classify the address, ignore the zone
+    'fe80::1%eth0', '[fe80::1%eth0]', '::1%lo0',
+    // Deprecated IPv4-compatible IPv6 (::w.x.y.z / ::7f00:1) embedding private/loopback IPv4
+    '::127.0.0.1', '::7f00:1', '[::127.0.0.1]', '::10.0.0.1', '::192.168.1.1',
+    // IPv4 private / loopback / link-local / this-host
+    '127.0.0.1', '127.255.255.254', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0',
+    // hostnames — incl. FQDN-root trailing-dot forms (resolve like the un-dotted name)
+    'localhost', 'api.localhost', 'localhost.', 'api.localhost.', 'localhost..',
+    '127.0.0.1.', // trailing-dot IP literal (belt-and-suspenders; new URL also strips this)
+];
+const ALLOW = [
+    '8.8.8.8', '1.1.1.1', '9.9.9.9',
+    '[2606:4700::1111]', '2606:4700::1111',
+    '::8.8.8.8', // IPv4-compatible embedding a PUBLIC IPv4 → allowed (consistent with 8.8.8.8)
+    'example.com', 'api.example.com', 'example.com.', // trailing-dot public FQDN stays allowed
+    // Boundaries just outside the private ranges
+    '172.15.0.1', '172.32.0.1',
+    // Deliberately allowed in V1 (per BAT-1088 decision)
+    '100.64.0.1',  // CGNAT
+    '198.18.0.1',  // benchmark
+];
+
+check('blocks every private/loopback/link-local literal (IPv4 + IPv6)', () => {
+    for (const h of BLOCK) assert.strictEqual(isBlockedAddress(h), true, `should BLOCK ${h}`);
+});
+
+check('allows public IPs, hostnames, boundaries, and the V1-excluded CGNAT/benchmark ranges', () => {
+    for (const h of ALLOW) assert.strictEqual(isBlockedAddress(h), false, `should ALLOW ${h}`);
+});
+
+check('IPv4 alt-radix literals: canonicalized by new URL() then blocked (regression)', () => {
+    for (const u of ['https://2130706433/', 'https://0x7f000001/', 'https://0177.0.0.1/', 'https://0/']) {
+        const hostname = new URL(u).hostname;
+        assert.strictEqual(isBlockedAddress(hostname), true, `${u} -> ${hostname} should block`);
+    }
+});
+
+check('userinfo confusion: host is the PUBLIC part, so allowed (not private-host SSRF)', () => {
+    // https://127.0.0.1@api.example.com/ -> hostname is api.example.com (public)
+    const hostname = new URL('https://127.0.0.1@api.example.com/').hostname;
+    assert.strictEqual(hostname, 'api.example.com');
+    assert.strictEqual(isBlockedAddress(hostname), false);
+});
+
+check('fails closed on junk input', () => {
+    for (const h of ['', null, undefined, '   ']) assert.strictEqual(isBlockedAddress(h), true, `junk ${JSON.stringify(h)} should block`);
+});
+
+// ---------------------------------------------------------------------------
+// webFetch integration — guard fires before any socket
+// ---------------------------------------------------------------------------
+console.log();
+
+(async () => {
+    await checkAsync('webFetch to a blocked host throws BEFORE any socket opens', async () => {
+        calls = 0;
+        await assert.rejects(() => webFetch('https://[::1]/'), /Blocked: private\/local address/);
+        assert.strictEqual(calls, 0, 'transport must not be called for a blocked host');
+    });
+
+    await checkAsync('webFetch to an alt-radix loopback literal is blocked before socket', async () => {
+        calls = 0;
+        await assert.rejects(() => webFetch('https://2130706433/'), /Blocked: private\/local address/);
+        assert.strictEqual(calls, 0);
+    });
+
+    await checkAsync('webFetch to a public host still reaches the transport (no regression)', async () => {
+        calls = 0;
+        const res = await webFetch('https://example.com/');
+        assert.strictEqual(calls, 1, 'public host must reach the transport');
+        assert.strictEqual(res.status, 200);
+    });
+
+    // Same-class sweep: telegram.js downloadFileByUrl shares the same classifier, so it
+    // gets the same IPv6/private coverage. Drift-guard that it actually calls the guard.
+    await checkAsync('telegram downloadFileByUrl rejects private hosts via the shared guard', async () => {
+        for (const u of ['https://127.0.0.1/x', 'https://[::1]/x', 'https://[::ffff:127.0.0.1]/x', 'https://localhost./x']) {
+            await assert.rejects(() => tg.downloadFileByUrl(u, 'f', 100), /Blocked: private\/local address/, `should block ${u}`);
+        }
+    });
+
+    console.log();
+    console.log(`Result: ${pass} passed, ${fail} failed`);
+    if (fail > 0) { console.error('FAIL: web-fetch-ssrf-guard.test.js'); process.exit(1); }
+    console.log('PASS: web-fetch-ssrf-guard.test.js');
+})();


### PR DESCRIPTION
## Summary
Promotes the three `web_fetch` / secret-hardening fixes to `main`. All merged into `integration/security-hardening` via #428/#429/#430, reviewed to zero Copilot blockers, reconciled with current `main` (v2.1.1: BAT-1109 + BAT-1033), and **device-tested on the Seeker**.

**Merge only — no release tag / version bump.** Documented under CHANGELOG `[Unreleased]`; version stays `2.1.1` (code 22) until the next release cut.

## What's included
- **BAT-1086** — cross-origin redirect drops all caller headers + blocks body-preserving 307/308 (credential/data exfil).
- **BAT-1087** — `agent_settings.json` key values masked before reaching the model; `read` masks, `js_eval`/`shell_exec` blocked for that file; save + BAT-236 sync intact.
- **BAT-1088** — SSRF guard rewritten as a full IPv4/IPv6 literal classifier (loopback, IPv4-mapped, ULA, link-local, zone-id, trailing-dot, decimal/hex/octal); same guard applied to `telegram.js` file-download path.

## Validation
- [x] `web-fetch-redirect-headers` (12) + `agent-settings-mask` (11) + `web-fetch-ssrf-guard` (9) unit tests
- [x] Full CI node suite **47/47** + `compileDappStoreDebugKotlin` BUILD SUCCESSFUL on the reconciled tree
- [x] **Device test on Seeker (SHA aa890bd)** — masking verified tool-level (read `[REDACTED]`, js_eval + shell blocked incl. quoted evasion, save/sync intact); SSRF `[::1]` blocked live + classifier deployed; header no-regression; BAT-1109 interim-text delivery confirmed; Settings + Logs UI healthy. All cross-checked against device logs.
- [x] Clean merge with `main` (only build.yml CI list union-resolved)

## Notes
- Follow-up **BAT-1093** (resolve-and-pin / DNS-rebind) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened handling of sensitive settings so secrets are masked before being shown, logged, or passed through shell/eval paths.
  * Improved web request protections by blocking unsafe redirects and preventing requests to private, loopback, and link-local addresses.
  * Reduced the chance of sensitive headers being forwarded during cross-origin requests.

* **Tests**
  * Added new coverage for secret masking, redirect behavior, and SSRF protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->