### PR TITLE
fix: read xAI's flat {code,error} shape, stop fabricating 403 copy (BAT-1172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Fixed a condition where the agent could stop responding — showing a misleading "out of extra usage" error — on a Pro/Max sign-in even with usage remaining. An automatically-generated internal note summarizing routine background check-ins could contain a phrase the AI service rejected; because that note was included in every request, it blocked all replies until it aged out. These trivial check-in notes are no longer generated, any left over from a previous version are filtered out, and the agent now automatically retries once without recent-activity context if a request is unexpectedly rejected — so a single bad note can no longer stall it. The background check-in (heartbeat) mechanism itself is unchanged.
 - Clearer authentication-error message: it no longer suggests "API key might be wrong" for Pro/Max sign-in users, who have no API key.
+- Grok (xAI) error messages now show the provider's real reason instead of a fabricated "your subscription tier doesn't include API access — add an xAI API key" notice. This applies to both chat replies and the Settings "Test connection" check, and Grok users signed in with a subscription are no longer wrongly told to add an API key. Debug logs also now record the real error code and message. (BAT-1172)
 
 ### Changed
 

--- a/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
+++ b/app/src/main/assets/nodejs-project/DIAGNOSTICS.md
@@ -216,14 +216,16 @@ grep -i "OAuth refresh\|oauth_refresh\|invalid_grant" node_debug.log | tail -20
 - **Cloudflare block during token exchange:** auth.x.ai is Cloudflare-gated and blocks empty/default User-Agents. The app sends `User-Agent: SeekerClaw/<version>` on the token POST, so this should not occur; if it does (`node_debug.log` / Logcat shows a Cloudflare "you have been blocked" HTML page), it is transient — retry.
 **Fix:** The OAuth section stays visible after a failed sign-in — the user just taps "Sign in with Grok" again (no need to re-pick the auth type). Sign-out (clears tokens, keeps OAuth selected) then sign back in is the last resort.
 
