### PR TITLE
test: add remaining setup_token diagnostic probes + gitignore JVM crash dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ tests/jupiter-ultra/fixtures/v2-flow-*.json
 tests/jupiter-ultra/node_modules/
 tests/jupiter-ultra/package-lock.json.local-backup
 tests/jupiter-ultra/package.json.local-backup
+
+# JVM crash dumps (from local Gradle/Android Studio builds)
+hs_err_pid*.log
+replay_pid*.log

--- a/testing/test-cc-bigrequest.js
+++ b/testing/test-cc-bigrequest.js
@@ -7,12 +7,12 @@
 // Run: node testing/test-cc-bigrequest.js
 'use strict';
 const https = require('https');
-const { loadEnv } = require('./lib');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
-const CC = process.env.CC_VER || '2.1.116';
-const billing = `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;`;
+const CC = process.env.CC_VER; // override only; default = the shipped CC_BILLING_HEADER
+const billing = CC ? `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;` : CC_BILLING_HEADER;
 const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // the agent's actual model
 
 function post(token, body) {

--- a/testing/test-cc-bigrequest.js
+++ b/testing/test-cc-bigrequest.js
@@ -45,7 +45,8 @@ async function run(label, token, { tools, maxTokens, sysPad }) {
     if (tools) body.tools = makeTools(tools);
     const payloadSize = JSON.stringify(body).length;
     const r = await post(token, body);
-    const errMsg = r.data?.error ? `${r.data.error.type}: ${r.data.error.message}` : '';
+    const errMsg = r.data?.error ? `${r.data.error.type}: ${r.data.error.message}`
+        : (r.status !== 200 ? `HTTP ${r.status}: ${(typeof r.data === 'string' ? r.data : JSON.stringify(r.data)).slice(0, 90)}` : '');
     const text = !r.data?.error && Array.isArray(r.data?.content) ? r.data.content.filter((b) => b.type === 'text').map((b) => b.text).join(' ') : '';
     console.log(`${label.padEnd(28)} payload=${String(payloadSize).padStart(7)}B tools=${tools || 0}  → ${r.status} ${errMsg ? '❌ ' + errMsg.slice(0, 90) : '✅ "' + text.slice(0, 40) + '"'}`);
     return r.status;

--- a/testing/test-cc-bigrequest.js
+++ b/testing/test-cc-bigrequest.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// test-cc-bigrequest.js — recreate the agent's "out of extra usage" condition.
+// The device log showed the agent failing on ~110K-byte payloads with 64 tools
+// on claude-sonnet-4-6, while a tiny probe succeeds. This sends a SMALL control
+// then a BIG (agent-sized) request on the same model + setup_token, to see if
+// request size / usage is what trips it.
+// Run: node testing/test-cc-bigrequest.js
+'use strict';
+const https = require('https');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+const CC = process.env.CC_VER || '2.1.116';
+const billing = `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;`;
+const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // the agent's actual model
+
+function post(token, body) {
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${token}` } },
+            (rp) => { let d = ''; rp.on('data', (c) => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(90000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(body)); r.end();
+    });
+}
+
+// Bulk a request to ~agent size: N tools with padded schemas + a big system block.
+function makeTools(n) {
+    const pad = 'Detailed behavior notes and usage guidance for this capability. '.repeat(16); // ~1KB
+    return Array.from({ length: n }, (_, i) => ({
+        name: `capability_${i}`,
+        description: `Capability #${i}. ${pad}`,
+        input_schema: { type: 'object', properties: { query: { type: 'string', description: pad }, options: { type: 'string', description: pad } }, required: ['query'] },
+    }));
+}
+
+async function run(label, token, { tools, maxTokens, sysPad }) {
+    const body = {
+        model: MODEL, max_tokens: maxTokens, stream: false,
+        system: [{ type: 'text', text: billing }, { type: 'text', text: ('You are a helpful assistant with many tools. ').repeat(sysPad) }],
+        messages: [{ role: 'user', content: 'Hey' }],
+    };
+    if (tools) body.tools = makeTools(tools);
+    const payloadSize = JSON.stringify(body).length;
+    const r = await post(token, body);
+    const errMsg = r.data?.error ? `${r.data.error.type}: ${r.data.error.message}` : '';
+    const text = !r.data?.error && Array.isArray(r.data?.content) ? r.data.content.filter((b) => b.type === 'text').map((b) => b.text).join(' ') : '';
+    console.log(`${label.padEnd(28)} payload=${String(payloadSize).padStart(7)}B tools=${tools || 0}  → ${r.status} ${errMsg ? '❌ ' + errMsg.slice(0, 90) : '✅ "' + text.slice(0, 40) + '"'}`);
+    return r.status;
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
+    console.log(`🧪 Recreate agent usage condition — model=${MODEL}, cc_version=${CC}\n`);
+    await run('SMALL (control)', token, { tools: 0, maxTokens: 128, sysPad: 1 });
+    await new Promise((r) => setTimeout(r, 1200));
+    await run('BIG (agent-sized, 64 tools)', token, { tools: 64, maxTokens: 4096, sysPad: 400 });
+    console.log('\nIf BIG → 400 "out of extra usage" but SMALL → 200: request size/usage is the trigger (account near its cap).');
+})();

