### PR TITLE
test: backfill live-models probes for anthropic/openrouter/custom (BAT-1144 Part 3)

### DIFF
--- a/tests/live/_shared/fixture.js
+++ b/tests/live/_shared/fixture.js
@@ -46,6 +46,8 @@ function write(p, content) {
 function seedFixture(dir, opts) {
     const {
         mode,
+        provider = 'openai',
+        authConfig = null,
         model = 'gpt-5.4',
         apiKey,
         oauthToken,
@@ -68,9 +70,15 @@ function seedFixture(dir, opts) {
     fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
 
     // ── config.json ──────────────────────────────────────────────────────────
+    // Provider-generic: pass `provider` + `authConfig` (the provider's own auth
+    // config.json fields, incl. `authType`) to seed any provider — e.g.
+    //   { provider:'claude',     authConfig:{ authType:'api_key', anthropicApiKey:'…' } }
+    //   { provider:'openrouter', authConfig:{ authType:'api_key', openrouterApiKey:'…' } }
+    //   { provider:'custom',     authConfig:{ authType:'api_key', customApiKey:'…', customBaseUrl:'…', customFormat:'chat_completions' } }
+    // The legacy OpenAI path (mode/apiKey/oauthToken, no authConfig) is preserved
+    // byte-for-byte so the Part-2 OpenAI harness is unchanged.
     const cfg = {
-        provider: 'openai',
-        authType: mode === 'oauth' ? 'oauth' : 'api_key',
+        provider,
         channel: 'telegram',
         botToken,
         ownerId,
@@ -78,11 +86,16 @@ function seedFixture(dir, opts) {
         agentName,
         bridgeToken: CANON_BRIDGE_TOKEN,
     };
-    if (mode === 'oauth') {
-        cfg.openaiOAuthToken = oauthToken || 'oauth-test-PLACEHOLDER';
-        if (oauthRefresh) cfg.openaiOAuthRefresh = oauthRefresh;
+    if (authConfig && typeof authConfig === 'object') {
+        Object.assign(cfg, authConfig);
     } else {
-        cfg.openaiApiKey = apiKey || 'sk-test-PLACEHOLDER';
+        cfg.authType = mode === 'oauth' ? 'oauth' : 'api_key';
+        if (mode === 'oauth') {
+            cfg.openaiOAuthToken = oauthToken || 'oauth-test-PLACEHOLDER';
+            if (oauthRefresh) cfg.openaiOAuthRefresh = oauthRefresh;
+        } else {
+            cfg.openaiApiKey = apiKey || 'sk-test-PLACEHOLDER';
+        }
     }
     write(path.join(dir, 'config.json'), JSON.stringify(cfg, null, 2) + '\n');
 
@@ -95,7 +108,7 @@ function seedFixture(dir, opts) {
         '- **Born:** 2026-07-09 (fixture seed)',
         '- **Purpose:** exercise the REAL system prompt + tool payload offline',
         '',
-        'You are TestBot, a deterministic fixture persona used only by the OpenAI',
+        'You are TestBot, a deterministic fixture persona used only by the SeekerClaw',
         'live-model harness. This file is synthetic and contains no production data.',
         '',
     ].join('\n'));
@@ -128,7 +141,7 @@ function seedFixture(dir, opts) {
         '# MEMORY.md',
         '',
         '## Long-term (synthetic)',
-        '- 2026-07-01: Fixture created for the BAT-1144 OpenAI live-model harness.',
+        '- 2026-07-01: Fixture created for the BAT-1144 live-model harness.',
         '- 2026-07-05: Confirmed the harness builds the real agent payload, not a mock.',
         '- Test User prefers concise, direct answers (synthetic preference).',
         '',

--- a/tests/live/anthropic/.env.test.example
+++ b/tests/live/anthropic/.env.test.example
@@ -1,0 +1,16 @@
+# tests/live/anthropic/.env.test.example
+# Copy to .env.test (gitignored) and fill in AT LEAST ONE credential.
+# Tokens are NEVER printed by the harness — only present(len=N).
+#
+# Used by live-models.probe.js (the EXACT-AGENT-COPY model probe).
+
+# api_key path → api.anthropic.com/v1/messages with the x-api-key header
+ANTHROPIC_API_KEY=
+
+# setup_token path → same endpoint with a Bearer token + the cc_version billing
+# block (the on-device Pro/Max "sign in" credential, sk-ant-oat01-…)
+SETUP_TOKEN=
+
+# optional — default model set to sweep (comma-separated). If unset, the harness
+# uses the model-registry.json claude list.
+# TEST_MODELS=claude-opus-4-8,claude-sonnet-5

--- a/tests/live/anthropic/README.live-models.md
+++ b/tests/live/anthropic/README.live-models.md
@@ -1,0 +1,117 @@
+# Anthropic (Claude) live model probe — EXACT AGENT COPY (BAT-1144, Part 3)
+
+> This file documents `live-models.probe.js` + `worker.js` — the exact-agent-copy
+> model-matrix probe. The existing `README.md` in this folder documents the older
+> `test-*.js` topic probes (auth / headers / thinking matrices); both are kept.
+
+Hits the **live** Anthropic Messages API with **your** credential and reports, per
+model, whether it responds — but the point is _how_ it builds the request.
+
+## What "exact copy" means
+
+Prior live harnesses fake the payload — a hand-written short system prompt and a
+handful of dummy tools. That means a "works here / breaks on device" gap can hide
+in everything they faked.
+
+This harness **imports the real agent modules** and builds the wire body the
+**exact way `ai.js chat()` does** — no re-implementation:
+
+| Piece | Real module (from the device bundle) |
+|-------|--------------------------------------|
+| System prompt (~54 KB) | `ai.buildSystemBlocks()` → `{ stable, dynamic }` |
+| Prompt formatting | `providers/claude.formatSystemPrompt(stable, dynamic, AUTH_TYPE)` |
+| Tools (64, telegram channel) | `tools/index` `TOOLS` → `formatTools()` |
+| Messages | `toApiMessages([{role:'user', content}])` |
+| Wire body | `formatRequest(model, 4096, system, messages, tools, requestOptions)` |
+| Transport (live) | `http.js httpStreamingRequest(options, body)` |
+
+The only intentional difference from the device payload is **MCP tools** — the
+harness omits them (no MCP manager), so it sends the 64 built-in tools. On device
+`getTools()` returns `[...TOOLS, ...mcp]`.
+
+## One process per auth mode
+
+`config.js` freezes `AUTH_TYPE` (and therefore which Claude credential + billing
+lane is live) at module-load time from the fixture's `config.json`. A single
+process can therefore only be `api_key` **or** `setup_token`. The parent forks
+**one worker per mode**:
+
+- **api_key** → `api.anthropic.com` `/v1/messages`, `x-api-key` header, **no**
+  billing block in `system`.
+- **setup_token** (Pro/Max OAuth) → same endpoint, `Authorization: Bearer …`
+  header, and a leading `cc_version` billing-attribution text block prepended to
+  `system` (required for a Pro/Max token to reach non-Haiku models).
+
+Both modes emit the same wire body otherwise: `model`, `max_tokens: 4096`,
+`stream: true`, `system` (array of cache-controlled text blocks), `messages`, and
+`tools` (Claude-native `{name, description, input_schema}`, last one carrying
+`cache_control:{type:'ephemeral'}`). No `thinking` block unless the reasoning
+toggle is on (adaptive thinking is gated on `reasoningEnabled` + registry support).
+
+## Run
+
+```bash
+# OFFLINE acceptance test — no secrets, no Anthropic/external network. This is the gate.
+# (buildSystemBlocks fires a fire-and-forget localhost /burner/status probe that fails
+#  silently with no bridge server, so it's "no external network", not literally no sockets.)
+node tests/live/anthropic/live-models.probe.js --self-check
+
+# Live sweep (needs credentials):
+cp tests/live/anthropic/.env.test.example tests/live/anthropic/.env.test
+# …edit .env.test, set ANTHROPIC_API_KEY and/or SETUP_TOKEN
+node tests/live/anthropic/live-models.probe.js
+
+# Options
+node tests/live/anthropic/live-models.probe.js --mode setup_token
+node tests/live/anthropic/live-models.probe.js --models claude-opus-4-8,claude-sonnet-5
+node tests/live/anthropic/live-models.probe.js --base-url http://127.0.0.1:8080
+node tests/live/anthropic/live-models.probe.js --help
+```
+
+Exit: **0** whenever the sweep/self-check ran; **1** only on setup/credential/assert error.
+
+## Flags
+
+- `--self-check` — offline. Seeds both fixtures with placeholder tokens, builds
+  the real body per mode, and asserts the wire shape (endpoint, `stream:true`,
+  `max_tokens`, `system` block layout incl. the setup_token billing block, tool
+  count == real `TOOLS.length` and Claude tool shape, and that the prompt reflects
+  the **seeded mock workspace** — proving it's the real payload, not a fake).
+  Prints both bodies (token-redacted).
+- `--mode apikey|setup_token|both` — default: whichever creds exist.
+- `--models <csv|all>` — `all` = the registry set for the provider (ignores
+  `TEST_MODELS`). Default = `TEST_MODELS` if set, else the registry set. **Verify
+  live model ids via a live `/v1/models` or context7** — do not hardcode from memory.
+- `--diagnose` — accepted for parity with the sibling probes; no-op for Claude
+  (no beyond-parity reasoning ladder).
+- `--base-url <url>` — gateway override for the live POST (the adapter's real
+  `/v1/messages` path is preserved).
+
+## Security
+
+- `.env.test` is gitignored. **Never commit it.** Tokens are never printed — only
+  `present(len=N)`; any secret is scrubbed from printed bodies/errors via
+  `redactIn`.
+- Generated `fixtures/**/config.json` + seeded workspace + `node_debug.log` are
+  gitignored. The fixture dirs are seeded at runtime by `_shared/fixture.js`.
+- Node builtins only — no `npm install`, no dependencies.
+
+## Fixtures
+
+`fixtures/{apikey,setup_token}/` are per-mode workDirs. `_shared/fixture.js` writes
+a `config.json` (`provider=claude`, `channel=telegram`, the mode's auth fields via
+`authConfig`, a canonical `bridgeToken`, a model) plus a **mock-but-realistic**
+workspace (`SOUL.md`, `IDENTITY.md` = "TestBot", `USER.md` = "Test User",
+`MEMORY.md`, two `memory/<date>.md`). All obviously synthetic — no real user data.
+
+## Shared helpers
+
+`env.js` + `fixture.js` live in the repo-wide `tests/live/_shared/` (shared by
+every live probe — `openai/`, `xai/`, `anthropic/`); this harness imports them as
+`require('../_shared/…')`.
+
+## Notes
+
+- Real telegram tool count is **64** (no MCP) — assembled from `tools/index`
+  `TOOLS` and asserted live by the self-check against `TOOLS.length`, so it stays
+  correct if the real count changes.

--- a/tests/live/anthropic/live-models.probe.js
+++ b/tests/live/anthropic/live-models.probe.js
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// tests/live/anthropic/live-models.probe.js
+// ─────────────────────────────────────────────────────────────────────────────
+// LIVE Anthropic (Claude) model-matrix probe — "EXACT AGENT COPY" edition
+// (BAT-1144, Part 3).
+//
+// Unlike a black-box live harness that fakes the system prompt + tools, THIS probe
+// imports the REAL agent modules and builds the Claude Messages API request the
+// EXACT way ai.js chat() does:
+//   • ai.buildSystemBlocks()   → the real ~54KB system prompt (seeded workspace)
+//   • tools/index TOOLS         → the real 64-tool telegram registry
+//   • providers/claude adapter  → formatSystemPrompt / formatTools / toApiMessages /
+//                                 formatRequest (the real wire body)
+//   • http.js httpStreamingRequest → the real Claude SSE transport (live path)
+//
+// config.js freezes AUTH_TYPE (and therefore the credential/billing lane) at module
+// load from the fixture's config.json, so ONE process = ONE auth mode. The parent
+// forks one worker per mode (api_key → x-api-key header, setup_token → Bearer +
+// cc_version billing block).
+//
+// SECURITY: credentials come ONLY from tests/live/anthropic/.env.test (gitignored).
+// Tokens are NEVER printed — only present(len=N). Node builtins only; no deps.
+//
+// USAGE
+//   node tests/live/anthropic/live-models.probe.js --self-check      # offline, no creds, no EXTERNAL network*
+//   node tests/live/anthropic/live-models.probe.js                   # live sweep (needs .env.test)
+//   node tests/live/anthropic/live-models.probe.js --mode setup_token
+//   node tests/live/anthropic/live-models.probe.js --models claude-opus-4-8,claude-sonnet-5
+//   node tests/live/anthropic/live-models.probe.js --base-url http://127.0.0.1:8080
+//
+//   * "no EXTERNAL network": --self-check makes no Anthropic/internet call, but the
+//     real buildSystemBlocks() fires a fire-and-forget /burner/status probe at the
+//     localhost bridge; with no bridge server it fails silently and doesn't affect
+//     the result.
+//
+// Exit: 0 whenever the sweep/self-check ran; 1 only on setup/credential/assert error.
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { fork } = require('child_process');
+
+const { loadEnvTest, redact } = require('../_shared/env');
+const { seedFixture } = require('../_shared/fixture');
+
+const HERE = __dirname;
+const WORKER = path.join(HERE, 'worker.js');
+const ENV_TEST = path.join(HERE, '.env.test');
+const FIXTURES = path.join(HERE, 'fixtures');
+const REGISTRY = path.resolve(HERE, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project', 'model-registry.json');
+
+const MODES = ['apikey', 'setup_token'];
+const AUTH_FIELD = { apikey: 'anthropicApiKey', setup_token: 'setupToken' };
+const AUTH_TYPE = { apikey: 'api_key', setup_token: 'setup_token' };
+const PLACEHOLDER = { apikey: 'sk-ant-api03-test-PLACEHOLDER', setup_token: 'sk-ant-oat01-test-PLACEHOLDER' };
+
+// ── args ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+    const out = { diagnose: false, selfCheck: false, mode: null, models: null, baseUrl: null, help: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--help' || a === '-h') out.help = true;
+        else if (a === '--diagnose') out.diagnose = true;
+        else if (a === '--self-check') out.selfCheck = true;
+        else if (a === '--mode') out.mode = (argv[++i] || '').toLowerCase();
+        else if (a === '--models') out.models = argv[++i] || '';
+        else if (a === '--base-url') out.baseUrl = argv[++i] || '';
+        else if (a.startsWith('--mode=')) out.mode = a.slice(7).toLowerCase();
+        else if (a.startsWith('--models=')) out.models = a.slice(9);
+        else if (a.startsWith('--base-url=')) out.baseUrl = a.slice(11);
+    }
+    return out;
+}
+
+function usage() {
+    console.log(`
+Anthropic (Claude) live model-matrix probe — EXACT AGENT COPY (BAT-1144)
+
+  node tests/live/anthropic/live-models.probe.js [flags]
+
+Flags:
+  --self-check        Offline acceptance test. No secrets, NO network. Seeds both
+                      fixtures with placeholders, builds the REAL body per mode via
+                      the agent seam, and asserts the wire shape. Exit 0 all-pass.
+  --mode <m>          apikey | setup_token | both. Default: whichever creds exist.
+  --models <csv|all>  Models to sweep. 'all' = the registry set for the provider.
+                      Default: TEST_MODELS if set, else the registry set.
+  --diagnose          Accepted for parity with the sibling probes; the Claude path
+                      has no beyond-parity ladder, so this is currently a no-op.
+  --base-url <url>    Gateway override for the live POST (host[:port]); the
+                      adapter's real path (/v1/messages) is preserved.
+  --help              This help.
+
+Credentials (tests/live/anthropic/.env.test, gitignored):
+  ANTHROPIC_API_KEY=...   api_key path (x-api-key header)
+  SETUP_TOKEN=...         setup_token path (Bearer + cc_version billing block)
+  TEST_MODELS=a,b,c       optional default model set
+
+"Exact copy": the probe does NOT re-implement the prompt or tools. It require()s
+the same ai.js / tools/index / providers/claude the device runs, so the body is
+byte-for-byte what the agent sends (minus MCP tools, which the harness omits).
+`);
+}
+
+// ── registry helpers (single source of truth: model-registry.json) ────────────
+function loadRegistryClaude() {
+    const j = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+    const claude = (j.providers || []).find((p) => p.id === 'claude') || {};
+    const models = (claude.models || []).map((m) => m.id);
+    return { models, defaultModel: claude.defaultModel || 'claude-opus-4-8' };
+}
+
+function modelsForMode(modelsFlag, regModels, testModelsEnv) {
+    // Explicit CSV always wins.
+    if (modelsFlag && modelsFlag !== 'all') {
+        return modelsFlag.split(',').map((s) => s.trim()).filter(Boolean);
+    }
+    // `--models all` → the registry set, IGNORING TEST_MODELS.
+    if (modelsFlag === 'all') return regModels.models;
+    // No flag → the TEST_MODELS default if set, else the registry set.
+    if (testModelsEnv) {
+        const list = testModelsEnv.split(',').map((s) => s.trim()).filter(Boolean);
+        if (list.length) return list;
+    }
+    return regModels.models;
+}
+
+// ── fork a worker for one mode ────────────────────────────────────────────────
+function runWorker(mode, { selfCheck, live, baseUrl, models, creds, defaultModel }) {
+    return new Promise((resolve) => {
+        const fixtureDir = path.join(FIXTURES, mode);
+        try {
+            // Provider-generic seed: pass the provider's own auth config.json fields.
+            // A placeholder credential keeps config.js's "missing key" gate happy in
+            // the offline self-check (config.js exits if the active key is empty).
+            const credValue = (mode === 'apikey' ? creds.apiKey : creds.token) || PLACEHOLDER[mode];
+            seedFixture(fixtureDir, {
+                provider: 'claude',
+                model: (models && models[0]) || defaultModel,
+                authConfig: { authType: AUTH_TYPE[mode], [AUTH_FIELD[mode]]: credValue },
+            });
+        } catch (e) {
+            return resolve({ mode, error: `[seed] ${e.message}` });
+        }
+
+        const env = {
+            ...process.env,
+            SC_MODE: mode,
+            SC_SELF_CHECK: selfCheck ? '1' : '',
+            SC_LIVE: live ? '1' : '',
+            SC_BASE_URL: baseUrl || '',
+            SC_MODELS: (models || []).join(','),
+        };
+        // argv[2] = fixtureDir → config.js picks it up as workDir.
+        const child = fork(WORKER, [fixtureDir], { env, stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+        let message = null;
+        child.on('message', (m) => { message = m; });
+        child.on('error', (e) => resolve({ mode, error: `[fork] ${e.message}` }));
+        child.on('exit', (code) => {
+            if (message) resolve({ ...message, _exit: code });
+            else resolve({ mode, error: `worker exited (code ${code}) without a result`, _exit: code });
+        });
+    });
+}
+
+// ── printing ──────────────────────────────────────────────────────────────────
+const BAR = '═'.repeat(78);
+const line = (s = '') => console.log(s);
+
+function printSelfCheck(result) {
+    const sc = result.selfCheck;
+    line(`\n${BAR}`);
+    line(`SELF-CHECK · mode=${result.mode}  endpoint=${sc.endpoint.hostname}${sc.endpoint.path}  model=${sc.model}  tools=${sc.toolCount}`);
+    line(BAR);
+    for (const a of sc.asserts) {
+        line(`  ${a.ok ? 'PASS' : 'FAIL'}  ${a.name}${a.detail ? `   (${a.detail})` : ''}`);
+    }
+    line(`\n  ── Built body (token-redacted; system/tools abbreviated) ──`);
+    line('  keys: ' + JSON.stringify(sc.render.keys));
+    line('  ' + JSON.stringify(sc.render.critical, null, 2).split('\n').join('\n  '));
+    line('\n  ── system prompt text (head + tail; full length above) ──');
+    line(sc.render.instructionsAbbrev.split('\n').map((l) => '  | ' + l).join('\n'));
+    line(`\n  → mode ${result.mode}: ${sc.pass ? 'PASS' : 'FAIL'}`);
+}
+
+function printLive(result, reg) {
+    const lv = result.live;
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP · mode=${result.mode}  endpoint=${lv.endpoint.hostname}${lv.endpoint.path}`);
+    line(BAR);
+    line('  model'.padEnd(24) + 'variant'.padEnd(28) + 'status  ok   lat     detail');
+    for (const r of lv.results) {
+        const detail = r.ok ? `"${r.text}"${r.toolCalls ? ` +${r.toolCalls} toolCalls` : ''}` : r.errBody;
+        line('  ' + String(r.model).padEnd(22) + String(r.variant).padEnd(28)
+            + String(r.status).padStart(5) + '  ' + (r.ok ? 'Y' : 'n') + '   '
+            + (String(r.latencyMs) + 'ms').padStart(7) + '  ' + (detail || '').slice(0, 60));
+    }
+    const listed = lv.listedModels || { status: -1, ids: [] };
+    line(`\n  ── registry vs live (/v1/models status=${listed.status}) ──`);
+    for (const m of reg.models) {
+        const seen = listed.ids.includes(m);
+        const parity = lv.results.find((r) => r.model === m);
+        const responds = parity ? (parity.ok ? 'responds' : `HTTP ${parity.status}`) : 'not-swept';
+        line(`    ${m.padEnd(22)} inModels=${seen ? 'YES' : 'no '}  ${responds}`);
+    }
+    const extra = (listed.ids || []).filter((id) => !reg.models.includes(id) && /^claude/i.test(id));
+    if (extra.length) line(`    (in /v1/models but NOT in registry: ${extra.join(', ')})`);
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+(async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) { usage(); process.exit(0); }
+
+    const { loaded } = loadEnvTest(ENV_TEST);
+    const creds = {
+        apiKey: (process.env.ANTHROPIC_API_KEY || '').trim(),
+        token: (process.env.SETUP_TOKEN || '').trim(),
+    };
+    const testModelsEnv = (process.env.TEST_MODELS || '').trim();
+    const reg = loadRegistryClaude();
+
+    line(`${BAR}`);
+    line('Anthropic (Claude) live model probe — EXACT AGENT COPY (BAT-1144)');
+    line(`.env.test: ${loaded ? 'loaded' : 'not found'}   ANTHROPIC_API_KEY=${redact(creds.apiKey)}   SETUP_TOKEN=${redact(creds.token)}`);
+    line(BAR);
+
+    // Resolve modes.
+    let modes;
+    if (args.mode === 'apikey' || args.mode === 'setup_token') modes = [args.mode];
+    else if (args.mode === 'both') modes = MODES.slice();
+    else if (args.selfCheck) modes = MODES.slice();
+    else {
+        modes = [];
+        if (creds.apiKey) modes.push('apikey');
+        if (creds.token) modes.push('setup_token');
+    }
+
+    // ── SELF-CHECK (offline) ──────────────────────────────────────────────────
+    if (args.selfCheck) {
+        line('\nMODE: --self-check (offline, no external network). Seeding both fixtures with placeholders.');
+        const results = [];
+        for (const mode of modes) {
+            const models = modelsForMode(args.models, reg, testModelsEnv);
+            results.push(await runWorker(mode, { selfCheck: true, live: false, baseUrl: null, models, creds: {}, defaultModel: reg.defaultModel }));
+        }
+        let anyFail = false;
+        let setupError = false;
+        for (const r of results) {
+            if (r.error) { setupError = true; line(`\n[SETUP ERROR] mode=${r.mode}: ${r.error}`); continue; }
+            printSelfCheck(r);
+            if (!r.selfCheck.pass) anyFail = true;
+        }
+        line(`\n${BAR}`);
+        if (setupError) { line('SELF-CHECK: SETUP ERROR (see above).'); line(BAR); process.exit(1); }
+        line(`SELF-CHECK RESULT: ${anyFail ? 'FAIL' : 'PASS'}  (modes: ${modes.join(', ')})`);
+        line(BAR);
+        process.exit(anyFail ? 1 : 0);
+    }
+
+    // ── LIVE sweep ────────────────────────────────────────────────────────────
+    if (!modes.length) {
+        line('\nNo credential found and no --self-check. Put ONE of these in tests/live/anthropic/.env.test:');
+        line('  ANTHROPIC_API_KEY=...     (api_key path)');
+        line('  SETUP_TOKEN=...           (setup_token / Pro-Max path)');
+        line('…or run with --self-check to validate the body offline (no creds, no external network).');
+        process.exit(1);
+    }
+    for (const mode of modes) {
+        if (mode === 'apikey' && !creds.apiKey) { line(`\n[SETUP ERROR] mode=apikey selected but ANTHROPIC_API_KEY is missing.`); process.exit(1); }
+        if (mode === 'setup_token' && !creds.token) { line(`\n[SETUP ERROR] mode=setup_token selected but SETUP_TOKEN is missing.`); process.exit(1); }
+    }
+
+    const results = [];
+    for (const mode of modes) {
+        const models = modelsForMode(args.models, reg, testModelsEnv);
+        results.push(await runWorker(mode, { selfCheck: false, live: true, baseUrl: args.baseUrl, models, creds, defaultModel: reg.defaultModel }));
+    }
+    let setupError = false;
+    for (const r of results) {
+        if (r.error) { setupError = true; line(`\n[ERROR] mode=${r.mode}: ${r.error}`); continue; }
+        printLive(r, reg);
+    }
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP COMPLETE (modes: ${modes.join(', ')}).`);
+    line(BAR);
+    process.exit(setupError ? 1 : 0);
+})();

--- a/tests/live/anthropic/worker.js
+++ b/tests/live/anthropic/worker.js
@@ -1,0 +1,402 @@
+// tests/live/anthropic/worker.js
+// ─────────────────────────────────────────────────────────────────────────────
+// CHILD worker (one process per auth mode). Its process.argv[2] is the fixture
+// workDir, so require('<bundle>/config') finds workDir/config.json and boots the
+// REAL agent stack for THIS auth mode.
+//
+// WHY ONE PROCESS PER MODE: config.js freezes AUTH_TYPE (and therefore which
+// Claude credential/billing lane is live) at module-load time from the fixture's
+// config.json. A single process can only ever be api_key OR setup_token — never
+// both. The parent forks one worker per mode.
+//
+// The worker imports the REAL modules and builds the wire body the EXACT way the
+// agent does (ai.js chat() seam), then either:
+//   • --self-check : validates the body's wire shape offline — no Anthropic/external
+//                    network (a fire-and-forget localhost bridge probe during prompt
+//                    assembly fails silently), OR
+//   • live         : POSTs each model's body via the REAL httpStreamingRequest.
+//
+// It reports back via IPC (process.send) when forked, else prints JSON to stdout.
+'use strict';
+
+const path = require('path');
+
+// ── Resolve the real nodejs-project bundle (…/app/src/main/assets/nodejs-project)
+const BUNDLE = path.resolve(__dirname, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+const req = (m) => require(path.join(BUNDLE, m));
+
+const { redact, redactIn } = require('../_shared/env');
+
+// ── Control inputs (from the parent via env; argv[2] is reserved for workDir) ──
+const MODE = (process.env.SC_MODE || 'apikey').toLowerCase();           // 'apikey' | 'setup_token'
+const SELF_CHECK = process.env.SC_SELF_CHECK === '1';
+const LIVE = process.env.SC_LIVE === '1';
+const BASE_URL = (process.env.SC_BASE_URL || '').trim();
+const MODELS = (process.env.SC_MODELS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const PROMPT = process.env.SC_PROMPT || 'Reply with the single word: pong';
+
+// The auth-mode label config.js will have frozen for this fixture.
+const EXPECTED_AUTH = MODE === 'setup_token' ? 'setup_token' : 'api_key';
+
+// Secrets to scrub from ANY printed/IPC'd text (CodeRabbit). Declared with `let`
+// BEFORE the boot block so fail() can reference it without a TDZ (empty pre-boot —
+// boot errors are config-load failures that don't echo a token); populated once the
+// fixture config is loaded (below).
+let SECRETS = [];
+
+function send(result) {
+    if (typeof process.send === 'function') process.send(result);
+    else process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+function fail(stage, err) {
+    const raw = err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err);
+    // Redact in case a runtime error (e.g. an auth failure) echoes a credential —
+    // upholds the harness's "tokens are NEVER printed" guarantee.
+    send({ mode: MODE, error: `[${stage}] ${redactIn(raw, SECRETS)}` });
+    process.exit(3);
+}
+
+// ── Boot the real stack ───────────────────────────────────────────────────────
+let cfg, adapter, TOOLS, ai, reasoningSupportFor, httpStreamingRequest;
+try {
+    cfg = req('config');                                   // reads workDir/config.json (argv[2])
+    ({ reasoningSupportFor } = req('model-catalog'));
+    const providers = req('providers');
+    adapter = providers.getAdapter('claude');
+    ({ TOOLS } = req(path.join('tools', 'index')));        // REAL 64-tool telegram registry
+    ai = req('ai');
+    ({ httpStreamingRequest } = req('http'));
+} catch (e) {
+    fail('boot', e);
+}
+
+// Sanity: the fixture must actually have booted Claude in the expected mode.
+if (!cfg || cfg.PROVIDER !== 'claude') fail('boot', new Error(`fixture provider is "${cfg && cfg.PROVIDER}", expected "claude"`));
+if (!adapter || adapter.id !== 'claude') fail('boot', new Error('claude adapter did not resolve'));
+if (cfg.AUTH_TYPE !== EXPECTED_AUTH) {
+    fail('boot', new Error(`AUTH_TYPE is "${cfg.AUTH_TYPE}", expected "${EXPECTED_AUTH}" (fixture/mode mismatch)`));
+}
+
+// Populate the redaction set now that config is loaded (declared above so fail() can
+// use it even during boot). Defense-in-depth; the built body itself carries no key.
+SECRETS = [cfg.ANTHROPIC_KEY, cfg.BOT_TOKEN].filter(Boolean);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+// Claude's `system` field is an ARRAY of {type:'text', text, cache_control?} blocks
+// (formatSystemPrompt output), not a bare string. Flatten to text so the seeded-
+// workspace assertions can search it.
+function systemText(system) {
+    if (typeof system === 'string') return system;
+    if (Array.isArray(system)) return system.map((b) => (b && typeof b.text === 'string' ? b.text : '')).join('\n');
+    return '';
+}
+
+// ── The seam: build the body the EXACT way ai.js chat() does ──────────────────
+// Mirrors ai.js chat():
+//   const { stable, dynamic } = buildSystemBlocks([], chatId, activeModel)
+//   systemBlocks   = adapter.formatSystemPrompt(stable, dynamic + resumeBlock, AUTH_TYPE)
+//   formattedTools = adapter.formatTools(getTools())      (== TOOLS here; no MCP)
+//   requestOptions = { reasoningEnabled, reasoningSupport, customEchoOverride, reasoningMode, synthetic }
+//   apiMessages    = adapter.toApiMessages(messages, activeModel, requestOptions)
+//   bodyStr        = adapter.formatRequest(activeModel, 4096, systemBlocks, apiMessages, formattedTools, requestOptions)
+function buildRequestOptions(model, { heartbeat = false } = {}) {
+    // Live runtime-state read, exactly like ai.js (reasoningEnabled / customEchoReasoning).
+    const rt = (() => {
+        try { return cfg.runtimeState ? cfg.runtimeState.read() : null; } catch (_) { return null; }
+    })();
+    return {
+        reasoningEnabled: !!(rt && rt.reasoningEnabled),
+        reasoningSupport: reasoningSupportFor('claude', model, cfg.AUTH_TYPE),
+        customEchoOverride: !!(rt && rt.customEchoReasoning),
+        // A normal turn is 'normal'; a heartbeat/synthetic turn is 'off' (suppresses
+        // the thinking block regardless of user-toggle / registry-support state).
+        reasoningMode: heartbeat ? 'off' : 'normal',
+        synthetic: heartbeat ? 'heartbeat' : null,
+    };
+}
+
+function buildBody(model, { heartbeat = false } = {}) {
+    // Deterministic wallet block: seed a "no burner configured" snapshot so the
+    // Wallets section is STABLE. Note: buildSystemBlocks() still fires a
+    // fire-and-forget /burner/status probe at the localhost bridge — but there is
+    // no bridge server here, so it fails silently and does NOT overwrite this seeded
+    // snapshot (the probe is why the self-check is "no EXTERNAL network", not
+    // literally "no sockets").
+    ai._setWalletPromptSnapshotForTests({ configured: false });
+
+    const { stable, dynamic } = ai.buildSystemBlocks([], null, model);
+    const resumeBlock = ''; // normal (non-resume) turn
+    const systemBlocks = adapter.formatSystemPrompt(stable, dynamic + resumeBlock, cfg.AUTH_TYPE);
+
+    const formattedTools = adapter.formatTools(TOOLS);
+    const requestOptions = buildRequestOptions(model, { heartbeat });
+    const apiMessages = adapter.toApiMessages([{ role: 'user', content: PROMPT }], model, requestOptions);
+    const bodyStr = adapter.formatRequest(model, 4096, systemBlocks, apiMessages, formattedTools, requestOptions);
+
+    const bodyObj = JSON.parse(bodyStr);
+
+    return {
+        model,
+        bodyObj,
+        bodyStr,
+        systemBlocks,
+        toolCount: formattedTools.length,
+        requestOptions,
+    };
+}
+
+// A compact, readable render of a (large) Claude Messages body: abbreviate the
+// 50KB+ system prompt and the 64-entry `tools`, keep wire-critical fields verbatim.
+function renderBody(bodyObj, toolCount) {
+    const instr = systemText(bodyObj.system);
+    const head = instr.slice(0, 600);
+    const tail = instr.length > 900 ? instr.slice(-260) : '';
+    const abbrevInstr = tail
+        ? `${head}\n        … [${instr.length} chars total; middle elided] …\n${tail}`
+        : instr;
+    const toolNames = Array.isArray(bodyObj.tools) ? bodyObj.tools.slice(0, 8).map((t) => t.name) : [];
+    const sysBlockKinds = Array.isArray(bodyObj.system)
+        ? bodyObj.system.map((b) => ({ type: b && b.type, len: b && typeof b.text === 'string' ? b.text.length : 0, cache: !!(b && b.cache_control) }))
+        : `‹string len=${instr.length}›`;
+    const view = {
+        model: bodyObj.model,
+        max_tokens: bodyObj.max_tokens,
+        stream: bodyObj.stream,
+        thinking: ('thinking' in bodyObj) ? bodyObj.thinking : '‹absent›',
+        system: sysBlockKinds,
+        messages: bodyObj.messages,
+        tools: `‹array len=${toolCount != null ? toolCount : (bodyObj.tools || []).length}; first8=${JSON.stringify(toolNames)}›`,
+    };
+    return {
+        keys: Object.keys(bodyObj),
+        critical: view,
+        instructionsAbbrev: redactIn(abbrevInstr, SECRETS),
+    };
+}
+
+// ── Offline self-check ────────────────────────────────────────────────────────
+function selfCheck() {
+    const asserts = [];
+    const A = (name, ok, detail) => asserts.push({ name, ok: !!ok, detail: detail == null ? '' : String(detail) });
+
+    const built = buildBody(cfg.MODEL, { heartbeat: false });
+    const b = built.bodyObj;
+    const ep = adapter.endpoint; // module-level object {hostname, path}
+    const instr = systemText(b.system);
+
+    // ── Common wire-shape assertions (both modes) ─────────────────────────────
+    A('endpoint === api.anthropic.com/v1/messages', ep.hostname === 'api.anthropic.com' && ep.path === '/v1/messages', `${ep.hostname}${ep.path}`);
+    A('model is a non-empty string', typeof b.model === 'string' && b.model.length > 0, `model=${b.model}`);
+    A('stream === true', b.stream === true, `stream=${b.stream}`);
+    A('max_tokens === 4096', b.max_tokens === 4096, `max_tokens=${b.max_tokens}`);
+    A('system is a non-empty array of text blocks', Array.isArray(b.system) && b.system.length > 0
+        && b.system.every((blk) => blk && blk.type === 'text' && typeof blk.text === 'string'),
+        `system.length=${Array.isArray(b.system) ? b.system.length : '‹not-array›'}`);
+    A('messages is a non-empty array', Array.isArray(b.messages) && b.messages.length > 0, `messages.length=${(b.messages || []).length}`);
+    A('first message is the user PROMPT', b.messages && b.messages[0] && b.messages[0].role === 'user', JSON.stringify(b.messages && b.messages[0] && b.messages[0].role));
+
+    // Tools: length === the real TOOLS registry, and every tool matches Claude's
+    // native shape {name, description, input_schema} — NOT the OpenAI
+    // {type:'function', ...} shape (proves we ran THIS adapter's formatTools).
+    A('tools length === real TOOLS length', Array.isArray(b.tools) && b.tools.length === TOOLS.length && b.tools.length > 0, `body.tools=${(b.tools || []).length} TOOLS=${TOOLS.length}`);
+    const claudeShape = Array.isArray(b.tools) && b.tools.every((t) => t
+        && typeof t.name === 'string' && t.name.length > 0
+        && typeof t.description === 'string'
+        && t.input_schema && typeof t.input_schema === 'object' && !Array.isArray(t.input_schema)
+        && !('type' in t)); // Claude tools have NO top-level `type` (that's the OpenAI shape)
+    A('every tool is {name, description, input_schema} (Claude shape)', claudeShape, claudeShape ? 'all ok' : 'a tool is malformed / wrong shape');
+    // formatTools stamps cache_control on the LAST tool for prompt caching.
+    const last = Array.isArray(b.tools) ? b.tools[b.tools.length - 1] : null;
+    A('last tool carries cache_control:{type:"ephemeral"}', last && last.cache_control && last.cache_control.type === 'ephemeral', JSON.stringify(last && last.cache_control));
+
+    // ── System prompt reflects the SEEDED MOCK WORKSPACE (the whole point) ────
+    A('prompt has real Identity section marker', instr.includes('You are a personal AI agent running inside SeekerClaw'), 'identity line present');
+    A('prompt has a Tooling/Architecture marker', instr.includes('## Architecture') || instr.includes('Tooling'), 'structural section present');
+    A('prompt embeds seeded IDENTITY.md (TestBot)', instr.includes('IDENTITY.md') && instr.includes('TestBot'), 'IDENTITY.md + TestBot present');
+    A('prompt embeds seeded USER.md (Test User)', instr.includes('USER.md') && instr.includes('Test User'), 'USER.md + Test User present');
+    A('prompt embeds seeded MEMORY.md line', instr.includes('BAT-1144 OpenAI live-model harness') || instr.includes('synthetic preference'), 'MEMORY.md content present');
+
+    // ── Mode-specific assertions ──────────────────────────────────────────────
+    // The stable system prompt block always carries cache_control:{ephemeral}.
+    const CC_BILLING_PREFIX = 'x-anthropic-billing-header: cc_version=';
+    if (MODE === 'setup_token') {
+        // formatSystemPrompt prepends a separate billing-attribution text block
+        // (NO cache_control) so an OAuth/Pro token can reach non-Haiku models.
+        A('setup_token: first system block is the cc_version billing header',
+            b.system[0] && typeof b.system[0].text === 'string' && b.system[0].text.startsWith(CC_BILLING_PREFIX), JSON.stringify(b.system[0] && b.system[0].text ? b.system[0].text.slice(0, 40) : null));
+        A('setup_token: billing header block has NO cache_control',
+            b.system[0] && !b.system[0].cache_control, `hasCache=${!!(b.system[0] && b.system[0].cache_control)}`);
+        A('setup_token: a stable block carries cache_control:{ephemeral}',
+            b.system.some((blk) => blk && blk.cache_control && blk.cache_control.type === 'ephemeral'), 'ephemeral cache block present');
+    } else {
+        // api_key path: NO billing header — the first block IS the cache-controlled
+        // stable prompt.
+        A('api_key: NO cc_version billing header block',
+            !b.system.some((blk) => blk && typeof blk.text === 'string' && blk.text.startsWith(CC_BILLING_PREFIX)), 'no billing block');
+        A('api_key: first system block carries cache_control:{ephemeral}',
+            b.system[0] && b.system[0].cache_control && b.system[0].cache_control.type === 'ephemeral', JSON.stringify(b.system[0] && b.system[0].cache_control));
+    }
+
+    // Reasoning: the fixture has no runtime_state (reasoningEnabled=false), so a
+    // normal turn emits NO `thinking` block (adaptive thinking is gated on the
+    // user toggle). This proves the real formatRequest gate ran.
+    A('NO thinking block (reasoning toggle off in fixture)', !('thinking' in b), `present=${'thinking' in b}`);
+
+    // ── HTTP header assertions (the OTHER half of the wire request) ───────────
+    // The body above is only half of what the device POSTs — the HTTP headers are
+    // the rest, and for Claude they DIFFER by auth mode (that's the whole reason
+    // the harness forks one worker per mode: the auth lane is a header-level fork).
+    // Build them from the REAL adapter with the SAME credential the live path uses
+    // (worker's liveOne()/listModels() both call buildHeaders(cfg.ANTHROPIC_KEY,
+    // cfg.AUTH_TYPE)). SECURITY: never print the raw key/token — assert on shape
+    // (present / startsWith / includes), and details carry "(value redacted)".
+    const headers = adapter.buildHeaders(cfg.ANTHROPIC_KEY, cfg.AUTH_TYPE);
+    const beta = typeof headers['anthropic-beta'] === 'string' ? headers['anthropic-beta'] : '';
+
+    // Both modes — fixed/pinned headers buildHeaders always emits.
+    A('header Content-Type === application/json',
+        headers['Content-Type'] === 'application/json', `Content-Type=${headers['Content-Type']}`);
+    A('header anthropic-version === 2023-06-01',
+        headers['anthropic-version'] === '2023-06-01', `anthropic-version=${headers['anthropic-version']}`);
+    A('header anthropic-beta includes prompt-caching-2024-07-31',
+        beta.includes('prompt-caching-2024-07-31'), `anthropic-beta=${beta}`);
+    A('header anthropic-beta includes interleaved-thinking-2025-05-14',
+        beta.includes('interleaved-thinking-2025-05-14'), `anthropic-beta=${beta}`);
+
+    if (MODE === 'setup_token') {
+        // OAuth / Pro-Max lane: Bearer auth + the oauth beta tag; NO x-api-key.
+        A('setup_token: Authorization header starts with "Bearer "',
+            typeof headers['Authorization'] === 'string' && headers['Authorization'].startsWith('Bearer '),
+            `Authorization present=${typeof headers['Authorization'] === 'string'} (value redacted)`);
+        A('setup_token: NO x-api-key header',
+            !('x-api-key' in headers), `has_x_api_key=${'x-api-key' in headers}`);
+        A('setup_token: anthropic-beta includes oauth-2025-04-20',
+            beta.includes('oauth-2025-04-20'), `anthropic-beta=${beta}`);
+    } else {
+        // Raw API-key lane: x-api-key auth; NO Authorization Bearer; NO oauth tag.
+        A('api_key: x-api-key header present (non-empty)',
+            typeof headers['x-api-key'] === 'string' && headers['x-api-key'].length > 0,
+            `has_x_api_key=${'x-api-key' in headers} (value redacted)`);
+        A('api_key: NO Authorization header',
+            !('Authorization' in headers), `has_authorization=${'Authorization' in headers}`);
+        A('api_key: anthropic-beta does NOT include oauth-2025-04-20',
+            !beta.includes('oauth-2025-04-20'), `anthropic-beta=${beta}`);
+    }
+
+    const pass = asserts.every((a) => a.ok);
+    send({
+        mode: MODE,
+        selfCheck: {
+            pass,
+            model: cfg.MODEL,
+            endpoint: { hostname: ep.hostname, path: ep.path },
+            toolCount: built.toolCount,
+            asserts,
+            render: renderBody(b, built.toolCount),
+        },
+    });
+    process.exit(pass ? 0 : 1);
+}
+
+// ── Live sweep ────────────────────────────────────────────────────────────────
+function resolveEndpoint() {
+    const ep = adapter.endpoint;
+    const base = { protocol: 'https:', hostname: ep.hostname, port: undefined, path: ep.path };
+    if (!BASE_URL) return base;
+    try {
+        const u = new URL(BASE_URL.includes('://') ? BASE_URL : `https://${BASE_URL}`);
+        return {
+            protocol: u.protocol || 'https:',
+            hostname: u.hostname,
+            port: u.port ? parseInt(u.port, 10) : undefined,
+            path: ep.path, // keep the adapter's real path (gateway proxies it)
+        };
+    } catch (_) {
+        return base;
+    }
+}
+
+async function liveOne(model, bodyStr) {
+    const ep = resolveEndpoint();
+    const headers = adapter.buildHeaders(cfg.ANTHROPIC_KEY, cfg.AUTH_TYPE);
+    const options = {
+        protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path,
+        method: 'POST', headers, timeout: 60000,
+    };
+    const started = Date.now();
+    try {
+        const res = await httpStreamingRequest(options, bodyStr);
+        const latencyMs = Date.now() - started;
+        let text = '', toolCalls = 0;
+        try {
+            const parsed = adapter.fromApiResponse(res.data);
+            text = (parsed.text || '').slice(0, 80);
+            toolCalls = (parsed.toolCalls || []).length;
+        } catch (_) { /* non-200 data may not parse to Messages shape */ }
+        const errBody = res.status === 200 ? '' : redactIn(typeof res.data === 'string' ? res.data.slice(0, 300) : JSON.stringify(res.data).slice(0, 300), SECRETS);
+        return { model, status: res.status, ok: res.status === 200 && (!!text || toolCalls > 0), text, toolCalls, latencyMs, errBody };
+    } catch (e) {
+        return { model, status: -1, ok: false, text: '', toolCalls: 0, latencyMs: Date.now() - started, errBody: redactIn(e.message, SECRETS) };
+    }
+}
+
+async function liveSweep() {
+    const models = MODELS.length ? MODELS : defaultModelsForMode();
+    const endpoint = resolveEndpoint();
+    const results = [];
+    for (const model of models) {
+        const built = buildBody(model, { heartbeat: false });
+        const r = await liveOne(model, built.bodyStr);
+        results.push({ ...r, variant: 'agent-parity (as-sent)' });
+    }
+    const listed = await listModels();
+    send({ mode: MODE, live: { endpoint: { hostname: endpoint.hostname, path: endpoint.path }, results, listedModels: listed } });
+    process.exit(0);
+}
+
+function defaultModelsForMode() {
+    // Fallback if the parent doesn't pass SC_MODELS. Both auth modes share the
+    // registry list (claude has no modelsByAuth split).
+    return ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5'];
+}
+
+// GET /v1/models via the adapter's testEndpoint (api.anthropic.com/v1/models) —
+// used only in live mode, for the registry show/hide comparison.
+function listModels() {
+    return new Promise((resolve) => {
+        const https = require('https');
+        const headers = adapter.buildHeaders(cfg.ANTHROPIC_KEY, cfg.AUTH_TYPE);
+        const te = adapter.testEndpoint; // { hostname:'api.anthropic.com', path:'/v1/models', method:'GET' }
+        const request = https.request({ hostname: te.hostname, path: te.path, method: 'GET', headers, timeout: 30000 }, (res) => {
+            let buf = '';
+            res.on('data', (c) => (buf += c));
+            res.on('end', () => {
+                let ids = [];
+                try {
+                    const j = JSON.parse(buf);
+                    if (Array.isArray(j.data)) ids = j.data.map((m) => m.id).sort();
+                } catch (_) {}
+                resolve({ status: res.statusCode, ids });
+            });
+        });
+        request.on('error', () => resolve({ status: -1, ids: [] }));
+        request.setTimeout(30000, () => { request.destroy(); resolve({ status: -2, ids: [] }); });
+        request.end();
+    });
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+(async function main() {
+    try {
+        if (SELF_CHECK) return selfCheck();
+        if (LIVE) return await liveSweep();
+        send({ mode: MODE, error: 'worker invoked without --self-check or SC_LIVE=1' });
+        process.exit(3);
+    } catch (e) {
+        fail('run', e);
+    }
+})();
+
+// silence unused-var lints for redact (kept in the shared API surface)
+void redact;

--- a/tests/live/anthropic/worker.js
+++ b/tests/live/anthropic/worker.js
@@ -215,7 +215,7 @@ function selfCheck() {
     A('prompt has a Tooling/Architecture marker', instr.includes('## Architecture') || instr.includes('Tooling'), 'structural section present');
     A('prompt embeds seeded IDENTITY.md (TestBot)', instr.includes('IDENTITY.md') && instr.includes('TestBot'), 'IDENTITY.md + TestBot present');
     A('prompt embeds seeded USER.md (Test User)', instr.includes('USER.md') && instr.includes('Test User'), 'USER.md + Test User present');
-    A('prompt embeds seeded MEMORY.md line', instr.includes('BAT-1144 OpenAI live-model harness') || instr.includes('synthetic preference'), 'MEMORY.md content present');
+    A('prompt embeds seeded MEMORY.md line', instr.includes('BAT-1144 live-model harness') || instr.includes('synthetic preference'), 'MEMORY.md content present');
 
     // ── Mode-specific assertions ──────────────────────────────────────────────
     // The stable system prompt block always carries cache_control:{ephemeral}.

--- a/tests/live/custom/.env.test.example
+++ b/tests/live/custom/.env.test.example
@@ -1,0 +1,16 @@
+# tests/live/custom/.env.test.example
+# Copy to .env.test (gitignored) and fill in ALL THREE values for a live sweep.
+# Tokens are NEVER printed by the harness — only present(len=N).
+#
+# The "custom" provider is a user-configured OpenAI-compatible gateway. All three
+# fields are required to boot: the bearer key, the gateway URL, and the model id.
+
+# Bearer token sent as `Authorization: Bearer <key>`
+CUSTOM_API_KEY=
+
+# Full gateway URL. Custom uses this URL verbatim (the whole path, not just a host).
+# e.g. https://my-gateway.example.com/v1/chat/completions
+CUSTOM_BASE_URL=
+
+# The model id to send to the gateway (freeform — whatever your gateway accepts).
+CUSTOM_MODEL=

--- a/tests/live/custom/.gitignore
+++ b/tests/live/custom/.gitignore
@@ -1,12 +1,11 @@
-.env
-node_modules/
-
-# ── live-models.probe.js (BAT-1144 Part 3) — secrets + generated fixtures ──
 # Secrets — never commit.
 .env.test
-# …but DO keep the documented template (the .env rule above would otherwise sweep it).
+
+# …but DO keep the documented template (the repo-root `.env.*` rule would
+# otherwise sweep it up).
 !.env.test.example
-# Generated per-mode fixture config + anything the harness writes at runtime.
+
+# Generated fixture config + any DB/log the harness writes at runtime.
 fixtures/**/config.json
 fixtures/**/*.db
 fixtures/**/node_debug.log

--- a/tests/live/custom/README.md
+++ b/tests/live/custom/README.md
@@ -1,0 +1,116 @@
+# Custom-provider live model probe — EXACT AGENT COPY (BAT-1144, Part 2)
+
+Hits a **live** user-configured OpenAI-compatible gateway (the "custom" provider)
+with **your** credential and reports whether the configured model responds — but
+the point is _how_ it builds the request.
+
+## What "exact copy" means
+
+Prior live harnesses fake the payload — a hand-written short system prompt and a
+handful of dummy tools. That means a "works here / breaks on device" gap can hide
+in everything they faked.
+
+This harness **imports the real agent modules** and builds the wire body the
+**exact way `ai.js chat()` does** — no re-implementation:
+
+| Piece | Real module (from the device bundle) |
+|-------|--------------------------------------|
+| System prompt (~54 KB) | `ai.buildSystemBlocks()` → `{ stable, dynamic }` |
+| Prompt formatting | `providers/custom.formatSystemPrompt(stable, dynamic, AUTH_TYPE)` |
+| Tools (64, telegram channel) | `tools/index` `TOOLS` → `formatTools()` |
+| Messages | `toApiMessages(messages, model, requestOptions)` |
+| Wire body | `formatRequest(model, 4096, instructions, input, tools, requestOptions)` |
+| Transport (live) | `http.js httpChatCompletionsStreamingRequest(options, body)` |
+
+The only intentional difference from the device payload is **MCP tools** — the
+harness omits them (no MCP manager), so it sends the 64 built-in tools. On device
+`getTools()` returns `[...TOOLS, ...mcp]`.
+
+## The custom provider
+
+`custom` is a **user-configured OpenAI-compatible gateway** (a middleman or
+self-hosted endpoint). Its default `customFormat` is `chat_completions`, so
+`providers/custom.js` delegates the request-shaping to `providers/openrouter.js`
+but emits its **own clean Chat Completions body** (no OpenRouter cache_control /
+fallback decorations):
+
+```json
+{ "model": "…", "stream": true, "max_tokens": 4096,
+  "messages": [ { "role": "system", "content": "‹the real system prompt›" }, … ],
+  "tools": [ { "type": "function", "function": { "name": "…", "parameters": {…} } }, … ] }
+```
+
+- **Single auth mode** — `api_key` only (bearer token). **No fork.**
+- **Endpoint** — built from your `customBaseUrl` **verbatim** (`config.js`
+  `parseCustomEndpoint`): the whole URL path is used, not just the host.
+- **Tools** — chat_completions shape `{type:'function', function:{name, description, parameters}}`.
+
+## Run
+
+```bash
+# OFFLINE acceptance test — no secrets, no gateway/external network. This is the gate.
+# (buildSystemBlocks fires a fire-and-forget localhost /burner/status probe that fails
+#  silently with no bridge server, so it's "no external network", not literally no sockets.)
+node tests/live/custom/live-models.probe.js --self-check
+
+# Live sweep (needs credentials):
+cp tests/live/custom/.env.test.example tests/live/custom/.env.test
+# …edit .env.test, set CUSTOM_API_KEY, CUSTOM_BASE_URL, CUSTOM_MODEL
+node tests/live/custom/live-models.probe.js
+
+# Options
+node tests/live/custom/live-models.probe.js --models gpt-4o-mini,llama-3.3-70b
+node tests/live/custom/live-models.probe.js --base-url http://127.0.0.1:8080
+node tests/live/custom/live-models.probe.js --help
+```
+
+Exit: **0** whenever the sweep/self-check ran; **1** only on setup/credential/assert error.
+
+## Flags
+
+- `--self-check` — offline. Seeds a fixture with a **placeholder** base URL
+  (`https://api.example.com/v1`) and model, builds the real chat_completions body,
+  asserts the wire shape (`stream:true`, `max_tokens`, `model`, a `system` message,
+  tool count == real `TOOLS.length` with the `{type:'function', function:{…}}`
+  shape, the endpoint host reflects the seeded `customBaseUrl`, and that the prompt
+  reflects the **seeded mock workspace** — proving it's the real payload, not a
+  fake). Prints the body (token-redacted).
+- `--models <csv>` — default: `CUSTOM_MODEL` from `.env.test`. Custom is freeform
+  (no registry model list).
+- `--mode apikey` — accepted for symmetry only; custom is single-auth.
+- `--diagnose` — accepted for symmetry; a documented **no-op** for chat_completions
+  custom (the body carries no `reasoning` field to sweep).
+- `--base-url <url>` — gateway override for the live POST (the adapter's real path
+  is preserved).
+
+## Security
+
+- `.env.test` is gitignored. **Never commit it.** Tokens are never printed — only
+  `present(len=N)`; any secret is scrubbed from printed bodies/errors via
+  `redactIn`.
+- Generated `fixtures/**/config.json` + seeded workspace + `node_debug.log` are
+  gitignored. The fixture dir is seeded at runtime by `_shared/fixture.js`.
+- Node builtins only — no `npm install`, no dependencies.
+
+## Fixtures
+
+`fixtures/apikey/` is the fixture workDir. `_shared/fixture.js` writes a
+`config.json` (provider=custom, channel=telegram, `customApiKey` / `customBaseUrl`
+/ `customFormat`, a canonical `bridgeToken`, a model) plus a **mock-but-realistic**
+workspace (`SOUL.md`, `IDENTITY.md` = "TestBot", `USER.md` = "Test User",
+`MEMORY.md`, two `memory/<date>.md`). All obviously synthetic — no real user data.
+
+## Shared helpers
+
+`env.js` + `fixture.js` live in the repo-wide `tests/live/_shared/` (shared by
+every live probe — `openai/`, `xai/`, `anthropic/`, `custom/`); this harness
+imports them as `require('../_shared/…')`.
+
+## Notes
+
+- Real telegram tool count is **64** (no MCP) — asserted live against
+  `tools/index` `TOOLS`, so the check stays correct if the real count changes.
+- A gateway configured for the Responses API (`customFormat: 'responses'`)
+  delegates to `openai.js` and produces a **different** body shape — out of scope
+  for this worker (use the openai harness). The worker fails loudly if booted with
+  a non-`chat_completions` format.

--- a/tests/live/custom/live-models.probe.js
+++ b/tests/live/custom/live-models.probe.js
@@ -114,7 +114,7 @@ function runWorker({ selfCheck, diagnose, live, baseUrl, models, creds }) {
         try {
             seedFixture(fixtureDir, {
                 provider: 'custom',
-                model: isLive ? (creds.model || (models && models[0]) || PLACEHOLDER_MODEL) : PLACEHOLDER_MODEL,
+                model: isLive ? ((models && models[0]) || creds.model || PLACEHOLDER_MODEL) : PLACEHOLDER_MODEL,
                 authConfig: {
                     authType: 'api_key',
                     customApiKey: isLive ? (creds.apiKey || 'sk-test-PLACEHOLDER') : 'sk-test-PLACEHOLDER',

--- a/tests/live/custom/live-models.probe.js
+++ b/tests/live/custom/live-models.probe.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// tests/live/custom/live-models.probe.js
+// ─────────────────────────────────────────────────────────────────────────────
+// LIVE Custom-provider model probe — "EXACT AGENT COPY" edition (BAT-1144, Part 2).
+//
+// The "custom" provider is a user-configured OpenAI-compatible gateway (a middleman
+// / self-hosted endpoint). Its default wire format is chat_completions, so the body
+// is a clean Chat Completions request (system message + tools + stream:true) sent to
+// whatever customBaseUrl the user configured.
+//
+// Unlike a black-box live harness that fakes the system prompt + tools, THIS probe
+// imports the REAL agent modules and builds the request the EXACT way ai.js chat()
+// does:
+//   • ai.buildSystemBlocks()   → the real ~54KB system prompt (seeded workspace)
+//   • tools/index TOOLS         → the real 64-tool telegram registry
+//   • providers/custom adapter  → formatSystemPrompt / formatTools / toApiMessages /
+//                                 formatRequest (the real wire body; delegates the
+//                                 chat_completions shaping to openrouter.js)
+//   • http.js httpChatCompletionsStreamingRequest → the real streaming transport
+//
+// config.js freezes CUSTOM_ENDPOINT / CUSTOM_FORMAT / CUSTOM_KEY at module load from
+// config.json (customBaseUrl / customFormat / customApiKey). Custom has a SINGLE auth
+// mode (api_key) — NO fork per mode. The parent forks ONE worker with a seeded
+// fixture workDir.
+//
+// SECURITY: credentials come ONLY from tests/live/custom/.env.test (gitignored).
+// Tokens are NEVER printed — only present(len=N). Node builtins only; no deps.
+//
+// USAGE
+//   node tests/live/custom/live-models.probe.js --self-check   # offline, no creds, no EXTERNAL network*
+//   node tests/live/custom/live-models.probe.js                # live sweep (needs .env.test)
+//   node tests/live/custom/live-models.probe.js --models gpt-4o-mini,llama-3.3-70b
+//   node tests/live/custom/live-models.probe.js --base-url http://127.0.0.1:8080
+//
+//   * "no EXTERNAL network": --self-check makes no gateway/internet call, but the real
+//     buildSystemBlocks() fires a fire-and-forget /burner/status probe at the localhost
+//     bridge; with no bridge server it fails silently and doesn't affect the result.
+//
+// Exit: 0 whenever the sweep/self-check ran; 1 only on setup/credential/assert error.
+'use strict';
+
+const path = require('path');
+const { fork } = require('child_process');
+
+const { loadEnvTest, redact } = require('../_shared/env');
+const { seedFixture } = require('../_shared/fixture');
+
+const HERE = __dirname;
+const WORKER = path.join(HERE, 'worker.js');
+const ENV_TEST = path.join(HERE, '.env.test');
+const FIXTURES = path.join(HERE, 'fixtures');
+
+// Placeholder base URL + model for the OFFLINE self-check (the adapter REQUIRES a
+// customBaseUrl + model to boot). The live sweep uses the real CUSTOM_BASE_URL /
+// CUSTOM_MODEL from .env.test.
+const PLACEHOLDER_BASE_URL = 'https://api.example.com/v1';
+const PLACEHOLDER_MODEL = 'gpt-4o-mini';
+
+// ── args ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+    const out = { diagnose: false, selfCheck: false, mode: null, models: null, baseUrl: null, help: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--help' || a === '-h') out.help = true;
+        else if (a === '--diagnose') out.diagnose = true;
+        else if (a === '--self-check') out.selfCheck = true;
+        else if (a === '--mode') out.mode = (argv[++i] || '').toLowerCase();
+        else if (a === '--models') out.models = argv[++i] || '';
+        else if (a === '--base-url') out.baseUrl = argv[++i] || '';
+        else if (a.startsWith('--mode=')) out.mode = a.slice(7).toLowerCase();
+        else if (a.startsWith('--models=')) out.models = a.slice(9);
+        else if (a.startsWith('--base-url=')) out.baseUrl = a.slice(11);
+    }
+    return out;
+}
+
+function usage() {
+    console.log(`
+Custom-provider live model probe — EXACT AGENT COPY (BAT-1144)
+
+  node tests/live/custom/live-models.probe.js [flags]
+
+Flags:
+  --self-check        Offline acceptance test. No secrets, NO network. Seeds a
+                      fixture with a PLACEHOLDER base URL + model, builds the REAL
+                      chat_completions body via the agent seam, and asserts the wire
+                      shape. Exit 0 all-pass.
+  --models <csv>      Models to sweep. Default: CUSTOM_MODEL from .env.test. Custom
+                      is freeform — model ids are whatever the gateway accepts, so
+                      there is no registry model list.
+  --mode apikey       Accepted for symmetry only — custom has a single auth mode.
+  --diagnose          Accepted for symmetry — documented NO-OP for chat_completions
+                      custom (the body carries no reasoning field to sweep).
+  --base-url <url>    Gateway override for the live POST (host[:port]); the
+                      adapter's real path is preserved.
+  --help              This help.
+
+Credentials (tests/live/custom/.env.test, gitignored):
+  CUSTOM_API_KEY=...          bearer token for the gateway
+  CUSTOM_BASE_URL=...         full gateway URL (e.g. https://my-gw.example/v1/chat/completions)
+  CUSTOM_MODEL=...            the model id to send
+
+"Exact copy": the probe does NOT re-implement the prompt or tools. It require()s
+the same ai.js / tools/index / providers/custom the device runs, so the body is
+byte-for-byte what the agent sends (minus MCP tools, which the harness omits).
+`);
+}
+
+// ── fork the worker ────────────────────────────────────────────────────────────
+function runWorker({ selfCheck, diagnose, live, baseUrl, models, creds }) {
+    return new Promise((resolve) => {
+        const fixtureDir = path.join(FIXTURES, 'apikey');
+        const isLive = !!live;
+        try {
+            seedFixture(fixtureDir, {
+                provider: 'custom',
+                model: isLive ? (creds.model || (models && models[0]) || PLACEHOLDER_MODEL) : PLACEHOLDER_MODEL,
+                authConfig: {
+                    authType: 'api_key',
+                    customApiKey: isLive ? (creds.apiKey || 'sk-test-PLACEHOLDER') : 'sk-test-PLACEHOLDER',
+                    customBaseUrl: isLive ? (creds.baseUrl || PLACEHOLDER_BASE_URL) : PLACEHOLDER_BASE_URL,
+                    customFormat: 'chat_completions',
+                },
+            });
+        } catch (e) {
+            return resolve({ mode: 'apikey', error: `[seed] ${e.message}` });
+        }
+
+        const env = {
+            ...process.env,
+            SC_SELF_CHECK: selfCheck ? '1' : '',
+            SC_DIAGNOSE: diagnose ? '1' : '',
+            SC_LIVE: live ? '1' : '',
+            SC_BASE_URL: baseUrl || '',
+            SC_MODELS: (models || []).join(','),
+        };
+        // argv[2] = fixtureDir → config.js picks it up as workDir.
+        const child = fork(WORKER, [fixtureDir], { env, stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+        let message = null;
+        child.on('message', (m) => { message = m; });
+        child.on('error', (e) => resolve({ mode: 'apikey', error: `[fork] ${e.message}` }));
+        child.on('exit', (code) => {
+            if (message) resolve({ ...message, _exit: code });
+            else resolve({ mode: 'apikey', error: `worker exited (code ${code}) without a result`, _exit: code });
+        });
+    });
+}
+
+// ── printing ──────────────────────────────────────────────────────────────────
+const BAR = '═'.repeat(78);
+const line = (s = '') => console.log(s);
+
+function printSelfCheck(result) {
+    const sc = result.selfCheck;
+    line(`\n${BAR}`);
+    line(`SELF-CHECK · provider=custom  endpoint=${sc.endpoint.hostname}${sc.endpoint.path}  model=${sc.model}  tools=${sc.toolCount}`);
+    line(BAR);
+    for (const a of sc.asserts) {
+        line(`  ${a.ok ? 'PASS' : 'FAIL'}  ${a.name}${a.detail ? `   (${a.detail})` : ''}`);
+    }
+    line(`\n  ── Built body (token-redacted; system/tools abbreviated) ──`);
+    line('  keys: ' + JSON.stringify(sc.render.keys));
+    line('  ' + JSON.stringify(sc.render.critical, null, 2).split('\n').join('\n  '));
+    line('\n  ── system message (head + tail; full length above) ──');
+    line(sc.render.instructionsAbbrev.split('\n').map((l) => '  | ' + l).join('\n'));
+    line(`\n  → custom: ${sc.pass ? 'PASS' : 'FAIL'}`);
+}
+
+function printLive(result) {
+    const lv = result.live;
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP · provider=custom  endpoint=${lv.endpoint.hostname}${lv.endpoint.path}`);
+    line(BAR);
+    line('  model'.padEnd(28) + 'variant'.padEnd(30) + 'status  ok   lat     detail');
+    for (const r of lv.results) {
+        const detail = r.ok ? `"${r.text}"${r.toolCalls ? ` +${r.toolCalls} toolCalls` : ''}` : r.errBody;
+        line('  ' + String(r.model).padEnd(26) + String(r.variant).padEnd(30)
+            + String(r.status).padStart(5) + '  ' + (r.ok ? 'Y' : 'n') + '   '
+            + (String(r.latencyMs) + 'ms').padStart(7) + '  ' + (detail || '').slice(0, 60));
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+(async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) { usage(); process.exit(0); }
+
+    const { loaded } = loadEnvTest(ENV_TEST);
+    const creds = {
+        apiKey: (process.env.CUSTOM_API_KEY || '').trim(),
+        baseUrl: (process.env.CUSTOM_BASE_URL || '').trim(),
+        model: (process.env.CUSTOM_MODEL || '').trim(),
+    };
+
+    line(`${BAR}`);
+    line('Custom-provider live model probe — EXACT AGENT COPY (BAT-1144)');
+    line(`.env.test: ${loaded ? 'loaded' : 'not found'}   CUSTOM_API_KEY=${redact(creds.apiKey)}   CUSTOM_BASE_URL=${creds.baseUrl ? 'set' : '(none)'}   CUSTOM_MODEL=${creds.model || '(none)'}`);
+    line(BAR);
+
+    // ── SELF-CHECK (offline) ──────────────────────────────────────────────────
+    if (args.selfCheck) {
+        line('\nMODE: --self-check (offline, no external network). Seeding fixture with placeholder base URL + model.');
+        const models = args.models ? args.models.split(',').map((s) => s.trim()).filter(Boolean) : [];
+        const result = await runWorker({ selfCheck: true, diagnose: false, live: false, baseUrl: null, models, creds: {} });
+        line(`\n${BAR}`);
+        if (result.error) { line(`\n[SETUP ERROR] ${result.error}`); line(BAR); process.exit(1); }
+        printSelfCheck(result);
+        line(`\n${BAR}`);
+        line(`SELF-CHECK RESULT: ${result.selfCheck.pass ? 'PASS' : 'FAIL'}`);
+        line(BAR);
+        process.exit(result.selfCheck.pass ? 0 : 1);
+    }
+
+    // ── LIVE sweep ────────────────────────────────────────────────────────────
+    if (!creds.apiKey || !creds.baseUrl || !creds.model) {
+        line('\nCustom provider needs ALL of the following in tests/live/custom/.env.test:');
+        line('  CUSTOM_API_KEY=...     (bearer token)');
+        line('  CUSTOM_BASE_URL=...    (full gateway URL)');
+        line('  CUSTOM_MODEL=...       (model id to send)');
+        line('…or run with --self-check to validate the body offline (no creds, no external network).');
+        process.exit(1);
+    }
+
+    const models = args.models ? args.models.split(',').map((s) => s.trim()).filter(Boolean) : [creds.model];
+    const result = await runWorker({ selfCheck: false, diagnose: args.diagnose, live: true, baseUrl: args.baseUrl, models, creds });
+    if (result.error) {
+        line(`\n[ERROR] ${result.error}`);
+        line(`\n${BAR}`);
+        line('LIVE SWEEP: SETUP ERROR (see above).');
+        line(BAR);
+        process.exit(1);
+    }
+    printLive(result);
+    line(`\n${BAR}`);
+    line('LIVE SWEEP COMPLETE (provider: custom).');
+    line(BAR);
+    // Report-only: exit 0 whenever the sweep ran; 1 only on setup error.
+    process.exit(0);
+})();

--- a/tests/live/custom/worker.js
+++ b/tests/live/custom/worker.js
@@ -1,0 +1,330 @@
+// tests/live/custom/worker.js
+// ─────────────────────────────────────────────────────────────────────────────
+// CHILD worker for the "custom" provider (a user-configured OpenAI-compatible
+// gateway). Its process.argv[2] is the fixture workDir, so require('<bundle>/config')
+// finds workDir/config.json and boots the REAL agent stack for THIS gateway config.
+//
+// WHY A CHILD PROCESS: config.js freezes CUSTOM_ENDPOINT / CUSTOM_FORMAT / CUSTOM_KEY
+// at module-load time from config.json (customBaseUrl / customFormat / customApiKey).
+// A fresh process per run is the clean way to boot the adapter against a specific
+// gateway config. `custom` has a SINGLE auth mode (api_key) — no fork per mode.
+//
+// The worker imports the REAL modules and builds the wire body the EXACT way the
+// agent does (ai.js chat() seam), then either:
+//   • --self-check : validates the body's wire shape offline — no external network
+//                    (a fire-and-forget localhost bridge probe during prompt
+//                    assembly fails silently), OR
+//   • live         : POSTs each model's body via the REAL
+//                    httpChatCompletionsStreamingRequest transport.
+//
+// It reports back via IPC (process.send) when forked, else prints JSON to stdout.
+'use strict';
+
+const path = require('path');
+
+// ── Resolve the real nodejs-project bundle (…/app/src/main/assets/nodejs-project)
+const BUNDLE = path.resolve(__dirname, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+const req = (m) => require(path.join(BUNDLE, m));
+
+const { redact, redactIn } = require('../_shared/env');
+
+// ── Control inputs (from the parent via env; argv[2] is reserved for workDir) ──
+const MODE = 'apikey'; // custom is single-auth (api_key)
+const SELF_CHECK = process.env.SC_SELF_CHECK === '1';
+const DIAGNOSE = process.env.SC_DIAGNOSE === '1';
+const LIVE = process.env.SC_LIVE === '1';
+const BASE_URL = (process.env.SC_BASE_URL || '').trim();
+const MODELS = (process.env.SC_MODELS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const PROMPT = process.env.SC_PROMPT || 'Reply with the single word: pong';
+
+// Secrets to scrub from ANY printed/IPC'd text (CodeRabbit). Declared with `let`
+// BEFORE the boot block so fail() can reference it without a TDZ (empty pre-boot —
+// boot errors are config-load failures that don't echo a token); populated once the
+// fixture config is loaded (below).
+let SECRETS = [];
+
+function send(result) {
+    if (typeof process.send === 'function') process.send(result);
+    else process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+function fail(stage, err) {
+    const raw = err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err);
+    // Redact in case a runtime error (e.g. an auth failure) echoes a credential —
+    // upholds the harness's "tokens are NEVER printed" guarantee.
+    send({ mode: MODE, error: `[${stage}] ${redactIn(raw, SECRETS)}` });
+    process.exit(3);
+}
+
+// ── Boot the real stack ───────────────────────────────────────────────────────
+let cfg, adapter, TOOLS, ai, reasoningSupportFor, httpChatCompletionsStreamingRequest;
+try {
+    cfg = req('config');                                   // reads workDir/config.json (argv[2])
+    ({ reasoningSupportFor } = req('model-catalog'));
+    const providers = req('providers');
+    adapter = providers.getAdapter('custom');
+    ({ TOOLS } = req(path.join('tools', 'index')));        // REAL 64-tool telegram registry
+    ai = req('ai');
+    ({ httpChatCompletionsStreamingRequest } = req('http'));
+} catch (e) {
+    fail('boot', e);
+}
+
+// Sanity: the fixture must actually have booted the custom provider.
+if (!cfg || cfg.PROVIDER !== 'custom') fail('boot', new Error(`fixture provider is "${cfg && cfg.PROVIDER}", expected "custom"`));
+if (!adapter || adapter.id !== 'custom') fail('boot', new Error('custom adapter did not resolve'));
+if (cfg.AUTH_TYPE !== 'api_key') fail('boot', new Error(`AUTH_TYPE is "${cfg.AUTH_TYPE}", expected "api_key" (custom is single-auth)`));
+// Custom's chat_completions body shape is the one this worker asserts. A gateway
+// configured for the Responses API delegates to openai.js and produces a DIFFERENT
+// body — out of scope here (that's the openai harness). Fail loudly instead of
+// silently asserting the wrong shape.
+if (cfg.CUSTOM_FORMAT && cfg.CUSTOM_FORMAT !== 'chat_completions') {
+    fail('boot', new Error(`CUSTOM_FORMAT is "${cfg.CUSTOM_FORMAT}", this worker asserts the chat_completions shape only`));
+}
+
+// Populate the redaction set now that config is loaded (declared above so fail() can
+// use it even during boot). Defense-in-depth; the built body itself carries none.
+SECRETS = [cfg.CUSTOM_KEY, cfg.BOT_TOKEN].filter(Boolean);
+
+// ── The seam: build the body the EXACT way ai.js chat() does ──────────────────
+// Mirrors ai.js:
+//   buildSystemBlocks(matchedSkills, chatId, activeModel)  → { stable, dynamic }
+//   formatSystemPrompt(stable, dynamic + resumeBlock, AUTH_TYPE)
+//   rawTools = getTools() (== TOOLS here; no MCP in the harness) → formatTools()
+//   requestOptions = { reasoningEnabled, reasoningSupport, customEchoOverride, reasoningMode, synthetic }
+//   toApiMessages(messages, activeModel, requestOptions)
+//   formatRequest(activeModel, 4096, systemBlocks, apiMessages, formattedTools, requestOptions)
+function buildRequestOptions(model, { heartbeat = false } = {}) {
+    // Live runtime-state read, exactly like ai.js (reasoningEnabled / customEchoReasoning).
+    const rt = (() => {
+        try { return cfg.runtimeState ? cfg.runtimeState.read() : null; } catch (_) { return null; }
+    })();
+    return {
+        reasoningEnabled: !!(rt && rt.reasoningEnabled),
+        reasoningSupport: reasoningSupportFor('custom', model, cfg.AUTH_TYPE),
+        // Per-Custom echo override (BAT-549) — read live like ai.js does.
+        customEchoOverride: !!(rt && rt.customEchoReasoning),
+        // A normal turn is 'normal'; a heartbeat/synthetic turn is 'off'.
+        reasoningMode: heartbeat ? 'off' : 'normal',
+        synthetic: heartbeat ? 'heartbeat' : null,
+    };
+}
+
+function buildBody(model, { heartbeat = false } = {}) {
+    // Deterministic wallet block: seed a "no burner configured" snapshot so the
+    // Wallets section is STABLE. buildSystemBlocks() still fires a fire-and-forget
+    // /burner/status probe at the localhost bridge — but there is no bridge server
+    // here, so it fails silently and does NOT overwrite this seeded snapshot (the
+    // probe is why the self-check is "no EXTERNAL network", not literally "no sockets").
+    ai._setWalletPromptSnapshotForTests({ configured: false });
+
+    const { stable, dynamic } = ai.buildSystemBlocks([], null, model);
+    const resumeBlock = ''; // normal (non-resume) turn
+    const systemBlocks = adapter.formatSystemPrompt(stable, dynamic + resumeBlock, cfg.AUTH_TYPE);
+
+    const formattedTools = adapter.formatTools(TOOLS);
+    const requestOptions = buildRequestOptions(model, { heartbeat });
+    const apiMessages = adapter.toApiMessages([{ role: 'user', content: PROMPT }], model, requestOptions);
+    const bodyStr = adapter.formatRequest(model, 4096, systemBlocks, apiMessages, formattedTools, requestOptions);
+
+    const bodyObj = JSON.parse(bodyStr);
+
+    return {
+        model,
+        bodyObj,
+        bodyStr,
+        instructions: systemBlocks,
+        toolCount: formattedTools.length,
+        requestOptions,
+    };
+}
+
+// A compact, readable render of a (large) Chat Completions body: abbreviate the
+// 50KB+ system message and the 64-entry `tools`, keep the wire-critical fields.
+function renderBody(bodyObj, instructions, toolCount) {
+    const instr = String(instructions || '');
+    const head = instr.slice(0, 600);
+    const tail = instr.length > 900 ? instr.slice(-260) : '';
+    const abbrevInstr = tail
+        ? `${head}\n        … [${instr.length} chars total; middle elided] …\n${tail}`
+        : instr;
+    const msgs = Array.isArray(bodyObj.messages) ? bodyObj.messages : [];
+    const toolNames = Array.isArray(bodyObj.tools)
+        ? bodyObj.tools.slice(0, 8).map((t) => (t && t.function && t.function.name) || t.name)
+        : [];
+    const msgSummary = msgs.map((m) => ({
+        role: m.role,
+        content: typeof m.content === 'string' ? `‹string len=${m.content.length}›` : m.content,
+    }));
+    const view = {
+        model: bodyObj.model,
+        stream: bodyObj.stream,
+        max_tokens: ('max_tokens' in bodyObj) ? bodyObj.max_tokens : '‹absent›',
+        messages: msgSummary,
+        tools: `‹array len=${toolCount != null ? toolCount : (bodyObj.tools || []).length}; first8=${JSON.stringify(toolNames)}›`,
+    };
+    return {
+        keys: Object.keys(bodyObj),
+        critical: view,
+        instructionsAbbrev: redactIn(abbrevInstr, SECRETS),
+    };
+}
+
+// ── Offline self-check ────────────────────────────────────────────────────────
+function selfCheck() {
+    const asserts = [];
+    const A = (name, ok, detail) => asserts.push({ name, ok: !!ok, detail: detail == null ? '' : String(detail) });
+
+    const built = buildBody(cfg.MODEL, { heartbeat: false });
+    const b = built.bodyObj;
+    const ep = adapter.endpoint; // getter → CUSTOM_ENDPOINT { protocol, hostname, port, path }
+    const instr = built.instructions;
+
+    // ── Chat Completions wire-shape assertions ────────────────────────────────
+    A('stream === true', b.stream === true, `stream=${b.stream}`);
+    A('model === configured model', b.model === cfg.MODEL, `model=${b.model} cfg.MODEL=${cfg.MODEL}`);
+    A('max_tokens === 4096', b.max_tokens === 4096, `max_tokens=${b.max_tokens}`);
+    A('messages is a non-empty array', Array.isArray(b.messages) && b.messages.length >= 2, `messages.length=${(b.messages || []).length}`);
+
+    const sys = Array.isArray(b.messages) ? b.messages[0] : null;
+    A('messages[0] is the system message', sys && sys.role === 'system' && typeof sys.content === 'string' && sys.content.length > 0, `role=${sys && sys.role} len=${sys && typeof sys.content === 'string' ? sys.content.length : 'n/a'}`);
+    const hasUser = Array.isArray(b.messages) && b.messages.some((m) => m && m.role === 'user');
+    A('messages contains the user turn', hasUser, hasUser ? 'user present' : 'no user message');
+
+    // Tools: length === real TOOLS.length AND every tool matches the chat_completions
+    // shape {type:'function', function:{name, description, parameters}}.
+    A('tools length === real TOOLS length', Array.isArray(b.tools) && b.tools.length === TOOLS.length && b.tools.length > 0, `body.tools=${(b.tools || []).length} TOOLS=${TOOLS.length}`);
+    const allFn = Array.isArray(b.tools) && b.tools.every((t) =>
+        t && t.type === 'function' && t.function && typeof t.function.name === 'string' && t.function.name.length > 0
+        && t.function.parameters && typeof t.function.parameters === 'object' && !Array.isArray(t.function.parameters));
+    A('every tool is {type:"function", function:{name, parameters:{…}}}', allFn, allFn ? 'all ok' : 'a tool is malformed (missing name or parameters object)');
+
+    // ── System prompt reflects the SEEDED MOCK WORKSPACE (the whole point) ────
+    const sysContent = sys && typeof sys.content === 'string' ? sys.content : '';
+    A('prompt has real Identity section marker', sysContent.includes('You are a personal AI agent running inside SeekerClaw'), 'identity line present');
+    A('prompt has an Architecture marker', sysContent.includes('## Architecture'), 'structural section present');
+    A('prompt embeds seeded IDENTITY.md (TestBot)', sysContent.includes('IDENTITY.md') && sysContent.includes('TestBot'), 'IDENTITY.md + TestBot present');
+    A('prompt embeds seeded USER.md (Test User)', sysContent.includes('USER.md') && sysContent.includes('Test User'), 'USER.md + Test User present');
+    A('prompt embeds seeded MEMORY.md line', sysContent.includes('BAT-1144') || sysContent.includes('synthetic preference'), 'MEMORY.md content present');
+
+    // ── Endpoint reflects the seeded customBaseUrl ────────────────────────────
+    A('endpoint hostname reflects configured customBaseUrl', ep && typeof ep.hostname === 'string' && ep.hostname.length > 0, `${ep && ep.hostname}${ep && ep.path}`);
+    A('endpoint host === cfg.CUSTOM_BASE_URL host', (() => {
+        try { return ep.hostname === new URL(cfg.CUSTOM_BASE_URL).hostname; } catch (_) { return false; }
+    })(), `endpoint=${ep && ep.hostname} base=${cfg.CUSTOM_BASE_URL}`);
+    A('streamProtocol === chat-completions', adapter.streamProtocol === 'chat-completions', `streamProtocol=${adapter.streamProtocol}`);
+
+    // ── HTTP header assertions (the REAL wire headers the device sends) ───────
+    // Headers are part of the real request but were never asserted (adversarial
+    // gap). Build them from the REAL adapter with the SAME credential the worker
+    // POSTs with (cfg.CUSTOM_KEY, api_key mode). custom.buildHeaders(apiKey) ignores
+    // authType (single auth mode) and returns:
+    //   { 'Content-Type':'application/json', ...customHeaders,
+    //     Authorization:`Bearer <key>` }
+    // where Authorization is added ONLY when a key is present AND customHeaders
+    // carries no auth header. This fixture seeds a key and NO customHeaders, so the
+    // exact shape is { 'Content-Type', 'Authorization' }. Secrets never printed —
+    // assert on prefix/shape, redact the token to its length.
+    const headers = adapter.buildHeaders(cfg.CUSTOM_KEY, cfg.AUTH_TYPE);
+    A('headers is a plain object', !!headers && typeof headers === 'object' && !Array.isArray(headers), `type=${Array.isArray(headers) ? 'array' : typeof headers}`);
+    A('header Content-Type === application/json', !!headers && headers['Content-Type'] === 'application/json', `Content-Type=${headers && headers['Content-Type']}`);
+    const authHdr = headers && headers.Authorization;
+    A('header Authorization is "Bearer <token>"',
+        typeof authHdr === 'string' && authHdr.startsWith('Bearer ') && authHdr.length > 'Bearer '.length,
+        `Authorization=Bearer <redacted len=${typeof authHdr === 'string' ? authHdr.length : 'n/a'}>`);
+    A('no header value carries a raw newline/control char', !!headers && Object.values(headers).every((v) => !/[\r\n]/.test(String(v))), `keys=${headers ? JSON.stringify(Object.keys(headers)) : 'n/a'}`);
+
+    const pass = asserts.every((a) => a.ok);
+    send({
+        mode: MODE,
+        selfCheck: {
+            pass,
+            model: cfg.MODEL,
+            endpoint: { hostname: ep.hostname, path: ep.path },
+            toolCount: built.toolCount,
+            asserts,
+            render: renderBody(b, instr, built.toolCount),
+        },
+    });
+    process.exit(pass ? 0 : 1);
+}
+
+// ── Live sweep ────────────────────────────────────────────────────────────────
+function resolveEndpoint() {
+    const ep = adapter.endpoint;
+    if (!BASE_URL) return { protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path };
+    try {
+        const u = new URL(BASE_URL.includes('://') ? BASE_URL : `https://${BASE_URL}`);
+        return {
+            protocol: u.protocol || 'https:',
+            hostname: u.hostname,
+            port: u.port ? parseInt(u.port, 10) : undefined,
+            // Keep the adapter's real path (the gateway is expected to proxy it).
+            path: ep.path,
+        };
+    } catch (_) {
+        return { protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path };
+    }
+}
+
+async function liveOne(model, bodyStr) {
+    const ep = resolveEndpoint();
+    const apiKey = cfg.CUSTOM_KEY;
+    const headers = adapter.buildHeaders(apiKey, cfg.AUTH_TYPE);
+    const options = {
+        protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path,
+        method: 'POST', headers, timeout: 60000,
+    };
+    const started = Date.now();
+    try {
+        const res = await httpChatCompletionsStreamingRequest(options, bodyStr);
+        const latencyMs = Date.now() - started;
+        let text = '', toolCalls = 0;
+        try {
+            const parsed = adapter.fromApiResponse(res.data);
+            text = (parsed.text || '').slice(0, 80);
+            toolCalls = (parsed.toolCalls || []).length;
+        } catch (_) { /* non-200 data may not parse to Chat Completions shape */ }
+        const errBody = res.status === 200 ? '' : redactIn(typeof res.data === 'string' ? res.data.slice(0, 300) : JSON.stringify(res.data).slice(0, 300), SECRETS);
+        return { model, status: res.status, ok: res.status === 200 && (!!text || toolCalls > 0), text, toolCalls, latencyMs, errBody };
+    } catch (e) {
+        return { model, status: -1, ok: false, text: '', toolCalls: 0, latencyMs: Date.now() - started, errBody: redactIn(e.message, SECRETS) };
+    }
+}
+
+async function liveSweep() {
+    // Default to the single configured model if none supplied.
+    const models = MODELS.length ? MODELS : [cfg.MODEL];
+    const endpoint = resolveEndpoint();
+    const results = [];
+    for (const model of models) {
+        const built = buildBody(model, { heartbeat: false });
+        const r = await liveOne(model, built.bodyStr);
+        // --diagnose is a documented no-op for chat_completions custom: the body
+        // carries NO `reasoning` field (custom emits a clean chat/completions body),
+        // so there is no reasoning-effort ladder to sweep. Label stays agent-parity.
+        results.push({ ...r, variant: 'agent-parity (as-sent)' });
+    }
+    // NOTE: custom has no /v1/models listing endpoint (no adapter.testEndpoint), so
+    // there is no registry-vs-live model diff — the registry ships an empty model
+    // list for custom (freeform, user-typed model ids).
+    send({ mode: MODE, live: { endpoint: { hostname: endpoint.hostname, path: endpoint.path }, results } });
+    process.exit(0);
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+(async function main() {
+    try {
+        if (SELF_CHECK) return selfCheck();
+        if (LIVE) return await liveSweep();
+        // No mode selected — nothing to do.
+        send({ mode: MODE, error: 'worker invoked without --self-check or SC_LIVE=1' });
+        process.exit(3);
+    } catch (e) {
+        fail('run', e);
+    }
+})();
+
+// silence unused-var lints for redact (kept in the shared API surface)
+void redact;
+void DIAGNOSE;

--- a/tests/live/openrouter/.env.test.example
+++ b/tests/live/openrouter/.env.test.example
@@ -1,0 +1,12 @@
+# tests/live/openrouter/.env.test.example
+# Copy to .env.test (gitignored) and fill in a real key to run the LIVE sweep.
+# The --self-check gate needs NO credentials.
+
+# OpenRouter API key — api_key path (openrouter.ai/api/v1/chat/completions).
+# Get one at https://openrouter.ai/keys  (shape: sk-or-v1-…)
+OPENROUTER_API_KEY=
+
+# Optional: default model set for the live sweep (comma-separated OpenRouter ids).
+# OpenRouter is freeform — pass provider-prefixed ids, e.g.:
+# TEST_MODELS=anthropic/claude-sonnet-4-6,openai/gpt-5.4
+TEST_MODELS=

--- a/tests/live/openrouter/.gitignore
+++ b/tests/live/openrouter/.gitignore
@@ -1,12 +1,11 @@
-.env
-node_modules/
-
-# ── live-models.probe.js (BAT-1144 Part 3) — secrets + generated fixtures ──
 # Secrets — never commit.
 .env.test
-# …but DO keep the documented template (the .env rule above would otherwise sweep it).
+
+# …but DO keep the documented template (the repo-root `.env.*` rule would
+# otherwise sweep it up).
 !.env.test.example
-# Generated per-mode fixture config + anything the harness writes at runtime.
+
+# Generated fixture config + any DB/log the harness writes at runtime.
 fixtures/**/config.json
 fixtures/**/*.db
 fixtures/**/node_debug.log

--- a/tests/live/openrouter/README.md
+++ b/tests/live/openrouter/README.md
@@ -1,0 +1,113 @@
+# OpenRouter live model probe — EXACT AGENT COPY (BAT-1144)
+
+Hits the **live** OpenRouter Chat Completions API (`openrouter.ai/api/v1/chat/completions`)
+with **your** key and reports, per model, whether it responds — but the point is
+_how_ it builds the request.
+
+## What "exact copy" means
+
+Prior live harnesses fake the payload — a hand-written short system prompt and a
+handful of dummy tools. That means a "works here / breaks on device" gap can hide
+in everything they faked.
+
+This harness **imports the real agent modules** and builds the wire body the
+**exact way `ai.js chat()` does** — no re-implementation:
+
+| Piece | Real module (from the device bundle) |
+|-------|--------------------------------------|
+| System prompt (~54 KB) | `ai.buildSystemBlocks()` → `{ stable, dynamic }` |
+| Prompt formatting | `providers/openrouter.formatSystemPrompt(stable, dynamic)` |
+| Tools (64, telegram channel) | `tools/index` `TOOLS` → `formatTools()` |
+| Messages | `toApiMessages(messages, model, requestOptions)` |
+| Wire body | `formatRequest(model, 4096, systemPrompt, messages, tools, requestOptions)` |
+| Transport (live) | `http.js httpChatCompletionsStreamingRequest(options, body)` |
+
+The only intentional difference from the device payload is **MCP tools** — the
+harness omits them (no MCP manager), so it sends the 64 built-in tools. On device
+`getTools()` returns `[...TOOLS, ...mcp]`.
+
+## Single auth mode
+
+OpenRouter authenticates with **one** mode: `api_key` (`Authorization: Bearer sk-or-v1-…`).
+There is **no** OAuth/Codex fork like OpenAI — the parent forks exactly one worker
+(`mode=apikey`). The Chat Completions body:
+
+- **model** — the OpenRouter model id (e.g. `anthropic/claude-sonnet-4-6`).
+- **stream** — `true` (the device path).
+- **max_tokens** — `4096`.
+- **messages** — `[{role:'system', content:<system prompt>}, {role:'user', …}]`.
+- **cache_control** — `{type:'ephemeral'}` (top-level, cross-provider prompt caching).
+- **tools** — 64 entries in Chat Completions shape:
+  `{type:'function', function:{name, description, parameters}}`.
+- **reasoning** — *omitted* on a normal turn (OpenRouter's `reasoningSupport`
+  resolves to `unknown` for every OR-prefixed model, so the toggle is a no-op);
+  synthetic/heartbeat turns send `reasoning:{effort:'none'}` as an explicit disable.
+
+## Run
+
+```bash
+# OFFLINE acceptance test — no secrets, no OpenRouter/external network. This is the gate.
+# (buildSystemBlocks fires a fire-and-forget localhost /burner/status probe that fails
+#  silently with no bridge server, so it's "no external network", not literally no sockets.)
+node tests/live/openrouter/live-models.probe.js --self-check
+
+# Live sweep (needs credentials):
+cp tests/live/openrouter/.env.test.example tests/live/openrouter/.env.test
+# …edit .env.test, set OPENROUTER_API_KEY
+node tests/live/openrouter/live-models.probe.js
+
+# Options
+node tests/live/openrouter/live-models.probe.js --diagnose
+node tests/live/openrouter/live-models.probe.js --models anthropic/claude-sonnet-4-6,openai/gpt-5.4
+node tests/live/openrouter/live-models.probe.js --base-url http://127.0.0.1:8080
+node tests/live/openrouter/live-models.probe.js --help
+```
+
+Exit: **0** whenever the sweep/self-check ran; **1** only on setup/credential/assert error.
+
+## Flags
+
+- `--self-check` — offline. Seeds the fixture with a placeholder key, builds the
+  real body, asserts the wire shape (endpoint, `stream:true`, `max_tokens`,
+  `cache_control`, `messages[0]` is the system message, tool count == real
+  `TOOLS.length` in OpenRouter's function shape, and that the prompt reflects the
+  **seeded mock workspace** — proving it's the real payload, not a fake). Prints
+  the body (token-redacted).
+- `--mode apikey` — the only mode (OpenRouter has no OAuth). Default: `apikey`.
+- `--models <csv|all>` — OpenRouter is freeform (`models[]` is empty in the
+  registry), so the default is the registry `defaultModel`
+  (`anthropic/claude-sonnet-4-6`) unless you pass an explicit CSV or set
+  `TEST_MODELS`. Pass real OpenRouter ids (provider-prefixed).
+- `--diagnose` — also sweeps the reasoning-effort ladder `none/low/medium/high`,
+  clearly labelled **beyond agent parity — param exploration**. Live only.
+- `--base-url <url>` — gateway override for the live POST (the adapter's real path
+  is preserved).
+
+## Security
+
+- `.env.test` is gitignored. **Never commit it.** Tokens are never printed — only
+  `present(len=N)`; any secret is scrubbed from printed bodies/errors.
+- Generated `fixtures/**/config.json` + seeded workspace + `node_debug.log` are
+  gitignored. The fixture dir is seeded at runtime by `_shared/fixture.js`.
+- Node builtins only — no `npm install`, no dependencies.
+
+## Fixtures
+
+`fixtures/apikey/` is the workDir. `_shared/fixture.js` writes a `config.json`
+(`provider=openrouter`, `channel=telegram`, `authType=api_key`,
+`openrouterApiKey`, a canonical `bridgeToken`, a model) plus a
+**mock-but-realistic** workspace (`SOUL.md`, `IDENTITY.md` = "TestBot",
+`USER.md` = "Test User", `MEMORY.md`, two `memory/<date>.md`). All obviously
+synthetic — no real user data.
+
+## Shared helpers
+
+`env.js` + `fixture.js` live in the repo-wide `tests/live/_shared/` (shared by
+every live probe — `openai/`, `xai/`, `anthropic/`, `openrouter/`); this harness
+imports them as `require('../_shared/…')`.
+
+## Notes
+
+- Real telegram tool count is **64** (no MCP) — asserted live by the self-check
+  against `tools/index` `TOOLS.length`, so it stays correct if the real count
+  changes.

--- a/tests/live/openrouter/live-models.probe.js
+++ b/tests/live/openrouter/live-models.probe.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// tests/live/openrouter/live-models.probe.js
+// ─────────────────────────────────────────────────────────────────────────────
+// LIVE OpenRouter model-matrix probe — "EXACT AGENT COPY" edition (BAT-1144).
+//
+// Unlike a black-box live harness that fakes the system prompt + tools, THIS probe
+// imports the REAL agent modules and builds the Chat Completions request the EXACT
+// way ai.js chat() does:
+//   • ai.buildSystemBlocks()      → the real ~54KB system prompt (seeded workspace)
+//   • tools/index TOOLS           → the real 64-tool telegram registry
+//   • providers/openrouter adapter → formatSystemPrompt / formatTools /
+//                                    toApiMessages / formatRequest (the real wire body)
+//   • http.js httpChatCompletionsStreamingRequest → the real streaming transport
+//
+// OpenRouter has a SINGLE auth mode (api_key) — no OAuth/Codex fork like OpenAI.
+// The parent forks exactly one worker (mode=apikey).
+//
+// SECURITY: credentials come ONLY from tests/live/openrouter/.env.test (gitignored).
+// Tokens are NEVER printed — only present(len=N). Node builtins only; no deps.
+//
+// USAGE
+//   node tests/live/openrouter/live-models.probe.js --self-check     # offline, no creds, no EXTERNAL network*
+//   node tests/live/openrouter/live-models.probe.js                  # live sweep (needs .env.test)
+//   node tests/live/openrouter/live-models.probe.js --diagnose
+//   node tests/live/openrouter/live-models.probe.js --models anthropic/claude-sonnet-4-6,openai/gpt-5.4
+//   node tests/live/openrouter/live-models.probe.js --base-url http://127.0.0.1:8080
+//
+//   * "no EXTERNAL network": --self-check makes no OpenRouter/internet call, but the
+//     real buildSystemBlocks() fires a fire-and-forget /burner/status probe at the
+//     localhost bridge; with no bridge server it fails silently and doesn't affect
+//     the result.
+//
+// Exit: 0 whenever the sweep/self-check ran; 1 only on setup/credential/assert error.
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { fork } = require('child_process');
+
+const { loadEnvTest, redact } = require('../_shared/env');
+const { seedFixture } = require('../_shared/fixture');
+
+const HERE = __dirname;
+const WORKER = path.join(HERE, 'worker.js');
+const ENV_TEST = path.join(HERE, '.env.test');
+const FIXTURES = path.join(HERE, 'fixtures');
+const REGISTRY = path.resolve(HERE, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project', 'model-registry.json');
+
+// ── args ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+    const out = { diagnose: false, selfCheck: false, mode: null, models: null, baseUrl: null, help: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--help' || a === '-h') out.help = true;
+        else if (a === '--diagnose') out.diagnose = true;
+        else if (a === '--self-check') out.selfCheck = true;
+        else if (a === '--mode') out.mode = (argv[++i] || '').toLowerCase();
+        else if (a === '--models') out.models = argv[++i] || '';
+        else if (a === '--base-url') out.baseUrl = argv[++i] || '';
+        else if (a.startsWith('--mode=')) out.mode = a.slice(7).toLowerCase();
+        else if (a.startsWith('--models=')) out.models = a.slice(9);
+        else if (a.startsWith('--base-url=')) out.baseUrl = a.slice(11);
+    }
+    return out;
+}
+
+function usage() {
+    console.log(`
+OpenRouter live model-matrix probe — EXACT AGENT COPY (BAT-1144)
+
+  node tests/live/openrouter/live-models.probe.js [flags]
+
+Flags:
+  --self-check        Offline acceptance test. No secrets, NO network. Seeds the
+                      fixture with a placeholder key, builds the REAL Chat
+                      Completions body via the agent seam, and asserts the wire
+                      shape. Exit 0 all-pass.
+  --mode <m>          apikey (the only mode; OpenRouter has no OAuth). Default: apikey.
+  --models <csv|all>  Models to sweep. 'all' / default = the registry default model
+                      (OpenRouter is freeform: models[] is empty in the registry, so
+                      the default model 'anthropic/claude-sonnet-4-6' is used unless
+                      you pass an explicit CSV). Pass real OpenRouter model ids
+                      (e.g. 'openai/gpt-5.4', 'anthropic/claude-sonnet-4-6').
+  --diagnose          Also sweep the reasoning-effort ladder (none/low/medium/high)
+                      — clearly BEYOND agent parity (the agent omits reasoning on OR
+                      normal turns; only synthetic turns send effort:'none'). Live only.
+  --base-url <url>    Gateway override for the live POST (host[:port]); the adapter's
+                      real path is preserved.
+  --help              This help.
+
+Credentials (tests/live/openrouter/.env.test, gitignored):
+  OPENROUTER_API_KEY=sk-or-v1-...   api_key path (openrouter.ai/api/v1/chat/completions)
+  TEST_MODELS=a,b,c                 optional default model set
+
+"Exact copy": the probe does NOT re-implement the prompt or tools. It require()s
+the same ai.js / tools/index / providers/openrouter the device runs, so the body is
+byte-for-byte what the agent sends (minus MCP tools, which the harness omits).
+`);
+}
+
+// ── registry helpers (single source of truth: model-registry.json) ────────────
+function loadRegistryOpenRouter() {
+    const j = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+    const or = (j.providers || []).find((p) => p.id === 'openrouter') || {};
+    const models = (or.models || []).map((m) => m.id);
+    return { models, defaultModel: or.defaultModel || 'anthropic/claude-sonnet-4-6' };
+}
+
+function resolveModels(modelsFlag, reg, testModelsEnv) {
+    // Explicit CSV always wins.
+    if (modelsFlag && modelsFlag !== 'all') {
+        return modelsFlag.split(',').map((s) => s.trim()).filter(Boolean);
+    }
+    // OpenRouter's registry model list is empty (freeform:true). Fall back to the
+    // TEST_MODELS default if set, else the single registry default model.
+    if (modelsFlag !== 'all' && testModelsEnv) {
+        const list = testModelsEnv.split(',').map((s) => s.trim()).filter(Boolean);
+        if (list.length) return list;
+    }
+    return reg.models.length ? reg.models : [reg.defaultModel];
+}
+
+// ── fork the worker (single mode) ─────────────────────────────────────────────
+function runWorker({ selfCheck, diagnose, live, baseUrl, models, apiKey }) {
+    return new Promise((resolve) => {
+        const fixtureDir = path.join(FIXTURES, 'apikey');
+        try {
+            seedFixture(fixtureDir, {
+                provider: 'openrouter',
+                model: (models && models[0]) || 'anthropic/claude-sonnet-4-6',
+                authConfig: { authType: 'api_key', openrouterApiKey: apiKey || 'sk-or-v1-test-PLACEHOLDER' },
+            });
+        } catch (e) {
+            return resolve({ mode: 'apikey', error: `[seed] ${e.message}` });
+        }
+
+        const env = {
+            ...process.env,
+            SC_SELF_CHECK: selfCheck ? '1' : '',
+            SC_DIAGNOSE: diagnose ? '1' : '',
+            SC_LIVE: live ? '1' : '',
+            SC_BASE_URL: baseUrl || '',
+            SC_MODELS: (models || []).join(','),
+        };
+        // argv[2] = fixtureDir → config.js picks it up as workDir.
+        const child = fork(WORKER, [fixtureDir], { env, stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+        let message = null;
+        child.on('message', (m) => { message = m; });
+        child.on('error', (e) => resolve({ mode: 'apikey', error: `[fork] ${e.message}` }));
+        child.on('exit', (code) => {
+            if (message) resolve({ ...message, _exit: code });
+            else resolve({ mode: 'apikey', error: `worker exited (code ${code}) without a result`, _exit: code });
+        });
+    });
+}
+
+// ── printing ──────────────────────────────────────────────────────────────────
+const BAR = '═'.repeat(78);
+const line = (s = '') => console.log(s);
+
+function printSelfCheck(result) {
+    const sc = result.selfCheck;
+    line(`\n${BAR}`);
+    line(`SELF-CHECK · mode=${result.mode}  endpoint=${sc.endpoint.hostname}${sc.endpoint.path}  model=${sc.model}  tools=${sc.toolCount}`);
+    line(BAR);
+    for (const a of sc.asserts) {
+        line(`  ${a.ok ? 'PASS' : 'FAIL'}  ${a.name}${a.detail ? `   (${a.detail})` : ''}`);
+    }
+    line(`\n  ── Built body (token-redacted; system message/tools abbreviated) ──`);
+    line('  keys: ' + JSON.stringify(sc.render.keys));
+    line('  ' + JSON.stringify(sc.render.critical, null, 2).split('\n').join('\n  '));
+    line('\n  ── system prompt (head + tail; full length above) ──');
+    line(sc.render.systemPromptAbbrev.split('\n').map((l) => '  | ' + l).join('\n'));
+    line(`\n  → mode ${result.mode}: ${sc.pass ? 'PASS' : 'FAIL'}`);
+}
+
+function printLive(result, reg) {
+    const lv = result.live;
+    line(`\n${BAR}`);
+    line(`LIVE SWEEP · mode=${result.mode}  endpoint=${lv.endpoint.hostname}${lv.endpoint.path}`);
+    line(BAR);
+    line('  model'.padEnd(38) + 'variant'.padEnd(34) + 'status  ok   lat     detail');
+    for (const r of lv.results) {
+        const detail = r.ok ? `"${r.text}"${r.toolCalls ? ` +${r.toolCalls} toolCalls` : ''}` : r.errBody;
+        line('  ' + String(r.model).padEnd(36) + String(r.variant).padEnd(34)
+            + String(r.status).padStart(5) + '  ' + (r.ok ? 'Y' : 'n') + '   '
+            + (String(r.latencyMs) + 'ms').padStart(7) + '  ' + (detail || '').slice(0, 60));
+    }
+    const listed = lv.listedModels || { status: -1, ids: [] };
+    line(`\n  ── /api/v1/models (status=${listed.status}; ${(listed.ids || []).length} ids visible to this key) ──`);
+    for (const r of lv.results) {
+        if (!String(r.variant).startsWith('agent-parity')) continue;
+        const seen = (listed.ids || []).includes(r.model);
+        line(`    ${String(r.model).padEnd(36)} inModels=${seen ? 'YES' : 'no '}  ${r.ok ? 'responds' : `HTTP ${r.status}`}`);
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+(async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) { usage(); process.exit(0); }
+
+    // OpenRouter only supports apikey; reject any other explicit --mode.
+    if (args.mode && args.mode !== 'apikey') {
+        line(`\n[SETUP ERROR] OpenRouter only supports --mode apikey (got "${args.mode}").`);
+        process.exit(1);
+    }
+
+    const { loaded } = loadEnvTest(ENV_TEST);
+    const apiKey = (process.env.OPENROUTER_API_KEY || '').trim();
+    const testModelsEnv = (process.env.TEST_MODELS || '').trim();
+    const reg = loadRegistryOpenRouter();
+    const models = resolveModels(args.models, reg, testModelsEnv);
+
+    line(`${BAR}`);
+    line('OpenRouter live model probe — EXACT AGENT COPY (BAT-1144)');
+    line(`.env.test: ${loaded ? 'loaded' : 'not found'}   OPENROUTER_API_KEY=${redact(apiKey)}`);
+    line(BAR);
+
+    // ── SELF-CHECK (offline) ──────────────────────────────────────────────────
+    if (args.selfCheck) {
+        line('\nMODE: --self-check (offline, no external network). Seeding the fixture with a placeholder key.');
+        const r = await runWorker({ selfCheck: true, diagnose: false, live: false, baseUrl: null, models, apiKey: '' });
+        line(`\n${BAR}`);
+        if (r.error) { line(`[SETUP ERROR] mode=${r.mode}: ${r.error}`); line(BAR); process.exit(1); }
+        printSelfCheck(r);
+        line(`\n${BAR}`);
+        line(`SELF-CHECK RESULT: ${r.selfCheck.pass ? 'PASS' : 'FAIL'}  (mode: apikey)`);
+        line(BAR);
+        process.exit(r.selfCheck.pass ? 0 : 1);
+    }
+
+    // ── LIVE sweep ────────────────────────────────────────────────────────────
+    if (!apiKey) {
+        line('\nNo credential found and no --self-check. Put this in tests/live/openrouter/.env.test:');
+        line('  OPENROUTER_API_KEY=sk-or-v1-...    (api_key path)');
+        line('…or run with --self-check to validate the body offline (no creds, no external network).');
+        process.exit(1);
+    }
+
+    const r = await runWorker({ selfCheck: false, diagnose: args.diagnose, live: true, baseUrl: args.baseUrl, models, apiKey });
+    if (r.error) { line(`\n[ERROR] mode=${r.mode}: ${r.error}`); line(`\n${BAR}`); line('LIVE SWEEP: SETUP ERROR (see above).'); line(BAR); process.exit(1); }
+    printLive(r, reg);
+    line(`\n${BAR}`);
+    line('LIVE SWEEP COMPLETE (mode: apikey).');
+    line(BAR);
+    // Report-only: exit 0 whenever the sweep ran.
+    process.exit(0);
+})();

--- a/tests/live/openrouter/live-models.probe.js
+++ b/tests/live/openrouter/live-models.probe.js
@@ -100,7 +100,12 @@ byte-for-byte what the agent sends (minus MCP tools, which the harness omits).
 
 // ── registry helpers (single source of truth: model-registry.json) ────────────
 function loadRegistryOpenRouter() {
-    const j = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+    let j;
+    try {
+        j = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+    } catch (e) {
+        throw new Error(`failed to read/parse model-registry.json at ${REGISTRY}: ${e.message}`);
+    }
     const or = (j.providers || []).find((p) => p.id === 'openrouter') || {};
     const models = (or.models || []).map((m) => m.id);
     return { models, defaultModel: or.defaultModel || 'anthropic/claude-sonnet-4-6' };
@@ -246,4 +251,7 @@ function printLive(result, reg) {
     line(BAR);
     // Report-only: exit 0 whenever the sweep ran.
     process.exit(0);
-})();
+})().catch((e) => {
+    console.error(`\n[SETUP ERROR] ${e.message}`);
+    process.exit(1);
+});

--- a/tests/live/openrouter/worker.js
+++ b/tests/live/openrouter/worker.js
@@ -1,0 +1,359 @@
+// tests/live/openrouter/worker.js
+// ─────────────────────────────────────────────────────────────────────────────
+// CHILD worker (single auth mode: api_key). Its process.argv[2] is the fixture
+// workDir, so require('<bundle>/config') finds workDir/config.json and boots the
+// REAL agent stack for OpenRouter.
+//
+// OpenRouter has ONE auth mode (api_key) — there is no OAuth/Codex fork like
+// OpenAI. The parent forks exactly one worker.
+//
+// The worker imports the REAL modules and builds the wire body the EXACT way the
+// agent does (ai.js chat() seam), then either:
+//   • --self-check : validates the Chat Completions body's wire shape offline — no
+//                    OpenRouter/external network (a fire-and-forget localhost
+//                    bridge probe during prompt assembly fails silently), OR
+//   • live         : POSTs each model's body via the REAL
+//                    httpChatCompletionsStreamingRequest.
+//
+// It reports back via IPC (process.send) when forked, else prints JSON to stdout.
+'use strict';
+
+const path = require('path');
+
+// ── Resolve the real nodejs-project bundle (…/app/src/main/assets/nodejs-project)
+const BUNDLE = path.resolve(__dirname, '..', '..', '..', 'app', 'src', 'main', 'assets', 'nodejs-project');
+const req = (m) => require(path.join(BUNDLE, m));
+
+const { redact, redactIn } = require('../_shared/env');
+
+// ── Control inputs (from the parent via env; argv[2] is reserved for workDir) ──
+const MODE = 'apikey'; // OpenRouter is single-mode; kept for symmetry with the OpenAI harness.
+const SELF_CHECK = process.env.SC_SELF_CHECK === '1';
+const DIAGNOSE = process.env.SC_DIAGNOSE === '1';
+const LIVE = process.env.SC_LIVE === '1';
+const BASE_URL = (process.env.SC_BASE_URL || '').trim();
+const MODELS = (process.env.SC_MODELS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const PROMPT = process.env.SC_PROMPT || 'Reply with the single word: pong';
+
+// Reasoning-ladder for --diagnose. Clearly BEYOND agent parity: on OpenRouter the
+// agent only ever sends reasoning:{effort:'none'} (synthetic/heartbeat turns) or
+// omits the field entirely (reasoningSupport resolves to 'unknown' for every
+// OR-prefixed model id, so the user toggle is a no-op). The ladder explores the
+// documented OpenRouter reasoning.effort values.
+const REASONING_LADDER = ['none', 'low', 'medium', 'high'];
+
+// Secrets to scrub from ANY printed/IPC'd text (CodeRabbit). Declared with `let`
+// BEFORE the boot block so fail() can reference it without a TDZ (empty pre-boot —
+// boot errors are config-load failures that don't echo a token); populated once the
+// fixture config is loaded (below).
+let SECRETS = [];
+
+function send(result) {
+    if (typeof process.send === 'function') process.send(result);
+    else process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+function fail(stage, err) {
+    const raw = err && err.stack ? err.stack.split('\n').slice(0, 4).join(' | ') : String(err);
+    // Redact in case a runtime error (e.g. an auth failure) echoes a credential —
+    // upholds the harness's "tokens are NEVER printed" guarantee.
+    send({ mode: MODE, error: `[${stage}] ${redactIn(raw, SECRETS)}` });
+    process.exit(3);
+}
+
+// ── Boot the real stack ───────────────────────────────────────────────────────
+let cfg, adapter, TOOLS, ai, reasoningSupportFor, httpChatCompletionsStreamingRequest;
+try {
+    cfg = req('config');                                   // reads workDir/config.json (argv[2])
+    ({ reasoningSupportFor } = req('model-catalog'));
+    const providers = req('providers');
+    adapter = providers.getAdapter('openrouter');
+    ({ TOOLS } = req(path.join('tools', 'index')));        // REAL 64-tool telegram registry
+    ai = req('ai');
+    ({ httpChatCompletionsStreamingRequest } = req('http'));
+} catch (e) {
+    fail('boot', e);
+}
+
+// Sanity: the fixture must actually have booted OpenRouter in api_key mode.
+if (!cfg || cfg.PROVIDER !== 'openrouter') fail('boot', new Error(`fixture provider is "${cfg && cfg.PROVIDER}", expected "openrouter"`));
+if (!adapter || adapter.id !== 'openrouter') fail('boot', new Error('openrouter adapter did not resolve'));
+if (cfg.AUTH_TYPE !== 'api_key') fail('boot', new Error(`AUTH_TYPE is "${cfg.AUTH_TYPE}", expected "api_key" (fixture/mode mismatch)`));
+
+// Populate the redaction set now that config is loaded (declared above so fail() can
+// use it even during boot). Defense-in-depth; the built body itself carries none.
+SECRETS = [cfg.OPENROUTER_KEY, cfg.BOT_TOKEN].filter(Boolean);
+
+// ── The seam: build the body the EXACT way ai.js chat() does ──────────────────
+// Mirrors ai.js:
+//   buildSystemBlocks(matchedSkills, chatId, activeModel)
+//   formatSystemPrompt(stablePrompt, dynamicPrompt + resumeBlock, AUTH_TYPE)
+//   formatTools(rawTools)   (rawTools == TOOLS here; no MCP in the harness)
+//   requestOptions = { reasoningEnabled, reasoningSupport, customEchoOverride, reasoningMode, synthetic }
+//   toApiMessages(messages, activeModel, requestOptions)
+//   formatRequest(activeModel, 4096, systemBlocks, apiMessages, formattedTools, requestOptions)
+function buildRequestOptions(model, { heartbeat = false } = {}) {
+    // Live runtime-state read, exactly like ai.js (reasoningEnabled / customEchoReasoning).
+    const rt = (() => {
+        try { return cfg.runtimeState ? cfg.runtimeState.read() : null; } catch (_) { return null; }
+    })();
+    return {
+        reasoningEnabled: !!(rt && rt.reasoningEnabled),
+        reasoningSupport: reasoningSupportFor('openrouter', model, cfg.AUTH_TYPE),
+        customEchoOverride: !!(rt && rt.customEchoReasoning),
+        // A normal turn is 'normal'; a heartbeat/synthetic turn is 'off' (on
+        // OpenRouter that emits reasoning:{effort:'none'} as an explicit disable).
+        reasoningMode: heartbeat ? 'off' : 'normal',
+        synthetic: heartbeat ? 'heartbeat' : null,
+    };
+}
+
+function buildBody(model, { heartbeat = false, reasoningEffortOverride = null } = {}) {
+    // Deterministic wallet block: seed a "no burner configured" snapshot so the
+    // Wallets section is STABLE. buildSystemBlocks() still fires a fire-and-forget
+    // /burner/status probe at the localhost bridge — but there is no bridge server
+    // here, so it fails silently and does NOT overwrite this seeded snapshot (the
+    // probe is why the self-check is "no EXTERNAL network", not literally "no sockets").
+    ai._setWalletPromptSnapshotForTests({ configured: false });
+
+    const { stable, dynamic } = ai.buildSystemBlocks([], null, model);
+    const resumeBlock = ''; // normal (non-resume) turn
+    const systemBlocks = adapter.formatSystemPrompt(stable, dynamic + resumeBlock, cfg.AUTH_TYPE);
+
+    const formattedTools = adapter.formatTools(TOOLS);
+    const requestOptions = buildRequestOptions(model, { heartbeat });
+    const apiMessages = adapter.toApiMessages([{ role: 'user', content: PROMPT }], model, requestOptions);
+    const bodyStr = adapter.formatRequest(model, 4096, systemBlocks, apiMessages, formattedTools, requestOptions);
+
+    let bodyObj = JSON.parse(bodyStr);
+    if (reasoningEffortOverride) bodyObj = applyReasoningEffort(bodyObj, reasoningEffortOverride);
+
+    return {
+        model,
+        bodyObj,
+        bodyStr: reasoningEffortOverride ? JSON.stringify(bodyObj) : bodyStr,
+        systemPrompt: systemBlocks,
+        toolCount: formattedTools.length,
+        requestOptions,
+    };
+}
+
+// BEYOND-PARITY mutation for --diagnose. Post-mutates reasoning.effort on the
+// already-built (real) body per OpenRouter's reasoning-tokens contract.
+function applyReasoningEffort(bodyObj, effort) {
+    const clone = JSON.parse(JSON.stringify(bodyObj));
+    clone.reasoning = { effort };
+    return clone;
+}
+
+// A compact, readable render of a (large) Chat Completions body: abbreviate the
+// 50KB+ system message + the 64-entry tools, keep the wire-critical fields verbatim.
+function renderBody(bodyObj, systemPrompt, toolCount) {
+    const instr = String(systemPrompt || '');
+    const head = instr.slice(0, 600);
+    const tail = instr.length > 900 ? instr.slice(-260) : '';
+    const abbrevInstr = tail
+        ? `${head}\n        … [${instr.length} chars total; middle elided] …\n${tail}`
+        : instr;
+    const toolNames = Array.isArray(bodyObj.tools)
+        ? bodyObj.tools.slice(0, 8).map((t) => t && t.function && t.function.name)
+        : [];
+    const msgs = Array.isArray(bodyObj.messages) ? bodyObj.messages : [];
+    const msgView = msgs.map((m) => ({
+        role: m.role,
+        content: typeof m.content === 'string' ? `‹string len=${m.content.length}›` : m.content,
+    }));
+    const view = {
+        model: ('model' in bodyObj) ? bodyObj.model : '‹absent›',
+        models: ('models' in bodyObj) ? bodyObj.models : '‹absent›',
+        stream: bodyObj.stream,
+        max_tokens: ('max_tokens' in bodyObj) ? bodyObj.max_tokens : '‹absent›',
+        cache_control: ('cache_control' in bodyObj) ? bodyObj.cache_control : '‹absent›',
+        reasoning: ('reasoning' in bodyObj) ? bodyObj.reasoning : '‹absent›',
+        messages: msgView,
+        tools: `‹array len=${toolCount != null ? toolCount : (bodyObj.tools || []).length}; first8=${JSON.stringify(toolNames)}›`,
+    };
+    return {
+        keys: Object.keys(bodyObj),
+        critical: view,
+        systemPromptAbbrev: redactIn(abbrevInstr, SECRETS),
+    };
+}
+
+// ── Offline self-check ────────────────────────────────────────────────────────
+function selfCheck() {
+    const asserts = [];
+    const A = (name, ok, detail) => asserts.push({ name, ok: !!ok, detail: detail == null ? '' : String(detail) });
+
+    const built = buildBody(cfg.MODEL, { heartbeat: false });
+    const b = built.bodyObj;
+    const ep = adapter.endpoint; // module-level object { hostname, path }
+    const instr = built.systemPrompt;
+    const msgs = Array.isArray(b.messages) ? b.messages : [];
+    const sysMsg = msgs[0] || {};
+
+    // ── Common Chat Completions wire-shape assertions ─────────────────────────
+    A('stream === true', b.stream === true, `stream=${b.stream}`);
+    A('max_tokens === 4096', b.max_tokens === 4096, `max_tokens=${b.max_tokens}`);
+    A('model === fixture model', b.model === cfg.MODEL, `model=${b.model}`);
+    A('cache_control === {type:"ephemeral"}', b.cache_control && b.cache_control.type === 'ephemeral', JSON.stringify(b.cache_control));
+    A('messages is a non-empty array', Array.isArray(b.messages) && b.messages.length > 0, `messages.length=${msgs.length}`);
+    A('messages[0] is the system message', sysMsg.role === 'system' && typeof sysMsg.content === 'string' && sysMsg.content.length > 0, `role=${sysMsg.role} len=${(sysMsg.content || '').length}`);
+    A('messages[1] is the user turn (PROMPT)', msgs[1] && msgs[1].role === 'user' && msgs[1].content === PROMPT, `role=${msgs[1] && msgs[1].role}`);
+
+    // ── Tools: count + OpenRouter's Chat Completions function shape ────────────
+    A('tools length === real TOOLS length', Array.isArray(b.tools) && b.tools.length === TOOLS.length && b.tools.length > 0, `body.tools=${(b.tools || []).length} TOOLS=${TOOLS.length}`);
+    const allFn = Array.isArray(b.tools) && b.tools.every((t) =>
+        t && t.type === 'function' && t.function && typeof t.function.name === 'string' && t.function.name.length > 0
+        && typeof t.function.parameters === 'object' && t.function.parameters !== null);
+    A('every tool is {type:"function", function:{name, parameters}}', allFn, allFn ? 'all ok' : 'a tool is malformed');
+
+    // ── No reasoning on a NORMAL turn (OR reasoningSupport is "unknown") ───────
+    A('NO reasoning on normal turn', !('reasoning' in b), `present=${'reasoning' in b}`);
+
+    // ── System prompt reflects the SEEDED MOCK WORKSPACE (the whole point) ─────
+    A('prompt has real Identity section marker', instr.includes('You are a personal AI agent running inside SeekerClaw'), 'identity line present');
+    A('prompt embeds seeded IDENTITY.md (TestBot)', instr.includes('IDENTITY.md') && instr.includes('TestBot'), 'IDENTITY.md + TestBot present');
+    A('prompt embeds seeded USER.md (Test User)', instr.includes('USER.md') && instr.includes('Test User'), 'USER.md + Test User present');
+    A('prompt embeds seeded MEMORY.md line', instr.includes('BAT-1144 OpenAI live-model harness') || instr.includes('synthetic preference'), 'MEMORY.md content present');
+
+    // ── Endpoint is the REAL OpenRouter endpoint ──────────────────────────────
+    A('endpoint === openrouter.ai/api/v1/chat/completions', ep.hostname === 'openrouter.ai' && ep.path === '/api/v1/chat/completions', `${ep.hostname}${ep.path}`);
+
+    // ── HTTP request headers are part of the wire request the device sends ─────
+    // Build them from the REAL adapter with the SAME credential the worker uses
+    // for this (api_key) mode. buildHeaders(apiKey) ignores AUTH_TYPE for
+    // OpenRouter (single-mode), but we pass it for symmetry/intent. Never print
+    // the raw key — assert on the "Bearer " scheme prefix, not equality.
+    const headers = adapter.buildHeaders(cfg.OPENROUTER_KEY, cfg.AUTH_TYPE);
+    const authVal = String(headers.Authorization || '');
+    A('header Authorization starts with "Bearer "', authVal.startsWith('Bearer ') && authVal.length > 'Bearer '.length, `scheme=${authVal.slice(0, 7)} len=${authVal.length}`);
+    A('header Content-Type === application/json', headers['Content-Type'] === 'application/json', headers['Content-Type']);
+    A('header HTTP-Referer === https://seekerclaw.com', headers['HTTP-Referer'] === 'https://seekerclaw.com', headers['HTTP-Referer']);
+    A('header X-Title === SeekerClaw', headers['X-Title'] === 'SeekerClaw', headers['X-Title']);
+
+    const pass = asserts.every((a) => a.ok);
+    send({
+        mode: MODE,
+        selfCheck: {
+            pass,
+            model: cfg.MODEL,
+            endpoint: { hostname: ep.hostname, path: ep.path },
+            toolCount: built.toolCount,
+            asserts,
+            render: renderBody(b, instr, built.toolCount),
+        },
+    });
+    process.exit(pass ? 0 : 1);
+}
+
+// ── Live sweep ────────────────────────────────────────────────────────────────
+function resolveEndpoint() {
+    const ep = adapter.endpoint; // { hostname, path } — no protocol/port on OR
+    const base = { protocol: ep.protocol || 'https:', hostname: ep.hostname, port: ep.port, path: ep.path };
+    if (!BASE_URL) return base;
+    try {
+        const u = new URL(BASE_URL.includes('://') ? BASE_URL : `https://${BASE_URL}`);
+        return {
+            protocol: u.protocol || 'https:',
+            hostname: u.hostname,
+            port: u.port ? parseInt(u.port, 10) : undefined,
+            // Keep the adapter's real path (the gateway is expected to proxy it).
+            path: ep.path,
+        };
+    } catch (_) {
+        return base;
+    }
+}
+
+async function liveOne(model, bodyStr) {
+    const ep = resolveEndpoint();
+    const headers = adapter.buildHeaders(cfg.OPENROUTER_KEY);
+    const options = {
+        protocol: ep.protocol, hostname: ep.hostname, port: ep.port, path: ep.path,
+        method: 'POST', headers, timeout: 60000,
+    };
+    const started = Date.now();
+    try {
+        const res = await httpChatCompletionsStreamingRequest(options, bodyStr);
+        const latencyMs = Date.now() - started;
+        let text = '', toolCalls = 0;
+        try {
+            const parsed = adapter.fromApiResponse(res.data);
+            text = (parsed.text || '').slice(0, 80);
+            toolCalls = (parsed.toolCalls || []).length;
+        } catch (_) { /* non-200 data may not parse to Chat Completions shape */ }
+        const errBody = res.status === 200 ? '' : redactIn(typeof res.data === 'string' ? res.data.slice(0, 300) : JSON.stringify(res.data).slice(0, 300), SECRETS);
+        return { model, status: res.status, ok: res.status === 200 && (!!text || toolCalls > 0), text, toolCalls, latencyMs, errBody };
+    } catch (e) {
+        return { model, status: -1, ok: false, text: '', toolCalls: 0, latencyMs: Date.now() - started, errBody: redactIn(e.message, SECRETS) };
+    }
+}
+
+async function liveSweep() {
+    const models = MODELS.length ? MODELS : [cfg.MODEL];
+    const endpoint = resolveEndpoint();
+    const results = [];
+    for (const model of models) {
+        if (DIAGNOSE) {
+            // Baseline (exact agent parity) first…
+            const base = buildBody(model, { heartbeat: false });
+            const baseRes = await liveOne(model, base.bodyStr);
+            results.push({ ...baseRes, variant: 'agent-parity (as-sent)' });
+            // …then the reasoning ladder (BEYOND parity — param exploration).
+            for (const effort of REASONING_LADDER) {
+                const v = buildBody(model, { heartbeat: false, reasoningEffortOverride: effort });
+                const r = await liveOne(model, v.bodyStr);
+                results.push({ ...r, variant: `beyond-parity reasoning.effort=${effort}` });
+            }
+        } else {
+            const built = buildBody(model, { heartbeat: false });
+            const r = await liveOne(model, built.bodyStr);
+            results.push({ ...r, variant: 'agent-parity (as-sent)' });
+        }
+    }
+    // Optionally list what THIS credential can actually see (/api/v1/models).
+    const listed = await listModels();
+    send({ mode: MODE, live: { endpoint: { hostname: endpoint.hostname, path: endpoint.path }, results, listedModels: listed } });
+    process.exit(0);
+}
+
+// GET /api/v1/models via OpenRouter (public list; 200 for any key). Used only in
+// live mode for the registry-vs-live comparison.
+function listModels() {
+    return new Promise((resolve) => {
+        const https = require('https');
+        const headers = adapter.buildHeaders(cfg.OPENROUTER_KEY);
+        const request = https.request({ hostname: 'openrouter.ai', path: '/api/v1/models', method: 'GET', headers, timeout: 30000 }, (res) => {
+            let buf = '';
+            res.on('data', (c) => (buf += c));
+            res.on('end', () => {
+                let ids = [];
+                try {
+                    const j = JSON.parse(buf);
+                    if (Array.isArray(j.data)) ids = j.data.map((m) => m.id).sort();
+                } catch (_) {}
+                resolve({ status: res.statusCode, ids });
+            });
+        });
+        request.on('error', () => resolve({ status: -1, ids: [] }));
+        request.setTimeout(30000, () => { request.destroy(); resolve({ status: -2, ids: [] }); });
+        request.end();
+    });
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+(async function main() {
+    try {
+        if (SELF_CHECK) return selfCheck();
+        if (LIVE) return await liveSweep();
+        // No mode selected — nothing to do.
+        send({ mode: MODE, error: 'worker invoked without --self-check or SC_LIVE=1' });
+        process.exit(3);
+    } catch (e) {
+        fail('run', e);
+    }
+})();
+
+// silence unused-var lints for redact (kept in the shared API surface)
+void redact;


### PR DESCRIPTION
## Summary

Completes BAT-1144's *"drives all 5 providers"*: adds the 3 missing exact-agent-copy live-models probes so the `provider-model-test` skill can dispatch to every provider.

| Provider | Endpoint | Transport | Modes |
|----------|----------|-----------|-------|
| `anthropic` | `api.anthropic.com/v1/messages` | `httpStreamingRequest` | api_key + setup_token (fork-per-mode) |
| `openrouter` | `openrouter.ai/api/v1/chat/completions` | `httpChatCompletionsStreamingRequest` | api_key |
| `custom` | user-configured base URL | `httpChatCompletionsStreamingRequest` | api_key |

Each is an **exact copy** of how `ai.js` builds the request (`buildSystemBlocks` + real 64-tool `TOOLS` + the provider's own adapter + transport, tapped at `formatRequest`). `_shared/fixture.js` parametrized (`provider` + `authConfig`) — **OpenAI legacy path preserved byte-for-byte** — seeded workspace text neutralized.

## Self-check rigor (offline gate)
Every probe's `--self-check` asserts the REAL wire shape: endpoint host+path, `stream:true`, provider-specific body fields, `tools.length===64` with the provider's real tool shape, the seeded mock workspace embedded in the prompt, **and the per-request HTTP headers** (anthropic's per-mode `x-api-key` vs `Bearer` + `oauth-2025-04-20` beta tag is an enforced contract). Report-only; never writes the registry. Secrets redacted; `.env.test` + generated fixtures gitignored.

## How it was built & verified
1. Fan-out build (1 agent/provider, cloning the OpenAI reference + swapping the adapter seam).
2. Adversarial review vs `ai.js`'s real dispatch → openrouter + custom **CONFIRMED**; anthropic's header-coverage gap **fixed**.
3. Self-check hardening → header assertions added across all 3, re-validated.

## Test plan
- [x] `node tests/live/<p>/live-models.probe.js --self-check` — **PASS** (anthropic both modes, openrouter, custom); 0 raw tokens in output
- [ ] **LIVE model sweeps** — need per-provider creds in each `.env.test` (report-only; produces the show/hide matrix)
- [ ] `pre-push-check.sh` Kotlin compile — N/A (zero `.kt`)

## Known coverage gaps (narrow, documented)
anthropic reasoning-ON + tools-vs-`getTools` MCP delta; openrouter synthetic-turn + fallback-model variants. Self-check exercises the dominant normal-turn path.

Follows #438 (consolidation) which is now merged. Skill orchestrator merged in seekerclaw-skills #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live model probes for Anthropic, OpenRouter, and a custom-compatible provider, including offline self-checks and credentialed model sweeps with per-model status, latency, and availability/parity checks.
  * Added provider-specific authentication handling and request-format generation for supported modes.
* **Bug Fixes**
  * Improved test fixture seeding to support provider-generic paths and configurable auth settings.
* **Documentation**
  * Added/expanded run guides, CLI instructions, and security guidance per provider.
* **Chores**
  * Updated ignore rules and templates to prevent committing credentials and generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->