### PR TITLE
test: exact-agent-copy OpenAI live model harness (BAT-1144 Part 2)

### DIFF
--- a/tests/live/openai/.env.test.example
+++ b/tests/live/openai/.env.test.example
@@ -1,0 +1,16 @@
+# tests/live/openai/.env.test.example
+# Copy to .env.test (gitignored) and fill in AT LEAST ONE credential.
+# Tokens are NEVER printed by the harness — only present(len=N).
+
+# api_key path → api.openai.com/v1/responses
+OPENAI_API_KEY=
+
+# oauth / Codex path → chatgpt.com/backend-api/codex/responses
+# (a ChatGPT/Codex OAuth access token — the on-device "Sign in with ChatGPT" path)
+OPENAI_OAUTH_TOKEN=
+# optional — enables the adapter's 401→refresh path on the live sweep
+OPENAI_OAUTH_REFRESH=
+
+# optional — default model set to sweep (comma-separated). If unset, the harness
+# uses the model-registry.json list for each auth mode.
+# TEST_MODELS=gpt-5.4,gpt-5.5

--- a/tests/live/openai/.gitignore
+++ b/tests/live/openai/.gitignore
@@ -1,0 +1,20 @@
+# Secrets — never commit.
+.env.test
+
+# …but DO keep the documented template (the repo-root `.env.*` rule would
+# otherwise sweep it up).
+!.env.test.example
+
+# Generated per-mode fixture config + any DB/log the harness writes at runtime.
+fixtures/**/config.json
+fixtures/**/*.db
+fixtures/**/node_debug.log
+fixtures/**/node_debug.log.old
+fixtures/**/*.md
+fixtures/**/memory/
+fixtures/**/api_usage_state
+fixtures/**/agent_health_state
+fixtures/**/runtime_state.json
+fixtures/**/agent_settings.json
+fixtures/**/skills/
+fixtures/**/tasks/

--- a/tests/live/openai/README.md
+++ b/tests/live/openai/README.md
@@ -64,10 +64,14 @@ Exit: **0** whenever the sweep/self-check ran; **1** only on setup/credential/as
   `TOOLS.length`, and that the prompt reflects the **seeded mock workspace** —
   proving it's the real payload, not a fake). Prints both bodies (token-redacted).
 - `--mode apikey|oauth|both` — default: whichever creds exist.
