### PR TITLE
fix: content-filter deadlock on setup_token agent + cc_version 2.1.195 (BAT-1130, BAT-1123)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,8 @@ jobs:
             confirmation-buttons-guard \
             bridge-token-validation \
             system-prompt-wallets \
+            system-prompt-recent-sessions \
+            recent-sessions-heartbeat-filter \
             wallet-registry \
             wallet-set-caps-errors \
             x402 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a condition where the agent could stop responding — showing a misleading "out of extra usage" error — on a Pro/Max sign-in even with usage remaining. An automatically-generated internal note summarizing routine background check-ins could contain a phrase the AI service rejected; because that note was included in every request, it blocked all replies until it aged out. These trivial check-in notes are no longer generated, any left over from a previous version are filtered out, and the agent now automatically retries once without recent-activity context if a request is unexpectedly rejected — so a single bad note can no longer stall it. The background check-in (heartbeat) mechanism itself is unchanged.
+- Clearer authentication-error message: it no longer suggests "API key might be wrong" for Pro/Max sign-in users, who have no API key.
+
+### Changed
+
+- The agent's system prompt now caches more effectively across background check-ins by keeping frequently-changing recent-activity context out of the cached section, lowering token usage per turn.
+- Refreshed the Claude Code client version reported on Pro/Max sign-in requests to the current stable, keeping the integration up to date.
+
 ### Security
 
 - Hardened `web_fetch` against credential exfiltration on cross-origin redirects: caller-supplied headers (API keys, bearer tokens) are now dropped when a request redirects to a different origin, and a cross-origin `307`/`308` can no longer forward the request body to the new host. Same-origin flows are unchanged. (BAT-1086)

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -143,6 +143,18 @@ grep -i "400\|context.*length\|too many tokens" node_debug.log | tail -5
 2. If a specific tool result was too large, note that tool results are auto-truncated at ~50K characters (HARD_MAX_TOOL_RESULT_CHARS) but the conversation can still accumulate
 3. MAX_HISTORY (35 messages) should prevent this in normal use — if it happens, it's likely a single very large message or tool result
 
+### Pro/Max Sign-in: "You're out of extra usage" (400, often misleading)
+**Symptoms:** On a Pro/Max sign-in (setup_token), API calls return `400` with "You're out of extra usage. Add more at claude.ai/settings/usage" — sometimes on every turn, even when the subscription still has usage left.
+**Check:**
+```
+grep -iE "out of extra usage|SelfHeal|invalid_request_error" node_debug.log | tail -10
+```
+**Diagnosis:** Anthropic's setup_token path can MISLABEL a content-filter rejection as this billing message. A specific phrase inside the request (historically an auto-generated session summary) trips a filter, and the rejection is dressed up as "out of extra usage" — the account is often NOT actually out of usage (a tiny request on the same sign-in still succeeds).
+**What the system does automatically:** On this 400, SeekerClaw retries the turn ONCE with volatile memory dropped (Recent Sessions + today's daily memory + MEMORY.md), logged as `[SelfHeal]`. If the lean retry succeeds, it was a content false-positive and the turn completes normally.
+**Fix (only if it persists after the auto-retry):**
+1. Content vs usage: if a short message succeeds but longer turns keep failing, it's content — trim any unusual phrase from recent memory files, or use `/new` to reset the conversation.
+2. If even a short message fails with this message, the subscription's Claude-Code usage really is exhausted → add usage at claude.ai/settings/usage, wait for the reset window, or switch to a direct Anthropic API key in Settings.
+
 ### Custom Provider — Connection or Format Errors
 **Symptoms:** All API calls fail immediately. Logs show connection refused, SSL errors, or unexpected response format (e.g., "Unexpected token" JSON parse errors).
 **Check:**

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1159,7 +1159,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     lines.push('');
     lines.push('**If API calls keep failing:**');
     lines.push('1. Read agent_health_state — check consecutiveFailures and lastError');
-    lines.push('2. Auth error (401/403): API key may be invalid — tell user to check Settings');
+    lines.push('2. Auth error (401/403): credentials were rejected — tell the user to re-check the API key OR re-pair the Pro/Max sign-in in Settings (setup_token users have no API key).');
     lines.push('3. Rate limit (429): slow down — reduce tool calls and response length');
     lines.push('4. Model not found (404): the configured model ID is wrong — likely a custom model ID typo. /model <valid-id> or Settings > AI Provider fixes it (slash commands work even when AI turns fail).');
     const billingUrl = PROVIDER === 'openai' ? 'platform.openai.com'
@@ -1171,6 +1171,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
         : PROVIDER === 'custom' ? (getAdapter(PROVIDER).getEndpoint().hostname || 'custom endpoint')
         : 'api.anthropic.com';
     lines.push(`5. Billing error (402): tell user to check their billing at ${billingUrl}`);
+    lines.push('5b. "Out of extra usage" 400 on a Pro/Max sign-in: usually a content-filter false-positive, NOT real usage exhaustion — SeekerClaw auto-retries once without recent-activity memory (`[SelfHeal]` in logs). If it persists, see DIAGNOSTICS.md → "out of extra usage".');
     const apiScheme = PROVIDER === 'custom' ? (getAdapter(PROVIDER).getEndpoint().protocol === 'http:' ? 'http' : 'https') : 'https';
     lines.push(`6. Network error: check connectivity with js_eval using require("${apiScheme}").get("${apiScheme}://${apiHost}") or shell_exec "curl -s ${apiScheme}://${apiHost}"`);
     lines.push('');

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -510,6 +510,14 @@ async function generateSessionSummary(chatId) {
 }
 
 async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = false } = {}) {
+    // BAT-1130: never summarize heartbeat sessions. They are automated liveness
+    // polls with no conversational continuity — summarizing them only adds noise
+    // to the Recent Sessions block, and the "HEARTBEAT_OK" ack text a summary
+    // produces is what tripped Anthropic's setup_token content filter (mislabeled
+    // as a "You're out of extra usage" 400), deadlocking every turn. The heartbeat
+    // mechanism itself (poll → HEARTBEAT_OK reply) is untouched. See testing/FINDINGS.md.
+    if (chatId === '__heartbeat__') return;
+
     const track = getSessionTrack(chatId);
 
     // Per-chatId debounce: at least 1 min between summaries (skipped for manual/shutdown)
@@ -587,7 +595,12 @@ async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = 
 // SYSTEM PROMPT
 // ============================================================================
 
-function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODEL) {
+// BAT-1130: `leanMemory` (used by the tool-loop self-heal) omits the volatile,
+// agent-authored memory sections (MEMORY.md, today's daily memory, Recent
+// Sessions) so a request that Anthropic rejected because of a poisoned memory
+// phrase can be retried without it. All other sections (identity, tooling,
+// safety, wallets, runtime, heartbeats, ...) are unchanged.
+function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODEL, { leanMemory = false } = {}) {
     const soul = loadSoul();
     const memory = loadMemory();
     const dailyMemory = loadDailyMemory();
@@ -1191,16 +1204,16 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
         lines.push('');
     }
 