--- a/testing/test-cc-bigrequest.js
+++ b/testing/test-cc-bigrequest.js
@@ -13,6 +13,7 @@ loadEnv();
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
 const CC = process.env.CC_VER; // override only; default = the shipped CC_BILLING_HEADER
 const billing = CC ? `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;` : CC_BILLING_HEADER;
+const EFFECTIVE_CC = (billing.match(/cc_version=([^;]+)/) || [])[1] || '(unknown)'; // what actually goes on the wire
 const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // the agent's actual model
 
 function post(token, body) {
@@ -53,7 +54,7 @@ async function run(label, token, { tools, maxTokens, sysPad }) {
 (async () => {
     const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
     if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
-    console.log(`🧪 Recreate agent usage condition — model=${MODEL}, cc_version=${CC}\n`);
+    console.log(`🧪 Recreate agent usage condition — model=${MODEL}, cc_version=${EFFECTIVE_CC}\n`);
     await run('SMALL (control)', token, { tools: 0, maxTokens: 128, sysPad: 1 });
     await new Promise((r) => setTimeout(r, 1200));
     await run('BIG (agent-sized, 64 tools)', token, { tools: 64, maxTokens: 4096, sysPad: 400 });

--- a/testing/test-cc-fullresponse.js
+++ b/testing/test-cc-fullresponse.js
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
 // test-cc-fullresponse.js — does the setup_token path return a REAL answer
 // (not just a 200)? Dumps the full response: status, error, content text,
-// stop_reason, usage. Tests the CURRENTLY-SHIPPED cc_version=2.1.116.
+// stop_reason, usage. Uses the shipped CC_BILLING_HEADER (currently cc_version
+// 2.1.195) by default; override with CC_VER to probe another version.
 // Run: node testing/test-cc-fullresponse.js
 'use strict';
 const https = require('https');
-const { loadEnv } = require('./lib');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
-const CC = process.env.CC_VER || '2.1.116';
-const billing = `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;`;
+const CC = process.env.CC_VER; // override only; default = the shipped CC_BILLING_HEADER
+const billing = CC ? `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;` : CC_BILLING_HEADER;
 const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
 
 function post(token, body) {

--- a/testing/test-cc-fullresponse.js
+++ b/testing/test-cc-fullresponse.js
@@ -12,6 +12,7 @@ loadEnv();
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
 const CC = process.env.CC_VER; // override only; default = the shipped CC_BILLING_HEADER
 const billing = CC ? `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;` : CC_BILLING_HEADER;
+const EFFECTIVE_CC = (billing.match(/cc_version=([^;]+)/) || [])[1] || '(unknown)'; // what actually goes on the wire
 const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
 
 function post(token, body) {
@@ -27,7 +28,7 @@ function post(token, body) {
 (async () => {
     const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
     if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
-    console.log(`🧪 Full-response check — setup_token, cc_version=${CC}\n`);
+    console.log(`🧪 Full-response check — setup_token, cc_version=${EFFECTIVE_CC}\n`);
     for (const model of MODELS) {
         const r = await post(token, {
             model, max_tokens: 256, stream: false,

--- a/testing/test-cc-fullresponse.js
+++ b/testing/test-cc-fullresponse.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// test-cc-fullresponse.js — does the setup_token path return a REAL answer
+// (not just a 200)? Dumps the full response: status, error, content text,
+// stop_reason, usage. Tests the CURRENTLY-SHIPPED cc_version=2.1.116.
+// Run: node testing/test-cc-fullresponse.js
+'use strict';
+const https = require('https');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+const CC = process.env.CC_VER || '2.1.116';
+const billing = `x-anthropic-billing-header: cc_version=${CC}; cc_entrypoint=cli; cch=00000;`;
+const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
+
+function post(token, body) {
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${token}` } },
+            (rp) => { let d = ''; rp.on('data', (c) => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(60000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(body)); r.end();
+    });
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
+    console.log(`🧪 Full-response check — setup_token, cc_version=${CC}\n`);
+    for (const model of MODELS) {
+        const r = await post(token, {
+            model, max_tokens: 256, stream: false,
+            system: [{ type: 'text', text: billing }, { type: 'text', text: 'You are a helpful assistant.' }],
+            messages: [{ role: 'user', content: 'What is 2+2? Reply in one short sentence.' }],
+        });
+        console.log(`=== ${model} ===`);
+        console.log(`  status: ${r.status}`);
+        if (r.data?.error) { console.log(`  ERROR: ${JSON.stringify(r.data.error)}`); }
+        else {
+            const blocks = Array.isArray(r.data?.content) ? r.data.content : [];
+            const text = blocks.filter((b) => b.type === 'text').map((b) => b.text).join(' ');
+            console.log(`  block types: [${blocks.map((b) => b.type).join(',')}]`);
+            console.log(`  TEXT: "${(text || '').slice(0, 200)}"`);
+            console.log(`  stop_reason: ${r.data?.stop_reason} | usage: in=${r.data?.usage?.input_tokens} out=${r.data?.usage?.output_tokens}`);
+        }
+        console.log('');
+        await new Promise((res) => setTimeout(res, 800));
+    }
+})();

--- a/testing/test-cc-version.js
+++ b/testing/test-cc-version.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// test-cc-version.js — verify a cc_version bump for the setup_token billing
+// masquerade BEFORE shipping it. Replicates exactly what SeekerClaw sends on the
+// setup_token path (Authorization: Bearer + oauth/interleaved betas + the
+// `x-anthropic-billing-header` cc_version as a SYSTEM BLOCK), and checks that
+// the target cc_version is accepted (HTTP 200) on our non-Haiku models.
+//
+// Current shipped: cc_version=2.1.116. Candidate: 2.1.195 (Claude Code stable).
+//
+// Setup: SETUP_TOKEN=sk-ant-oat01-… in testing/.env   Run: node testing/test-cc-version.js
+'use strict';
+
+const https = require('https');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+const CC_VERSIONS = (process.env.CC_VERSIONS && process.env.CC_VERSIONS.trim())
+    ? process.env.CC_VERSIONS.split(',').map((s) => s.trim())
+    : ['2.1.116', '2.1.195']; // control (shipped) + candidate (stable)
+const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
+
+const billingHeader = (ver) => `x-anthropic-billing-header: cc_version=${ver}; cc_entrypoint=cli; cch=00000;`;
+
+function httpPost(token, bodyObj) {
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${token}` },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } resolve({ status: res.statusCode, data: p }); }); });
+        req.on('error', reject); req.setTimeout(60000, () => req.destroy(new Error('timeout')));
+        req.write(JSON.stringify(bodyObj)); req.end();
+    });
+}
+
+async function probe(model, token, ccVersion) {
+    const r = await httpPost(token, {
+        model, max_tokens: 64, stream: false,
+        system: [{ type: 'text', text: billingHeader(ccVersion) }, { type: 'text', text: 'You are a helpful assistant.' }],
+        messages: [{ role: 'user', content: 'Say hi in exactly one word.' }],
+    });
+    if (r.status === 200) return '200 ✅';
+    const m = r.data?.error?.message || JSON.stringify(r.data);
+    return `${r.status} ❌ ${m.slice(0, 70)}`;
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ Set SETUP_TOKEN in testing/.env'); process.exit(1); }
+    console.log('🧪 cc_version acceptance check (setup_token path, real billing-header format)\n');
+    console.log('cc_version'.padEnd(12) + MODELS.map((m) => m.padEnd(22)).join(''));
+    console.log('─'.repeat(12 + MODELS.length * 22));
+    for (const ver of CC_VERSIONS) {
+        const cells = [];
+        for (const model of MODELS) { cells.push(await probe(model, token, ver)); await new Promise((r) => setTimeout(r, 900)); }
+        console.log(ver.padEnd(12) + cells.map((c) => c.padEnd(22)).join(''));
+    }
+    console.log('\n→ candidate 2.1.195 must be 200 on both models to be safe to ship.');
+})();

--- a/testing/test-cc-version.js
+++ b/testing/test-cc-version.js
@@ -18,9 +18,9 @@ loadEnv();
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
 // Current shipped value — parsed from CC_BILLING_HEADER so there's ONE source of truth.
 const SHIPPED_CC = (CC_BILLING_HEADER.match(/cc_version=([^;]+)/) || [])[1] || '2.1.195';
-const CC_VERSIONS = (process.env.CC_VERSIONS && process.env.CC_VERSIONS.trim())
-    ? process.env.CC_VERSIONS.split(',').map((s) => s.trim())
-    : ['2.1.116', SHIPPED_CC]; // legacy control + current shipped (from CC_BILLING_HEADER)
+// Parse the override, dropping blanks (a trailing/double comma must not send cc_version=).
+const parsedCC = (process.env.CC_VERSIONS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const CC_VERSIONS = parsedCC.length ? parsedCC : ['2.1.116', SHIPPED_CC]; // else: legacy control + current shipped (from CC_BILLING_HEADER)
 const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
 
 const billingHeader = (ver) => `x-anthropic-billing-header: cc_version=${ver}; cc_entrypoint=cli; cch=00000;`;

--- a/testing/test-cc-version.js
+++ b/testing/test-cc-version.js
@@ -12,13 +12,15 @@
 'use strict';
 
 const https = require('https');
-const { loadEnv } = require('./lib');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+// Current shipped value — parsed from CC_BILLING_HEADER so there's ONE source of truth.
+const SHIPPED_CC = (CC_BILLING_HEADER.match(/cc_version=([^;]+)/) || [])[1] || '2.1.195';
 const CC_VERSIONS = (process.env.CC_VERSIONS && process.env.CC_VERSIONS.trim())
     ? process.env.CC_VERSIONS.split(',').map((s) => s.trim())
-    : ['2.1.116', '2.1.195']; // legacy control + current shipped (keep 2nd in sync with CC_BILLING_HEADER)
+    : ['2.1.116', SHIPPED_CC]; // legacy control + current shipped (from CC_BILLING_HEADER)
 const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
 
 const billingHeader = (ver) => `x-anthropic-billing-header: cc_version=${ver}; cc_entrypoint=cli; cch=00000;`;
@@ -56,5 +58,5 @@ async function probe(model, token, ccVersion) {
         for (const model of MODELS) { cells.push(await probe(model, token, ver)); await new Promise((r) => setTimeout(r, 900)); }
         console.log(ver.padEnd(12) + cells.map((c) => c.padEnd(22)).join(''));
     }
-    console.log('\n→ each cc_version must be 200 on both models; 2.1.195 is the current shipped value.');
+    console.log(`\n→ each cc_version must be 200 on both models; ${SHIPPED_CC} is the current shipped value.`);
 })();

--- a/testing/test-cc-version.js
+++ b/testing/test-cc-version.js
@@ -16,7 +16,8 @@ const { loadEnv, CC_BILLING_HEADER } = require('./lib');
 loadEnv();
 
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
-// Current shipped value — parsed from CC_BILLING_HEADER so there's ONE source of truth.
+// Current shipped value — read from the testing helper's CC_BILLING_HEADER (testing/lib.js,
+// a mirror of providers/claude.js kept in sync) so this probe list has one place to update.
 const SHIPPED_CC = (CC_BILLING_HEADER.match(/cc_version=([^;]+)/) || [])[1] || '2.1.195';
 // Parse the override, dropping blanks (a trailing/double comma must not send cc_version=).
 const parsedCC = (process.env.CC_VERSIONS || '').split(',').map((s) => s.trim()).filter(Boolean);

--- a/testing/test-cc-version.js
+++ b/testing/test-cc-version.js
@@ -5,7 +5,8 @@
 // `x-anthropic-billing-header` cc_version as a SYSTEM BLOCK), and checks that
 // the target cc_version is accepted (HTTP 200) on our non-Haiku models.
 //
-// Current shipped: cc_version=2.1.116. Candidate: 2.1.195 (Claude Code stable).
+// Legacy control: cc_version=2.1.116. Current shipped: 2.1.195 (BAT-1123 — see
+// providers/claude.js CC_BILLING_HEADER). Override the pair via CC_VERSIONS.
 //
 // Setup: SETUP_TOKEN=sk-ant-oat01-… in testing/.env   Run: node testing/test-cc-version.js
 'use strict';
@@ -17,7 +18,7 @@ loadEnv();
 const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
 const CC_VERSIONS = (process.env.CC_VERSIONS && process.env.CC_VERSIONS.trim())
     ? process.env.CC_VERSIONS.split(',').map((s) => s.trim())
-    : ['2.1.116', '2.1.195']; // control (shipped) + candidate (stable)
+    : ['2.1.116', '2.1.195']; // legacy control + current shipped (keep 2nd in sync with CC_BILLING_HEADER)
 const MODELS = ['claude-sonnet-5', 'claude-opus-4-8'];
 
 const billingHeader = (ver) => `x-anthropic-billing-header: cc_version=${ver}; cc_entrypoint=cli; cch=00000;`;
@@ -55,5 +56,5 @@ async function probe(model, token, ccVersion) {
         for (const model of MODELS) { cells.push(await probe(model, token, ver)); await new Promise((r) => setTimeout(r, 900)); }
         console.log(ver.padEnd(12) + cells.map((c) => c.padEnd(22)).join(''));
     }
-    console.log('\n→ candidate 2.1.195 must be 200 on both models to be safe to ship.');
+    console.log('\n→ each cc_version must be 200 on both models; 2.1.195 is the current shipped value.');
 })();