-- `--models <csv|all|newest>` — `all` = the registry set for the mode; `newest` =
-  resolve live from `/v1/models` (live only; offline falls back to the registry
-  set); default = the registry set. **Verify live model ids** (e.g. `gpt-5.6-*`)
-  via a live `/v1/models` or context7 — do not hardcode from memory.
+- `--models <csv|all|newest>` — `all` = the registry set for the mode (ignores
+  `TEST_MODELS`); `newest` currently sweeps the registry set too, but the worker
+  fetches `/v1/models` live and prints a **registry-vs-listed diff** so newly-listed
+  ids surface for the show/hide decision. (Auto-sweeping *only* the new ids from
+  `/v1/models` is a documented follow-up — the plumbing to resolve them in the
+  parent before dispatch isn't in place yet.) Default = `TEST_MODELS` if set, else
+  the registry set. **Verify live model ids** (e.g. `gpt-5.6-*`) via a live
+  `/v1/models` or context7 — do not hardcode from memory.
 - `--diagnose` — also sweeps the reasoning-effort ladder
   `none/minimal/low/medium/high/xhigh/max`, clearly labelled **beyond agent
   parity — param exploration** (the agent only ever sends `medium/auto`). Live only.

--- a/tests/live/openai/README.md
+++ b/tests/live/openai/README.md
@@ -1,0 +1,114 @@
+# OpenAI live model probe — EXACT AGENT COPY (BAT-1144, Part 2)
+
+Hits the **live** OpenAI Responses API with **your** credential and reports, per
+model, whether it responds — but the point is _how_ it builds the request.
+
+## What "exact copy" means
+
+The xAI harness (`tests/xai-models/live-models.test.js`) imports **zero** agent
+code: it hand-fakes a short system prompt and a handful of dummy tools. That
+means a "works here / breaks on device" gap can hide in everything it faked.
+
+This harness **imports the real agent modules** and builds the wire body the
+**exact way `ai.js chat()` does** — no re-implementation:
+
+| Piece | Real module (from the device bundle) |
+|-------|--------------------------------------|
+| System prompt (~54 KB) | `ai.buildSystemBlocks()` → `{ stable, dynamic }` |
+| Prompt formatting | `providers/openai.formatSystemPrompt(stable, dynamic, AUTH_TYPE)` |
+| Tools (64, telegram channel) | `tools/index` `TOOLS` → `formatTools()` |
+| Messages | `toApiMessages(messages, model, requestOptions)` |
+| Wire body | `formatRequest(model, 4096, instructions, input, tools, requestOptions)` |
+| Transport (live) | `http.js httpOpenAIStreamingRequest(options, body)` |
+
+The only intentional difference from the device payload is **MCP tools** — the
+harness omits them (no MCP manager), so it sends the 64 built-in tools. On device
+`getTools()` returns `[...TOOLS, ...mcp]`.
+
+## One process per auth mode
+
+`providers/openai.js` freezes `isOAuth` **and** the `endpoint` object at
+module-load time from `OPENAI_AUTH_TYPE`. A single process can therefore only be
+`api_key` **or** `oauth`. The parent forks **one worker per mode**:
+
+- **api_key** → `api.openai.com` `/v1/responses` — body has `max_output_tokens`, no `store`.
+- **oauth** (Codex) → `chatgpt.com` `/backend-api/codex/responses` — body has
+  `store:false`, no `max_output_tokens`, `reasoning:{effort:'medium',summary:'auto'}`,
+  `include:['reasoning.encrypted_content']`.
+
+## Run
+
+```bash
+# OFFLINE acceptance test — no secrets, no network. This is the gate.
+node tests/live/openai/live-models.probe.js --self-check
+
+# Live sweep (needs credentials):
+cp tests/live/openai/.env.test.example tests/live/openai/.env.test
+# …edit .env.test, set OPENAI_API_KEY and/or OPENAI_OAUTH_TOKEN
+node tests/live/openai/live-models.probe.js
+
+# Options
+node tests/live/openai/live-models.probe.js --mode oauth --diagnose
+node tests/live/openai/live-models.probe.js --models gpt-5.4,gpt-5.5
+node tests/live/openai/live-models.probe.js --base-url http://127.0.0.1:8080
+node tests/live/openai/live-models.probe.js --help
+```
+
+Exit: **0** whenever the sweep/self-check ran; **1** only on setup/credential/assert error.
+
+## Flags
+
+- `--self-check` — offline. Seeds both fixtures with placeholder tokens, builds
+  the real body per mode, asserts the wire shape (endpoint, `store`/
+  `max_output_tokens`/`reasoning`/`include`, `stream:true`, tool count == real
+  `TOOLS.length`, and that the prompt reflects the **seeded mock workspace** —
+  proving it's the real payload, not a fake). Prints both bodies (token-redacted).
+- `--mode apikey|oauth|both` — default: whichever creds exist.
+- `--models <csv|all|newest>` — `all` = the registry set for the mode; `newest` =
+  resolve live from `/v1/models` (live only; offline falls back to the registry
+  set); default = the registry set. **Verify live model ids** (e.g. `gpt-5.6-*`)
+  via a live `/v1/models` or context7 — do not hardcode from memory.
+- `--diagnose` — also sweeps the reasoning-effort ladder
+  `none/minimal/low/medium/high/xhigh/max`, clearly labelled **beyond agent
+  parity — param exploration** (the agent only ever sends `medium/auto`). Live only.
+- `--base-url <url>` — gateway override for the live POST (the adapter's real
+  path is preserved).
+
+## Security
+
+- `.env.test` is gitignored. **Never commit it.** Tokens are never printed — only
+  `present(len=N)`; any secret is scrubbed from printed bodies/errors.
+- Generated `fixtures/**/config.json` + seeded workspace + `node_debug.log` are
+  gitignored. The fixture dirs are seeded at runtime by `_shared/fixture.js`.
+- Node builtins only — no `npm install`, no dependencies.
+
+## Fixtures
+
+`fixtures/{apikey,oauth}/` are per-mode workDirs. `_shared/fixture.js` writes a
+`config.json` (provider=openai, channel=telegram, the mode's auth fields, a
+canonical `bridgeToken`, a model) plus a **mock-but-realistic** workspace
+(`SOUL.md`, `IDENTITY.md` = "TestBot", `USER.md` = "Test User", `MEMORY.md`, two
+`memory/<date>.md`). All obviously synthetic — no real user data. `config.js`
+does **not** hard-require `bridgeToken` to load; it's included for realism.
+
+### DB fixture — follow-up
+
+The SQL.js **Recent-Sessions** DB is intentionally **not** seeded.
+`getRecentSessions()` returns `[]` when the DB is absent, so the system prompt
+simply omits the Recent-Sessions rollup. Seeding real rows means driving the
+SQL.js WASM loader (async) + the `api_request_log` schema — punted to a follow-up
+so the harness stays synchronous and dependency-free.
+
+## Part-1 note
+
+`_shared/` currently lives here (`tests/live/openai/_shared/`). Part 1 (repo-wide)
+will introduce a shared `tests/live/_shared/`; `env.js` + `fixture.js` move there
+then and the two `require('./_shared/…')` paths become `require('../_shared/…')`.
+
+## Notes
+
+- Real telegram tool count is **64** (no MCP). The "66" in project memory and the
+  `~67` `input_schema` string count in `tools/*.js` count schema occurrences in
+  source, which differ from the assembled runtime array — reconciling that memory
+  note is a follow-up. The harness asserts against the **live** `TOOLS.length`, so
+  it stays correct if the real count changes.

--- a/tests/live/openai/README.md
+++ b/tests/live/openai/README.md
@@ -5,9 +5,9 @@ model, whether it responds — but the point is _how_ it builds the request.
 
 ## What "exact copy" means
 
-The xAI harness (`tests/xai-models/live-models.test.js`) imports **zero** agent
-code: it hand-fakes a short system prompt and a handful of dummy tools. That
-means a "works here / breaks on device" gap can hide in everything it faked.
+Prior live harnesses fake the payload — a hand-written short system prompt and a
+handful of dummy tools. That means a "works here / breaks on device" gap can hide
+in everything they faked.
 
 This harness **imports the real agent modules** and builds the wire body the
 **exact way `ai.js chat()` does** — no re-implementation:

--- a/tests/live/openai/README.md
+++ b/tests/live/openai/README.md
@@ -39,7 +39,9 @@ module-load time from `OPENAI_AUTH_TYPE`. A single process can therefore only be
 ## Run
 
 ```bash
-# OFFLINE acceptance test — no secrets, no network. This is the gate.
+# OFFLINE acceptance test — no secrets, no OpenAI/external network. This is the gate.
+# (buildSystemBlocks fires a fire-and-forget localhost /burner/status probe that fails
+#  silently with no bridge server, so it's "no external network", not literally no sockets.)
 node tests/live/openai/live-models.probe.js --self-check
 
 # Live sweep (needs credentials):

--- a/tests/live/openai/_shared/env.js
+++ b/tests/live/openai/_shared/env.js
@@ -15,7 +15,7 @@ const fs = require('fs');
  *
  * @param {string} filePath absolute path to .env.test
  * @param {{assign?: boolean}} [opts] if assign (default true), copies parsed
- *        keys into process.env when not already set (mirrors the xai harness).
+ *        keys into process.env when not already set.
  * @returns {{loaded: boolean, values: Object<string,string>}}
  */
 function loadEnvTest(filePath, { assign = true } = {}) {

--- a/tests/live/openai/_shared/env.js
+++ b/tests/live/openai/_shared/env.js
@@ -1,0 +1,61 @@
+// tests/live/openai/_shared/env.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Hand-rolled .env.test parser + secret redaction. Node builtins only (no dotenv).
+//
+// PART-1 NOTE: this lives under tests/live/openai/_shared/ for now. Part 1
+// (repo-wide) will move the shared bits to tests/live/_shared/. Keep the API
+// small (loadEnvTest / redact / redactIn) so the move is a path change only.
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Parse a KEY=VALUE .env file. Ignores blank lines and #-comments. Strips one
+ * layer of matching single/double quotes. Never throws on a missing file.
+ *
+ * @param {string} filePath absolute path to .env.test
+ * @param {{assign?: boolean}} [opts] if assign (default true), copies parsed
+ *        keys into process.env when not already set (mirrors the xai harness).
+ * @returns {{loaded: boolean, values: Object<string,string>}}
+ */
+function loadEnvTest(filePath, { assign = true } = {}) {
+    const values = {};
+    if (!filePath || !fs.existsSync(filePath)) return { loaded: false, values };
+    for (const line of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+        const t = line.trim();
+        if (!t || t.startsWith('#')) continue;
+        const eq = t.indexOf('=');
+        if (eq < 0) continue;
+        const k = t.slice(0, eq).trim();
+        let v = t.slice(eq + 1).trim();
+        if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+            v = v.slice(1, -1);
+        }
+        values[k] = v;
+        if (assign && !(k in process.env)) process.env[k] = v;
+    }
+    return { loaded: true, values };
+}
+
+/** Redact a single token to a length-only witness. Never prints the value. */
+function redact(tok) {
+    return tok ? `present(len=${String(tok).length})` : '(none)';
+}
+
+/**
+ * Redact any occurrence of known secret values inside an arbitrary string
+ * (e.g. a request body dump). Defense-in-depth — the Responses body itself
+ * carries no credential, but the Authorization header and any accidental echo
+ * would. Only redacts secrets ≥ 6 chars so a short placeholder / empty value
+ * can't blank out unrelated text.
+ */
+function redactIn(str, secrets) {
+    let s = String(str == null ? '' : str);
+    for (const sec of (secrets || [])) {
+        const v = String(sec || '');
+        if (v.length >= 6) s = s.split(v).join(`«redacted:present(len=${v.length})»`);
+    }
+    return s;
+}
+
+module.exports = { loadEnvTest, redact, redactIn };

--- a/tests/live/openai/_shared/fixture.js
+++ b/tests/live/openai/_shared/fixture.js
@@ -55,6 +55,16 @@ function seedFixture(dir, opts) {
         agentName = 'TestBot',
     } = opts || {};
 
+    // Clear any stale state from a PRIOR run before re-seeding (Copilot): config.js
+    // prefers runtime_state.json over config.json, and buildSystemBlocks reads the
+    // workspace files — so a leftover runtime_state / memory file could silently poison
+    // the next seed (e.g. wrong provider/auth mode, or stale prompt content).
+    for (const f of ['config.json', 'runtime_state.json', 'agent_settings.json', 'node_debug.log',
+                     'SOUL.md', 'IDENTITY.md', 'USER.md', 'MEMORY.md', 'HEARTBEAT.md', 'BOOTSTRAP.md']) {
+        try { fs.rmSync(path.join(dir, f), { force: true }); } catch (_) { /* best-effort */ }
+    }
+    try { fs.rmSync(path.join(dir, 'memory'), { recursive: true, force: true }); } catch (_) { /* best-effort */ }
+
     fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
 
     // ── config.json ──────────────────────────────────────────────────────────

--- a/tests/live/openai/_shared/fixture.js
+++ b/tests/live/openai/_shared/fixture.js
@@ -1,0 +1,146 @@
+// tests/live/openai/_shared/fixture.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Seeds a per-mode fixture workDir that the REAL agent modules can boot against:
+//   • config.json  — provider=openai, channel=telegram, the mode's auth fields,
+//                     a canonical bridgeToken, and a model. (gitignored)
+//   • SOUL/IDENTITY/USER/MEMORY.md + memory/<date>.md — obviously-synthetic but
+//     realistically-shaped workspace so buildSystemBlocks() reads REAL content
+//     into the system prompt (the whole point: real payload, not a fake one).
+//
+// config.js derives every workspace path from workDir=process.argv[2]
+// (SOUL/MEMORY/HEARTBEAT + memory/ + the DB), and memory.js reads
+// IDENTITY.md/USER.md/BOOTSTRAP.md from workDir too — so writing these files
+// into `dir` is enough to populate the prompt.
+//
+// DB FIXTURE (follow-up): we deliberately do NOT seed the SQL.js Recent-Sessions
+// DB. database.js loads SQL.js WASM and getRecentSessions() returns [] when the
+// DB is absent — the system prompt simply omits the "Recent Sessions" rollup.
+// Seeding real rows means driving the SQL.js WASM loader (async) + the
+// api_request_log schema; punted to a follow-up so the harness stays synchronous
+// and dependency-free. See README "DB fixture follow-up".
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// A canonical 8-4-4-4-12 UUID that satisfies bridge-token's isCanonicalBridgeToken.
+// config.js does NOT hard-require bridgeToken to load (BRIDGE_TOKEN is only
+// shape-validated on live per-request reads via getBridgeToken()), but a valid
+// one keeps the fixture realistic and future-proof if a loader check tightens.
+const CANON_BRIDGE_TOKEN = '11111111-2222-4333-8444-555555555555';
+
+function write(p, content) {
+    fs.writeFileSync(p, content);
+}
+
+/**
+ * @param {string} dir absolute fixture workDir
+ * @param {object} opts
+ * @param {'apikey'|'oauth'} opts.mode
+ * @param {string} [opts.model='gpt-5.4']
+ * @param {string} [opts.apiKey]        api_key mode — real key (live) or placeholder
+ * @param {string} [opts.oauthToken]    oauth mode — real token (live) or placeholder
+ * @param {string} [opts.oauthRefresh]  optional oauth refresh token
+ * @returns {string} the fixture dir
+ */
+function seedFixture(dir, opts) {
+    const {
+        mode,
+        model = 'gpt-5.4',
+        apiKey,
+        oauthToken,
+        oauthRefresh,
+        botToken = '100000000:TEST-BOT-TOKEN-PLACEHOLDER',
+        ownerId = '100000001',
+        agentName = 'TestBot',
+    } = opts || {};
+
+    fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
+
+    // ── config.json ──────────────────────────────────────────────────────────
+    const cfg = {
+        provider: 'openai',
+        authType: mode === 'oauth' ? 'oauth' : 'api_key',
+        channel: 'telegram',
+        botToken,
+        ownerId,
+        model,
+        agentName,
+        bridgeToken: CANON_BRIDGE_TOKEN,
+    };
+    if (mode === 'oauth') {
+        cfg.openaiOAuthToken = oauthToken || 'oauth-test-PLACEHOLDER';
+        if (oauthRefresh) cfg.openaiOAuthRefresh = oauthRefresh;
+    } else {
+        cfg.openaiApiKey = apiKey || 'sk-test-PLACEHOLDER';
+    }
+    write(path.join(dir, 'config.json'), JSON.stringify(cfg, null, 2) + '\n');
+
+    // ── Mock-but-realistic workspace (NO real user data) ─────────────────────
+    write(path.join(dir, 'IDENTITY.md'), [
+        '# IDENTITY.md',
+        '',
+        '- **Name:** TestBot',
+        '- **Nature:** synthetic fixture agent (BAT-1144 exact-agent-copy harness)',
+        '- **Born:** 2026-07-09 (fixture seed)',
+        '- **Purpose:** exercise the REAL system prompt + tool payload offline',
+        '',
+        'You are TestBot, a deterministic fixture persona used only by the OpenAI',
+        'live-model harness. This file is synthetic and contains no production data.',
+        '',
+    ].join('\n'));
+
+    write(path.join(dir, 'USER.md'), [
+        '# USER.md',
+        '',
+        '- **Name:** Test User',
+        '- **Handle:** @test_user_synthetic',
+        '- **Timezone:** UTC',
+        '- **Interests:** verifying that the harness builds the real agent request',
+        '- **Notes:** Synthetic owner profile. Contains no real personal data.',
+        '',
+    ].join('\n'));
+
+    write(path.join(dir, 'SOUL.md'), [
+        '# SOUL.md — Who You Are',
+        '',
+        "_You're not a chatbot. You're a fixture — but act the part: be genuinely",
+        'helpful, have opinions, stay concise._',
+        '',
+        '## Core Truths',
+        '- Be resourceful before asking.',
+        '- Earn trust through competence.',
+        '- This is synthetic test data — never treat it as production memory.',
+        '',
+    ].join('\n'));
+
+    write(path.join(dir, 'MEMORY.md'), [
+        '# MEMORY.md',
+        '',
+        '## Long-term (synthetic)',
+        '- 2026-07-01: Fixture created for the BAT-1144 OpenAI live-model harness.',
+        '- 2026-07-05: Confirmed the harness builds the real agent payload, not a mock.',
+        '- Test User prefers concise, direct answers (synthetic preference).',
+        '',
+    ].join('\n'));
+
+    // A couple of daily memory files (realistic shape/size).
+    write(path.join(dir, 'memory', '2026-07-08.md'), [
+        '# 2026-07-08',
+        '',
+        '- Ran the offline self-check; both api_key and oauth bodies validated.',
+        '- Noted that the Codex/OAuth path forces reasoning + store:false.',
+        '',
+    ].join('\n'));
+    write(path.join(dir, 'memory', '2026-07-09.md'), [
+        '# 2026-07-09',
+        '',
+        '- Test User asked TestBot to summarize the day. Nothing else of note.',
+        '- Reminder (synthetic): the DB fixture is a follow-up, so Recent Sessions is empty.',
+        '',
+    ].join('\n'));
+
+    return dir;
+}
+
+module.exports = { seedFixture, CANON_BRIDGE_TOKEN };

--- a/tests/live/openai/fixtures/apikey/.gitkeep
+++ b/tests/live/openai/fixtures/apikey/.gitkeep
@@ -1,0 +1,2 @@
+# Keeps the per-mode fixture dir in git. Generated config.json + workspace
+# files are seeded at runtime and gitignored (see ../../.gitignore).

--- a/tests/live/openai/fixtures/oauth/.gitkeep
+++ b/tests/live/openai/fixtures/oauth/.gitkeep
@@ -1,0 +1,2 @@
+# Keeps the per-mode fixture dir in git. Generated config.json + workspace
+# files are seeded at runtime and gitignored (see ../../.gitignore).

--- a/tests/live/openai/live-models.probe.js
+++ b/tests/live/openai/live-models.probe.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// tests/live/openai/live-models.probe.js
+// ─────────────────────────────────────────────────────────────────────────────
+// LIVE OpenAI model-matrix probe — "EXACT AGENT COPY" edition (BAT-1144, Part 2).
+//
+// Unlike the xAI harness (tests/xai-models/live-models.test.js) which fakes the
+// system prompt + tools, THIS probe imports the REAL agent modules and builds the
+// Responses API request the EXACT way ai.js chat() does:
+//   • ai.buildSystemBlocks()  → the real ~54KB system prompt (seeded workspace)
+//   • tools/index TOOLS        → the real 64-tool telegram registry
+//   • providers/openai adapter → formatSystemPrompt / formatTools / toApiMessages /
+//                                formatRequest (the real wire body)
+//   • http.js httpOpenAIStreamingRequest → the real streaming transport (live path)
+//
+// providers/openai.js freezes `isOAuth` + `endpoint` at module load from
+// OPENAI_AUTH_TYPE, so ONE process = ONE auth mode. The parent forks one worker
+// per mode (api_key → api.openai.com/v1/responses, oauth → chatgpt.com Codex).
+//
+// SECURITY: credentials come ONLY from tests/live/openai/.env.test (gitignored).
+// Tokens are NEVER printed — only present(len=N). Node builtins only; no deps.
+//
+// USAGE
+//   node tests/live/openai/live-models.probe.js --self-check      # offline, no creds, no network
+//   node tests/live/openai/live-models.probe.js                   # live sweep (needs .env.test)
+//   node tests/live/openai/live-models.probe.js --mode oauth --diagnose
+//   node tests/live/openai/live-models.probe.js --models gpt-5.4,gpt-5.5
+//   node tests/live/openai/live-models.probe.js --base-url http://127.0.0.1:8080
+//
+// Exit: 0 whenever the sweep/self-check ran; 1 only on setup/credential/assert error.
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { fork } = require('child_process');
+
+const { loadEnvTest, redact } = require('./_shared/env');
+const { seedFixture } = require('./_shared/fixture');
+
+const HERE = __dirname;
+const WORKER = path.join(HERE, 'worker.js');
+const ENV_TEST = path.join(HERE, '.env.test');
+const FIXTURES = path.join(HERE, 'fixtures');
+const REGISTRY = path.resolve(HERE, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project', 'model-registry.json');
+
+// ── args ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+    const out = { diagnose: false, selfCheck: false, mode: null, models: null, baseUrl: null, help: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--help' || a === '-h') out.help = true;
+        else if (a === '--diagnose') out.diagnose = true;
+        else if (a === '--self-check') out.selfCheck = true;
+        else if (a === '--mode') out.mode = (argv[++i] || '').toLowerCase();
+        else if (a === '--models') out.models = argv[++i] || '';
+        else if (a === '--base-url') out.baseUrl = argv[++i] || '';
+        else if (a.startsWith('--mode=')) out.mode = a.slice(7).toLowerCase();
+        else if (a.startsWith('--models=')) out.models = a.slice(9);
+        else if (a.startsWith('--base-url=')) out.baseUrl = a.slice(11);
+    }
+    return out;
+}
+
+function usage() {
+    console.log(`
+OpenAI live model-matrix probe — EXACT AGENT COPY (BAT-1144)
+
+  node tests/live/openai/live-models.probe.js [flags]
+
+Flags:
+  --self-check        Offline acceptance test. No secrets, NO network. Seeds both
+                      fixtures with placeholders, builds the REAL body per mode via
+                      the agent seam, and asserts the wire shape. Exit 0 all-pass.
+  --mode <m>          apikey | oauth | both. Default: whichever creds exist.
+  --models <csv|all|newest>
+                      Models to sweep. 'all' = the registry set for the mode.
+                      'newest' = resolve live from /v1/models (live only).
+                      Default: the registry set for the mode.
+  --diagnose          Also sweep the reasoning-effort ladder
+                      (none/minimal/low/medium/high/xhigh/max) — clearly BEYOND
+                      agent parity (the agent only sends medium/auto). Live only.
+  --base-url <url>    Gateway override for the live POST (host[:port]); the
+                      adapter's real path is preserved.
+  --help              This help.
+
+Credentials (tests/live/openai/.env.test, gitignored):
+  OPENAI_API_KEY=...          api_key path (api.openai.com/v1/responses)
+  OPENAI_OAUTH_TOKEN=...      oauth path (chatgpt.com Codex)
+  OPENAI_OAUTH_REFRESH=...    optional
+  TEST_MODELS=a,b,c           optional default model set
+
+"Exact copy": the probe does NOT re-implement the prompt or tools. It require()s
+the same ai.js / tools/index / providers/openai the device runs, so the body is
+byte-for-byte what the agent sends (minus MCP tools, which the harness omits).
+`);
+}
+
+// ── registry helpers (single source of truth: model-registry.json) ────────────
+function loadRegistryOpenAI() {
+    const j = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+    const openai = (j.providers || []).find((p) => p.id === 'openai') || {};
+    const apikey = (openai.models || []).map((m) => m.id);
+    const oauth = ((openai.modelsByAuth && openai.modelsByAuth.oauth) || openai.models || []).map((m) => m.id);
+    return { apikey, oauth, defaultModel: openai.defaultModel || 'gpt-5.4' };
+}
+
+function modelsForMode(mode, modelsFlag, regModels, testModelsEnv) {
+    if (modelsFlag && modelsFlag !== 'all' && modelsFlag !== 'newest') {
+        return modelsFlag.split(',').map((s) => s.trim()).filter(Boolean);
+    }
+    if (modelsFlag === 'newest') {
+        // Live-only; the worker resolves /v1/models. Offline we can't — fall back.
+        return mode === 'oauth' ? regModels.oauth : regModels.apikey;
+    }
+    if (testModelsEnv) {
+        const list = testModelsEnv.split(',').map((s) => s.trim()).filter(Boolean);
+        if (list.length) return list;
+    }
+    return mode === 'oauth' ? regModels.oauth : regModels.apikey;
+}
+
+// ── fork a worker for one mode ────────────────────────────────────────────────
+function runWorker(mode, { selfCheck, diagnose, live, baseUrl, models, creds }) {
+    return new Promise((resolve) => {
+        const fixtureDir = path.join(FIXTURES, mode);
+        try {
+            seedFixture(fixtureDir, {
+                mode,
+                model: (models && models[0]) || 'gpt-5.4',
+                apiKey: mode === 'apikey' ? (creds.apiKey || undefined) : undefined,
+                oauthToken: mode === 'oauth' ? (creds.oauth || undefined) : undefined,
+                oauthRefresh: mode === 'oauth' ? (creds.refresh || undefined) : undefined,
+            });
+        } catch (e) {
+            return resolve({ mode, error: `[seed] ${e.message}` });
+        }
+
+        const env = {
+            ...process.env,
+            SC_MODE: mode,
+            SC_SELF_CHECK: selfCheck ? '1' : '',
+            SC_DIAGNOSE: diagnose ? '1' : '',
+            SC_LIVE: live ? '1' : '',
+            SC_BASE_URL: baseUrl || '',
+            SC_MODELS: (models || []).join(','),
+        };
+        // argv[2] = fixtureDir → config.js picks it up as workDir.
+        const child = fork(WORKER, [fixtureDir], { env, stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+        let message = null;
+        child.on('message', (m) => { message = m; });
+        child.on('error', (e) => resolve({ mode, error: `[fork] ${e.message}` }));
+        child.on('exit', (code) => {
+            if (message) resolve({ ...message, _exit: code });
+            else resolve({ mode, error: `worker exited (code ${code}) without a result`, _exit: code });
+        });
+    });
+}
+
+// ── printing ──────────────────────────────────────────────────────────────────
+const BAR = '═'.repeat(78);
+const line = (s = '') => console.log(s);
+
+function printSelfCheck(result) {
+    const sc = result.selfCheck;
+    line(`\n${BAR}`);
+    line(`SELF-CHECK · mode=${result.mode}  endpoint=${sc.endpoint.hostname}${sc.endpoint.path}  model=${sc.model}  tools=${sc.toolCount}`);
+    line(BAR);
+    for (const a of sc.asserts) {
+        line(`  ${a.ok ? 'PASS' : 'FAIL'}  ${a.name}${a.detail ? `   (${a.detail})` : ''}`);
+    }
+    line(`\n  ── Built body (token-redacted; instructions/tools abbreviated) ──`);
+    line('  keys: ' + JSON.stringify(sc.render.keys));
+    line('  ' + JSON.stringify(sc.render.critical, null, 2).split('\n').join('\n  '));
+    line('\n  ── instructions (head + tail; full length above) ──');
+    line(sc.render.instructionsAbbrev.split('\n').map((l) => '  | ' + l).join('\n'));
+    line(`\n  → mode ${result.mode}: ${sc.pass ? 'PASS' : 'FAIL'}`);
+}
+
+function printLive(result, reg) {
+    const lv = result.live;
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP · mode=${result.mode}  endpoint=${lv.endpoint.hostname}${lv.endpoint.path}`);
+    line(BAR);
+    line('  model'.padEnd(22) + 'variant'.padEnd(34) + 'status  ok   lat     detail');
+    for (const r of lv.results) {
+        const detail = r.ok ? `"${r.text}"${r.toolCalls ? ` +${r.toolCalls} toolCalls` : ''}` : r.errBody;
+        line('  ' + String(r.model).padEnd(20) + String(r.variant).padEnd(34)
+            + String(r.status).padStart(5) + '  ' + (r.ok ? 'Y' : 'n') + '   '
+            + (String(r.latencyMs) + 'ms').padStart(7) + '  ' + (detail || '').slice(0, 60));
+    }
+    // registry show/hide comparison
+    const regList = result.mode === 'oauth' ? reg.oauth : reg.apikey;
+    const listed = lv.listedModels || { status: -1, ids: [] };
+    line(`\n  ── registry vs live (/v1/models status=${listed.status}) ──`);
+    for (const m of regList) {
+        const seen = listed.ids.includes(m);
+        const parity = lv.results.find((r) => r.model === m && r.variant.startsWith('agent-parity'));
+        const responds = parity ? (parity.ok ? 'responds' : `HTTP ${parity.status}`) : 'not-swept';
+        line(`    ${m.padEnd(20)} inModels=${seen ? 'YES' : 'no '}  ${responds}`);
+    }
+    const extra = (listed.ids || []).filter((id) => !regList.includes(id) && /^(gpt|o[0-9]|chatgpt|codex)/i.test(id));
+    if (extra.length) line(`    (in /v1/models but NOT in registry: ${extra.join(', ')})`);
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+(async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) { usage(); process.exit(0); }
+
+    const { loaded } = loadEnvTest(ENV_TEST);
+    const creds = {
+        apiKey: (process.env.OPENAI_API_KEY || '').trim(),
+        oauth: (process.env.OPENAI_OAUTH_TOKEN || '').trim(),
+        refresh: (process.env.OPENAI_OAUTH_REFRESH || '').trim(),
+    };
+    const testModelsEnv = (process.env.TEST_MODELS || '').trim();
+    const reg = loadRegistryOpenAI();
+
+    line(`${BAR}`);
+    line('OpenAI live model probe — EXACT AGENT COPY (BAT-1144)');
+    line(`.env.test: ${loaded ? 'loaded' : 'not found'}   OPENAI_API_KEY=${redact(creds.apiKey)}   OPENAI_OAUTH_TOKEN=${redact(creds.oauth)}`);
+    line(BAR);
+
+    // Resolve modes.
+    let modes;
+    if (args.mode === 'apikey' || args.mode === 'oauth') modes = [args.mode];
+    else if (args.mode === 'both') modes = ['apikey', 'oauth'];
+    else if (args.selfCheck) modes = ['apikey', 'oauth'];
+    else {
+        modes = [];
+        if (creds.apiKey) modes.push('apikey');
+        if (creds.oauth) modes.push('oauth');
+    }
+
+    // ── SELF-CHECK (offline) ──────────────────────────────────────────────────
+    if (args.selfCheck) {
+        line('\nMODE: --self-check (offline, no network). Seeding both fixtures with placeholders.');
+        const results = [];
+        for (const mode of modes) {
+            const models = modelsForMode(mode, args.models, reg, testModelsEnv);
+            results.push(await runWorker(mode, { selfCheck: true, diagnose: false, live: false, baseUrl: null, models, creds: {} }));
+        }
+        let anyFail = false;
+        let setupError = false;
+        for (const r of results) {
+            if (r.error) { setupError = true; line(`\n[SETUP ERROR] mode=${r.mode}: ${r.error}`); continue; }
+            printSelfCheck(r);
+            if (!r.selfCheck.pass) anyFail = true;
+        }
+        line(`\n${BAR}`);
+        if (setupError) { line('SELF-CHECK: SETUP ERROR (see above).'); line(BAR); process.exit(1); }
+        line(`SELF-CHECK RESULT: ${anyFail ? 'FAIL' : 'PASS'}  (modes: ${modes.join(', ')})`);
+        line(BAR);
+        process.exit(anyFail ? 1 : 0);
+    }
+
+    // ── LIVE sweep ────────────────────────────────────────────────────────────
+    if (!modes.length) {
+        line('\nNo credential found and no --self-check. Put ONE of these in tests/live/openai/.env.test:');
+        line('  OPENAI_API_KEY=...        (api_key path)');
+        line('  OPENAI_OAUTH_TOKEN=...    (oauth / Codex path)');
+        line('…or run with --self-check to validate the body offline (no creds, no network).');
+        process.exit(1);
+    }
+    // A mode was requested/selected but its credential is missing → setup error.
+    for (const mode of modes) {
+        if (mode === 'apikey' && !creds.apiKey) { line(`\n[SETUP ERROR] mode=apikey selected but OPENAI_API_KEY is missing.`); process.exit(1); }
+        if (mode === 'oauth' && !creds.oauth) { line(`\n[SETUP ERROR] mode=oauth selected but OPENAI_OAUTH_TOKEN is missing.`); process.exit(1); }
+    }
+
+    const results = [];
+    for (const mode of modes) {
+        const models = modelsForMode(mode, args.models, reg, testModelsEnv);
+        results.push(await runWorker(mode, { selfCheck: false, diagnose: args.diagnose, live: true, baseUrl: args.baseUrl, models, creds }));
+    }
+    let setupError = false;
+    for (const r of results) {
+        if (r.error) { setupError = true; line(`\n[ERROR] mode=${r.mode}: ${r.error}`); continue; }
+        printLive(r, reg);
+    }
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP COMPLETE (modes: ${modes.join(', ')}).`);
+    line(BAR);
+    // Report-only: exit 0 whenever the sweep ran; 1 only on setup error.
+    process.exit(setupError ? 1 : 0);
+})();

--- a/tests/live/openai/live-models.probe.js
+++ b/tests/live/openai/live-models.probe.js
@@ -3,9 +3,9 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // LIVE OpenAI model-matrix probe — "EXACT AGENT COPY" edition (BAT-1144, Part 2).
 //
-// Unlike the xAI harness (tests/xai-models/live-models.test.js) which fakes the
-// system prompt + tools, THIS probe imports the REAL agent modules and builds the
-// Responses API request the EXACT way ai.js chat() does:
+// Unlike a black-box live harness that fakes the system prompt + tools, THIS probe
+// imports the REAL agent modules and builds the Responses API request the EXACT way
+// ai.js chat() does:
 //   • ai.buildSystemBlocks()  → the real ~54KB system prompt (seeded workspace)
 //   • tools/index TOOLS        → the real 64-tool telegram registry
 //   • providers/openai adapter → formatSystemPrompt / formatTools / toApiMessages /

--- a/tests/live/openai/live-models.probe.js
+++ b/tests/live/openai/live-models.probe.js
@@ -72,9 +72,12 @@ Flags:
                       the agent seam, and asserts the wire shape. Exit 0 all-pass.
   --mode <m>          apikey | oauth | both. Default: whichever creds exist.
   --models <csv|all|newest>
-                      Models to sweep. 'all' = the registry set for the mode.
-                      'newest' = resolve live from /v1/models (live only).
-                      Default: the registry set for the mode.
+                      Models to sweep. 'all' = the registry set for the mode
+                      (ignores TEST_MODELS). 'newest' currently sweeps the registry
+                      set too, but the worker prints a live /v1/models-vs-registry
+                      DIFF so newly-listed ids surface for show/hide review
+                      (auto-sweeping only the new ids is a follow-up).
+                      Default: TEST_MODELS if set, else the registry set.
   --diagnose          Also sweep the reasoning-effort ladder
                       (none/minimal/low/medium/high/xhigh/max) — clearly BEYOND
                       agent parity (the agent only sends medium/auto). Live only.
@@ -104,18 +107,25 @@ function loadRegistryOpenAI() {
 }
 
 function modelsForMode(mode, modelsFlag, regModels, testModelsEnv) {
+    const registrySet = () => (mode === 'oauth' ? regModels.oauth : regModels.apikey);
+    // Explicit CSV always wins.
     if (modelsFlag && modelsFlag !== 'all' && modelsFlag !== 'newest') {
         return modelsFlag.split(',').map((s) => s.trim()).filter(Boolean);
     }
-    if (modelsFlag === 'newest') {
-        // Live-only; the worker resolves /v1/models. Offline we can't — fall back.
-        return mode === 'oauth' ? regModels.oauth : regModels.apikey;
-    }
+    // `--models all` → the registry set for the mode, IGNORING TEST_MODELS. An
+    // explicit `all` must not be silently narrowed by the env default (CodeRabbit).
+    if (modelsFlag === 'all') return registrySet();
+    // `--models newest` currently maps to the registry set too; the worker still
+    // fetches /v1/models live and prints a registry-vs-listed DIFF for the show/hide
+    // decision, so newly-listed ids surface there. (Auto-sweeping only the newest
+    // ids from /v1/models is a documented follow-up — see README.)
+    if (modelsFlag === 'newest') return registrySet();
+    // No flag → the TEST_MODELS default if set, else the registry set.
     if (testModelsEnv) {
         const list = testModelsEnv.split(',').map((s) => s.trim()).filter(Boolean);
         if (list.length) return list;
     }
-    return mode === 'oauth' ? regModels.oauth : regModels.apikey;
+    return registrySet();
 }
 
 // ── fork a worker for one mode ────────────────────────────────────────────────

--- a/tests/live/openai/live-models.probe.js
+++ b/tests/live/openai/live-models.probe.js
@@ -20,11 +20,15 @@
 // Tokens are NEVER printed — only present(len=N). Node builtins only; no deps.
 //
 // USAGE
-//   node tests/live/openai/live-models.probe.js --self-check      # offline, no creds, no network
+//   node tests/live/openai/live-models.probe.js --self-check      # offline, no creds, no EXTERNAL network*
 //   node tests/live/openai/live-models.probe.js                   # live sweep (needs .env.test)
 //   node tests/live/openai/live-models.probe.js --mode oauth --diagnose
 //   node tests/live/openai/live-models.probe.js --models gpt-5.4,gpt-5.5
 //   node tests/live/openai/live-models.probe.js --base-url http://127.0.0.1:8080
+//
+//   * "no EXTERNAL network": --self-check makes no OpenAI/internet call, but the real
+//     buildSystemBlocks() fires a fire-and-forget /burner/status probe at the localhost
+//     bridge; with no bridge server it fails silently and doesn't affect the result.
 //
 // Exit: 0 whenever the sweep/self-check ran; 1 only on setup/credential/assert error.
 'use strict';
@@ -243,7 +247,7 @@ function printLive(result, reg) {
 
     // ── SELF-CHECK (offline) ──────────────────────────────────────────────────
     if (args.selfCheck) {
-        line('\nMODE: --self-check (offline, no network). Seeding both fixtures with placeholders.');
+        line('\nMODE: --self-check (offline, no external network). Seeding both fixtures with placeholders.');
         const results = [];
         for (const mode of modes) {
             const models = modelsForMode(mode, args.models, reg, testModelsEnv);
@@ -268,7 +272,7 @@ function printLive(result, reg) {
         line('\nNo credential found and no --self-check. Put ONE of these in tests/live/openai/.env.test:');
         line('  OPENAI_API_KEY=...        (api_key path)');
         line('  OPENAI_OAUTH_TOKEN=...    (oauth / Codex path)');
-        line('…or run with --self-check to validate the body offline (no creds, no network).');
+        line('…or run with --self-check to validate the body offline (no creds, no external network).');
         process.exit(1);
     }
     // A mode was requested/selected but its credential is missing → setup error.

--- a/tests/live/openai/worker.js
+++ b/tests/live/openai/worker.js
@@ -11,7 +11,9 @@
 //
 // The worker imports the REAL modules and builds the wire body the EXACT way the
 // agent does (ai.js chat() seam), then either:
-//   • --self-check : validates the body's wire shape offline (no network), OR
+//   • --self-check : validates the body's wire shape offline — no OpenAI/external
+//                    network (a fire-and-forget localhost bridge probe during prompt
+//                    assembly fails silently), OR
 //   • live         : POSTs each model's body via the REAL httpOpenAIStreamingRequest.
 //
 // It reports back via IPC (process.send) when forked, else prints JSON to stdout.
@@ -113,7 +115,11 @@ function buildRequestOptions(model, { heartbeat = false } = {}) {
 
 function buildBody(model, { heartbeat = false, reasoningEffortOverride = null } = {}) {
     // Deterministic wallet block: seed a "no burner configured" snapshot so the
-    // Wallets section renders WITHOUT firing a localhost:8765 bridge call.
+    // Wallets section is STABLE. Note (Copilot): buildSystemBlocks() still fires a
+    // fire-and-forget /burner/status probe at the localhost bridge — but there is no
+    // bridge server here, so it fails silently and does NOT overwrite this seeded
+    // snapshot (the probe is why the self-check is "no EXTERNAL network", not literally
+    // "no sockets").
     ai._setWalletPromptSnapshotForTests({ configured: false });
 
     const { stable, dynamic } = ai.buildSystemBlocks([], null, model);

--- a/tests/live/openai/worker.js
+++ b/tests/live/openai/worker.js
@@ -39,16 +39,22 @@ const PROMPT = process.env.SC_PROMPT || 'Reply with the single word: pong';
 // reportedly adds 'max'. 'none' is a probe of the omit-vs-none boundary.
 const REASONING_LADDER = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
 
+// Secrets to scrub from ANY printed/IPC'd text (CodeRabbit). Declared with `let`
+// BEFORE the boot block so fail() can reference it without a TDZ (empty pre-boot —
+// boot errors are config-load failures that don't echo a token); populated once the
+// fixture config is loaded (below).
+let SECRETS = [];
+
 function send(result) {
     if (typeof process.send === 'function') process.send(result);
     else process.stdout.write(JSON.stringify(result, null, 2) + '\n');
 }
 
 function fail(stage, err) {
-    send({
-        mode: MODE,
-        error: `[${stage}] ${err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err)}`,
-    });
+    const raw = err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err);
+    // Redact in case a runtime error (e.g. an auth failure) echoes a credential —
+    // upholds the harness's "tokens are NEVER printed" guarantee.
+    send({ mode: MODE, error: `[${stage}] ${redactIn(raw, SECRETS)}` });
     process.exit(3);
 }
 
@@ -75,8 +81,9 @@ if (cfg.OPENAI_AUTH_TYPE !== expectedAuth) {
     fail('boot', new Error(`OPENAI_AUTH_TYPE is "${cfg.OPENAI_AUTH_TYPE}", expected "${expectedAuth}" (fixture/mode mismatch)`));
 }
 
-// Secrets to scrub from any printed text (defense-in-depth; the body carries none).
-const SECRETS = [cfg.OPENAI_KEY, cfg.OPENAI_OAUTH_TOKEN, cfg.OPENAI_OAUTH_REFRESH, cfg.BOT_TOKEN].filter(Boolean);
+// Populate the redaction set now that config is loaded (declared above so fail() can
+// use it even during boot). Defense-in-depth; the built body itself carries none.
+SECRETS = [cfg.OPENAI_KEY, cfg.OPENAI_OAUTH_TOKEN, cfg.OPENAI_OAUTH_REFRESH, cfg.BOT_TOKEN].filter(Boolean);
 
 // ── The seam: build the body the EXACT way ai.js chat() does ──────────────────
 // Mirrors ai.js:

--- a/tests/live/openai/worker.js
+++ b/tests/live/openai/worker.js
@@ -213,8 +213,19 @@ function selfCheck() {
         A('endpoint === api.openai.com/v1/responses', ep.hostname === 'api.openai.com' && ep.path === '/v1/responses', `${ep.hostname}${ep.path}`);
         A('has max_output_tokens (=== 4096)', b.max_output_tokens === 4096, `max_output_tokens=${b.max_output_tokens}`);
         A('NO store', !('store' in b), `present=${'store' in b}`);
-        // api_key + non-codex + reasoningEnabled:false → agent sends NO reasoning block.
-        A('NO reasoning (api_key non-codex default)', !('reasoning' in b), `present=${'reasoning' in b}`);
+        // Reasoning on the api_key transport is model-dependent (Copilot): a `*-codex`
+        // model is transport-required to send `reasoning` even on api.openai.com, while
+        // a non-codex model with reasoningEnabled:false sends none. Mirror the real
+        // adapter's `wantReasoning = isOAuth || model.includes('codex') || userToggle`.
+        const isCodex = String(cfg.MODEL || '').includes('codex');
+        if (isCodex) {
+            A('reasoning present (api_key + codex → transport-required)',
+                b.reasoning && b.reasoning.effort === 'medium' && b.reasoning.summary === 'auto', JSON.stringify(b.reasoning));
+            A("include === ['reasoning.encrypted_content'] (codex)",
+                Array.isArray(b.include) && b.include[0] === 'reasoning.encrypted_content', JSON.stringify(b.include));
+        } else {
+            A('NO reasoning (api_key non-codex, reasoning toggle off)', !('reasoning' in b), `present=${'reasoning' in b}`);
+        }
     }
 
     const pass = asserts.every((a) => a.ok);

--- a/tests/live/openai/worker.js
+++ b/tests/live/openai/worker.js
@@ -1,0 +1,350 @@
+// tests/live/openai/worker.js
+// ─────────────────────────────────────────────────────────────────────────────
+// CHILD worker (one process per auth mode). Its process.argv[2] is the fixture
+// workDir, so require('<bundle>/config') finds workDir/config.json and boots the
+// REAL agent stack for THIS auth mode.
+//
+// WHY ONE PROCESS PER MODE: providers/openai.js freezes `isOAuth` (and the
+// `endpoint` object) at module-load time from OPENAI_AUTH_TYPE. A single process
+// can therefore only ever be api_key OR oauth — never both. The parent forks one
+// worker per mode.
+//
+// The worker imports the REAL modules and builds the wire body the EXACT way the
+// agent does (ai.js chat() seam), then either:
+//   • --self-check : validates the body's wire shape offline (no network), OR
+//   • live         : POSTs each model's body via the REAL httpOpenAIStreamingRequest.
+//
+// It reports back via IPC (process.send) when forked, else prints JSON to stdout.
+'use strict';
+
+const path = require('path');
+
+// ── Resolve the real nodejs-project bundle (…/app/src/main/assets/nodejs-project)
+const BUNDLE = path.resolve(__dirname, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+const req = (m) => require(path.join(BUNDLE, m));
+
+const { redact, redactIn } = require('./_shared/env');
+
+// ── Control inputs (from the parent via env; argv[2] is reserved for workDir) ──
+const MODE = (process.env.SC_MODE || 'apikey').toLowerCase();           // 'apikey' | 'oauth'
+const SELF_CHECK = process.env.SC_SELF_CHECK === '1';
+const DIAGNOSE = process.env.SC_DIAGNOSE === '1';
+const LIVE = process.env.SC_LIVE === '1';
+const BASE_URL = (process.env.SC_BASE_URL || '').trim();
+const MODELS = (process.env.SC_MODELS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const PROMPT = process.env.SC_PROMPT || 'Reply with the single word: pong';
+
+// Reasoning-ladder for --diagnose. Clearly BEYOND agent parity: the agent only
+// ever sends medium/auto (or suppresses via reasoningMode:'off'). gpt-5.6
+// reportedly adds 'max'. 'none' is a probe of the omit-vs-none boundary.
+const REASONING_LADDER = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+
+function send(result) {
+    if (typeof process.send === 'function') process.send(result);
+    else process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+function fail(stage, err) {
+    send({
+        mode: MODE,
+        error: `[${stage}] ${err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err)}`,
+    });
+    process.exit(3);
+}
+
+// ── Boot the real stack ───────────────────────────────────────────────────────
+let cfg, adapter, TOOLS, ai, reasoningSupportFor, httpOpenAIStreamingRequest;
+try {
+    cfg = req('config');                                   // reads workDir/config.json (argv[2])
+    ({ reasoningSupportFor } = req('model-catalog'));
+    const providers = req('providers');
+    adapter = providers.getAdapter('openai');
+    ({ TOOLS } = req(path.join('tools', 'index')));        // REAL 64-tool telegram registry
+    ai = req('ai');
+    ({ httpOpenAIStreamingRequest } = req('http'));
+} catch (e) {
+    fail('boot', e);
+}
+
+// Sanity: the fixture must actually have booted OpenAI in the expected mode.
+if (!cfg || cfg.PROVIDER !== 'openai') fail('boot', new Error(`fixture provider is "${cfg && cfg.PROVIDER}", expected "openai"`));
+if (!adapter || adapter.id !== 'openai') fail('boot', new Error('openai adapter did not resolve'));
+
+const expectedAuth = MODE === 'oauth' ? 'oauth' : 'api_key';
+if (cfg.OPENAI_AUTH_TYPE !== expectedAuth) {
+    fail('boot', new Error(`OPENAI_AUTH_TYPE is "${cfg.OPENAI_AUTH_TYPE}", expected "${expectedAuth}" (fixture/mode mismatch)`));
+}
+
+// Secrets to scrub from any printed text (defense-in-depth; the body carries none).
+const SECRETS = [cfg.OPENAI_KEY, cfg.OPENAI_OAUTH_TOKEN, cfg.OPENAI_OAUTH_REFRESH, cfg.BOT_TOKEN].filter(Boolean);
+
+// ── The seam: build the body the EXACT way ai.js chat() does ──────────────────
+// Mirrors ai.js:
+//   2455  const { stable, dynamic } = buildSystemBlocks(matchedSkills, chatId, activeModel)
+//   2487  formatSystemPrompt(stablePrompt, dynamicPrompt + resumeBlock, AUTH_TYPE)
+//   2566  rawTools = _deps.getTools()   (== TOOLS here; no MCP in the harness)
+//   2567  formatTools(rawTools)
+//   2663  requestOptions = { reasoningEnabled, reasoningSupport, customEchoOverride, reasoningMode, synthetic }
+//   2745  toApiMessages(messages, activeModel, requestOptions)
+//   2746  formatRequest(activeModel, 4096, systemBlocks, apiMessages, formattedTools, requestOptions)
+function buildRequestOptions(model, { heartbeat = false } = {}) {
+    // Live runtime-state read, exactly like ai.js (reasoningEnabled / customEchoReasoning).
+    const rt = (() => {
+        try { return cfg.runtimeState ? cfg.runtimeState.read() : null; } catch (_) { return null; }
+    })();
+    return {
+        reasoningEnabled: !!(rt && rt.reasoningEnabled),
+        reasoningSupport: reasoningSupportFor('openai', model, cfg.OPENAI_AUTH_TYPE),
+        customEchoOverride: !!(rt && rt.customEchoReasoning),
+        // A normal turn is 'normal'; a heartbeat/synthetic turn is 'off' (suppresses
+        // the OPTIONAL user-toggle reasoning only — the OAuth/Codex transport-required
+        // reasoning stays regardless, per the adapter).
+        reasoningMode: heartbeat ? 'off' : 'normal',
+        synthetic: heartbeat ? 'heartbeat' : null,
+    };
+}
+
+function buildBody(model, { heartbeat = false, reasoningEffortOverride = null } = {}) {
+    // Deterministic wallet block: seed a "no burner configured" snapshot so the
+    // Wallets section renders WITHOUT firing a localhost:8765 bridge call.
+    ai._setWalletPromptSnapshotForTests({ configured: false });
+
+    const { stable, dynamic } = ai.buildSystemBlocks([], null, model);
+    const resumeBlock = ''; // normal (non-resume) turn
+    const systemBlocks = adapter.formatSystemPrompt(stable, dynamic + resumeBlock, cfg.AUTH_TYPE);
+
+    const formattedTools = adapter.formatTools(TOOLS);
+    const requestOptions = buildRequestOptions(model, { heartbeat });
+    const apiMessages = adapter.toApiMessages([{ role: 'user', content: PROMPT }], model, requestOptions);
+    const bodyStr = adapter.formatRequest(model, 4096, systemBlocks, apiMessages, formattedTools, requestOptions);
+
+    let bodyObj = JSON.parse(bodyStr);
+    if (reasoningEffortOverride) bodyObj = applyReasoningEffort(bodyObj, reasoningEffortOverride);
+
+    return {
+        model,
+        bodyObj,
+        bodyStr: reasoningEffortOverride ? JSON.stringify(bodyObj) : bodyStr,
+        instructions: systemBlocks,
+        toolCount: formattedTools.length,
+        requestOptions,
+    };
+}
+
+// BEYOND-PARITY mutation for --diagnose. Post-mutates reasoning.effort on the
+// already-built (real) body. If the agent didn't include a `reasoning` block
+// (api_key non-codex), we synthesize one so the ladder can be explored.
+function applyReasoningEffort(bodyObj, effort) {
+    const clone = JSON.parse(JSON.stringify(bodyObj));
+    const base = clone.reasoning && typeof clone.reasoning === 'object' ? clone.reasoning : { summary: 'auto' };
+    clone.reasoning = { ...base, effort };
+    return clone;
+}
+
+// A compact, readable render of a (large) Responses body: abbreviate the 50KB+
+// `instructions` and the 64-entry `tools`, keep the wire-critical fields verbatim.
+function renderBody(bodyObj, instructions, toolCount) {
+    const instr = String(instructions || bodyObj.instructions || '');
+    const head = instr.slice(0, 600);
+    const tail = instr.length > 900 ? instr.slice(-260) : '';
+    const abbrevInstr = tail
+        ? `${head}\n        … [${instr.length} chars total; middle elided] …\n${tail}`
+        : instr;
+    const toolNames = Array.isArray(bodyObj.tools) ? bodyObj.tools.slice(0, 8).map((t) => t.name) : [];
+    const view = {
+        model: bodyObj.model,
+        stream: bodyObj.stream,
+        max_output_tokens: ('max_output_tokens' in bodyObj) ? bodyObj.max_output_tokens : '‹absent›',
+        store: ('store' in bodyObj) ? bodyObj.store : '‹absent›',
+        reasoning: ('reasoning' in bodyObj) ? bodyObj.reasoning : '‹absent›',
+        include: ('include' in bodyObj) ? bodyObj.include : '‹absent›',
+        instructions: `‹string len=${instr.length}›`,
+        input: bodyObj.input,
+        tools: `‹array len=${toolCount != null ? toolCount : (bodyObj.tools || []).length}; first8=${JSON.stringify(toolNames)}›`,
+    };
+    return {
+        keys: Object.keys(bodyObj),
+        critical: view,
+        instructionsAbbrev: redactIn(abbrevInstr, SECRETS),
+    };
+}
+
+// ── Offline self-check ────────────────────────────────────────────────────────
+function selfCheck() {
+    const asserts = [];
+    const A = (name, ok, detail) => asserts.push({ name, ok: !!ok, detail: detail == null ? '' : String(detail) });
+
+    const built = buildBody(cfg.MODEL, { heartbeat: false });
+    const b = built.bodyObj;
+    const ep = adapter.endpoint; // module-level object {hostname, path}
+    const instr = built.instructions;
+
+    // ── Common wire-shape assertions (both modes) ─────────────────────────────
+    A('stream === true', b.stream === true, `stream=${b.stream}`);
+    A('instructions is a non-empty string', typeof b.instructions === 'string' && b.instructions.length > 0, `len=${(b.instructions || '').length}`);
+    A('input is a non-empty array', Array.isArray(b.input) && b.input.length > 0, `input.length=${(b.input || []).length}`);
+    A('tools length === real TOOLS length', Array.isArray(b.tools) && b.tools.length === TOOLS.length && b.tools.length > 0, `body.tools=${(b.tools || []).length} TOOLS=${TOOLS.length}`);
+    const allFn = Array.isArray(b.tools) && b.tools.every((t) => t && t.type === 'function' && typeof t.name === 'string' && t.name.length > 0);
+    A('every tool is {type:"function", name:string}', allFn, allFn ? 'all ok' : 'a tool is malformed');
+
+    // ── System prompt reflects the SEEDED MOCK WORKSPACE (the whole point) ────
+    A('prompt has real Identity section marker', instr.includes('You are a personal AI agent running inside SeekerClaw'), 'identity line present');
+    A('prompt has a Tooling/Architecture marker', instr.includes('## Architecture') || instr.includes('Tooling'), 'structural section present');
+    A('prompt embeds seeded IDENTITY.md (TestBot)', instr.includes('IDENTITY.md') && instr.includes('TestBot'), 'IDENTITY.md + TestBot present');
+    A('prompt embeds seeded USER.md (Test User)', instr.includes('USER.md') && instr.includes('Test User'), 'USER.md + Test User present');
+    A('prompt embeds seeded MEMORY.md line', instr.includes('BAT-1144 OpenAI live-model harness') || instr.includes('synthetic preference'), 'MEMORY.md content present');
+
+    // ── Mode-specific assertions ──────────────────────────────────────────────
+    if (MODE === 'oauth') {
+        A('endpoint === chatgpt.com/backend-api/codex/responses', ep.hostname === 'chatgpt.com' && ep.path === '/backend-api/codex/responses', `${ep.hostname}${ep.path}`);
+        A('store === false', b.store === false, `store=${JSON.stringify(b.store)}`);
+        A('NO max_output_tokens', !('max_output_tokens' in b), `present=${'max_output_tokens' in b}`);
+        const r = b.reasoning;
+        A('reasoning === {effort:"medium", summary:"auto"}', r && r.effort === 'medium' && r.summary === 'auto', JSON.stringify(r));
+        A("include === ['reasoning.encrypted_content']", Array.isArray(b.include) && b.include.length === 1 && b.include[0] === 'reasoning.encrypted_content', JSON.stringify(b.include));
+    } else {
+        A('endpoint === api.openai.com/v1/responses', ep.hostname === 'api.openai.com' && ep.path === '/v1/responses', `${ep.hostname}${ep.path}`);
+        A('has max_output_tokens (=== 4096)', b.max_output_tokens === 4096, `max_output_tokens=${b.max_output_tokens}`);
+        A('NO store', !('store' in b), `present=${'store' in b}`);
+        // api_key + non-codex + reasoningEnabled:false → agent sends NO reasoning block.
+        A('NO reasoning (api_key non-codex default)', !('reasoning' in b), `present=${'reasoning' in b}`);
+    }
+
+    const pass = asserts.every((a) => a.ok);
+    send({
+        mode: MODE,
+        selfCheck: {
+            pass,
+            model: cfg.MODEL,
+            endpoint: { hostname: ep.hostname, path: ep.path },
+            toolCount: built.toolCount,
+            asserts,
+            render: renderBody(b, instr, built.toolCount),
+        },
+    });
+    process.exit(pass ? 0 : 1);
+}
+
+// ── Live sweep ────────────────────────────────────────────────────────────────
+function resolveEndpoint() {
+    const ep = adapter.endpoint;
+    if (!BASE_URL) return { protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path };
+    try {
+        const u = new URL(BASE_URL.includes('://') ? BASE_URL : `https://${BASE_URL}`);
+        return {
+            protocol: u.protocol || 'https:',
+            hostname: u.hostname,
+            port: u.port ? parseInt(u.port, 10) : undefined,
+            // Keep the adapter's real path (the gateway is expected to proxy it).
+            path: ep.path,
+        };
+    } catch (_) {
+        return { protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path };
+    }
+}
+
+async function liveOne(model, bodyStr) {
+    const ep = resolveEndpoint();
+    const apiKey = cfg.OPENAI_KEY; // ignored by buildHeaders on the oauth path
+    const headers = adapter.buildHeaders(apiKey, cfg.AUTH_TYPE);
+    const options = {
+        protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path,
+        method: 'POST', headers, timeout: 60000,
+    };
+    const started = Date.now();
+    try {
+        const res = await httpOpenAIStreamingRequest(options, bodyStr);
+        const latencyMs = Date.now() - started;
+        let text = '', toolCalls = 0;
+        try {
+            const parsed = adapter.fromApiResponse(res.data);
+            text = (parsed.text || '').slice(0, 80);
+            toolCalls = (parsed.toolCalls || []).length;
+        } catch (_) { /* non-200 data may not parse to Responses shape */ }
+        const errBody = res.status === 200 ? '' : redactIn(typeof res.data === 'string' ? res.data.slice(0, 300) : JSON.stringify(res.data).slice(0, 300), SECRETS);
+        return { model, status: res.status, ok: res.status === 200 && (!!text || toolCalls > 0), text, toolCalls, latencyMs, errBody };
+    } catch (e) {
+        return { model, status: -1, ok: false, text: '', toolCalls: 0, latencyMs: Date.now() - started, errBody: redactIn(e.message, SECRETS) };
+    }
+}
+
+async function liveSweep() {
+    // Default the model set from the mode's registry list if none supplied.
+    const models = MODELS.length ? MODELS : defaultModelsForMode();
+    const endpoint = resolveEndpoint();
+    const results = [];
+    for (const model of models) {
+        if (DIAGNOSE) {
+            // Baseline (exact agent parity) first…
+            const base = buildBody(model, { heartbeat: false });
+            const baseRes = await liveOne(model, base.bodyStr);
+            results.push({ ...baseRes, variant: 'agent-parity (as-sent)' });
+            // …then the reasoning ladder (BEYOND parity — param exploration).
+            for (const effort of REASONING_LADDER) {
+                const v = buildBody(model, { heartbeat: false, reasoningEffortOverride: effort });
+                const r = await liveOne(model, v.bodyStr);
+                results.push({ ...r, variant: `beyond-parity reasoning.effort=${effort}` });
+            }
+        } else {
+            const built = buildBody(model, { heartbeat: false });
+            const r = await liveOne(model, built.bodyStr);
+            results.push({ ...r, variant: 'agent-parity (as-sent)' });
+        }
+    }
+    // Optionally list what THIS credential can actually see (/v1/models) for the
+    // registry show/hide comparison the parent assembles.
+    const listed = await listModels();
+    send({ mode: MODE, live: { endpoint: { hostname: endpoint.hostname, path: endpoint.path }, results, listedModels: listed } });
+    process.exit(0);
+}
+
+function defaultModelsForMode() {
+    // Kept in sync with model-registry.json (the parent passes SC_MODELS in
+    // practice; this is the fallback if it doesn't).
+    return MODE === 'oauth'
+        ? ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex']
+        : ['gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex'];
+}
+
+// GET /v1/models via the adapter's testEndpoint (api.openai.com/v1/models) — used
+// only in live mode. On the OAuth path this may 403 on first touch even when chat
+// works; we surface that rather than treat it as authoritative.
+function listModels() {
+    return new Promise((resolve) => {
+        const https = require('https');
+        const apiKey = cfg.OPENAI_KEY;
+        const headers = adapter.buildHeaders(apiKey, cfg.AUTH_TYPE);
+        const te = adapter.testEndpoint; // { hostname:'api.openai.com', path:'/v1/models', method:'GET' }
+        const request = https.request({ hostname: te.hostname, path: te.path, method: 'GET', headers, timeout: 30000 }, (res) => {
+            let buf = '';
+            res.on('data', (c) => (buf += c));
+            res.on('end', () => {
+                let ids = [];
+                try {
+                    const j = JSON.parse(buf);
+                    if (Array.isArray(j.data)) ids = j.data.map((m) => m.id).sort();
+                } catch (_) {}
+                resolve({ status: res.statusCode, ids });
+            });
+        });
+        request.on('error', () => resolve({ status: -1, ids: [] }));
+        request.setTimeout(30000, () => { request.destroy(); resolve({ status: -2, ids: [] }); });
+        request.end();
+    });
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+(async function main() {
+    try {
+        if (SELF_CHECK) return selfCheck();
+        if (LIVE) return await liveSweep();
+        // No mode selected — nothing to do.
+        send({ mode: MODE, error: 'worker invoked without --self-check or SC_LIVE=1' });
+        process.exit(3);
+    } catch (e) {
+        fail('run', e);
+    }
+})();
+
+// silence unused-var lints for redact (kept in the shared API surface)
+void redact;


### PR DESCRIPTION
## Summary
Part 2 of BAT-1144. A standalone live/offline harness under `tests/live/openai/` that builds an OpenAI **Responses** request the EXACT way the agent does — importing the **real** `config`, `providers/openai` adapter, `ai.buildSystemBlocks()`, the real `tools/index` `TOOLS` registry, and `http.js` `httpOpenAIStreamingRequest` via a fixture workDir. Because `providers/openai.js` freezes `isOAuth`/`endpoint` at module load, it forks one worker per auth mode.

This fixes the blind spot in the existing Grok/Anthropic harnesses (synthetic prompt + fake tools) that hid the 2026-07-07 content-filter outage — synthetic probes returned 200 while only the agent's *real* system prompt 400'd.

## What it verifies (offline `--self-check`, both modes, no secrets)
- **api_key:** `api.openai.com/v1/responses`, has `max_output_tokens`, no `store`, no `reasoning`.
- **oauth:** `chatgpt.com/backend-api/codex/responses`, `store:false`, no `max_output_tokens`, `reasoning:{effort:medium,summary:auto}`, `include:['reasoning.encrypted_content']`.
- The ~55KB `instructions` carries the **real** Identity/Architecture sections **and** the seeded mock workspace (proves `buildSystemBlocks` read the fixture — real payload, not a fake).
- `body.tools.length === TOOLS.length` (self-correcting, not a hardcoded number).

## Test plan
- [x] `node tests/live/openai/live-models.probe.js --self-check` — **PASS both modes, exit 0** (re-run independently)
- [x] `bash scripts/pre-push-check.sh` — **ALL CHECKS PASSED** (78/78 parse, 27/27 load, 64 tools schema-valid, wallet regression, Kotlin `BUILD SUCCESSFUL`)
- [ ] Live model sweep + `--diagnose` reasoning ladder — needs real creds in `tests/live/openai/.env.test` (not committed)

## Notes / follow-ups
- **Finding:** the real assembled tool count is **64** (telegram, no MCP) — the pre-push check reports "64 tools" too. The **66** in CLAUDE.md/PROJECT.md/memory is stale; reconcile in a follow-up.
- The SQL.js Recent-Sessions DB fixture is a documented follow-up (getRecentSessions → [] when absent; prompt omits that rollup).
- Generated `config.json`/workspace/`.env.test` are gitignored; only 9 source files are tracked.
- **Coming on this branch:** Part 1 (consolidate `testing/` → `tests/live/` + update refs) and Part 3 (reusable `provider-model-test` skill). `_shared/` will move to `tests/live/_shared/` in Part 1.

## Self-Awareness Checklist
- [x] N/A — test-only infrastructure; no `buildSystemBlocks()`/`DIAGNOSTICS.md`/user-visible AI capability change, no new JS error log sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live OpenAI model probe with API key and OAuth support, including offline self-checks and live model sweeps.
  * Added optional reasoning diagnostics, model selection, and base URL override.
  * Added shared live-test utilities for loading `.env` credentials and redacting secrets in output.
  * Added reusable fixtures for workspace seeding across auth modes.
* **Documentation**
  * Added a README describing the probe, flags, security constraints, and expected behavior.
* **Chores**
  * Added live-test credential templates, ignore rules, and gitkeep markers to keep secrets and generated artifacts out of version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->