-    // MEMORY.md
-    if (memory) {
+    // MEMORY.md — omitted on the lean self-heal retry (BAT-1130)
+    if (!leanMemory && memory) {
         lines.push('## MEMORY.md');
         lines.push('');
         lines.push(memory.length > 3000 ? memory.slice(0, 3000) + '\n...(truncated)' : memory);
         lines.push('');
     }
 
-    // Today's daily memory
-    if (dailyMemory) {
+    // Today's daily memory — omitted on the lean self-heal retry (BAT-1130)
+    if (!leanMemory && dailyMemory) {
         const date = localDateStr();
         lines.push(`## memory/${date}.md`);
         lines.push('');
@@ -1208,25 +1221,10 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
         lines.push('');
     }
 
-    // Recent Sessions — temporal context awareness (BAT-322)
-    // Gives the agent awareness of when past conversations happened
-    const recentSessions = getRecentSessions(5);
-    if (recentSessions.length > 0) {
-        lines.push('## Recent Sessions');
-        lines.push('Your recent conversation sessions (use this to maintain continuity):');
-        lines.push('');
-        for (const s of recentSessions) {
-            const dur = s.durationMin < 60
-                ? `${s.durationMin}min`
-                : `${Math.floor(s.durationMin / 60)}h${s.durationMin % 60 ? ` ${s.durationMin % 60}m` : ''}`;
-            let line = `- **${s.relativeTime}** (${dur}, ${s.messageCount} msgs)`;
-            if (s.summaryText) line += `: ${s.summaryText}`;
-            lines.push(line);
-        }
-        lines.push('');
-        lines.push('Use this to: pick up where you left off, follow up on mentioned plans, notice time gaps, and maintain conversational continuity. Be natural — don\'t mechanically list previous sessions unless asked.');
-        lines.push('');
-    }
+    // Recent Sessions (BAT-322) is emitted in the DYNAMIC block below, not here
+    // (BAT-1130): it rotates every session, so keeping it in the cached stable
+    // prefix busted the ~60 KB prompt cache on every rotation. See the dynamic
+    // section further down.
 
     // Heartbeat section
     lines.push('## Heartbeats');
@@ -1479,6 +1477,30 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     dynamicLines.push(`Current time: ${weekday} ${localTimestamp(now)} (${now.toLocaleString()})`);
     const uptimeSec = Math.floor((Date.now() - sessionStartedAt) / 1000);
     dynamicLines.push(`Session uptime: ${Math.floor(uptimeSec / 60)}m ${uptimeSec % 60}s (conversation context is ephemeral — cleared on each restart)`);
+
+    // Recent Sessions — temporal context awareness (BAT-322). Lives in the
+    // DYNAMIC block (BAT-1130) so session rotation no longer busts the cached
+    // stable prefix. Heartbeat-ack summaries are dropped at the DB layer
+    // (getRecentSessions). Omitted entirely on the lean self-heal retry.
+    if (!leanMemory) {
+        const recentSessions = getRecentSessions(5);
+        if (recentSessions.length > 0) {
+            dynamicLines.push('');
+            dynamicLines.push('## Recent Sessions');
+            dynamicLines.push('Your recent conversation sessions (use this to maintain continuity):');
+            dynamicLines.push('');
+            for (const s of recentSessions) {
+                const dur = s.durationMin < 60
+                    ? `${s.durationMin}min`
+                    : `${Math.floor(s.durationMin / 60)}h${s.durationMin % 60 ? ` ${s.durationMin % 60}m` : ''}`;
+                let line = `- **${s.relativeTime}** (${dur}, ${s.messageCount} msgs)`;
+                if (s.summaryText) line += `: ${s.summaryText}`;
+                dynamicLines.push(line);
+            }
+            dynamicLines.push('');
+            dynamicLines.push('Use this to: pick up where you left off, follow up on mentioned plans, notice time gaps, and maintain conversational continuity. Be natural — don\'t mechanically list previous sessions unless asked.');
+        }
+    }
     const lastMsg = chatId && _deps.lastIncomingMessages ? _deps.lastIncomingMessages.get(String(chatId)) : null;
     if (lastMsg && REACTION_GUIDANCE !== 'off') {
         const toolHint = CHANNEL === 'telegram' ? ' (use with telegram_react or telegram_send_file)' : '';
@@ -1564,6 +1586,20 @@ const SESSION_PROBE_INTERVAL_MS = 5 * 60 * 1000; // 5 min cooldown probe
 // BAT-315: Error classification delegated to provider adapter
 function classifyApiError(status, data) {
     return getAdapter(PROVIDER).classifyError(status, data);
+}
+
+// BAT-1130: Anthropic's setup_token (Claude Code OAuth) path mislabels some
+// content-filter rejections as a billing "You're out of extra usage" 400 — even
+// when the account has usage left (proven: a tiny request on the same token
+// succeeds; see testing/FINDINGS.md). Detect that specific shape so the tool
+// loop can self-heal by retrying without volatile agent-authored memory. Matches
+// on the message text (provider-agnostic; no other provider emits this string).
+function _isUsageFilter400(status, data) {
+    if (status !== 400) return false;
+    const msg = (data && data.error && typeof data.error.message === 'string' && data.error.message)
+        || (typeof data === 'string' ? data : '')
+        || '';
+    return /extra usage/i.test(msg);
 }
 
 function classifyNetworkError(err) {
@@ -2430,7 +2466,9 @@ async function chat(chatId, userMessage, options = {}) {
 
     // BAT-315: Provider-agnostic system prompt formatting
     const adapter = getAdapter(PROVIDER);
-    const systemBlocks = adapter.formatSystemPrompt(stablePrompt, dynamicPrompt + resumeBlock, AUTH_TYPE);
+    // BAT-1130: `let` (not `const`) so the content-filter self-heal can rebuild
+    // it lean (without volatile memory) and retry the same turn.
+    let systemBlocks = adapter.formatSystemPrompt(stablePrompt, dynamicPrompt + resumeBlock, AUTH_TYPE);
 
     // Add user message to history (neutral format)
     addToConversation(chatId, 'user', userMessage);
@@ -2451,6 +2489,9 @@ async function chat(chatId, userMessage, options = {}) {
     // (Copilot R1 thread 1, BAT-549 PR #354).
     const messages = getConversation(chatId);
     let _reasoningRecoveryStep = 0;
+    // BAT-1130: at most one lean self-heal retry per turn (guards against a
+    // genuine usage-exhaustion 400 looping forever).
+    let _contentFilterSelfHealed = false;
 
     // P2.4b: Extract original goal from conversation for checkpoint persistence.
     // On resume, this lets the agent know exactly what it was trying to accomplish.
@@ -2859,6 +2900,25 @@ async function chat(chatId, userMessage, options = {}) {
                     }
                     if (recovered) continue;
                     log(`[ReasoningRecovery] All 3 recovery steps returned ok=false — bubbling error to user`, 'ERROR');
+                }
+
+                // BAT-1130: self-heal the "out of extra usage" content-filter
+                // false-positive. Anthropic's setup_token path can mislabel a
+                // content rejection (e.g. a poisoned memory phrase) as this
+                // billing 400 even when the account has usage left. Retry the
+                // turn ONCE with the volatile agent-authored memory dropped
+                // (Recent Sessions / daily memory / MEMORY.md via leanMemory) —
+                // if that succeeds it was content, not usage. If the lean retry
+                // also fails, fall through and surface the real error. F1/F2
+                // fix the known heartbeat trigger; this is the general backstop
+                // so no future poison can permanently deadlock. See testing/FINDINGS.md.
+                if (!_contentFilterSelfHealed && _isUsageFilter400(res.status, res.data)) {
+                    _contentFilterSelfHealed = true;
+                    const lean = buildSystemBlocks(matchedSkills, chatId, activeModel, { leanMemory: true });
+                    systemBlocks = adapter.formatSystemPrompt(lean.stable, lean.dynamic + resumeBlock, AUTH_TYPE);
+                    _ctxCache = null; // systemBlocks shrank — force context re-measure next iteration
+                    log(`[SelfHeal] status=${res.status} usage-filter false-positive — retrying turn without volatile memory (Recent Sessions / daily / MEMORY.md)`, 'WARN');
+                    continue;
                 }
 
                 const errClass = classifyApiError(res.status, res.data);
@@ -3510,4 +3570,6 @@ module.exports = {
     // reads cached burner state). Production code never calls these.
     buildSystemBlocks,
     _setWalletPromptSnapshotForTests,
+    // BAT-1130: exposed for the content-filter self-heal regression test.
+    _isUsageFilter400,
 };

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -1603,15 +1603,18 @@ function classifyApiError(status, data) {
 // BAT-1130: Anthropic's setup_token (Claude Code OAuth) path mislabels some
 // content-filter rejections as a billing "You're out of extra usage" 400 — even
 // when the account has usage left (proven: a tiny request on the same token
-// succeeds; see testing/FINDINGS.md). Detect that specific shape so the tool
-// loop can self-heal by retrying without volatile agent-authored memory. Matches
-// on the message text (provider-agnostic; no other provider emits this string).
+// succeeds; see testing/FINDINGS.md). Detect that EXACT mislabelled message so
+// the tool loop can self-heal by retrying without volatile agent-authored
+// memory. Matches the specific phrase (not just "extra usage") to avoid firing
+// on unrelated 400s; the call site additionally gates on the setup_token flow.
+// Handles object/string/Buffer bodies like the other error paths.
 function _isUsageFilter400(status, data) {
     if (status !== 400) return false;
-    const msg = (data && data.error && typeof data.error.message === 'string' && data.error.message)
-        || (typeof data === 'string' ? data : '')
-        || '';
-    return /extra usage/i.test(msg);
+    let msg = '';
+    if (data && data.error && typeof data.error.message === 'string') msg = data.error.message;
+    else if (typeof data === 'string') msg = data;
+    else if (Buffer.isBuffer(data)) msg = data.toString('utf8');
+    return /out of extra usage/i.test(msg);
 }
 
 function classifyNetworkError(err) {
@@ -2924,7 +2927,10 @@ async function chat(chatId, userMessage, options = {}) {
                 // also fails, fall through and surface the real error. F1/F2
                 // fix the known heartbeat trigger; this is the general backstop
                 // so no future poison can permanently deadlock. See testing/FINDINGS.md.
-                if (!_contentFilterSelfHealed && _isUsageFilter400(res.status, res.data)) {
+                // Gated to the setup_token flow — that's the only path Anthropic
+                // mislabels this way; a raw-API-key 400 with this text would be a
+                // genuine error, not a content-filter false-positive.
+                if (!_contentFilterSelfHealed && AUTH_TYPE === 'setup_token' && _isUsageFilter400(res.status, res.data)) {
                     _contentFilterSelfHealed = true;
                     const lean = buildSystemBlocks(matchedSkills, chatId, activeModel, { leanMemory: true });
                     systemBlocks = adapter.formatSystemPrompt(lean.stable, lean.dynamic + resumeBlock, AUTH_TYPE);

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -516,7 +516,15 @@ async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = 
     // produces is what tripped Anthropic's setup_token content filter (mislabeled
     // as a "You're out of extra usage" 400), deadlocking every turn. The heartbeat
     // mechanism itself (poll → HEARTBEAT_OK reply) is untouched. See testing/FINDINGS.md.
-    if (chatId === '__heartbeat__') return;
+    // Still perform the cheap housekeeping the full path used to do (reset the
+    // session track, drop any pending idle-summary timer) so the heartbeat track
+    // can't grow unbounded across polls now that it's never summarized.
+    if (chatId === '__heartbeat__') {
+        cancelIdleSummary(chatId);
+        const hbTrack = sessionTracking.get(chatId);
+        if (hbTrack) { hbTrack.messageCount = 0; hbTrack.firstMessageTime = 0; hbTrack.lastSummaryTime = Date.now(); }
+        return;
+    }
 
     const track = getSessionTrack(chatId);
 
@@ -602,8 +610,12 @@ async function saveSessionSummary(chatId, trigger, { force = false, skipIndex = 
 // safety, wallets, runtime, heartbeats, ...) are unchanged.
 function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODEL, { leanMemory = false } = {}) {
     const soul = loadSoul();
-    const memory = loadMemory();
-    const dailyMemory = loadDailyMemory();
+    // BAT-1130: skip the MEMORY.md / daily-memory disk reads entirely on the lean
+    // self-heal retry — they're omitted from the prompt anyway, so the recovery
+    // path avoids unnecessary I/O (and any read error) when it's trying to get a
+    // rejected request through.
+    const memory = leanMemory ? '' : loadMemory();
+    const dailyMemory = leanMemory ? '' : loadDailyMemory();
     const allSkills = loadSkills();
     const bootstrap = loadBootstrap();
     const identity = loadIdentity();

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -535,14 +535,24 @@ function relativeTimeLabel(isoTimestamp) {
 function getRecentSessions(limit = 5) {
     if (!db) return [];
     try {
+        // BAT-1130: over-fetch, then drop legacy heartbeat-ack summaries. New
+        // builds no longer summarize heartbeat sessions (see ai.js
+        // saveSessionSummary), but rows written by older builds persist — their
+        // "...HEARTBEAT_OK..." text is both noise AND trips Anthropic's
+        // setup_token content filter (mislabeled "out of extra usage" — see
+        // testing/FINDINGS.md). Filtering at read fixes existing installs on
+        // upgrade with no schema change and no DB surgery.
         const rows = db.exec(
             `SELECT started_at, ended_at, duration_min, message_count, summary_file, summary_excerpt, trigger, model
              FROM sessions ORDER BY ended_at DESC LIMIT ?`,
-            [limit]
+            [Math.max(limit * 4, 20)]
         );
         if (!rows.length || !rows[0].values.length) return [];
 
-        return rows[0].values.map(([startedAt, endedAt, durationMin, messageCount, summaryFile, summaryExcerpt, trigger, model]) => ({
+        return rows[0].values
+            .filter(row => !/HEARTBEAT_OK/i.test(String(row[5] || ''))) // row[5] = summary_excerpt
+            .slice(0, limit)
+            .map(([startedAt, endedAt, durationMin, messageCount, summaryFile, summaryExcerpt, trigger, model]) => ({
             startedAt,
             endedAt,
             durationMin: durationMin ?? 0,

--- a/app/src/main/assets/nodejs-project/database.js
+++ b/app/src/main/assets/nodejs-project/database.js
@@ -535,23 +535,27 @@ function relativeTimeLabel(isoTimestamp) {
 function getRecentSessions(limit = 5) {
     if (!db) return [];
     try {
-        // BAT-1130: over-fetch, then drop legacy heartbeat-ack summaries. New
-        // builds no longer summarize heartbeat sessions (see ai.js
-        // saveSessionSummary), but rows written by older builds persist — their
-        // "...HEARTBEAT_OK..." text is both noise AND trips Anthropic's
-        // setup_token content filter (mislabeled "out of extra usage" — see
-        // testing/FINDINGS.md). Filtering at read fixes existing installs on
-        // upgrade with no schema change and no DB surgery.
+        // BAT-1130: exclude legacy heartbeat-ack summaries in SQL so the LIMIT is
+        // applied AFTER filtering. New builds no longer summarize heartbeat
+        // sessions (see ai.js saveSessionSummary), but rows written by older
+        // builds persist — their "...HEARTBEAT_OK..." text is both noise AND trips
+        // Anthropic's setup_token content filter (mislabeled "out of extra usage",
+        // see testing/FINDINGS.md). A JS post-filter over a fixed over-fetch would
+        // return 0 sessions when the most-recent rows are ALL heartbeat-ack
+        // (exactly the deadlock state), hiding real conversations further back — so
+        // filter in SQL. The '_' in the LIKE pattern is a single-char wildcard, so
+        // escape it to match the literal token; SQLite LIKE is ASCII-case-insensitive.
+        // (NULL excerpts are kept — they're real, non-heartbeat sessions.)
         const rows = db.exec(
             `SELECT started_at, ended_at, duration_min, message_count, summary_file, summary_excerpt, trigger, model
-             FROM sessions ORDER BY ended_at DESC LIMIT ?`,
-            [Math.max(limit * 4, 20)]
+             FROM sessions
+             WHERE summary_excerpt IS NULL OR summary_excerpt NOT LIKE '%HEARTBEAT\\_OK%' ESCAPE '\\'
+             ORDER BY ended_at DESC LIMIT ?`,
+            [limit]
         );
         if (!rows.length || !rows[0].values.length) return [];
 
         return rows[0].values
-            .filter(row => !/HEARTBEAT_OK/i.test(String(row[5] || ''))) // row[5] = summary_excerpt
-            .slice(0, limit)
             .map(([startedAt, endedAt, durationMin, messageCount, summaryFile, summaryExcerpt, trigger, model]) => ({
             startedAt,
             endedAt,

--- a/app/src/main/assets/nodejs-project/providers/claude.js
+++ b/app/src/main/assets/nodejs-project/providers/claude.js
@@ -228,7 +228,10 @@ function fromApiResponse(raw) {
 
 // ── Billing attribution (required for OAuth/setup-token access to non-Haiku models) ─
 
-const CC_BILLING_HEADER = 'x-anthropic-billing-header: cc_version=2.1.116; cc_entrypoint=cli; cch=00000;';
+// BAT-1123: cc_version tracks the Claude Code CLI version we identify as on the
+// setup_token billing path. Bumped 2.1.116 → 2.1.195 (verified HTTP 200 on our
+// models via testing/test-cc-version.js). Keep in sync with testing/lib.js.
+const CC_BILLING_HEADER = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
 
 // ── System prompt ───────────────────────────────────────────────────────────
 
@@ -371,9 +374,11 @@ const streamProtocol = 'claude';
 
 function classifyError(status, data) {
     if (status === 401 || status === 403) {
+        // BAT-1130: auth-agnostic copy — setup_token users have no "API key", so
+        // "API key might be wrong" was misleading. Covers both auth modes.
         return {
             type: 'auth', retryable: false,
-            userMessage: '🔑 Can\'t reach the AI — API key might be wrong. Check Settings?'
+            userMessage: '🔑 The AI rejected the credentials. If you use an API key, re-check it in Settings; if you signed in with a Pro/Max token, re-pair in Settings.'
         };
     }
     if (status === 402) {

--- a/docs/internal/audits/SAB-AUDIT-v42.md
+++ b/docs/internal/audits/SAB-AUDIT-v42.md
@@ -1,0 +1,69 @@
+# SAB-AUDIT-v42 — SeekerClaw Agent Self-Knowledge Audit
+
+> **Date:** 2026-07-07
+> **SAB Version:** v3
+> **Scope:** Delta-audit for BAT-1130 (PR #435) — content-filter deadlock fix. Touches `buildSystemBlocks()` in `ai.js` and `DIAGNOSTICS.md`, so the pre-merge gate applies.
+> **Method:** Focused read of the `buildSystemBlocks()` sections the diff touches + a new-failure-mode diagnostic check + the auth/billing behavioral probe. Unchanged sections carry forward from v41.
+> **Baseline:** SAB-AUDIT-v41.md (2026-07-03, 98.4% → 100%)
+
+## What changed in this PR (self-awareness surface)
+
+1. **Recent Sessions** block moved from the cached *stable* block to the uncached *dynamic* block — **same content**, different block (verified by `system-prompt-recent-sessions.test.js`). The agent still sees "## Recent Sessions" every turn.
+2. **`leanMemory`** option added to `buildSystemBlocks()` — omits Recent Sessions + MEMORY.md + daily memory. Used **only** by the tool-loop self-heal retry; the normal turn is unaffected.
+3. **Heartbeat sessions are no longer summarized** → they no longer appear in Recent Sessions (they carried no continuity value). The **Heartbeats section** of the prompt (poll → `HEARTBEAT_OK` protocol) is **untouched** — the agent's knowledge of the heartbeat protocol is unchanged.
+4. **`getRecentSessions()`** filters legacy `HEARTBEAT_OK` rows in SQL.
+5. New failure mode + auto-recovery: a setup_token `400 "out of extra usage"` is now recognized as a likely content-filter false-positive and auto-retried lean (`[SelfHeal]` WARN).
+6. `cc_version` 2.1.116 → 2.1.195 (billing header — **not** agent-facing; no prompt/DIAGNOSTICS surface).
+
+## Scores
+
+| Section | Pre-fix | Post-fix | Max |
+|---------|---------|----------|-----|
+| A: Knowledge & Doors (delta items) | 15 | 15 | 15 |
+| B: Diagnostics — new failure mode ("out of extra usage") | 0 | 3 | 3 |
+| C: Tool Consistency (spot-check, unchanged) | 6 | 6 | 6 |
+| D: Behavioral Probes (auth/billing + channel) | 4 | 6 | 6 |
+| **Combined (delta)** | **25 (83.3%)** | **30 (100%)** | **30** |
+
+> This is a **delta-audit**: only the surface the PR touches is re-scored. The full-suite baseline (v41: 252/252 = 100% post-fix) is otherwise unchanged — no tool added/removed, no capability added, no identity/architecture/config drift. The single pre-fix gap is the new failure mode this PR introduces, filled in the **same PR** per the same-PR rule.
+
+## Pre-fix Trend
+| Audit | Pre-fix % | Post-fix % |
+|-------|-----------|------------|
+| v40 | 100% | 100% |
+| v41 | 98.4% | 100% |
+| v42 (delta) | 83.3% (delta only) | 100% |
+
+## Section details
+
+**A — Knowledge & Doors (no drift).**
+- Recent Sessions: still presented (dynamic block) — the agent's temporal-continuity awareness is intact. ✅
+- Heartbeats: protocol section unchanged; agent still knows to read `HEARTBEAT.md` and reply `HEARTBEAT_OK`. ✅
+- Auth-error guidance (in-prompt "If API calls keep failing" playbook): softened line 2 to be auth-agnostic (setup_token users have no API key). ✅ (was slightly misleading, now accurate)
+- `leanMemory` is an internal recovery mechanism, not a user-visible capability — no door needed (agent doesn't advertise it; DIAGNOSTICS documents the observable `[SelfHeal]` behavior). ✅
+- cc_version: billing header, no agent-facing surface — correctly absent from the prompt. ✅
+
+**B — Diagnostics (1 gap, fixed).**
+- **GAP (pre-fix):** no DIAGNOSTICS entry for the setup_token `400 "out of extra usage"` content-filter false-positive — a user asking "why out of extra usage?" would get the wrong answer ("you're out of credits"). ❌→✅
+- **FIX:** added `DIAGNOSTICS.md → "Pro/Max Sign-in: 'You're out of extra usage' (400, often misleading)"` (symptoms, `node_debug.log` check, content-vs-usage diagnosis, the auto-`[SelfHeal]` behavior, and the persist-past-retry fix) + a one-line in-prompt door (playbook item 5b) pointing to it.
+- New WARN log site `[SelfHeal]` is now covered by that DIAGNOSTICS entry (the `grep` check surfaces it). ✅
+
+**C — Tool Consistency (spot-check, unchanged).** No tool descriptions, schemas, or confirmation gates changed in this PR. Spot-checked `solana_swap` / `agent_pay` prompt-vs-policy agreement — unchanged and consistent. ✅
+
+**D — Behavioral Probes.**
+- Fixed probe "Agent won't respond to messages" → channel-connection door → DIAGNOSTICS channel section: unchanged, ✅.
+- Rotated probe **"API key not working" / auth-billing**: pre-fix the "out of extra usage" variant hit no door (⚠, 1/3 — 401 door existed but the 400 case didn't); post-fix the new door + DIAGNOSTICS room make it actionable (✅ 3/3).
+- Rotated probe **"Agent shows 'out of extra usage'"** (new, this PR): pre-fix ❌ (no coverage) → post-fix ✅ (door + room + auto-recovery description).
+
+## Gaps Found (Pre-fix)
+1. No DIAGNOSTICS/prompt coverage for the setup_token `400 "out of extra usage"` content-filter false-positive (the failure mode this PR fixes).
+
+## Fixes Applied (same PR)
+1. `DIAGNOSTICS.md`: new "out of extra usage" troubleshooting room (self-contained; on-device readable).
+2. `ai.js buildSystemBlocks()`: in-prompt playbook door (item 5b) + auth-agnostic 401/403 line.
+
+## Code Issues Found
+None (the code correctness issues in this PR were caught in the Copilot review cycle, not the SAB audit).
+
+## Remaining Gaps
+None. Post-fix delta score 100%; the full-suite baseline is unchanged from v41.

--- a/testing/FINDINGS.md
+++ b/testing/FINDINGS.md
@@ -1,0 +1,72 @@
+# Testing Findings — hard-won diagnoses
+
+Living log of non-obvious failures and how we proved/fixed them. When an outage
+"makes no sense," check here first for the playbook.
+
+---
+
+## 2026-07-07 — "You're out of extra usage" 400 is a CONTENT-FILTER false-positive (NOT usage)
+
+**Symptom.** The on-device agent (setup_token / Claude Code OAuth path) returned on
+every turn:
+
+```
+status=400 type=invalid_request_error
+"You're out of extra usage. Add more at claude.ai/settings/usage and keep going"
+```
+
+Started ~10:35 local, never recovered. The account was NOT out of usage.
+
+**Root cause.** An auto-generated **session summary** injected into the system prompt
+("Recent Sessions" block, `ai.js` `getRecentSessions()`, `sessions.summary_excerpt`)
+contained the phrase:
+
+> "…Responded with standard **heartbeat acknowledgment (HEARTBEAT_OK)** per instructions."
+
+The **co-occurrence of the words `heartbeat` + `acknowledgment` + the token `HEARTBEAT_OK`**
+in the request body deterministically makes Anthropic's setup_token endpoint reject the
+request — and it dresses the rejection as the **billing** message above. It is a content
+filter, not a usage cap.
+
+**Proof (deterministic, 3/3).**
+- `heartbeat acknowledgment (HEARTBEAT_OK)` → **400**
+- drop any one of the three (`acknowledgment token (HEARTBEAT_OK)`, `heartbeat token (HEARTBEAT_OK)`, `heartbeat acknowledgment (HEARTBEAT)`) → **200**
+- The phrases are ~40 chars → cost ≈ 0 → categorically NOT usage.
+
+**Why it fooled us for hours (the trap).**
+- The error *message* says billing → looks like a subscription cap.
+- App can't poll usage for setup_token (`[Usage] Skipped`) → no counter-evidence.
+- Repro tests with **synthetic** prompts always returned 200 — on the *same* token,
+  account, model, and even from the *device's own network via curl*. Only the agent's
+  **real** system prompt (carrying the poisoned summary) 400s.
+- **Deadlock:** every turn 400s → the agent can't summarize new sessions → the poisoned
+  summary never rotates out of the top-5.
+
+**How we nailed it (reusable playbook).**
+1. Pull `api_request_log` + `node_debug.log` from the device → read the *actual* error
+   string and fingerprint (`msgFp`), not the user-facing copy.
+2. Rule out the environment: replay an identical request with the same token from your
+   machine AND **from the device's own network** (`curl` on-device). If both pass, it's
+   the request bytes, not usage/token/headers/network.
+3. Capture the agent's REAL outgoing request: instrument `http.js` `httpStreamingRequest`
+   to dump `{headers (Authorization redacted), body}` to `workspace/seekerclaw-req-dump.json`,
+   restart the `:node` process, trigger one turn, pull the dump, then revert `http.js`.
+4. Replay the captured bytes → reproduce the 400. Then **binary-search the body**:
+   system-vs-tools → quarter the system prompt → the offending section → the bullet →
+   the phrase. Keep each slice tiny so cost can't be the variable.
+
+**How to fight it in future.**
+- Never trust the setup_token error *copy*. A 400 "out of extra usage" that a *tiny*
+  probe on the same token does NOT reproduce = content-triggered, not billing.
+- Regression probe: `testing/test-content-filter-trigger.js` (LIVE=1) asserts the known
+  trigger phrase still 400s and the neutralized form 200s — run it if this recurs.
+- Repro of a full captured request: `testing/test-recreate-failure.js`.
+
+**Fix shipped.** (see PR) — (1) drop/neutralize trivial heartbeat-ack session summaries
+before they enter the prompt; (2) self-heal: on a 400 whose minimal-probe doesn't
+reproduce, retry the turn without the Recent-Sessions block; (3) correct the misleading
+error copy.
+
+**Ruled out (all on the exact same token/account):** usage/billing, token identity,
+headers (device `claude.js` byte-identical to repo), model (Opus vs Sonnet), stream flag,
+request size/cost, network/egress.

--- a/testing/lib.js
+++ b/testing/lib.js
@@ -12,7 +12,8 @@ const ALL_MODELS = [
     'claude-haiku-4-5',
 ];
 
-const CC_BILLING_HEADER = 'x-anthropic-billing-header: cc_version=2.1.116; cc_entrypoint=cli; cch=00000;';
+// BAT-1123: mirror of providers/claude.js CC_BILLING_HEADER (cc_version 2.1.195).
+const CC_BILLING_HEADER = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
 
 function loadEnv() {
     const envPath = path.join(__dirname, '.env');

--- a/testing/test-content-filter-trigger.js
+++ b/testing/test-content-filter-trigger.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/*
+ * test-content-filter-trigger.js — regression probe for the 2026-07-07 outage
+ * (see testing/FINDINGS.md). Anthropic's setup_token path rejects a request whose
+ * content contains the co-occurrence of `heartbeat` + `acknowledgment` +
+ * `HEARTBEAT_OK`, and MISLABELS it as `400 "You're out of extra usage"`. This
+ * poison entered the agent's "Recent Sessions" system-prompt block via an
+ * auto-generated heartbeat session summary and deadlocked every turn.
+ *
+ * This probe confirms, on the setup_token path:
+ *   - the known trigger phrase still 400s (so we notice if Anthropic changes it)
+ *   - the neutralized phrasing 200s (so our sanitizer's target stays valid)
+ *
+ * Deliberately tiny (~40-char system) so a 400 can ONLY be the content filter,
+ * never usage. LIVE — needs SETUP_TOKEN in testing/.env. Run: node testing/test-content-filter-trigger.js
+ */
+'use strict';
+const path = require('path');
+const https = require('https');
+const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
+const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const MODEL = process.env.TEST_MODEL || 'claude-opus-4-8';
+const BILL = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
+
+// [phrase, expected] — the minimal trigger + the safe variants (drop any one word).
+const CASES = [
+    ['heartbeat acknowledgment (HEARTBEAT_OK)', 400], // THE trigger
+    ['heartbeat acknowledgment token (HEARTBEAT_OK)', 400],
+    ['acknowledgment token (HEARTBEAT_OK)', 200], // no "heartbeat"
+    ['heartbeat token (HEARTBEAT_OK)', 200], // no "acknowledgment"
+    ['heartbeat acknowledgment (HEARTBEAT)', 200], // no "_OK" token
+    ['responded with the heartbeat ack signal', 200], // neutralized form (sanitizer target)
+];
+
+function probe(text) {
+    const body = JSON.stringify({ model: MODEL, max_tokens: 16, stream: false,
+        system: [{ type: 'text', text: BILL }, { type: 'text', text }],
+        messages: [{ role: 'user', content: 'Hey' }] });
+    const headers = claude.buildHeaders(process.env.SETUP_TOKEN, 'setup_token');
+    return new Promise((res) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST', headers },
+            (rp) => { rp.on('data', () => {}); rp.on('end', () => res(rp.statusCode)); });
+        r.on('error', () => res(0)); r.setTimeout(30000, () => r.destroy());
+        r.write(body); r.end();
+    });
+}
+
+(async () => {
+    if (!process.env.SETUP_TOKEN) { console.error('❌ SETUP_TOKEN required in testing/.env'); process.exit(1); }
+    console.log(`🧪 content-filter regression probe (setup_token, ${MODEL})\n`);
+    let fails = 0;
+    for (const [text, expect] of CASES) {
+        const got = await probe(text);
+        const ok = got === expect;
+        if (!ok) fails++;
+        console.log(`  ${ok ? '✅' : '❌'} expect ${expect}, got ${got}  "${text}"`);
+        await new Promise((r) => setTimeout(r, 800));
+    }
+    console.log(fails === 0
+        ? '\n✅ Behavior unchanged — trigger still 400s, safe variants 200. Sanitizer contract holds.'
+        : `\n⚠️ ${fails} case(s) changed — Anthropic altered the filter. Re-derive the trigger + update the sanitizer.`);
+    process.exit(fails === 0 ? 0 : 1);
+})();

--- a/testing/test-content-filter-trigger.js
+++ b/testing/test-content-filter-trigger.js
@@ -21,11 +21,12 @@ const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-projec
 require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
     exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
 const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
-const { loadEnv } = require('./lib');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const MODEL = process.env.TEST_MODEL || 'claude-opus-4-8';
-const BILL = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
+const BILL = CC_BILLING_HEADER; // shared with providers/claude.js — no drift on cc_version bumps
+const TOKEN = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
 
 // [phrase, expected] — the minimal trigger + the safe variants (drop any one word).
 const CASES = [
@@ -41,7 +42,7 @@ function probe(text) {
     const body = JSON.stringify({ model: MODEL, max_tokens: 16, stream: false,
         system: [{ type: 'text', text: BILL }, { type: 'text', text }],
         messages: [{ role: 'user', content: 'Hey' }] });
-    const headers = claude.buildHeaders(process.env.SETUP_TOKEN, 'setup_token');
+    const headers = claude.buildHeaders(TOKEN, 'setup_token');
     return new Promise((res) => {
         const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST', headers },
             (rp) => { rp.on('data', () => {}); rp.on('end', () => res(rp.statusCode)); });
@@ -51,7 +52,7 @@ function probe(text) {
 }
 
 (async () => {
-    if (!process.env.SETUP_TOKEN) { console.error('❌ SETUP_TOKEN required in testing/.env'); process.exit(1); }
+    if (!TOKEN) { console.error('❌ SETUP_TOKEN (or ANTHROPIC_SETUP_TOKEN) required in testing/.env'); process.exit(1); }
     console.log(`🧪 content-filter regression probe (setup_token, ${MODEL})\n`);
     let fails = 0;
     for (const [text, expect] of CASES) {

--- a/testing/test-provider-cache.js
+++ b/testing/test-provider-cache.js
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/*
+ * test-provider-cache.js — reusable prompt-cache / request-shape diagnostic
+ * across ALL providers (claude, openai, openrouter, custom).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * On 2026-07-07 the on-device agent (setup_token, sonnet-4-6) started billing
+ * ~26K UNCACHED tokens every turn — only the 8192-token tool block was
+ * caching, the ~26K system prompt was not. Heartbeats every 30 min at 26K
+ * fresh tokens drained the claude.ai subscription's Claude Code usage
+ * allowance, and Anthropic then rejected the large requests at the billing
+ * gate: `400 invalid_request_error "You're out of extra usage …"`. A tiny
+ * request still succeeded — so the request SHAPE was valid; the caching was
+ * the problem. This test pins that class of regression for every provider.
+ *
+ * MODES
+ * -----
+ *  DRY-RUN (default, FREE, no network): builds the request with the provider's
+ *    REAL formatters and asserts cache_control lands where it should
+ *    (stable system block + last tool) and NOT on the per-turn dynamic block.
+ *    Also prints stable/dynamic/tools byte+token estimates. Safe for CI.
+ *  LIVE (LIVE=1): sends the request TWICE with a CHANGING dynamic block and
+ *    reports the provider's cache metrics (cache_read/write). Costs tokens —
+ *    run deliberately. NOTE: on setup_token this bills the user's subscription.
+ *
+ * KNOBS
+ * -----
+ *  TEST_PROVIDER=claude|openai|openrouter|custom   (default claude)
+ *  TEST_AUTH=setup_token|api_key                   (claude only; default setup_token)
+ *  TEST_MODEL=<id>                                 (default per provider)
+ *  AGENT_SIZE=full                                 (recreate the ~26K agent prompt; default small)
+ *  LIVE=1                                          (actually send; default dry-run)
+ *
+ * Run: node testing/test-provider-cache.js
+ *      TEST_PROVIDER=openrouter node testing/test-provider-cache.js
+ *      LIVE=1 AGENT_SIZE=full node testing/test-provider-cache.js
+ */
+'use strict';
+
+const path = require('path');
+const https = require('https');
+
+// Stub config.js so provider adapters load standalone.
+const NP = path.resolve(__dirname, '../app/src/main/assets/nodejs-project');
+const configPath = path.join(NP, 'config.js');
+require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
+
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const PROVIDER = (process.env.TEST_PROVIDER || 'claude').toLowerCase();
+const AUTH = process.env.TEST_AUTH || 'setup_token';
+const AGENT_SIZE = process.env.AGENT_SIZE || 'small';
+const LIVE = process.env.LIVE === '1';
+
+// ── Provider registry: real adapter + endpoint + how it wraps a request ──────
+const REG = {
+    claude: {
+        adapter: () => require(path.join(NP, 'providers/claude')),
+        model: process.env.TEST_MODEL || 'claude-sonnet-4-6',
+        host: 'api.anthropic.com', reqPath: '/v1/messages',
+        // claude: formatSystemPrompt(stable, dynamic, authType) → block[]; formatRequest(model,max,systemBlocks,messages,tools,opts)
+        build(a, model, stable, dyn, tools, msgs) {
+            const sys = a.formatSystemPrompt(stable, dyn, AUTH);
+            const ftools = a.formatTools(tools);
+            return JSON.parse(a.formatRequest(model, 4096, sys, msgs, ftools, { reasoningMode: 'off' }));
+        },
+        headers(a, keyOrToken) { return a.buildHeaders(keyOrToken, AUTH); },
+        secret: () => (AUTH === 'api_key'
+            ? process.env.ANTHROPIC_API_KEY
+            : (process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN)),
+    },
+    openrouter: {
+        adapter: () => require(path.join(NP, 'providers/openrouter')),
+        model: process.env.TEST_MODEL || 'anthropic/claude-3.5-sonnet',
+        host: 'openrouter.ai', reqPath: '/api/v1/chat/completions',
+        // openrouter: formatSystemPrompt(stable,dynamic)→string; formatRequest(model,max,systemPrompt,messages,tools,opts)
+        build(a, model, stable, dyn, tools, msgs) {
+            const sys = a.formatSystemPrompt(stable, dyn);
+            const ftools = a.formatTools(tools);
+            return JSON.parse(a.formatRequest(model, 4096, sys, msgs, ftools, {}));
+        },
+        headers(a, key) { return a.buildHeaders(key); },
+        secret: () => process.env.OPENROUTER_API_KEY,
+    },
+    openai: {
+        adapter: () => require(path.join(NP, 'providers/openai')),
+        model: process.env.TEST_MODEL || 'gpt-4o',
+        host: 'api.openai.com', reqPath: '/v1/responses',
+        // openai: formatSystemPrompt(stable,dynamic); formatRequest(model,max,instructions,input,tools,opts)
+        build(a, model, stable, dyn, tools, msgs) {
+            const instr = a.formatSystemPrompt(stable, dyn);
+            const ftools = a.formatTools(tools);
+            return JSON.parse(a.formatRequest(model, 4096, instr, msgs, ftools, {}));
+        },
+        headers(a, key) { return a.buildHeaders(key); },
+        secret: () => process.env.OPENAI_API_KEY,
+    },
+    custom: {
+        adapter: () => require(path.join(NP, 'providers/custom')),
+        model: process.env.TEST_MODEL || 'gpt-4o',
+        host: (process.env.CUSTOM_BASE_URL || '').replace(/^https?:\/\//, '').split('/')[0] || 'api.openai.com',
+        reqPath: '/v1/chat/completions',
+        build(a, model, stable, dyn, tools, msgs) {
+            const instr = a.formatSystemPrompt(stable, dyn, AUTH);
+            const ftools = a.formatTools(tools);
+            return JSON.parse(a.formatRequest(model, 4096, instr, msgs, ftools, {}));
+        },
+        headers(a, key) { return a.buildHeaders(key); },
+        secret: () => process.env.CUSTOM_API_KEY,
+    },
+};
+
+// ── Agent-shaped payload ─────────────────────────────────────────────────────
+const REPEAT = AGENT_SIZE === 'full' ? 360 : 12; // full ≈ agent's ~26K system; small ≈ cheap
+const STABLE = ('You are a capable on-device personal AI agent running inside a mobile app. '
+    + 'You have tools for messaging, memory, files, skills, cron, wallet and web access. '
+    + 'Follow the safety, confirmation-gate, and reply-formatting rules precisely. ').repeat(REPEAT);
+const dynamic = (seed) => `Runtime tick ${seed}. Burner balance snapshot: SOL ${seed % 1000}. Current message_id: ${seed}.`;
+const TOOLCOUNT = AGENT_SIZE === 'full' ? 64 : 8;
+function rawTools(n) {
+    const d = 'Detailed capability with usage guidance, safety notes, and parameter semantics. '.repeat(AGENT_SIZE === 'full' ? 9 : 2);
+    return Array.from({ length: n }, (_, i) => ({
+        name: `tool_${i}`, description: `Tool ${i}: ${d}`,
+        input_schema: { type: 'object', properties: { query: { type: 'string', description: d } }, required: ['query'] },
+    }));
+}
+const MESSAGES = [{ role: 'user', content: 'Hey' }];
+const approxTokens = (s) => Math.round((s || '').length / 4);
+
+// Deep-scan a built request for cache_control markers → list of paths.
+function findCacheControl(obj, prefix = '') {
+    const hits = [];
+    if (Array.isArray(obj)) obj.forEach((v, i) => hits.push(...findCacheControl(v, `${prefix}[${i}]`)));
+    else if (obj && typeof obj === 'object') {
+        for (const [k, v] of Object.entries(obj)) {
+            if (k === 'cache_control') hits.push(prefix || '(root)');
+            else hits.push(...findCacheControl(v, prefix ? `${prefix}.${k}` : k));
+        }
+    }
+    return hits;
+}
+
+function post(host, reqPath, headers, bodyObj) {
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: host, path: reqPath, method: 'POST', headers },
+            (rp) => { let d = ''; rp.on('data', (c) => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(90000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(bodyObj)); r.end();
+    });
+}
+// Normalize cache usage across Anthropic + OpenAI/OpenRouter response shapes.
+function readUsage(data) {
+    const u = data?.usage || {};
+    return {
+        cacheRead: u.cache_read_input_tokens ?? u.prompt_tokens_details?.cached_tokens ?? u.input_tokens_details?.cached_tokens ?? 0,
+        cacheWrite: u.cache_creation_input_tokens ?? u.prompt_tokens_details?.cache_write_tokens ?? 0,
+        input: u.input_tokens ?? u.prompt_tokens ?? 0,
+        output: u.output_tokens ?? u.completion_tokens ?? 0,
+    };
+}
+
+(async () => {
+    const cfg = REG[PROVIDER];
+    if (!cfg) { console.error(`❌ unknown TEST_PROVIDER "${PROVIDER}" (claude|openai|openrouter|custom)`); process.exit(1); }
+    const a = cfg.adapter();
+    const model = cfg.model;
+    console.log(`🧪 provider=${PROVIDER}${PROVIDER === 'claude' ? ` auth=${AUTH}` : ''}  model=${model}  size=${AGENT_SIZE}  mode=${LIVE ? 'LIVE' : 'DRY-RUN'}\n`);
+
+    // ---- DRY-RUN structural check (free) ----
+    const body1 = cfg.build(a, model, STABLE, dynamic(1001), rawTools(TOOLCOUNT), MESSAGES);
+    const cc = findCacheControl(body1);
+    console.log(`Sizes: stable≈${approxTokens(STABLE)}tok  dynamic≈${approxTokens(dynamic(1001))}tok  tools≈${approxTokens(JSON.stringify(rawTools(TOOLCOUNT)))}tok  (${TOOLCOUNT} tools)`);
+    console.log(`cache_control markers at: ${cc.length ? cc.join(', ') : '(none — provider uses implicit prefix caching, e.g. OpenAI)'}`);
+
+    // Structural verdict for providers with explicit markers (claude, openrouter).
+    if (['claude', 'openrouter'].includes(PROVIDER)) {
+        // The stable/system block must be marked; the dynamic block must NOT sit after
+        // an unmarked boundary that a per-turn change would invalidate. For claude we can
+        // check the system array precisely.
+        let verdict = 'PASS';
+        const notes = [];
+        if (PROVIDER === 'claude') {
+            const sys = body1.system || [];
+            const stableIdx = sys.findIndex(b => b.cache_control && (b.text || '').length > 500);
+            const dynIdx = sys.length - 1;
+            if (stableIdx === -1) { verdict = 'FAIL'; notes.push('stable system block has NO cache_control → whole system re-billed each turn'); }
+            if (sys[dynIdx]?.cache_control && dynIdx !== stableIdx) { verdict = 'FAIL'; notes.push('dynamic (last) block IS cached → per-turn change invalidates the cache every turn'); }
+            const toolsMarked = (body1.tools || []).some(t => t.cache_control);
+            if ((body1.tools || []).length && !toolsMarked) { verdict = 'FAIL'; notes.push('no tool carries cache_control → tool block never caches'); }
+        }
+        console.log(`\nStructural verdict: ${verdict === 'PASS' ? '✅ PASS' : '❌ FAIL'}${notes.length ? ' — ' + notes.join('; ') : ' (stable cached, dynamic uncached, tools cached)'}`);
+    } else {
+        console.log('\nStructural verdict: N/A (implicit prefix caching — validate with LIVE mode)');
+    }
+
+    if (!LIVE) {
+        console.log('\n(dry-run only — set LIVE=1 to send twice and measure real cache_read. LIVE bills tokens.)');
+        return;
+    }
+
+    // ---- LIVE: send twice with a CHANGING dynamic block ----
+    const secret = cfg.secret();
+    if (!secret) { console.error(`\n❌ LIVE requested but no credential for ${PROVIDER} (${PROVIDER === 'claude' ? (AUTH === 'api_key' ? 'ANTHROPIC_API_KEY' : 'SETUP_TOKEN') : PROVIDER.toUpperCase() + '_API_KEY'}) in testing/.env`); process.exit(1); }
+    const headers = cfg.headers(a, secret);
+    console.log('\nLIVE — sending twice (dynamic block changes between calls):');
+    for (const [label, seed] of [['REQ 1 (cold)   ', 1001], ['REQ 2 (dyn ≠ 1) ', 2002]]) {
+        const body = cfg.build(a, model, STABLE, dynamic(seed), rawTools(TOOLCOUNT), MESSAGES);
+        if (body.stream) body.stream = false; // read usage synchronously
+        const r = await post(cfg.host, cfg.reqPath, headers, body);
+        if (r.data?.error) { console.log(`  ${label} → ${r.status} ❌ ${r.data.error.type}: ${(r.data.error.message || '').slice(0, 70)}`); }
+        else { const u = readUsage(r.data); console.log(`  ${label} → ${r.status} | input=${u.input} cache_write=${u.cacheWrite} cache_read=${u.cacheRead} out=${u.output}`); }
+        await new Promise(res => setTimeout(res, 1500));
+    }
+    console.log('\nHealthy caching: REQ 2 cache_read ≈ stable+tools (dynamic change should NOT reset the big prefix).');
+})();

--- a/testing/test-provider-cache.js
+++ b/testing/test-provider-cache.js
@@ -190,6 +190,11 @@ function readUsage(data) {
             if (sys[dynIdx]?.cache_control && dynIdx !== stableIdx) { verdict = 'FAIL'; notes.push('dynamic (last) block IS cached → per-turn change invalidates the cache every turn'); }
             const toolsMarked = (body1.tools || []).some(t => t.cache_control);
             if ((body1.tools || []).length && !toolsMarked) { verdict = 'FAIL'; notes.push('no tool carries cache_control → tool block never caches'); }
+        } else if (PROVIDER === 'openrouter') {
+            // OpenRouter caches via a top-level cache_control injected by formatRequest
+            // (no per-block markers to inspect), so validate at least one marker exists —
+            // otherwise nothing caches and a blind PASS would be misleading.
+            if (cc.length === 0) { verdict = 'FAIL'; notes.push('no cache_control marker present → nothing will cache'); }
         }
         console.log(`\nStructural verdict: ${verdict === 'PASS' ? '✅ PASS' : '❌ FAIL'}${notes.length ? ' — ' + notes.join('; ') : ' (stable cached, dynamic uncached, tools cached)'}`);
     } else {

--- a/testing/test-recreate-failure.js
+++ b/testing/test-recreate-failure.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// test-recreate-failure.js — recreate the DEVICE's FAILING turn, not a success.
+// The device's 400 "out of extra usage" turns had payloadSize≈116014 bytes,
+// 64 tools, model sonnet-4-6, ~26K UNCACHED tokens billed. My earlier
+// recreations passed because they were cheap (cached/tiny). This one matches
+// the device's WEIGHT: ~26K fresh tokens on the same setup_token, so it hits
+// the shared usage meter as hard as the device does. If the account is at its
+// ceiling, this returns the SAME 400. Sends the exact same bytes TWICE so you
+// can see cold vs (attempted) warm.
+// Run: node testing/test-recreate-failure.js
+'use strict';
+const path = require('path');
+const https = require('https');
+const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
+const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // device's real model = claude-opus-4-8
+const TARGET_BYTES = 116014;                  // device's exact failing payloadSize
+
+// Build system (~26K tokens) + 64 tools, tuned to hit the device's payload size.
+// BUST=1 prepends a unique marker so the prefix has NEVER been cached → bills
+// full FRESH tokens, matching the device's uncached 26K/turn cost profile.
+const BUST = process.env.BUST === '1' ? `UNIQUE-${process.pid}-${Date.now && Date.now()}-${Math.round(Math.random ? Math.random() * 1e9 : 0)} ` : '';
+const STABLE = BUST + ('You are a capable on-device personal AI agent. You have tools for messaging, '
+    + 'memory, files, skills, cron, wallet and web access. Follow safety and reply rules. ').repeat(560);
+const dynamic = (seed) => `Runtime tick ${seed}. Burner snapshot SOL ${seed % 1000}. message_id ${seed}.`;
+function rawTools(n) {
+    const d = 'Detailed capability with usage guidance, safety notes, and parameter semantics. '.repeat(9);
+    return Array.from({ length: n }, (_, i) => ({
+        name: `tool_${i}`, description: `Tool ${i}: ${d}`,
+        input_schema: { type: 'object', properties: { query: { type: 'string', description: d } }, required: ['query'] },
+    }));
+}
+const MESSAGES = [{ role: 'user', content: 'status' }];
+
+// NOCACHE=1 strips cache_control everywhere → the whole prefix bills as PURE
+// input_tokens with cache_write=0, cache_read=0 — the device's exact billing
+// profile (input≈26K, no cache benefit). Combine with BUST for unique content.
+const NOCACHE = process.env.NOCACHE === '1';
+function build(seed) {
+    const sys = claude.formatSystemPrompt(STABLE, dynamic(seed), 'setup_token');
+    let tools = claude.formatTools(rawTools(64));
+    if (NOCACHE) {
+        sys.forEach(b => { delete b.cache_control; });
+        tools = tools.map(t => { const c = { ...t }; delete c.cache_control; return c; });
+    }
+    const body = JSON.parse(claude.formatRequest(MODEL, 4096, sys, MESSAGES, tools, { reasoningMode: 'off' }));
+    if (process.env.STREAM !== '1') body.stream = false; // STREAM=1 → match the agent exactly (stream:true)
+    return body;
+}
+
+function post(token, body) {
+    const headers = claude.buildHeaders(token, 'setup_token');
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST', headers },
+            (rp) => { let d = ''; rp.on('data', c => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(90000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(body)); r.end();
+    });
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
+    const sample = build(1);
+    console.log(`token …${token.slice(-6)}  model=${MODEL}  payload=${JSON.stringify(sample).length}B (device failing turn=${TARGET_BYTES}B)  tools=64\n`);
+    for (const [label, seed] of [['SEND 1 (cold)', 7001], ['SEND 2 (same bytes)', 7001]]) {
+        const r = await post(token, build(seed));
+        if (r.data?.error) {
+            console.log(`${label} → ${r.status} ❌ ${r.data.error.type}: "${r.data.error.message}"`);
+            if (/extra usage|usage/i.test(r.data.error.message || '')) console.log('   ✅ RECREATED — identical to the device error.');
+        } else {
+            const u = r.data.usage || {};
+            console.log(`${label} → ${r.status} ✅ input=${u.input_tokens} cache_write=${u.cache_creation_input_tokens} cache_read=${u.cache_read_input_tokens} out=${u.output_tokens}`);
+        }
+        await new Promise(res => setTimeout(res, 1500));
+    }
+    console.log('\n400 "out of extra usage" here = same token + device-weight request reproduces the failure → shared usage meter, not a device difference.');
+    console.log('200 here = meter has headroom this instant; the device fails because it spends ~26K FRESH tokens every 30-min heartbeat and keeps the meter pinned.');
+})();

--- a/testing/test-recreate-failure.js
+++ b/testing/test-recreate-failure.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // test-recreate-failure.js — recreate the DEVICE's FAILING turn, not a success.
 // The device's 400 "out of extra usage" turns had payloadSize≈116014 bytes,
-// 64 tools, model sonnet-4-6, ~26K UNCACHED tokens billed. My earlier
+// 64 tools, model claude-opus-4-8, ~26K UNCACHED tokens billed. My earlier
 // recreations passed because they were cheap (cached/tiny). This one matches
 // the device's WEIGHT: ~26K fresh tokens on the same setup_token, so it hits
 // the shared usage meter as hard as the device does. If the account is at its
@@ -18,7 +18,7 @@ const claude = require('../app/src/main/assets/nodejs-project/providers/claude')
 const { loadEnv } = require('./lib');
 loadEnv();
 
-const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // device's real model = claude-opus-4-8
+const MODEL = process.env.TEST_MODEL || 'claude-opus-4-8'; // the device's real failing model
 const TARGET_BYTES = 116014;                  // device's exact failing payloadSize
 
 // Build system (~26K tokens) + 64 tools, tuned to hit the device's payload size.

--- a/testing/test-usage-probe.js
+++ b/testing/test-usage-probe.js
@@ -14,11 +14,11 @@ const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-projec
 require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
     exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
 const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
-const { loadEnv } = require('./lib');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const MODEL = 'claude-sonnet-4-6'; // the agent's exact model
-const BILL = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
+const BILL = CC_BILLING_HEADER; // shared with providers/claude.js — no drift on cc_version bumps
 
 function post(token, body) {
     const headers = claude.buildHeaders(token, 'setup_token');

--- a/testing/test-usage-probe.js
+++ b/testing/test-usage-probe.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// test-usage-probe.js — minimal one-shot to read the CURRENT account state on the
+// setup_token billing path. The device agent is 400ing with
+// "You're out of extra usage. Add more at claude.ai/settings/usage" — an
+// invalid_request_error returned at the billing gate (0 tokens), NOT a malformed
+// request. This sends the smallest possible request on the agent's exact model
+// (claude-sonnet-4-6) via the setup_token to confirm whether the account is
+// capped right now. Deliberately tiny — every setup_token call bills the user's
+// subscription quota. Run: node testing/test-usage-probe.js
+'use strict';
+const path = require('path');
+const https = require('https');
+const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
+const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const MODEL = 'claude-sonnet-4-6'; // the agent's exact model
+const BILL = 'x-anthropic-billing-header: cc_version=2.1.195; cc_entrypoint=cli; cch=00000;';
+
+function post(token, body) {
+    const headers = claude.buildHeaders(token, 'setup_token');
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST', headers },
+            (rp) => { let d = ''; rp.on('data', (c) => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(30000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(body)); r.end();
+    });
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ no SETUP_TOKEN in testing/.env'); process.exit(1); }
+    console.log(`token tail …${token.slice(-6)}  model=${MODEL}\n`);
+    const r = await post(token, {
+        model: MODEL, max_tokens: 8, stream: false,
+        system: [{ type: 'text', text: BILL }, { type: 'text', text: 'Reply with the single word OK.' }],
+        messages: [{ role: 'user', content: 'ping' }],
+    });
+    console.log(`HTTP ${r.status}`);
+    if (r.data?.error) {
+        console.log(`ERROR type: ${r.data.error.type}`);
+        console.log(`ERROR message: "${r.data.error.message}"`);
+        console.log(`\n→ Account state on this token: ${/extra usage|usage/i.test(r.data.error.message) ? 'USAGE-CAPPED (matches the device error)' : 'other'}`);
+    } else {
+        const txt = Array.isArray(r.data?.content) ? r.data.content.filter(b => b.type === 'text').map(b => b.text).join('') : '';
+        console.log(`OK — reply: "${txt}"  usage in=${r.data?.usage?.input_tokens} out=${r.data?.usage?.output_tokens}`);
+        console.log('\n→ Account has room RIGHT NOW (the cap is intermittent / at the edge — the agent burns it faster than a tiny probe).');
+    }
+})();

--- a/tests/nodejs-project/recent-sessions-heartbeat-filter.test.js
+++ b/tests/nodejs-project/recent-sessions-heartbeat-filter.test.js
@@ -78,6 +78,23 @@ function check(label, fn) {
         assert.strictEqual(three.length, 3, 'limit honored after filtering');
         assert.ok(three.every(s => !/HEARTBEAT_OK/i.test(String(s.summaryText || ''))), 'still no heartbeat rows');
     });
+    check('does NOT false-empty when the newest 20+ rows are all heartbeat (Copilot R5)', () => {
+        // A real conversation, then 25 NEWER heartbeat-ack rows (> the old over-fetch of 20).
+        // The old JS-post-filter would have fetched 20 all-heartbeat rows → returned [].
+        // SQL filtering applies the LIMIT AFTER filtering, so the real session survives.
+        db.saveSession({ ...base, startedAt: '2026-07-09T00:00:00Z', endedAt: '2026-07-09T00:05:00Z',
+            summaryExcerpt: 'A real conversation buried under many heartbeats' });
+        for (let i = 0; i < 25; i++) {
+            const hh = String(i).padStart(2, '0');
+            db.saveSession({ ...base, durationMin: 1, messageCount: 1,
+                startedAt: `2026-07-10T${hh}:00:00Z`, endedAt: `2026-07-10T${hh}:05:00Z`,
+                summaryExcerpt: `Responded with heartbeat acknowledgment (HEARTBEAT_OK) #${i}` });
+        }
+        const recent = db.getRecentSessions(5);
+        assert.ok(recent.length > 0, 'must NOT return empty when real sessions exist behind 25 heartbeat rows');
+        assert.ok(recent.every(s => !/HEARTBEAT_OK/i.test(String(s.summaryText || ''))), 'no heartbeat rows survive');
+        assert.ok(recent.some(s => /buried under many heartbeats/.test(String(s.summaryText || ''))), 'the buried real session surfaces');
+    });
 
     try { fs.unlinkSync(TMP_DB); } catch (_) {}
 

--- a/tests/nodejs-project/recent-sessions-heartbeat-filter.test.js
+++ b/tests/nodejs-project/recent-sessions-heartbeat-filter.test.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// recent-sessions-heartbeat-filter.test.js — BAT-1130 F2.
+//
+// getRecentSessions() must DROP legacy heartbeat-ack session summaries (any row
+// whose summary_excerpt contains the literal protocol token "HEARTBEAT_OK") so
+// they can't re-enter the system prompt and re-trigger Anthropic's setup_token
+// content filter (mislabeled as a "You're out of extra usage" 400 — see
+// testing/FINDINGS.md). New builds no longer create these rows (F1), but rows
+// written by older builds persist across upgrade; this read-time filter fixes
+// existing installs with no schema change and no DB migration.
+//
+// Uses the REAL database.js + a fresh in-memory SQL.js database.
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+function _stub(modPath, exports) {
+    const resolved = require.resolve(modPath);
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports };
+}
+
+const TMP_DB = path.join(os.tmpdir(), `bat1130-sessions-${process.pid}.db`);
+try { fs.unlinkSync(TMP_DB); } catch (_) {}
+
+_stub(path.join(BUNDLE, 'config.js'), {
+    workDir: os.tmpdir(),
+    log: () => {},
+    localTimestamp: () => '2026-07-07T00:00:00Z',
+    localDateStr: () => '2026-07-07',
+    DB_PATH: TMP_DB,
+    MEMORY_PATH: path.join(os.tmpdir(), 'bat1130-MEMORY.md'),
+    MEMORY_DIR: path.join(os.tmpdir(), 'bat1130-memory-nonexistent'),
+});
+_stub(path.join(BUNDLE, 'memory.js'), { setDb: () => {} });
+
+const db = require(path.join(BUNDLE, 'database.js'));
+
+let failures = 0;
+function check(label, fn) {
+    try { fn(); console.log(`  ✓ ${label}`); }
+    catch (e) { failures++; console.error(`  ✗ ${label}\n    ${e.stack || e.message}`); }
+}
+
+(async () => {
+    await db.initDatabase();
+
+    const base = { durationMin: 2, messageCount: 2, summaryFile: 'x.md', trigger: 'idle', model: 'claude-opus-4-8' };
+    // Two real conversations + one heartbeat-ack (the poison shape).
+    db.saveSession({ ...base, startedAt: '2026-07-07T01:00:00Z', endedAt: '2026-07-07T01:05:00Z',
+        summaryExcerpt: 'Discussed the quarterly budget and agreed on next steps' });
+    db.saveSession({ ...base, durationMin: 1, messageCount: 1, startedAt: '2026-07-07T02:00:00Z', endedAt: '2026-07-07T02:05:00Z',
+        summaryExcerpt: 'Checked HEARTBEAT.md. Responded with standard heartbeat acknowledgment (HEARTBEAT_OK) per instructions' });
+    db.saveSession({ ...base, startedAt: '2026-07-07T03:00:00Z', endedAt: '2026-07-07T03:05:00Z',
+        summaryExcerpt: 'Planned the trip itinerary for next week' });
+
+    const recent = db.getRecentSessions(5);
+
+    check('drops the HEARTBEAT_OK row', () => {
+        assert.ok(recent.every(s => !/HEARTBEAT_OK/i.test(String(s.summaryText || ''))),
+            'no summary containing HEARTBEAT_OK may survive getRecentSessions');
+    });
+    check('keeps the two real conversation rows', () => {
+        assert.strictEqual(recent.length, 2, 'exactly the 2 non-heartbeat rows should remain');
+        assert.ok(recent.some(s => /quarterly budget/.test(s.summaryText)), 'budget session must be kept');
+        assert.ok(recent.some(s => /trip itinerary/.test(s.summaryText)), 'trip session must be kept');
+    });
+    check('respects the limit after filtering', () => {
+        // Insert 6 more real rows; ask for 3 → get 3, none of them heartbeat.
+        for (let i = 0; i < 6; i++) {
+            db.saveSession({ ...base, startedAt: `2026-07-07T0${i}:30:00Z`, endedAt: `2026-07-07T0${i}:35:00Z`,
+                summaryExcerpt: `Real conversation number ${i}` });
+        }
+        const three = db.getRecentSessions(3);
+        assert.strictEqual(three.length, 3, 'limit honored after filtering');
+        assert.ok(three.every(s => !/HEARTBEAT_OK/i.test(String(s.summaryText || ''))), 'still no heartbeat rows');
+    });
+
+    try { fs.unlinkSync(TMP_DB); } catch (_) {}
+
+    if (failures > 0) { console.error(`\n${failures} failure(s).`); process.exit(1); }
+    console.log('\nPASS: recent-sessions-heartbeat-filter.test.js (F2 — heartbeat rows filtered at read).');
+})();

--- a/tests/nodejs-project/system-prompt-recent-sessions.test.js
+++ b/tests/nodejs-project/system-prompt-recent-sessions.test.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// system-prompt-recent-sessions.test.js — BAT-1130 F5 + F3.
+//
+// F5 (caching): the "Recent Sessions" block must be emitted in the DYNAMIC
+//   block, NOT the cached stable block. It rotates every session, so keeping it
+//   in the stable prefix busted the ~60 KB prompt cache on every rotation.
+//
+// F3 (self-heal): buildSystemBlocks({ leanMemory: true }) must omit the volatile
+//   agent-authored memory (Recent Sessions + MEMORY.md + today's daily memory)
+//   so the tool-loop self-heal can retry a request that Anthropic rejected
+//   because of a poisoned memory phrase. Also unit-tests _isUsageFilter400.
+//
+// Mocks every ai.js dependency (same approach as system-prompt-wallets.test.js).
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const BUNDLE = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+
+function _stub(modPath, exports) {
+    const resolved = require.resolve(modPath);
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports };
+}
+
+_stub(path.join(BUNDLE, 'config.js'), {
+    workDir: '/tmp/fixture-wd',
+    MODEL: 'claude-opus-4-8',
+    resolveActiveModel: () => 'claude-opus-4-8',
+    PROVIDER: 'claude',
+    CHANNEL: 'telegram',
+    ANTHROPIC_KEY: 'k', OPENAI_KEY: '', OPENROUTER_KEY: '', CUSTOM_KEY: '',
+    CUSTOM_BASE_URL: '', CUSTOM_FORMAT: '', OPENROUTER_FALLBACK_MODEL: '',
+    OPENROUTER_MODEL_CONTEXT: 0, OPENROUTER_FALLBACK_CONTEXT: 0,
+    AUTH_TYPE: 'setup_token', OPENAI_AUTH_TYPE: 'apiKey',
+    REACTION_GUIDANCE: 'on', REACTION_NOTIFICATIONS: 'on', MEMORY_DIR: '/tmp/fixture-wd/memory',
+    TOOL_RATE_LIMITS: {}, TOOL_STATUS_MAP: {},
+    API_TIMEOUT_RETRIES: 3, API_TIMEOUT_BACKOFF_MS: 100, API_TIMEOUT_MAX_BACKOFF_MS: 1000,
+    truncateToolResult: (s) => s,
+    localTimestamp: () => '2026-07-07T00:00:00Z',
+    localDateStr: () => '2026-07-07',
+    log: () => {},
+    getOwnerId: () => 'OWNER',
+    USER_ENV_KEYS: [],
+    config: { jupiterApiKey: '', agentName: 'TestAgent' },
+    runtimeState: {},
+});
+_stub(path.join(BUNDLE, 'model-catalog.js'), { reasoningSupportFor: () => 'none', displayNameForProvider: () => 'Claude' });
+_stub(path.join(BUNDLE, 'reasoning-gating.js'), { logSuppression: () => {}, SUPPRESSION_REASONS: {} });
+_stub(path.join(BUNDLE, 'security.js'), { redactSecrets: (s) => s });
+_stub(path.join(BUNDLE, 'channel.js'), { sendMessage: async () => {}, sendTyping: async () => {} });
+_stub(path.join(BUNDLE, 'telegram.js'), {
+    sentMessageCache: new Map(), SENT_CACHE_TTL: 60_000,
+    deferStatus: () => ({ cleanup: async () => {} }), deferThinkingStatus: () => ({ cleanup: async () => {} }),
+});
+_stub(path.join(BUNDLE, 'http.js'), {
+    httpStreamingRequest: async () => ({}), httpOpenAIStreamingRequest: async () => ({}),
+    httpChatCompletionsStreamingRequest: async () => ({}), httpRequest: async () => ({ status: 200 }),
+});
+_stub(path.join(BUNDLE, 'providers/index.js'), { getAdapter: () => null });
+_stub(path.join(BUNDLE, 'bridge.js'), {
+    androidBridgeCall: async (endpoint) => (endpoint === '/burner/status' ? { error: 'mocked-no-bridge' } : {}),
+    fetchMcpToken: async () => '',
+});
+_stub(path.join(BUNDLE, 'silent-reply.js'), { stripSilentReply: (s) => s, TOKEN: '__SILENT_REPLY__' });
+// Memory markers — MEMORY.md + today's daily memory must land in stable normally,
+// and must vanish under leanMemory.
+_stub(path.join(BUNDLE, 'memory.js'), {
+    loadSoul: () => '', loadBootstrap: () => '', loadIdentity: () => '', loadUser: () => '',
+    loadMemory: () => 'MEMORY_MARKER_XYZ', loadDailyMemory: () => 'DAILY_MARKER_XYZ',
+});
+_stub(path.join(BUNDLE, 'skills.js'), { findMatchingSkills: () => [], loadSkills: () => [] });
+// Fixture recent session — its marker text is what we assert on for placement.
+_stub(path.join(BUNDLE, 'database.js'), {
+    getDb: () => null, markDbDirty: () => {}, markDbSummaryDirty: () => {}, indexMemoryFiles: () => {},
+    saveSession: () => {},
+    getRecentSessions: () => [{ relativeTime: '2 hours ago', durationMin: 10, messageCount: 2, summaryText: 'RECENT_SESSION_MARKER' }],
+});
+_stub(path.join(BUNDLE, 'task-store.js'), { saveCheckpoint: () => {}, cleanupChatCheckpoints: () => {} });
+_stub(path.join(BUNDLE, 'loop-detector.js'), { detectToolLoop: () => null, reset: () => {} });
+_stub(path.join(BUNDLE, 'reasoning-recovery.js'), { handleReasoningError: () => null });
+_stub(path.join(BUNDLE, 'reasoning-redact.js'), { fingerprint: () => '' });
+_stub(path.join(BUNDLE, 'confirmation/index.js'), { getConfirmationPolicy: () => 'none', normalizePolicy: (r) => (typeof r === 'string' ? { policy: r } : r) });
+_stub(path.join(BUNDLE, 'wallet/index.js'), { getWalletState: async () => ({ burnerConfigured: false }) });
+
+const ai = require(path.join(BUNDLE, 'ai.js'));
+const { buildSystemBlocks, _setWalletPromptSnapshotForTests, _isUsageFilter400 } = ai;
+_setWalletPromptSnapshotForTests({ configured: false }); // deterministic, no async wallet noise
+
+let failures = 0;
+function check(label, fn) {
+    try { fn(); console.log(`  ✓ ${label}`); }
+    catch (e) { failures++; console.error(`  ✗ ${label}\n    ${e.stack || e.message}`); }
+}
+
+// ── F5: Recent Sessions lives in the DYNAMIC block, not the cached stable ────
+check('F5: Recent Sessions is emitted in the DYNAMIC block', () => {
+    const { stable, dynamic } = buildSystemBlocks([], 'chat-1', 'claude-opus-4-8');
+    assert.ok(dynamic.includes('## Recent Sessions'), 'dynamic block must contain the Recent Sessions header');
+    assert.ok(dynamic.includes('RECENT_SESSION_MARKER'), 'dynamic block must contain the session summary text');
+    assert.ok(!stable.includes('## Recent Sessions'), 'stable (cached) block must NOT contain Recent Sessions');
+    assert.ok(!stable.includes('RECENT_SESSION_MARKER'), 'stable (cached) block must NOT contain the session summary text');
+});
+
+check('F5: MEMORY.md and daily memory still live in the stable block', () => {
+    const { stable } = buildSystemBlocks([], 'chat-2', 'claude-opus-4-8');
+    assert.ok(stable.includes('MEMORY_MARKER_XYZ'), 'MEMORY.md stays in stable (changes rarely)');
+    assert.ok(stable.includes('DAILY_MARKER_XYZ'), 'daily memory stays in stable');
+});
+
+// ── F3: leanMemory omits ALL volatile agent-authored memory ──────────────────
+check('F3: leanMemory omits Recent Sessions + MEMORY.md + daily memory', () => {
+    const { stable, dynamic } = buildSystemBlocks([], 'chat-3', 'claude-opus-4-8', { leanMemory: true });
+    const all = stable + '\n' + dynamic;
+    assert.ok(!all.includes('RECENT_SESSION_MARKER'), 'lean: Recent Sessions must be gone');
+    assert.ok(!all.includes('MEMORY_MARKER_XYZ'), 'lean: MEMORY.md must be gone');
+    assert.ok(!all.includes('DAILY_MARKER_XYZ'), 'lean: daily memory must be gone');
+    // Core prompt still intact (self-heal must keep a usable agent).
+    assert.ok(stable.includes('## Wallets'), 'lean: core sections (Wallets) still present');
+    assert.ok(stable.includes('## Wallet Key Policy'), 'lean: security policy still present');
+});
+
+check('F3: default (non-lean) keeps the volatile memory', () => {
+    const { stable, dynamic } = buildSystemBlocks([], 'chat-4', 'claude-opus-4-8');
+    const all = stable + '\n' + dynamic;
+    assert.ok(all.includes('RECENT_SESSION_MARKER') && all.includes('MEMORY_MARKER_XYZ') && all.includes('DAILY_MARKER_XYZ'),
+        'non-lean build must still include all memory sections');
+});
+
+// ── F3: _isUsageFilter400 detector ───────────────────────────────────────────
+check('_isUsageFilter400: matches the 400 "out of extra usage" shape', () => {
+    assert.strictEqual(_isUsageFilter400(400, { error: { message: "You're out of extra usage. Add more at claude.ai/settings/usage and keep going." } }), true);
+    assert.strictEqual(_isUsageFilter400(400, 'You are out of extra usage'), true, 'raw-string bodies also match');
+});
+check('_isUsageFilter400: does NOT match unrelated 400s or other statuses', () => {
+    assert.strictEqual(_isUsageFilter400(400, { error: { message: 'messages.0.content: invalid' } }), false, 'other 400 must not match');
+    assert.strictEqual(_isUsageFilter400(429, { error: { message: 'extra usage' } }), false, 'only status 400 qualifies');
+    assert.strictEqual(_isUsageFilter400(400, null), false, 'null body is safe');
+    assert.strictEqual(_isUsageFilter400(200, { error: { message: 'extra usage' } }), false, '200 never qualifies');
+});
+
+if (failures > 0) { console.error(`\n${failures} failure(s).`); process.exit(1); }
+console.log('\nPASS: system-prompt-recent-sessions.test.js (F5 placement + F3 leanMemory + _isUsageFilter400).');

--- a/tests/nodejs-project/system-prompt-recent-sessions.test.js
+++ b/tests/nodejs-project/system-prompt-recent-sessions.test.js
@@ -65,9 +65,12 @@ _stub(path.join(BUNDLE, 'bridge.js'), {
 _stub(path.join(BUNDLE, 'silent-reply.js'), { stripSilentReply: (s) => s, TOKEN: '__SILENT_REPLY__' });
 // Memory markers — MEMORY.md + today's daily memory must land in stable normally,
 // and must vanish under leanMemory.
+// Call counters pin BAT-1130's read-skip: leanMemory must not even READ memory from disk.
+let _memReads = 0, _dailyReads = 0;
 _stub(path.join(BUNDLE, 'memory.js'), {
     loadSoul: () => '', loadBootstrap: () => '', loadIdentity: () => '', loadUser: () => '',
-    loadMemory: () => 'MEMORY_MARKER_XYZ', loadDailyMemory: () => 'DAILY_MARKER_XYZ',
+    loadMemory: () => { _memReads++; return 'MEMORY_MARKER_XYZ'; },
+    loadDailyMemory: () => { _dailyReads++; return 'DAILY_MARKER_XYZ'; },
 });
 _stub(path.join(BUNDLE, 'skills.js'), { findMatchingSkills: () => [], loadSkills: () => [] });
 // Fixture recent session — its marker text is what we assert on for placement.
@@ -118,6 +121,19 @@ check('F3: leanMemory omits Recent Sessions + MEMORY.md + daily memory', () => {
     // Core prompt still intact (self-heal must keep a usable agent).
     assert.ok(stable.includes('## Wallets'), 'lean: core sections (Wallets) still present');
     assert.ok(stable.includes('## Wallet Key Policy'), 'lean: security policy still present');
+});
+
+check('F3: leanMemory does NOT read MEMORY.md / daily memory from disk', () => {
+    _memReads = 0; _dailyReads = 0;
+    buildSystemBlocks([], 'chat-lean-io', 'claude-opus-4-8', { leanMemory: true });
+    assert.strictEqual(_memReads, 0, 'loadMemory must not be called on the lean retry');
+    assert.strictEqual(_dailyReads, 0, 'loadDailyMemory must not be called on the lean retry');
+});
+
+check('F3: default (non-lean) build DOES read memory from disk', () => {
+    _memReads = 0; _dailyReads = 0;
+    buildSystemBlocks([], 'chat-nonlean-io', 'claude-opus-4-8');
+    assert.ok(_memReads >= 1 && _dailyReads >= 1, 'non-lean build must read memory + daily memory');
 });
 
 check('F3: default (non-lean) keeps the volatile memory', () => {

--- a/tests/nodejs-project/system-prompt-recent-sessions.test.js
+++ b/tests/nodejs-project/system-prompt-recent-sessions.test.js
@@ -144,15 +144,17 @@ check('F3: default (non-lean) keeps the volatile memory', () => {
 });
 
 // ── F3: _isUsageFilter400 detector ───────────────────────────────────────────
-check('_isUsageFilter400: matches the 400 "out of extra usage" shape', () => {
+check('_isUsageFilter400: matches the exact 400 "out of extra usage" shape (object/string/Buffer)', () => {
     assert.strictEqual(_isUsageFilter400(400, { error: { message: "You're out of extra usage. Add more at claude.ai/settings/usage and keep going." } }), true);
     assert.strictEqual(_isUsageFilter400(400, 'You are out of extra usage'), true, 'raw-string bodies also match');
+    assert.strictEqual(_isUsageFilter400(400, Buffer.from("You're out of extra usage")), true, 'Buffer bodies also match');
 });
-check('_isUsageFilter400: does NOT match unrelated 400s or other statuses', () => {
-    assert.strictEqual(_isUsageFilter400(400, { error: { message: 'messages.0.content: invalid' } }), false, 'other 400 must not match');
-    assert.strictEqual(_isUsageFilter400(429, { error: { message: 'extra usage' } }), false, 'only status 400 qualifies');
+check('_isUsageFilter400: requires the exact phrase — not just "extra usage" — and status 400', () => {
+    assert.strictEqual(_isUsageFilter400(400, { error: { message: 'Your extra usage balance is low' } }), false, '"extra usage" without "out of" must NOT match (tightened)');
+    assert.strictEqual(_isUsageFilter400(400, { error: { message: 'messages.0.content: invalid' } }), false, 'unrelated 400 must not match');
+    assert.strictEqual(_isUsageFilter400(429, { error: { message: 'out of extra usage' } }), false, 'only status 400 qualifies');
     assert.strictEqual(_isUsageFilter400(400, null), false, 'null body is safe');
-    assert.strictEqual(_isUsageFilter400(200, { error: { message: 'extra usage' } }), false, '200 never qualifies');
+    assert.strictEqual(_isUsageFilter400(200, { error: { message: 'out of extra usage' } }), false, '200 never qualifies');
 });
 
 if (failures > 0) { console.error(`\n${failures} failure(s).`); process.exit(1); }


### PR DESCRIPTION
## Summary

Fixes a production outage where the on-device agent (Pro/Max **setup_token**) returned `400 "You're out of extra usage"` on **every turn** from ~10:35, never recovering — **even with usage remaining**.

**It was not usage.** An auto-generated **heartbeat session summary** ("…standard **heartbeat acknowledgment (HEARTBEAT_OK)** per instructions") injected into the **Recent Sessions** block made Anthropic's setup_token endpoint reject the request and **mislabel** it as the billing message above. Because the poisoned summary was in every request and the agent couldn't summarize new sessions while failing, it **never rotated out → permanent deadlock.**

Proven empirically (see `testing/FINDINGS.md`): captured the agent's real outgoing request off-device, replayed it (400), and binary-searched the 66 KB system prompt → the `sessions` row → a **~40-char phrase**, deterministic 3/3 (drop any one of `heartbeat` / `acknowledgment` / `HEARTBEAT_OK` → 200; the phrases cost ≈0 tokens, so categorically not usage). Ruled out on the **exact same token/account**: usage, token identity, headers (device `claude.js` byte-identical to repo), model (Opus vs Sonnet), stream flag, size/cost, and network (curl of the identical request from the device's own network → 200).

## Implementation contract

- **F1 — Don't summarize heartbeat sessions.** `saveSessionSummary()` returns early for `chatId === '__heartbeat__'`. No new poison, less prompt noise. Heartbeat mechanism (poll → `HEARTBEAT_OK` reply) untouched.
- **F2 — Filter legacy heartbeat rows at read.** `getRecentSessions()` over-fetches and drops rows whose `summary_excerpt` contains `HEARTBEAT_OK`. Fixes existing installs on upgrade — **no schema change, no DB surgery.**
- **F3 — Self-heal backstop.** On a usage-filter `400` (`_isUsageFilter400`), retry the turn **once** with volatile memory dropped (`buildSystemBlocks({leanMemory:true})` omits Recent Sessions + daily memory + MEMORY.md); log `[SelfHeal]`. Lean retry also fails → surface the real error. General guard so no future opaque content-poison can deadlock.
- **F4 — Truthful auth-error copy.** setup_token 401 no longer claims "API key might be wrong".
- **F5 — Caching.** Recent Sessions moved from the cached `stable` block to the uncached `dynamic` block so session rotation stops busting the ~60 KB stable-prompt cache.
- **BAT-1123 (bundled):** `cc_version` 2.1.116 → **2.1.195** on the setup_token billing header (verified HTTP 200 via `testing/test-cc-version.js`). **No app version bump** — not releasing yet.

**Constraints:** no schema change, no memory-format change, fail-safe (query error → `[]`; self-heal only on the exact error signature).

## Test plan

- [x] `node tests/nodejs-project/recent-sessions-heartbeat-filter.test.js` — F2 filter — passed
- [x] `node tests/nodejs-project/system-prompt-recent-sessions.test.js` — F5 placement + F3 leanMemory + `_isUsageFilter400` — passed
- [x] `node tests/nodejs-project/system-prompt-wallets.test.js` + `idle-summary-timers.test.js` — no regression — passed
- [x] `node tests/nodejs-project/ci-coverage-manifest.test.js` — new tests registered — passed
- [x] `bash scripts/pre-push-check.sh` — Node smoke 78/78, tool schemas, wallets regression, Kotlin `BUILD SUCCESSFUL` — passed
- [ ] `testing/test-content-filter-trigger.js` (LIVE) — trigger still 400s / safe variants 200 — opt-in, bills setup_token
- [ ] **Device test** — agent recovers on-device (poison rotates via F2), heartbeats still fire, Recent Sessions still shows real conversations
- [ ] **SAB audit** — `buildSystemBlocks()` touched → run before merge

## Known limitations

- F2 identifies legacy heartbeat rows by the literal `HEARTBEAT_OK` token in the summary (the `sessions` table has no chat-id column). A real user conversation that literally contained `HEARTBEAT_OK` would also be filtered — acceptable and rare.
- 1-hour cache TTL (bigger heartbeat savings) was evaluated and deliberately **deferred** to a separate measured optimization; this PR does content-placement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pro/Max sign-in reliability and error messaging when provider setup_token fails, including an automatic one-time retry that avoids problematic session context.
  * Filtered “heartbeat acknowledgment” entries from recent sessions so they can’t reappear.
  * Refined system-prompt caching behavior to exclude volatile recent-activity context; updated reported client version for Pro/Max requests.
* **New Features**
  * Added “lean memory” prompt handling to support safer retries.
* **Tests**
  * Added/expanded regression scripts and coverage for recent-sessions filtering, cache behavior, prompt construction, and content-filter 400 “extra usage” failures.
* **Documentation**
  * Added a living incident log describing the failure and mitigation playbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->