-### xAI Grok — 403 "API access" / Tier-Gate (add API key, do NOT re-login)
-**Symptoms:** Grok messages fail with a 403 / "update permissions at console.x.ai" / "permission-denied". The user is signed in via OAuth.
-**Check:** `grep -i "xai\|grok" node_debug.log | tail -20` — look for `403`, `permission-denied`, or the terminal message "Your Grok subscription tier doesn't include API access".
-**Diagnosis:** xAI enforces API entitlement server-side.
-- On the **first** login, `/v1/models` can 403 because API access provisions *lazily on first touch* — the provider retries once after a short delay, so a single transient 403 is expected and self-heals.
-- A **persistent** 403 means the account's Grok tier does not include `api.x.ai` access. This is NOT an auth failure — do NOT trigger a token refresh or ask the user to re-login (that would burn xAI's single-use refresh-token rotation for nothing).
-**Fix:** Tell the user to add an **xAI API key** instead: Settings > AI Provider > xAI > Auth Type → API Key, and paste a key from `console.x.ai`. The api_key path is always selectable even while OAuth is the chosen auth type.
-- **api_key mode 403 (BAT-1124):** an api_key 403 is a real credit/tier gate — **terminal on the FIRST hit** (the retry-once grace is OAuth-first-touch only, never api_key). Message: "Your xAI API key doesn't have access to this model or endpoint. Check your plan at `console.x.ai`." Fix: the key lacks access to that model/endpoint — check the plan, or pick a broadly-available model (`grok-4.3`, the default).
+### xAI Grok — 403 "Grok denied the request" (read the REAL reason — not automatically a tier-gate)
+**Symptoms:** Grok messages fail with a 403 / "Grok denied the request" / "permission-denied". The user is signed in via OAuth.
+**Check:** `grep -i "xai\|grok" node_debug.log | tail -20` — look for the `[xAI] 403 forbidden: code=<...> reason=<...>` line the provider logs on every terminal 403 (it records xAI's REAL error code + message).
+**Diagnosis:** A 403 is **NOT** automatically a subscription-tier gate — that copy used to be fabricated from the HTTP status alone (fixed in BAT-1172). xAI returns a flat `{code, error}` body; the provider now reads it and classifies on the real code/message:
+- On the **first** touch, API access can provision *lazily* — the provider retries a 403 ONCE after a short delay, so a single transient 403 is expected and self-heals.
+- A **persistent** 403 is surfaced with xAI's actual reason. If the code/message is auth-ish (`unauthenticated:*`, "bad credentials", expired) it is treated as a sign-in problem → reconnect. Otherwise it is a genuine permission/entitlement limit and xAI's real message is shown. A genuine non-auth gate does NOT trigger a token refresh (no rotation is burned).
+**Fix:** Follow the surfaced reason — do NOT assert "your subscription tier doesn't include API access" unless xAI's message actually says so:
+- **Auth-ish 403** ("reconnect xAI in Settings") — the sign-in/credentials are bad: Settings > AI Provider > xAI > Sign in with Grok.
+- **Genuine access/entitlement 403** ("Grok denied the request: <reason>") — the account/plan lacks access to that model or endpoint. The user can pick a broadly-available model, upgrade their plan, or add an **xAI API key** (Settings > AI Provider > xAI > Auth Type → API Key, key from `console.x.ai` — always selectable even while OAuth is chosen).
+- **api_key mode 403 (BAT-1124):** an api_key 403 is a real credit/tier gate — **terminal on the FIRST hit** (the retry-once grace is OAuth-first-touch only, never api_key). The provider surfaces xAI's real reason when present, else "Your xAI API key doesn't have access to this model or endpoint. Check your plan at `console.x.ai`." Fix: check the plan, or pick a broadly-available model.
 - **Billing / quota (402, or 429 with a quota/credit message):** mode-aware — an **OAuth** user sees "check your SuperGrok / X Premium+ subscription" (their billing lives on their X subscription, NOT `console.x.ai`); an **api_key** user sees "check billing at `console.x.ai`". A plain 429 (no quota text) is transient rate-limiting and self-heals with backoff.
 
 ### xAI Grok OAuth — Token Refresh / Persist Failure

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -192,7 +192,14 @@ async function visionAnalyzeImage(imageBase64, prompt, maxTokens = 400) {
     const res = await claudeApiCall(body, 'vision');
 
     if (res.status !== 200) {
-        return { error: `Vision API error: ${res.data?.error?.message || res.status}` };
+        // BAT-1172: also read the FLAT `{error:string}` shape (xAI) — nested `error.message`
+        // is undefined for it, which used to drop xAI's real reason to a bare status number.
+        const vErr = res.data && (
+            (res.data.error && res.data.error.message)
+            || (typeof res.data.error === 'string' ? res.data.error : '')
+            || res.data.message
+        );
+        return { error: `Vision API error: ${vErr || res.status}` };
     }
 
     const parsed = adapter.fromApiResponse(res.data);
@@ -488,15 +495,20 @@ async function generateSessionSummary(chatId) {
         // HTML error pages from upstream CDNs would otherwise log
         // msgLen=0 msgFp=- and lose ALL diagnostic signal).
         const d = res.data;
+        // BAT-1172: also read the FLAT `{code, error:string}` shape (xAI's REST) so this
+        // path keeps diagnostic signal on xAI failures — see the matching chat() logger below.
         const errType = (d && d.error && d.error.type) || 'unknown';
-        const errCode = (d && d.error && d.error.code) || null;
+        const errCode = (d && d.error && d.error.code)
+            || (d && typeof d.code === 'string' ? d.code : null)
+            || null;
         let errMsg = '';
         if (typeof d === 'string') {
             errMsg = d;
         } else if (Buffer.isBuffer(d)) {
             errMsg = d;
         } else if (d) {
-            errMsg = (d.error && d.error.message) || d.message || '';
+            errMsg = (typeof d.error === 'string' ? d.error : null)
+                || (d.error && d.error.message) || d.message || '';
         }
         // R6 Copilot: report msgLen in UTF-8 BYTES (not JS String code-point
         // length) so the value aligns with what _reasoningFingerprint hashes.
@@ -1196,7 +1208,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
     // xAI Grok OAuth-specific playbook (only injected when running on OAuth)
     if (PROVIDER === 'xai' && AUTH_TYPE === 'oauth') {
         lines.push('**If xAI (Grok) OAuth fails:**');
-        lines.push('1. 403 tier-gate: a persistent 403 means your Grok subscription tier does NOT include API access on api.x.ai. The system retries a 403 ONCE (access can provision lazily on first touch), then stops. If it keeps failing, the fix is to add an xAI API key in Settings > AI Provider > xAI — do NOT keep retrying, and this is NOT a sign-in expiry.');
+        lines.push('1. 403 (Grok denied the request): a 403 is NOT automatically a subscription-tier gate. The system retries a 403 ONCE (access can provision lazily on first touch), then surfaces xAI\'s REAL error code + message (e.g. `permission-denied`, `unauthenticated:*`) — read THAT actual reason instead of assuming a fixed cause. If it looks like bad credentials / an expired sign-in, the fix is to reconnect via Settings > AI Provider > xAI; if it is a genuine access/entitlement limit, the user may need a plan with access or an xAI API key. Do NOT tell an OAuth user their "subscription tier doesn\'t include API access" unless xAI\'s message actually says so.');
         lines.push('2. Token expired (401): the system auto-refreshes via the refresh token. If you see "OAuth refresh failed" in node_debug.log, the refresh token is invalid (revoked, or already rotated) — the user must re-sign-in via Settings > AI Provider > xAI > Sign in with Grok.');
         lines.push('3. "token persist failed" in node_debug.log: the rotated token could not be saved. The current session keeps working, but a re-login may be needed after the next restart — tell the user to sign in again if Grok stops responding after a restart.');
         lines.push('4. Sign-in canceled or failed mid-flow: tell the user to retry from Settings > AI Provider > xAI. They can also switch to API Key in the auth picker if they have a console.x.ai key.');
@@ -1429,7 +1441,7 @@ function buildSystemBlocks(matchedSkills = [], chatId = null, activeModel = MODE
         lines.push('## Provider');
         lines.push(`You are running on xAI Grok (model: ${activeModel}, auth: ${AUTH_TYPE}).`);
         if (AUTH_TYPE === 'oauth') {
-            lines.push('Auth mode: **Sign in with Grok (OAuth)** — the user signed in with their SuperGrok / X Premium+ subscription instead of using an API key. Requests route through api.x.ai/v1/chat/completions with the subscription\'s OAuth token (auto-refreshed on expiry). If the tier does not include API access you will get a 403 tier-gate — the fix is to add an xAI API key, NOT to re-sign-in. If refresh fails, the user must re-sign-in via Settings > AI Provider > xAI > Sign in with Grok.');
+            lines.push('Auth mode: **Sign in with Grok (OAuth)** — the user signed in with their SuperGrok / X Premium+ subscription instead of using an API key. Requests route through api.x.ai/v1/chat/completions with the subscription\'s OAuth token (auto-refreshed on expiry). A 403 means Grok denied the request — the system retries once (access can provision lazily), then surfaces xAI\'s real reason; treat it per that message (a genuine access limit vs. an auth problem), NOT as an automatic "add an API key" tier-gate. If token refresh fails, the user must re-sign-in via Settings > AI Provider > xAI > Sign in with Grok.');
         } else {
             lines.push('Auth mode: **API Key** — the user configured an xAI API key from console.x.ai. Requests route through api.x.ai/v1/chat/completions. To use a Grok subscription instead (SuperGrok / X Premium+), the user can switch to "Sign in with Grok" in Settings > AI Provider > xAI.');
         }
@@ -2956,15 +2968,23 @@ async function chat(chatId, userMessage, options = {}) {
                 // loses ALL diagnostic signal. Strings are still safe to
                 // fingerprint via _reasoningFingerprint (it's
                 // length+sha256[:8], no raw content).
+                // BAT-1172: also read the FLAT error shape some providers return —
+                // xAI's REST returns `{ code: "<machine>", error: "<string message>" }`,
+                // where `error` is a string, not an `{type,code,message}` object. Without
+                // this the log showed type=unknown code=- msgLen=0 for every xAI failure,
+                // erasing all diagnostic signal (the exact gap behind the BAT-1155 403).
                 const errType = (res.data && res.data.error && res.data.error.type) || 'unknown';
-                const errCode = (res.data && res.data.error && res.data.error.code) || null;
+                const errCode = (res.data && res.data.error && res.data.error.code)
+                    || (res.data && typeof res.data.code === 'string' ? res.data.code : null)
+                    || null;
                 let errMsg = '';
                 if (typeof res.data === 'string') {
                     errMsg = res.data;
                 } else if (Buffer.isBuffer(res.data)) {
                     errMsg = res.data; // _reasoningFingerprint handles Buffer
                 } else if (res.data) {
-                    errMsg = (res.data.error && res.data.error.message)
+                    errMsg = (typeof res.data.error === 'string' ? res.data.error : null)
+                        || (res.data.error && res.data.error.message)
                         || res.data.message
                         || '';
                 }

--- a/app/src/main/assets/nodejs-project/ai.js
+++ b/app/src/main/assets/nodejs-project/ai.js
@@ -192,13 +192,17 @@ async function visionAnalyzeImage(imageBase64, prompt, maxTokens = 400) {
     const res = await claudeApiCall(body, 'vision');
 
     if (res.status !== 200) {
-        // BAT-1172: also read the FLAT `{error:string}` shape (xAI) — nested `error.message`
-        // is undefined for it, which used to drop xAI's real reason to a bare status number.
-        const vErr = res.data && (
-            (res.data.error && res.data.error.message)
-            || (typeof res.data.error === 'string' ? res.data.error : '')
-            || res.data.message
-        );
+        // BAT-1172: read the FLAT `{error:string}` shape (xAI) AND raw string/Buffer bodies
+        // (plaintext/HTML error pages from upstream CDNs) — the same shapes the [SessionSummary]
+        // and chat() loggers handle. Nested `error.message` is undefined for xAI's flat body, and
+        // a string/Buffer body has no `.error` at all, so both used to drop to a bare status.
+        const vErr = typeof res.data === 'string' ? res.data
+            : Buffer.isBuffer(res.data) ? res.data.toString('utf8')
+            : res.data && (
+                (res.data.error && res.data.error.message)
+                || (typeof res.data.error === 'string' ? res.data.error : '')
+                || res.data.message
+            );
         return { error: `Vision API error: ${vErr || res.status}` };
     }
 

--- a/app/src/main/assets/nodejs-project/providers/xai.js
+++ b/app/src/main/assets/nodejs-project/providers/xai.js
@@ -318,6 +318,53 @@ function _getStateForTests() {
     };
 }
 
+// BAT-1172: xAI's REST /v1/chat/completions returns a FLAT error shape
+// `{ code: "<machine-code>", error: "<human message string>" }` — NOT the nested
+// OpenAI/Anthropic `{ error: { type, code, message } }`. classifyError used to read
+// `error.message` (always undefined here) and hallucinated copy from the HTTP status
+// alone. Read BOTH shapes so we key on xAI's REAL code + message. (WebSocket/Responses
+// mode uses the nested shape, so tolerate it too.)
+function _xaiError(data) {
+    if (!data) return { code: '', message: '' };
+    if (typeof data === 'string') return { code: '', message: data };
+    if (Buffer.isBuffer(data)) return { code: '', message: data.toString('utf8') };
+    const err = data.error;
+    let code = '';
+    let message = '';
+    if (typeof err === 'string') {                    // flat REST: `error` IS the message
+        message = err;
+        code = typeof data.code === 'string' ? data.code : '';
+    } else if (err && typeof err === 'object') {      // nested: `error.{code,message}`
+        message = typeof err.message === 'string' ? err.message : '';
+        code = (typeof err.code === 'string' && err.code) || (typeof data.code === 'string' && data.code) || '';
+    } else {                                          // no `error` field
+        message = typeof data.message === 'string' ? data.message : '';
+        code = typeof data.code === 'string' ? data.code : '';
+    }
+    return { code: code || '', message: message || '' };
+}
+
+// Neutralize markdown/HTML formatting from a provider-controlled message before
+// showing it to the user, then bound the length. Strip only the chars that open
+// formatting or inject links/tags (`* _ \` ~ | [ ] < >`) — KEEP ordinary punctuation
+// (`. - : / ( )`) so model IDs (grok-4.5) and hosts (console.x.ai) stay readable. The
+// old inline strip removed `.`/`-` too, mangling exactly the identifiers we want to show.
+function _errReason(message) {
+    return (typeof message === 'string' ? message : '')
+        .replace(/[*_`~|\[\]<>]/g, '').replace(/\s+/g, ' ').trim().slice(0, 200);
+}
+
+// Is this xAI error fundamentally an AUTH/credential failure (vs a genuine
+// permission/entitlement or request error)? Keeps us from telling an OAuth user to
+// "add an xAI API key" for what is really a sign-in problem (xAI's own copy is
+// api-key-centric even on the OAuth path). BAT-1172: narrowed to concrete auth phrases —
+// NO bare `\bapi key\b`, so a genuine entitlement 403 that merely says "requires an API key"
+// is NOT misrouted to reconnect (only "incorrect/invalid api key" — a real credential error — is).
+function _xaiAuthReason(code, message) {
+    return /unauthenticated|bad[ _-]?credential|no[ _-]?credential|(incorrect|invalid)[ _-]?(api[ _-]?key|token)|expired/i
+        .test(`${code || ''} ${message || ''}`);
+}
+
 function classifyError(status, data) {
     if (status === 401) {
         // BAT-1155 D3: a dead OAuth family (revoked / persisted reauth) never attempts a
@@ -391,11 +438,37 @@ function classifyError(status, data) {
                 userMessage: 'Your Grok sign-in was revoked — reconnect xAI in Settings.'
             };
         }
+        // BAT-1172: terminal 403 (not refreshable, not first-touch grace, not known-dead).
+        // Per xAI docs a 403 is a permissions/entitlement gate. Read xAI's REAL {code,error}
+        // and surface the actual reason instead of fabricating "subscription tier / add an
+        // API key" (that copy was wrong — the tier was fine in the BAT-1155 incident). Log the
+        // real code + sanitized reason so an unmapped in-the-wild 403 code gets precise copy later.
+        const { code: c403, message: m403 } = _xaiError(data);
+        const reason403 = _errReason(m403);
+        log(`[xAI] 403 forbidden: code=${c403 || '-'} reason=${reason403 || '(none)'}`, 'WARN');
+        // BAT-1172 D3 (Codex ruling: Option B). An auth-ish terminal 403 (xAI says
+        // "unauthenticated"/"bad credentials" while our clock still thinks the token is live —
+        // a server-side revoke not yet reflected, or clock skew) steers the COPY toward
+        // reconnect, but STAYS type:'provisioning' — NOT 'reauth'. 'reauth' participates in
+        // ai.js's D10 session-expiry counting + dead-family notify-once; latching it from a
+        // not-dead 403 would count toward _sessionExpired and suppress the LATER genuine
+        // dead-family reconnect notice (guarded by !_sessionExpired). 'reauth' stays reserved
+        // for known-dead durable state (handled above at the _refreshDead branch). We keep the
+        // real reason OUT of the auth-ish OAuth copy (it's in the WARN log for ops) so xAI's
+        // api-key-centric phrasing can never reach an OAuth user; a genuine (non-auth) 403
+        // surfaces xAI's real reason verbatim.
+        const authish403 = isOAuth && _xaiAuthReason(c403, m403);
         return {
             type: 'provisioning', retryable: false,
             userMessage: isOAuth
-                ? 'Your Grok subscription tier doesn\'t include API access — add an xAI API key instead'
-                : 'Your xAI API key doesn\'t have access to this model or endpoint. Check your plan at console.x.ai.'
+                ? (authish403
+                    ? 'Your Grok sign-in may need reconnecting — open Settings > AI Provider > xAI.'
+                    : (reason403
+                        ? `Grok denied the request: ${reason403} — if this keeps happening, reconnect xAI in Settings.`
+                        : 'Grok denied the request (403). Your Grok access may be limited — try reconnecting xAI in Settings.'))
+                : (reason403
+                    ? `xAI denied the request: ${reason403} Check your plan/permissions at console.x.ai.`
+                    : 'Your xAI API key doesn\'t have access to this model or endpoint. Check your plan at console.x.ai.')
         };
     }
     if (status === 402) {
@@ -410,8 +483,16 @@ function classifyError(status, data) {
         };
     }
     if (status === 429) {
-        const msg = data?.error?.message || '';
-        if (/quota|insufficient|credit/i.test(msg)) {
+        // BAT-1172: xAI's flat `{code, error:string}` never had `error.message`, so
+        // quota-vs-rate-limit always fell through to rate_limit (retry forever on a
+        // hard quota wall). Read the real message + code.
+        const { code: qCode, message: msg } = _xaiError(data);
+        // Genuine quota/credit signals only — NOT bare "limit" (would swallow a
+        // transient "rate limit exceeded" into a non-retryable quota wall). Codex: keep
+        // conservative — an unmatched 429 correctly stays retryable rate_limit rather than
+        // inventing a billing diagnosis. ('exhausted' dropped: unverified 429 shape, and
+        // "rate limit exhausted" phrasing would misclassify a transient throttle.)
+        if (/quota|insufficient|credit/i.test(`${qCode} ${msg}`)) {
             // Same mode-aware surface as 402 (console.x.ai is api-key-only).
             return {
                 type: 'quota', retryable: false,
@@ -437,13 +518,25 @@ function classifyError(status, data) {
             userMessage: 'xAI API is temporarily unavailable. Retrying...'
         };
     }
-    const rawReason = data?.error?.message || '';
-    const reason = rawReason.replace(/[*_`\[\]()~>#+\-=|{}.!]/g, '').slice(0, 200);
+    // BAT-1172: fallback for any unhandled status (incl. 400). Read xAI's REAL
+    // {code, error} — the old `data.error.message` was always undefined for xAI's
+    // flat shape, so every unmapped error degraded to a bare "Unexpected API error".
+    const { code: uCode, message: uMsg } = _xaiError(data);
+    // xAI's own copy is api-key-centric even on the OAuth path (e.g. a bad access
+    // token yields "Incorrect API key provided… obtain from console.x.ai"). Don't
+    // relay that to an OAuth user — an auth-ish error means reconnect, not "add a key".
+    if (isOAuth && _xaiAuthReason(uCode, uMsg)) {
+        return {
+            type: 'unknown', retryable: false,
+            userMessage: 'Can\'t reach Grok — your xAI sign-in may need reconnecting in Settings.'
+        };
+    }
+    const reason = _errReason(uMsg);
     return {
         type: 'unknown', retryable: false,
-        userMessage: reason.trim()
-            ? `API error (${status}): ${reason.trim()}`
-            : `Unexpected API error (${status}). Please try again.`
+        userMessage: reason
+            ? `xAI error (${status})${uCode ? ` [${uCode}]` : ''}: ${reason}`
+            : `Unexpected xAI error (${status}). Please try again.`
     };
 }
 
@@ -1179,4 +1272,8 @@ module.exports = {
     _resetErrorStateForTests,
     _setStateForTests,
     _getStateForTests,
+    // BAT-1172: shape-adapter internals, exposed for direct unit tests.
+    _xaiError,
+    _errReason,
+    _xaiAuthReason,
 };

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -1381,8 +1381,14 @@ private fun xaiChatPing(bearer: String, isOAuth: Boolean) {
         val errorBody = try {
             (conn.errorStream ?: conn.inputStream)?.bufferedReader()?.use { it.readText() } ?: ""
         } catch (_: Exception) { "" }
+        // BAT-1172: xAI REST returns a FLAT error shape `{code, error:"<string>"}`, NOT the
+        // nested `{error:{message}}` (OpenAI/Anthropic). The old nested-only parse was ALWAYS
+        // blank for xAI → the 403 branch below always fell through to fabricated tier-gate copy.
+        // Read both: nested `error.message` when `error` is an object, else the flat string `error`.
         val apiMessage = try {
-            JSONObject(errorBody).optJSONObject("error")?.optString("message", "") ?: ""
+            val json = JSONObject(errorBody)
+            if (json.optJSONObject("error") != null) json.optJSONObject("error")?.optString("message", "") ?: ""
+            else json.optString("error", "")
         } catch (_: Exception) { "" }
         val errorMessage = when {
             status == 401 -> apiMessage.ifBlank {
@@ -1390,10 +1396,11 @@ private fun xaiChatPing(bearer: String, isOAuth: Boolean) {
                 else "Unauthorized — check your xAI API key"
             }
             status == 403 -> apiMessage.ifBlank {
-                // Path-specific: an OAuth user needs an API key (tier-gate); an api_key user
-                // already has one, so their 403 means the key lacks access/credits.
-                if (isOAuth) "Your Grok subscription tier doesn't include API access — add an xAI API key instead"
-                else "This API key lacks API access or credits — check your plan at console.x.ai"
+                // BAT-1172: no fabricated tier-gate. A 403 is a permissions/entitlement or auth
+                // response — xAI's real reason (parsed above) is surfaced when present; only an
+                // empty body falls back to this truthful, non-fabricated copy.
+                if (isOAuth) "Grok denied the request (403). If this persists, reconnect via Settings > AI Provider > xAI."
+                else "This xAI API key lacks access to that model or endpoint — check your plan at console.x.ai."
             }
             status == 429 -> "Rate limited — try again in a moment"
             status in 500..599 -> "xAI unavailable"

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -1354,6 +1354,48 @@ private suspend fun testXaiConnection(apiKey: String): Result<Unit> = withContex
  * May-2026 retirements redirect TO it), NOT the registry default `grok-4.5`: a newer default
  * can be tier-gated on some accounts and would make a working sign-in fail the connection test.
  */
+// ── BAT-1172: xAI connection-test error helpers (pure, unit-tested; mirror providers/xai.js) ──
+
+// Parse the xAI error body. Mirrors `_xaiError` message extraction: nested `error.message`
+// (OpenAI/Anthropic) → flat `error` string (xAI REST) → top-level `message`. "" when none.
+internal fun parseXaiConnErrorMessage(errorBody: String): String = try {
+    val json = JSONObject(errorBody)
+    when (val error = json.opt("error")) {
+        is JSONObject -> error.optString("message", "")
+        is String -> error
+        else -> json.optString("message", "")
+    }
+} catch (_: Exception) { "" }
+
+// Mirrors the narrowed `_xaiAuthReason` (NO bare "api key"): is this reason fundamentally an
+// auth/credential failure (vs a genuine permission/entitlement or request error)?
+private val XAI_AUTH_LIKE_REASON = Regex(
+    "unauthenticated|bad[ _-]?credential|no[ _-]?credential|(incorrect|invalid)[ _-]?(api[ _-]?key|token)|expired",
+    RegexOption.IGNORE_CASE,
+)
+internal fun isXaiAuthLikeReason(msg: String): Boolean = msg.isNotBlank() && XAI_AUTH_LIKE_REASON.containsMatchIn(msg)
+
+// Build the connection-test error text. For OAuth, an AUTH-like reason (xAI's api-key-centric
+// copy) must NOT override the reconnect guidance — mirrors classifyError's Option-B behavior.
+// A genuine non-auth 403 reason still surfaces; api_key users always see the real reason.
+internal fun xaiConnErrorText(status: Int, apiMessage: String, isOAuth: Boolean): String {
+    val suppressForOAuth = isOAuth && isXaiAuthLikeReason(apiMessage)
+    return when {
+        status == 401 -> if (apiMessage.isBlank() || suppressForOAuth) {
+            if (isOAuth) "Unauthorized — your Grok sign-in may have expired; sign in again"
+            else "Unauthorized — check your xAI API key"
+        } else apiMessage
+        status == 403 -> if (apiMessage.isBlank() || suppressForOAuth) {
+            // No fabricated tier-gate: a 403 is a permissions/entitlement or auth response.
+            if (isOAuth) "Grok denied the request (403). If this persists, reconnect via Settings > AI Provider > xAI."
+            else "This xAI API key lacks access to that model or endpoint — check your plan at console.x.ai."
+        } else apiMessage
+        status == 429 -> "Rate limited — try again in a moment"
+        status in 500..599 -> "xAI unavailable"
+        else -> apiMessage.ifBlank { "HTTP $status" }
+    }
+}
+
 private fun xaiChatPing(bearer: String, isOAuth: Boolean) {
     val url = URL("https://api.x.ai/v1/chat/completions")
     val conn = url.openConnection() as HttpURLConnection
@@ -1381,31 +1423,12 @@ private fun xaiChatPing(bearer: String, isOAuth: Boolean) {
         val errorBody = try {
             (conn.errorStream ?: conn.inputStream)?.bufferedReader()?.use { it.readText() } ?: ""
         } catch (_: Exception) { "" }
-        // BAT-1172: xAI REST returns a FLAT error shape `{code, error:"<string>"}`, NOT the
-        // nested `{error:{message}}` (OpenAI/Anthropic). The old nested-only parse was ALWAYS
-        // blank for xAI → the 403 branch below always fell through to fabricated tier-gate copy.
-        // Read both: nested `error.message` when `error` is an object, else the flat string `error`.
-        val apiMessage = try {
-            val json = JSONObject(errorBody)
-            if (json.optJSONObject("error") != null) json.optJSONObject("error")?.optString("message", "") ?: ""
-            else json.optString("error", "")
-        } catch (_: Exception) { "" }
-        val errorMessage = when {
-            status == 401 -> apiMessage.ifBlank {
-                if (isOAuth) "Unauthorized — your Grok sign-in may have expired; sign in again"
-                else "Unauthorized — check your xAI API key"
-            }
-            status == 403 -> apiMessage.ifBlank {
-                // BAT-1172: no fabricated tier-gate. A 403 is a permissions/entitlement or auth
-                // response — xAI's real reason (parsed above) is surfaced when present; only an
-                // empty body falls back to this truthful, non-fabricated copy.
-                if (isOAuth) "Grok denied the request (403). If this persists, reconnect via Settings > AI Provider > xAI."
-                else "This xAI API key lacks access to that model or endpoint — check your plan at console.x.ai."
-            }
-            status == 429 -> "Rate limited — try again in a moment"
-            status in 500..599 -> "xAI unavailable"
-            else -> apiMessage.ifBlank { "HTTP $status" }
-        }
+        // BAT-1172: xAI REST returns a FLAT `{code, error:"<string>"}`, NOT the nested
+        // `{error:{message}}` (OpenAI/Anthropic). parseXaiConnErrorMessage reads both (+ top-level
+        // `message`); xaiConnErrorText builds mode-aware copy that never shows an OAuth user xAI's
+        // api-key-centric auth text (mirrors classifyError). Both are pure + unit-tested.
+        val apiMessage = parseXaiConnErrorMessage(errorBody)
+        val errorMessage = xaiConnErrorText(status, apiMessage, isOAuth)
         error("Connection failed ($errorMessage)")
     } catch (_: java.net.SocketTimeoutException) {
         error("Connection timed out")

--- a/app/src/test/java/com/seekerclaw/app/ui/settings/XaiConnTestHelperTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/ui/settings/XaiConnTestHelperTest.kt
@@ -1,0 +1,68 @@
+package com.seekerclaw.app.ui.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * BAT-1172 — xAI connection-test error helpers (Settings "Test connection" for Grok).
+ * Pins the two gaps CodeRabbit flagged on PR #444: the parse must fall back to top-level
+ * `message`, and OAuth users must never be shown xAI's api-key-centric auth copy.
+ */
+class XaiConnTestHelperTest {
+
+    // NOTE: parseXaiConnErrorMessage (the nested→flat→top-level `message` extraction) is NOT
+    // unit-tested here — this module sets `unitTests.isReturnDefaultValues = true`, so the
+    // android.jar `org.json.JSONObject` stub returns empty for everything and real parsing can't
+    // run without adding an org.json test dependency. That extraction mirrors the Node `_xaiError`
+    // helper, which IS covered by tests/nodejs-project/xai.test.js (flat/nested/string/Buffer/null).
+
+    // ── isXaiAuthLikeReason — narrowed (no bare "api key") ──
+    @Test fun `auth-like reasons detected`() {
+        assertTrue(isXaiAuthLikeReason("Incorrect API key provided."))
+        assertTrue(isXaiAuthLikeReason("unauthenticated: bad credentials"))
+        assertTrue(isXaiAuthLikeReason("token expired"))
+    }
+
+    @Test fun `genuine entitlement reasons are NOT auth-like`() {
+        assertFalse(isXaiAuthLikeReason("Access to grok-4.5 is not enabled for your team."))
+        assertFalse(isXaiAuthLikeReason("Access requires an xAI API key.")) // narrowed: bare "api key" excluded
+        assertFalse(isXaiAuthLikeReason(""))
+    }
+
+    // ── xaiConnErrorText — the Major fix: never show OAuth users api-key copy ──
+    @Test fun `OAuth 403 with api-key-worded reason maps to reconnect, never api-key text`() {
+        val out = xaiConnErrorText(403, "Incorrect API key provided. Obtain one from console.x.ai.", isOAuth = true)
+        assertTrue(out.contains("reconnect", ignoreCase = true))
+        assertFalse(out.contains("API key", ignoreCase = true))
+        assertFalse(out.contains("console.x.ai", ignoreCase = true))
+    }
+
+    @Test fun `OAuth 403 with a GENUINE reason surfaces that reason`() {
+        val reason = "Access to grok-4.5 is not enabled for your team."
+        assertEquals(reason, xaiConnErrorText(403, reason, isOAuth = true))
+    }
+
+    @Test fun `api_key 403 surfaces the real reason (api-key users should see it)`() {
+        val reason = "Incorrect API key provided. Obtain one from console.x.ai."
+        assertEquals(reason, xaiConnErrorText(403, reason, isOAuth = false))
+    }
+
+    @Test fun `OAuth 401 auth-like maps to sign-in guidance`() {
+        val out = xaiConnErrorText(401, "unauthenticated: bad credentials", isOAuth = true)
+        assertTrue(out.contains("sign in", ignoreCase = true))
+        assertFalse(out.contains("API key", ignoreCase = true))
+    }
+
+    @Test fun `blank body falls back to mode-aware copy`() {
+        assertTrue(xaiConnErrorText(403, "", isOAuth = true).contains("reconnect", ignoreCase = true))
+        assertTrue(xaiConnErrorText(403, "", isOAuth = false).contains("console.x.ai", ignoreCase = true))
+    }
+
+    @Test fun `429 and 5xx are fixed strings, unknown status surfaces the reason`() {
+        assertTrue(xaiConnErrorText(429, "whatever", isOAuth = true).contains("Rate limited"))
+        assertEquals("xAI unavailable", xaiConnErrorText(503, "boom", isOAuth = true))
+        assertEquals("weird thing", xaiConnErrorText(418, "weird thing", isOAuth = true))
+    }
+}

--- a/docs/internal/audits/SAB-AUDIT-v44.md
+++ b/docs/internal/audits/SAB-AUDIT-v44.md
@@ -19,6 +19,7 @@
 > **The low delta pre-fix is the whole point of BAT-1172, not new drift.** The xAI-403 self-knowledge (prompt + diagnostics) was a *fabrication* — "your Grok subscription tier doesn't include API access — add an xAI API key" — presented as fact. v43 scored these items ✅ because the prompt *matched the code*; but the code itself was fabricating, which was only proven afterward by the BAT-1155 incident + the live probe (`xai_403_probe.js`) + context7 `/websites/x_ai_developers` (403 = permissions/entitlement, NOT tier/API-key). With that ground truth, the pre-fix state is correctly re-scored ⚠️. This PR corrects prompt + code + diagnostics + Kotlin in lockstep → post-fix 100%, no leftover gaps, no new drift. Negative-knowledge boundaries unchanged (6/6); no identity/architecture/config drift.
 
 ## Pre-fix Trend
+
 | Audit | Pre-fix % | Post-fix % |
 |-------|-----------|------------|
 | v40 | 100% | 100% |

--- a/docs/internal/audits/SAB-AUDIT-v44.md
+++ b/docs/internal/audits/SAB-AUDIT-v44.md
@@ -1,0 +1,76 @@
+# SAB-AUDIT-v44 — SeekerClaw Agent Self-Knowledge Audit
+
+> **Date:** 2026-07-16
+> **SAB Version:** v3
+> **Scope:** Delta-audit for BAT-1172 (xAI error-shape mis-parse fix). Touches `buildSystemBlocks()` in `ai.js` (xAI OAuth failure playbook item 1 + xAI OAuth Provider block), adds a new WARN log site in `providers/xai.js` (`[xAI] 403 forbidden: code=<...> reason=<...>`), and rewrites the `DIAGNOSTICS.md` xAI-403 section — so the pre-merge gate applies. Also fixes Node classifyError + two `ai.js` loggers + the vision path + the Kotlin Settings connection test, but those are code-only (no self-knowledge surface).
+> **Method:** Full read of the xAI-403 surface in `buildSystemBlocks()` + diagnostic coverage map for the rewritten 403 section and the new WARN site + behavioral probe on the "signed-in-but-Grok-fails" path.
+> **Baseline:** SAB-AUDIT-v43.md (BAT-1124 delta; full-suite baseline v41 = 252/252 = 100% post-fix).
+
+## Scores
+
+| Section | Pre-fix | Post-fix | Max |
+|---------|---------|----------|-----|
+| A: Knowledge & Doors (2 changed xAI-403 items) | 2 | 6 | 6 |
+| B: Diagnostics (xAI-403 section + new WARN line) | 1 | 3 | 3 |
+| C: Tool Consistency (no tools changed) | N/A | N/A | — |
+| D: Behavioral Probes ("signed in but Grok fails") | 1 | 3 | 3 |
+| **Combined (delta)** | **4 (33.3%)** | **12 (100%)** | **12** |
+
+> **The low delta pre-fix is the whole point of BAT-1172, not new drift.** The xAI-403 self-knowledge (prompt + diagnostics) was a *fabrication* — "your Grok subscription tier doesn't include API access — add an xAI API key" — presented as fact. v43 scored these items ✅ because the prompt *matched the code*; but the code itself was fabricating, which was only proven afterward by the BAT-1155 incident + the live probe (`xai_403_probe.js`) + context7 `/websites/x_ai_developers` (403 = permissions/entitlement, NOT tier/API-key). With that ground truth, the pre-fix state is correctly re-scored ⚠️. This PR corrects prompt + code + diagnostics + Kotlin in lockstep → post-fix 100%, no leftover gaps, no new drift. Negative-knowledge boundaries unchanged (6/6); no identity/architecture/config drift.
+
+## Pre-fix Trend
+| Audit | Pre-fix % | Post-fix % |
+|-------|-----------|------------|
+| v40 | 100% | 100% |
+| v41 | 98.4% | 100% |
+| v42 (delta) | 83.3% (delta only) | 100% |
+| v43 (delta) | 95.2% (delta only) | 100% |
+| v44 (delta) | 33.3% (delta only — corrects a pre-existing fabrication) | 100% |
+
+## Section A — Knowledge & Doors (delta) — 2/6 pre, 6/6 post
+
+| Item | Pre | Post | Evidence |
+|------|-----|------|----------|
+| xAI OAuth playbook item 1 (403) | ⚠️ | ✅ | Pre (`ai.js` ~1199, old): "a persistent 403 means your Grok subscription tier does NOT include API access… the fix is to add an xAI API key" — **fabricated**; would make the agent give wrong advice (add-a-key) for what is often an auth/reconnect issue. Post (`ai.js:1211`): "a 403 is NOT automatically a subscription-tier gate… surfaces xAI's REAL error code + message… read THAT actual reason… auth-ish → reconnect; genuine limit → plan/key. Do NOT tell an OAuth user their 'subscription tier doesn't include API access' unless xAI's message actually says so." |
+| xAI OAuth Provider block (403 sentence) | ⚠️ | ✅ | Pre (`ai.js` ~1432, old): "If the tier does not include API access you will get a 403 tier-gate — the fix is to add an xAI API key, NOT to re-sign-in." Post (`ai.js:1444`): "A 403 means Grok denied the request — the system retries once… then surfaces xAI's real reason; treat it per that message (a genuine access limit vs. an auth problem), NOT as an automatic 'add an API key' tier-gate." |
+
+Unchanged xAI items (Provider self-description, "Sign in with Grok" capability, `grok-4.5` via dynamic `${activeModel}`, DIAGNOSTICS door, config surface) remain ✅ — not re-scored. Internal BAT-1143 breaker comments referencing "tier-gate" (`ai.js` ~1736/1844/1968/2481) are correct and out of scope: the breaker's narrow "fresh-token-still-403s" case genuinely IS an entitlement situation (not an expiry) and produces no user-facing copy — the user message comes from `classifyError`, now fixed.
+
+## Section B — Diagnostics (delta) — 1/3 pre, 3/3 post
+
+| Failure mode | Log site | Pre | Post | DIAGNOSTICS |
+|--------------|----------|-----|------|-------------|
+| xAI OAuth 403 (terminal) | `providers/xai.js:448` **new** `[xAI] 403 forbidden: code=<...> reason=<...>` (WARN) | ⚠️ | ✅ | Pre: "xAI Grok — 403 API access / Tier-Gate (add API key, do NOT re-login)" diagnosed the fabricated tier-gate and told operators to grep for the now-deleted "subscription tier doesn't include API access" string. Post (`DIAGNOSTICS.md:219`): "xAI Grok — 403 (read the REAL reason — not automatically a tier-gate)"; grep target = the new `[xAI] 403 forbidden: code=` WARN line (verified present in both code and doc); fix steps split auth-ish (reconnect) vs genuine access/entitlement (real reason → model/plan/key). |
+
+Doc↔log coupling is now pinned by a source assertion in `xai.test.js` (both the emitter and the DIAGNOSTICS grep target contain the literal `[xAI] 403 forbidden: code=`). The two `ai.js` diagnostic loggers + the vision path now read the flat `{code, error:string}` shape — also source-pinned — so xAI failures stop logging `type=unknown code=- msgLen=0` (the blindness that hid the original 403 body). Curated "AI API — Auth error (401/403)" item remains covered.
+
+## Section C — Tool Consistency (spot-check) — N/A
+
+BAT-1172 adds/changes **no tools** (`tools/*.js` untouched). Fixed-7 + rotated-5 consistency unchanged from the v41 full-suite / v43 baseline. Not re-scored.
+
+## Section D — Behavioral Probes (delta) — 1/3 pre, 3/3 post
+
+1. **"I'm signed in with Grok but it fails" / "my API key isn't working" (403)** → prompt OAuth playbook item 1 + DIAGNOSTICS "xAI Grok — 403". **Pre: ⚠️** — the path led to the fabricated "add an xAI API key" fix (v43's probe 1 literally described the expected answer as "gives the add-API-key / model-switch fix" — that was the wrong ground truth). **Post: ✅** — the agent now finds "read xAI's real reason; auth-ish → reconnect via Settings; genuine access/entitlement → the real message, then model/plan/key," and is explicitly told not to assert a tier-gate unless xAI says so. Actionable and truthful.
+
+Fixed probes ("Web search is broken", "Agent won't respond") unaffected by this PR — unchanged from baseline.
+
+## Gaps Found (Pre-fix)
+- The entire xAI-403 self-knowledge surface (prompt playbook item 1, Provider block, DIAGNOSTICS section, behavioral-probe answer) taught a **fabricated tier-gate** as fact. Root cause: the copy was invented from the HTTP status alone because every parse site read the nested `error.message` (undefined for xAI's flat `{code, error}` body).
+
+## Fixes Applied (all in THIS PR — same-PR rule)
+- `buildSystemBlocks()` playbook item 1 + Provider block rewritten (truthful; read the real reason; never assert a tier-gate unless xAI says so; keep room for genuine plan gates).
+- `DIAGNOSTICS.md` xAI-403 section rewritten; grep target = the new WARN line.
+- Node `classifyError` + both `ai.js` loggers + vision path read the flat shape; new `[xAI] 403 forbidden` WARN capture line.
+- Kotlin `ProviderConfigScreen.kt` `xaiChatPing` (the Settings connection test — the most user-visible instance) parses the flat shape + truthful copy.
+- Regression pins added (source-level logger pins + doc↔log coupling + no-fabrication + narrowed-regex negative pin).
+
+## Code Issues Found
+None beyond the fabrication this PR fixes. No separate Linear task needed.
+
+## Remaining Gaps
+None. Post-fix 100%. The 403/429 wire shapes remain INFERRED from the captured 400/401 (the fix degrades safely to truthful generic copy on any unrecognized shape); capturing a real 403 + quota-429 is a device-test acceptance step, not a self-knowledge gap.
+
+## Validation
+- `node tests/nodejs-project/smoke.js` — PASS
+- `node tests/nodejs-project/xai.test.js` — 189 PASS / 0 FAIL
+- `bash scripts/pre-push-check.sh` — Node smoke + 64 tool schemas + wallet regression + Kotlin compile (dappStoreDebug) BUILD SUCCESSFUL

--- a/tests/nodejs-project/xai.test.js
+++ b/tests/nodejs-project/xai.test.js
@@ -240,7 +240,13 @@ function restoreHttps() { https.request = _origHttpsRequest; }
     const e403b = xai.classifyError(403, {});
     ok('403 (2nd): type is STILL NOT "auth" (C1)', e403b.type !== 'auth', e403b.type);
     ok('403 (2nd): retryable false — bounded to ONE retry then terminal', e403b.retryable === false);
-    ok('403 (2nd): terminal tier-gate userMessage', /subscription tier doesn't include API access — add an xAI API key/.test(e403b.userMessage), e403b.userMessage);
+    // BAT-1172: terminal 403 with no body must be TRUTHFUL — never fabricate a
+    // "subscription tier / add an xAI API key" gate (the tier was fine in the
+    // BAT-1155 incident; the message was hallucinated from the HTTP status alone).
+    ok('403 (2nd): terminal copy is truthful, NOT a fabricated tier-gate (BAT-1172)',
+        !/subscription tier|add an xAI API key/i.test(e403b.userMessage)
+        && /reconnect xAI in Settings|Grok access may be limited/i.test(e403b.userMessage),
+        e403b.userMessage);
 
     // A third 403 stays terminal (one-shot flag, not MAX_RETRIES).
     ok('403 (3rd): still terminal, still not auth', xai.classifyError(403, {}).retryable === false && xai.classifyError(403, {}).type !== 'auth');
@@ -276,6 +282,112 @@ function restoreHttps() { https.request = _origHttpsRequest; }
         /API key doesn't have access to this model or endpoint/.test(eak403.userMessage)
         && !/provisioning — retrying/.test(eak403.userMessage), eak403.userMessage);
     ok('403 (api_key, 2nd): stays terminal', xaiApi.classifyError(403, {}).retryable === false);
+})();
+
+// ── BAT-1172: xAI flat error-shape adapter ───────────────────────────────────
+// xAI's REST /v1/chat/completions returns a FLAT `{code, error:string}`, not the
+// nested OpenAI/Anthropic `{error:{type,code,message}}`. classifyError used to read
+// `error.message` (always undefined here) and hallucinated copy from the status.
+// These pin: (a) the extractor tolerates both shapes; (b) classifyError surfaces the
+// REAL reason; (c) an OAuth user is never told to "add an xAI API key".
+(function testXaiErrorShapeAdapter() {
+    console.log('\n── BAT-1172: flat {code,error} shape adapter ──');
+    const xai = loadXai({ authType: 'oauth', oauthToken: 'a.b.c', refresh: 'r' });
+
+    // ---- _xaiError extractor: both shapes + degenerate inputs ----
+    const flat = xai._xaiError({ code: 'permission-denied', error: 'Access to grok-4.5 is not enabled for your team.' });
+    ok('_xaiError flat: reads top-level code', flat.code === 'permission-denied', flat.code);
+    ok('_xaiError flat: reads string error as message', /Access to grok-4.5/.test(flat.message), flat.message);
+
+    const nested = xai._xaiError({ error: { code: 'model_not_found', message: 'no such model', type: 'invalid_request_error' } });
+    ok('_xaiError nested: reads error.code', nested.code === 'model_not_found', nested.code);
+    ok('_xaiError nested: reads error.message', nested.message === 'no such model', nested.message);
+
+    ok('_xaiError string body → whole string is the message', xai._xaiError('502 Bad Gateway').message === '502 Bad Gateway');
+    ok('_xaiError Buffer body → decoded utf8 is the message', xai._xaiError(Buffer.from('502 Bad Gateway', 'utf8')).message === '502 Bad Gateway');
+    ok('_xaiError null → empty, no throw', xai._xaiError(null).code === '' && xai._xaiError(null).message === '');
+    ok('_xaiError {} → empty, no throw', xai._xaiError({}).code === '' && xai._xaiError({}).message === '');
+    // Defensive: a numeric `code` (spec says string) must not crash or leak a number into copy.
+    ok('_xaiError non-string code coerces to empty', xai._xaiError({ code: 42, error: 'x' }).code === '');
+
+    // ---- _xaiAuthReason: auth-ish vs genuine-permission (narrowed per Codex) ----
+    ok('_xaiAuthReason: unauthenticated code → true', xai._xaiAuthReason('unauthenticated:bad-credentials', 'Bad credentials.') === true);
+    ok('_xaiAuthReason: "Incorrect API key" → true', xai._xaiAuthReason('invalid-argument', 'Incorrect API key provided.') === true);
+    ok('_xaiAuthReason: genuine permission gate → false', xai._xaiAuthReason('permission-denied', 'Model not enabled for your team.') === false);
+    // Negative pin (Codex): a genuine entitlement 403 that merely mentions "api key" must NOT
+    // be misrouted to reconnect — only "incorrect/invalid api key" (a real credential error) is.
+    ok('_xaiAuthReason: "requires an API key" entitlement → false (no bare "api key" match)',
+        xai._xaiAuthReason('permission-denied', 'Access requires an xAI API key.') === false);
+
+    // ---- classifyError surfaces the REAL 403 reason (OAuth) ----
+    const x1 = loadXai({ authType: 'oauth', oauthToken: 'a.b.c', refresh: 'r' });
+    x1._resetErrorStateForTests();
+    x1.classifyError(403, { code: 'permission-denied', error: 'Access to grok-4.5 is not enabled for your team.' }); // burn the provisioning grace
+    const real403 = x1.classifyError(403, { code: 'permission-denied', error: 'Access to grok-4.5 is not enabled for your team.' });
+    ok('403 terminal: surfaces xAI\'s REAL reason', /Access to grok-4.5 is not enabled for your team/.test(real403.userMessage), real403.userMessage);
+    ok('403 terminal: no fabricated tier-gate / api-key advice to OAuth user',
+        !/subscription tier|add an xAI API key/i.test(real403.userMessage), real403.userMessage);
+
+    // ---- a 403 that is REALLY an auth failure (OAuth): Codex D3 Option B ----
+    // Stays type:'provisioning' — NOT 'reauth' (which participates in D10 session-expiry +
+    // dead-family notify; latching it from a not-dead 403 would suppress the later genuine
+    // dead-family reconnect notice). The auth-ish signal steers COPY to reconnect only.
+    const x2 = loadXai({ authType: 'oauth', oauthToken: 'a.b.c', refresh: 'r' });
+    x2._resetErrorStateForTests();
+    x2.classifyError(403, { code: 'unauthenticated:bad-credentials', error: 'Bad credentials.' }); // burn grace
+    const auth403 = x2.classifyError(403, { code: 'unauthenticated:bad-credentials', error: 'Bad credentials.' });
+    ok('403 auth-ish (OAuth): stays provisioning, NOT reauth (D3 Option B)', auth403.type === 'provisioning', auth403.type);
+    ok('403 auth-ish (OAuth): reconnect-flavored copy, never "API key"',
+        /reconnect/i.test(auth403.userMessage) && /Settings/i.test(auth403.userMessage) && !/api key/i.test(auth403.userMessage), auth403.userMessage);
+
+    // ---- 429 quota-detect now reads the flat shape ----
+    const x3 = loadXai({ authType: 'oauth', oauthToken: 'a.b.c', refresh: 'r' });
+    const quota429 = x3.classifyError(429, { code: 'resource-exhausted', error: 'Monthly quota exceeded.' });
+    ok('429 flat quota body → quota, NOT retryable', quota429.type === 'quota' && quota429.retryable === false, `${quota429.type}/${quota429.retryable}`);
+    const rate429 = x3.classifyError(429, { code: 'rate-limit', error: 'Too many requests, slow down.' });
+    ok('429 flat rate-limit body → still retryable rate_limit', rate429.type === 'rate_limit' && rate429.retryable === true, `${rate429.type}/${rate429.retryable}`);
+
+    // ---- unknown fallback (400) surfaces the real reason; OAuth auth-ish maps to reconnect ----
+    const x4api = loadXai({ authType: 'api_key', apiKey: 'xai-k' });
+    const badKey400 = x4api.classifyError(400, { code: 'invalid-argument', error: 'Incorrect API key provided.' });
+    ok('400 (api_key): surfaces real reason in fallback', /Incorrect API key provided/.test(badKey400.userMessage), badKey400.userMessage);
+
+    const x4oauth = loadXai({ authType: 'oauth', oauthToken: 'a.b.c', refresh: 'r' });
+    x4oauth._resetErrorStateForTests();
+    const badKey400oauth = x4oauth.classifyError(400, { code: 'invalid-argument', error: 'Incorrect API key provided.' });
+    ok('400 (OAuth, api-key-worded body): maps to reconnect, never relays "API key"',
+        /reconnect/i.test(badKey400oauth.userMessage) && !/API key/i.test(badKey400oauth.userMessage), badKey400oauth.userMessage);
+})();
+
+// ── BAT-1172: source pins the adversarial pass flagged (loggers + doc↔log coupling) ──
+// The two ai.js diagnostic loggers and the vision path can't be behavior-tested (they emit
+// via log() side-effects), so a revert to nested-only `error.message` would restore
+// `type=unknown code=- msgLen=0` for every xAI failure with ZERO test failures. Pin at source.
+(function testFlatShapeLoggerSourcePins() {
+    console.log('\n── BAT-1172: flat-shape logger + doc↔log source pins ──');
+    const aiSrc = fs.readFileSync(path.join(BUNDLE, 'ai.js'), 'utf8');
+    const xaiSrc = fs.readFileSync(path.join(BUNDLE, 'providers', 'xai.js'), 'utf8');
+
+    // Both loggers must fall back to the flat shape: top-level `data.code` + string `error`.
+    // Count occurrences so BOTH sites (SessionSummary + chat) are covered, not just one.
+    const codeFallbacks = (aiSrc.match(/typeof (res\.data|d)\.code === 'string'/g) || []).length;
+    ok('ai.js: BOTH loggers read top-level data.code (flat) — 2 sites', codeFallbacks >= 2, `found=${codeFallbacks}`);
+    const errStrFallbacks = (aiSrc.match(/typeof (res\.data|d)\.error === 'string'/g) || []).length;
+    ok('ai.js: BOTH loggers read string data.error (flat) — 2 sites', errStrFallbacks >= 2, `found=${errStrFallbacks}`);
+    // Vision path reads the flat string error too (was `res.data?.error?.message` only).
+    ok('ai.js vision path: reads string res.data.error (flat)',
+        /typeof res\.data\.error === 'string' \? res\.data\.error/.test(aiSrc));
+
+    // DIAGNOSTICS.md tells operators to grep for this exact WARN line — pin that xai.js emits it,
+    // so the emitter and the playbook can't silently drift apart.
+    ok('xai.js emits the documented `[xAI] 403 forbidden: code=` WARN line',
+        /\[xAI\] 403 forbidden: code=/.test(xaiSrc));
+    const diagSrc = fs.readFileSync(path.join(BUNDLE, 'DIAGNOSTICS.md'), 'utf8');
+    ok('DIAGNOSTICS.md references the same `[xAI] 403 forbidden: code=` grep target',
+        /\[xAI\] 403 forbidden: code=/.test(diagSrc));
+    // And the fabricated tier-gate string is gone from the shipped bundle (Node side).
+    ok('xai.js no longer contains the fabricated "subscription tier" copy',
+        !/subscription tier doesn't include API access/.test(xaiSrc));
 })();
 
 // ── refreshOAuthToken: single-flight + await-persist + H1 registration ───────


### PR DESCRIPTION
## Summary
xAI's REST `/v1/chat/completions` returns a **FLAT** error `{code, error:"<string>"}`, not the nested OpenAI/Anthropic `{error:{type,code,message}}`. Every site that read `error.message` got `undefined` for xAI and fell back to status-only copy — most visibly **fabricating** "Your Grok subscription tier doesn't include API access — add an xAI API key" on the terminal OAuth 403. In the BAT-1155 incident the tier was fine; the message was hallucinated. Surfaced by Beka: *"we should start reading error codes, not hallucinate with them. It's wider I guess!"* — and it was: the same fabrication was live in Kotlin's Settings connection test, shown right after "Sign in with Grok".

Contract **Codex-approved** on [BAT-1172](https://linear.app/batcave/issue/BAT-1172) (D3 **Option B** required). 3-lens adversarially validated before Codex.

## Implementation contract
- **Substrate:** shared `_xaiError(data)→{code,message}` extractor tolerant of flat / nested / string / Buffer / null; `_errReason` markdown-strip that KEEPS `.-:/()` so `grok-4.5` / `console.x.ai` stay readable (defense-in-depth — the channel already HTML-escapes); narrowed `_xaiAuthReason` (no bare "api key" → a genuine entitlement 403 isn't misrouted to reconnect).
- **classifyError:** surfaces xAI's REAL reason on 403 (never the fabrication); reads the flat shape for 429 quota-detect (conservative: `quota|insufficient|credit`) and the unknown/400 fallback; new `[xAI] 403 forbidden: code=<...> reason=<...>` WARN capture line.
- **D3 Option B:** an auth-ish terminal 403 stays `type:'provisioning'` with reconnect-flavored copy — **NOT** `reauth`. `reauth` participates in D10 session-expiry + dead-family notify; latching it from a *not-dead* 403 would suppress the later genuine dead-family reconnect notice (guarded by `!_sessionExpired`). `reauth` stays reserved for known-dead durable state.
- **ai.js:** both diagnostic loggers + the vision-error path read the flat shape (top-level `data.code` + string `error`) → xAI failures stop logging `type=unknown code=- msgLen=0`.
- **Self-knowledge:** `buildSystemBlocks()` xAI OAuth playbook + Provider block and `DIAGNOSTICS.md` rewritten — a 403 is not automatically a tier-gate; read the real reason; keep room for genuine xAI-stated plan gates.
- **Kotlin:** `ProviderConfigScreen.kt` `xaiChatPing` parsed the nested shape (always blank for xAI) → the Settings connection test ALWAYS showed the fabrication on any 403. Now parses the flat shape + truthful copy. Sibling nested pings (Anthropic/OpenAI/OpenRouter/Custom) are genuinely nested — left as-is.

**Evidence honesty:** the 403/429 body shapes are **inferred** from captured 400/401 (live probe); safety rests on `_xaiError` tolerance (unknown shape → truthful generic copy, never a fabrication). Capturing a real 403 + quota-429 is a device-test acceptance step.

## Test plan
- [x] `node tests/nodejs-project/smoke.js` — PASS
- [x] `node tests/nodejs-project/xai.test.js` — **189 PASS / 0 FAIL** (adds `_xaiError` flat/nested/string/Buffer/null; narrowed-regex negative pin; D3 Option B: auth-ish 403 → provisioning not reauth; 429 quota vs rate-limit; 400 OAuth-vs-api_key; source pins for both loggers + the WARN line + doc↔log coupling; updated the stale test asserting the fabricated copy)
- [x] `bash scripts/pre-push-check.sh` — Node smoke + 64 tool schemas + wallet regression + **Kotlin compile (dappStoreDebug) BUILD SUCCESSFUL**
- [ ] Device test on Seeker (after review clean) — real 403 surfaces xAI's actual reason in Telegram + the Settings connection test; capture the real 403 + quota-429 bodies; OAuth reconnect unaffected

## Self-Awareness Checklist
- [x] SAB-audited — **SAB-AUDIT-v44** (delta: pre-fix 33.3% → post-fix 100%; the low pre-fix flags the corrected fabrication, not new drift; all fixes in this PR)

## Known limitations
- 403/429 wire shapes inferred from 400/401 captures (degrades safely to truthful generic copy); real capture is a device-test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of xAI 403 errors by displaying the provider’s actual reason instead of assuming a subscription-tier restriction.
  * Added clearer guidance for authentication, access, quota, and API-key-related failures.
  * Improved xAI connection checks and image-analysis error messages.
  * Enhanced diagnostics for xAI error codes and messages across supported response formats.

* **Documentation**
  * Updated xAI troubleshooting guidance to explain retry, reconnect, access, and API-key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->