--- a/testing/test-recreate-agent.js
+++ b/testing/test-recreate-agent.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// test-recreate-agent.js — recreate the agent's EXACT request using SeekerClaw's
+// own request builders (formatSystemPrompt + formatTools + formatRequest from
+// providers/claude.js — the same calls ai.js:2433/2510/2689 make on a real turn),
+// at the agent's real size, via the setup_token. Sends TWICE with a CHANGING
+// dynamic block (mimicking the per-turn burner snapshot / timestamps) to measure
+// whether the 64 tools actually cache — the crux of the ~26K-uncached-per-turn burn.
+//
+// Compare against the device DB: input_tokens ~26K, cache_read_tokens ~8192.
+// Run: node testing/test-recreate-agent.js
+'use strict';
+
+const path = require('path');
+const https = require('https');
+
+// Stub config.js (claude.js + reasoning-gating require it) before load.
+const configPath = path.resolve(__dirname, '../app/src/main/assets/nodejs-project/config.js');
+require.cache[configPath] = { id: configPath, filename: configPath, loaded: true,
+    exports: { log: () => {}, CHANNEL: 'telegram', config: {}, API_TIMEOUT_MS: 60000 } };
+const claude = require('../app/src/main/assets/nodejs-project/providers/claude');
+const { loadEnv } = require('./lib');
+loadEnv();
+
+const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // the agent's actual model
+const THINK = process.env.THINK === 'on';
+
+// ---- build an agent-sized payload -------------------------------------------
+// Stable system (~8K tokens ⇒ the cached prefix). Realistic prose, ~4 chars/token.
+const STABLE = ('You are a capable on-device personal AI agent running inside a mobile app. '
+    + 'You have tools for messaging, memory, files, skills, cron, wallet and web access. '
+    + 'Follow the safety, confirmation-gate, and reply-formatting rules precisely. ').repeat(360);
+
+// Dynamic block (changes every turn — burner snapshot, timestamps). This sits
+// BETWEEN the cached stable block and the tools, which is the whole question.
+const dynamic = (seed) => `Runtime: ${seed}. Burner balance snapshot: SOL ${seed % 1000}, USDC ${seed % 500}. `
+    + `Active model: ${MODEL}. Heartbeat window token: ${seed}.`;
+
+// 64 realistic tool schemas (~18K tokens total).
+function rawTools(n) {
+    const desc = 'Detailed capability with usage guidance, safety notes, parameter semantics, and examples. '.repeat(9);
+    return Array.from({ length: n }, (_, i) => ({
+        name: `tool_${i}`,
+        description: `Tool ${i}: ${desc}`,
+        input_schema: { type: 'object', properties: {
+            query: { type: 'string', description: desc },
+            options: { type: 'string', description: desc },
+        }, required: ['query'] },
+    }));
+}
+
+const MESSAGES = [{ role: 'user', content: 'Hey' }];
+const REQ_OPTS = THINK ? { reasoningEnabled: true, reasoningSupport: 'yes' } : { reasoningEnabled: false, reasoningSupport: 'no' };
+
+function buildBody(seed) {
+    const systemBlocks = claude.formatSystemPrompt(STABLE, dynamic(seed), 'setup_token'); // [billing, stable+cache, dynamic]
+    const tools = claude.formatTools(rawTools(64)); // cache_control on last tool
+    const bodyStr = claude.formatRequest(MODEL, 4096, systemBlocks, MESSAGES, tools, REQ_OPTS);
+    const body = JSON.parse(bodyStr);
+    body.stream = false; // easier usage read; does NOT affect caching or billing
+    return body;
+}
+
+function post(token, bodyObj) {
+    const headers = claude.buildHeaders(token, 'setup_token'); // exact betas + Authorization
+    return new Promise((res, rej) => {
+        const r = https.request({ hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST', headers },
+            (rp) => { let d = ''; rp.on('data', (c) => d += c); rp.on('end', () => { let p; try { p = JSON.parse(d); } catch { p = d; } res({ status: rp.statusCode, data: p }); }); });
+        r.on('error', rej); r.setTimeout(90000, () => r.destroy(new Error('timeout')));
+        r.write(JSON.stringify(bodyObj)); r.end();
+    });
+}
+
+async function send(label, token, seed) {
+    const body = buildBody(seed);
+    const payloadSize = JSON.stringify(body).length;
+    const r = await post(token, body);
+    const u = r.data?.usage || {};
+    if (r.data?.error) { console.log(`${label}  payload=${payloadSize}B → ${r.status} ❌ ${r.data.error.type}: ${(r.data.error.message || '').slice(0, 80)}`); return r.status; }
+    console.log(`${label}  payload=${payloadSize}B → ${r.status} | input(non-cached)=${u.input_tokens} cache_write=${u.cache_creation_input_tokens} cache_read=${u.cache_read_input_tokens} out=${u.output_tokens}`);
+    return r.status;
+}
+
+(async () => {
+    const token = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+    if (!token) { console.error('❌ no SETUP_TOKEN'); process.exit(1); }
+    console.log(`🧪 Recreate agent request — model=${MODEL}, /think=${THINK ? 'on' : 'off'}, SeekerClaw's own builders\n`);
+    console.log('Device DB reference: input≈26,000  cache_read≈8,192  (tools NOT cached)\n');
+    await send('REQ 1 (dyn=A, cold)  ', token, 1001);
+    await new Promise((r) => setTimeout(r, 1500));
+    await send('REQ 2 (dyn=B, changed)', token, 2002);
+    console.log('\nIf REQ 2 cache_read ≈ stable only (~8K) while input ≈ tools (~18-26K):');
+    console.log('→ the dynamic block between stable-cache and tools INVALIDATES the tool cache — exactly the agent pattern.');
+})();

--- a/testing/test-recreate-agent.js
+++ b/testing/test-recreate-agent.js
@@ -25,7 +25,9 @@ const MODEL = process.env.TEST_MODEL || 'claude-sonnet-4-6'; // the agent's actu
 const THINK = process.env.THINK === 'on';
 
 // ---- build an agent-sized payload -------------------------------------------
-// Stable system (~8K tokens ⇒ the cached prefix). Realistic prose, ~4 chars/token.
+// Stable system (~21K tokens; realistic prose, ~4 chars/token) ⇒ becomes the cached
+// prefix. Larger than the device's ~8K cached prefix, but size isn't the point here —
+// the diagnostic is whether cache_read tracks stable-only vs stable+tools (see below).
 const STABLE = ('You are a capable on-device personal AI agent running inside a mobile app. '
     + 'You have tools for messaging, memory, files, skills, cron, wallet and web access. '
     + 'Follow the safety, confirmation-gate, and reply-formatting rules precisely. ').repeat(360);
@@ -88,6 +90,6 @@ async function send(label, token, seed) {
     await send('REQ 1 (dyn=A, cold)  ', token, 1001);
     await new Promise((r) => setTimeout(r, 1500));
     await send('REQ 2 (dyn=B, changed)', token, 2002);
-    console.log('\nIf REQ 2 cache_read ≈ stable only (~8K) while input ≈ tools (~18-26K):');
+    console.log('\nIf REQ 2 cache_read ≈ stable only (~21K) while input ≈ tools (~18K):');
     console.log('→ the dynamic block between stable-cache and tools INVALIDATES the tool cache — exactly the agent pattern.');
 })();

--- a/testing/test-recreate-agent.js
+++ b/testing/test-recreate-agent.js
@@ -77,7 +77,11 @@ async function send(label, token, seed) {
     const payloadSize = JSON.stringify(body).length;
     const r = await post(token, body);
     const u = r.data?.usage || {};
-    if (r.data?.error) { console.log(`${label}  payload=${payloadSize}B → ${r.status} ❌ ${r.data.error.type}: ${(r.data.error.message || '').slice(0, 80)}`); return r.status; }
+    if (r.data?.error || r.status !== 200) {
+        const detail = r.data?.error ? `${r.data.error.type}: ${(r.data.error.message || '').slice(0, 80)}`
+            : (typeof r.data === 'string' ? r.data : JSON.stringify(r.data)).slice(0, 120); // non-JSON/HTML error body
+        console.log(`${label}  payload=${payloadSize}B → ${r.status} ❌ ${detail}`); return r.status;
+    }
     console.log(`${label}  payload=${payloadSize}B → ${r.status} | input(non-cached)=${u.input_tokens} cache_write=${u.cache_creation_input_tokens} cache_read=${u.cache_read_input_tokens} out=${u.output_tokens}`);
     return r.status;
 }

--- a/testing/test-recreate-failure.js
+++ b/testing/test-recreate-failure.js
@@ -70,9 +70,11 @@ function post(token, body) {
     console.log(`token …${token.slice(-6)}  model=${MODEL}  payload=${JSON.stringify(sample).length}B (device failing turn=${TARGET_BYTES}B)  tools=64\n`);
     for (const [label, seed] of [['SEND 1 (cold)', 7001], ['SEND 2 (same bytes)', 7001]]) {
         const r = await post(token, build(seed));
-        if (r.data?.error) {
-            console.log(`${label} → ${r.status} ❌ ${r.data.error.type}: "${r.data.error.message}"`);
-            if (/extra usage|usage/i.test(r.data.error.message || '')) console.log('   ✅ RECREATED — identical to the device error.');
+        if (r.data?.error || r.status !== 200) {
+            const msg = r.data?.error ? `${r.data.error.type}: "${r.data.error.message}"`
+                : (typeof r.data === 'string' ? r.data : JSON.stringify(r.data)).slice(0, 120); // non-JSON/HTML error body
+            console.log(`${label} → ${r.status} ❌ ${msg}`);
+            if (/extra usage|usage/i.test(r.data?.error?.message || '')) console.log('   ✅ RECREATED — identical to the device error.');
         } else {
             const u = r.data.usage || {};
             console.log(`${label} → ${r.status} ✅ input=${u.input_tokens} cache_write=${u.cache_creation_input_tokens} cache_read=${u.cache_read_input_tokens} out=${u.output_tokens}`);

--- a/testing/test-sse-dump.js
+++ b/testing/test-sse-dump.js
@@ -24,6 +24,7 @@ const req = https.request({
     hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
     headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${TOKEN}` },
 }, (res) => {
+    res.setEncoding('utf8'); // decode UTF-8 across chunk boundaries so a split multibyte char can't corrupt JSON
     if (res.statusCode !== 200) { let e = ''; res.on('data', (c) => e += c); res.on('end', () => console.error(`❌ HTTP ${res.statusCode}: ${e.slice(0, 300)}`)); return; }
     let buf = ''; // hold partial lines across chunks → truly incremental parse
     res.on('data', (chunk) => {

--- a/testing/test-sse-dump.js
+++ b/testing/test-sse-dump.js
@@ -1,0 +1,12 @@
+const https=require('https');const {loadEnv,CC_BILLING_HEADER}=require('./lib');loadEnv();
+const t=process.env.SETUP_TOKEN||process.env.ANTHROPIC_SETUP_TOKEN;
+const body=JSON.stringify({model:'claude-sonnet-5',max_tokens:2048,stream:true,
+  system:[{type:'text',text:CC_BILLING_HEADER},{type:'text',text:'Use tools when appropriate.'}],
+  tools:[{name:'get_weather',description:'Weather',input_schema:{type:'object',properties:{city:{type:'string'}},required:['city']}}],
+  messages:[{role:'user',content:'Weather in Tbilisi? Use get_weather then tell me.'}]});
+const req=https.request({hostname:'api.anthropic.com',path:'/v1/messages',method:'POST',headers:{'Content-Type':'application/json','anthropic-version':'2023-06-01','anthropic-beta':'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14','Authorization':`Bearer ${t}`}},res=>{let buf='';res.on('data',c=>buf+=c);res.on('end',()=>{
+  for(const line of buf.split('\n')){if(!line.startsWith('data:'))continue;const j=line.slice(5).trim();if(j==='[DONE]')continue;let p;try{p=JSON.parse(j)}catch{continue}
+    if(p.type==='content_block_start'&&p.content_block&&(p.content_block.type==='thinking'||p.content_block.type==='redacted_thinking'))console.log('START idx',p.index,JSON.stringify(p.content_block));
+    if(p.type==='content_block_delta'&&/thinking|signature/.test(p.delta?.type||''))console.log('DELTA idx',p.index,p.delta.type,JSON.stringify(p.delta).slice(0,80));
+  }});});
+req.end(body);

--- a/testing/test-sse-dump.js
+++ b/testing/test-sse-dump.js
@@ -1,12 +1,49 @@
-const https=require('https');const {loadEnv,CC_BILLING_HEADER}=require('./lib');loadEnv();
-const t=process.env.SETUP_TOKEN||process.env.ANTHROPIC_SETUP_TOKEN;
-const body=JSON.stringify({model:'claude-sonnet-5',max_tokens:2048,stream:true,
-  system:[{type:'text',text:CC_BILLING_HEADER},{type:'text',text:'Use tools when appropriate.'}],
-  tools:[{name:'get_weather',description:'Weather',input_schema:{type:'object',properties:{city:{type:'string'}},required:['city']}}],
-  messages:[{role:'user',content:'Weather in Tbilisi? Use get_weather then tell me.'}]});
-const req=https.request({hostname:'api.anthropic.com',path:'/v1/messages',method:'POST',headers:{'Content-Type':'application/json','anthropic-version':'2023-06-01','anthropic-beta':'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14','Authorization':`Bearer ${t}`}},res=>{let buf='';res.on('data',c=>buf+=c);res.on('end',()=>{
-  for(const line of buf.split('\n')){if(!line.startsWith('data:'))continue;const j=line.slice(5).trim();if(j==='[DONE]')continue;let p;try{p=JSON.parse(j)}catch{continue}
-    if(p.type==='content_block_start'&&p.content_block&&(p.content_block.type==='thinking'||p.content_block.type==='redacted_thinking'))console.log('START idx',p.index,JSON.stringify(p.content_block));
-    if(p.type==='content_block_delta'&&/thinking|signature/.test(p.delta?.type||''))console.log('DELTA idx',p.index,p.delta.type,JSON.stringify(p.delta).slice(0,80));
-  }});});
+#!/usr/bin/env node
+// test-sse-dump.js — raw SSE event dump for the Claude setup_token stream.
+// Prints thinking / signature content-block events AS THEY ARRIVE (incremental,
+// not buffered) so you can watch the wire during live debugging (the BAT-1033
+// signature-drop class). LIVE — needs SETUP_TOKEN in testing/.env.
+// Run: node testing/test-sse-dump.js
+'use strict';
+const https = require('https');
+const { loadEnv, CC_BILLING_HEADER } = require('./lib');
+loadEnv();
+
+const TOKEN = process.env.SETUP_TOKEN || process.env.ANTHROPIC_SETUP_TOKEN;
+if (!TOKEN) { console.error('❌ SETUP_TOKEN (or ANTHROPIC_SETUP_TOKEN) required in testing/.env'); process.exit(1); }
+
+const BETA = 'prompt-caching-2024-07-31,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+const body = JSON.stringify({
+    model: process.env.TEST_MODEL || 'claude-sonnet-5', max_tokens: 2048, stream: true,
+    system: [{ type: 'text', text: CC_BILLING_HEADER }, { type: 'text', text: 'Use tools when appropriate.' }],
+    tools: [{ name: 'get_weather', description: 'Weather', input_schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] } }],
+    messages: [{ role: 'user', content: 'Weather in Tbilisi? Use get_weather then tell me.' }],
+});
+
+const req = https.request({
+    hostname: 'api.anthropic.com', path: '/v1/messages', method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01', 'anthropic-beta': BETA, 'Authorization': `Bearer ${TOKEN}` },
+}, (res) => {
+    if (res.statusCode !== 200) { let e = ''; res.on('data', (c) => e += c); res.on('end', () => console.error(`❌ HTTP ${res.statusCode}: ${e.slice(0, 300)}`)); return; }
+    let buf = ''; // hold partial lines across chunks → truly incremental parse
+    res.on('data', (chunk) => {
+        buf += chunk;
+        let nl;
+        while ((nl = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.startsWith('data:')) continue;
+            const j = line.slice(5).trim(); if (!j || j === '[DONE]') continue;
+            let p; try { p = JSON.parse(j); } catch { continue; }
+            if (p.type === 'content_block_start' && p.content_block && (p.content_block.type === 'thinking' || p.content_block.type === 'redacted_thinking')) {
+                console.log('START idx', p.index, JSON.stringify(p.content_block));
+            }
+            if (p.type === 'content_block_delta' && /thinking|signature/.test(p.delta?.type || '')) {
+                console.log('DELTA idx', p.index, p.delta.type, JSON.stringify(p.delta).slice(0, 80));
+            }
+        }
+    });
+    res.on('end', () => console.log('— stream ended —'));
+});
+req.on('error', (e) => { console.error('❌ request error:', e.message); process.exit(1); });
+req.setTimeout(60000, () => req.destroy(new Error('timeout')));
 req.end(body);


### PR DESCRIPTION
## Summary
Commits the leftover diagnostic scripts from the BAT-1130 / BAT-1123 investigation so the `testing/` toolkit is complete for future setup_token debugging.

All are **opt-in / LIVE** (require `SETUP_TOKEN` in `testing/.env`), **none are `*.test.js`**, and **none run in CI** (the coverage manifest only governs `tests/nodejs-project/*.test.js`):
- `test-cc-version.js` — cc_version acceptance matrix (the BAT-1123 verifier, referenced in that ticket)
- `test-cc-fullresponse.js` — setup_token full-response health probe
- `test-cc-bigrequest.js` — agent-sized-payload probe
- `test-recreate-agent.js` — agent-request recreation (cache-effectiveness)
- `test-sse-dump.js` — raw SSE event dump

Also `.gitignore` `hs_err_pid*.log` / `replay_pid*.log` (local JVM crash dumps from Gradle/Android Studio builds).

## Test plan
- [x] `node --check` on all 5 scripts — pass
- [x] No app code / no `nodejs-project/**` touched → no device impact, no smoke/coverage-manifest impact
- [ ] N/A — diagnostic scripts, exercised manually during the BAT-1130 investigation

## Notes
Pure test-tooling + gitignore. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to skip local JVM crash dump logs from Android Studio and Java runtimes.
* **Tests**
  * Added several diagnostic CLI scripts to exercise API request flows, streaming output, version checks, and large-payload scenarios.
  * Improved coverage for full-response handling and server-sent event parsing during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->