### PR TITLE
feat(ui): UX polish pass — 42 audit findings, Compose-only (BAT-1247)

### DIFF
--- a/app/src/main/java/com/seekerclaw/app/ui/components/ProviderPicker.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/ProviderPicker.kt
@@ -60,7 +60,9 @@ fun ProviderPicker(
                     selected = isSelected,
                     onClick = null,
                     colors = RadioButtonDefaults.colors(
-                        selectedColor = SeekerClawColors.Primary,
+                        // Q5 (BAT-1247): green is THE active-control accent —
+                        // brand red is reserved for destructive/warning emphasis.
+                        selectedColor = SeekerClawColors.ActionPrimary,
                         unselectedColor = SeekerClawColors.TextDim,
                     ),
                 )

--- a/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
@@ -585,6 +586,9 @@ fun ConfigField(
     // BAT-1247: incomplete/attention states render the value in Warning amber
     // ("Brave Search (not configured)") instead of masquerading as configured.
     valueColor: Color = SeekerClawColors.TextPrimary,
+    // BAT-1247 (audit: Jupiter/Helius rows double-indented): callers already
+    // inside a padded CardSurface pass 0.dp so the row aligns with siblings.
+    horizontalPadding: androidx.compose.ui.unit.Dp = Spacing.lg,
 ) {
     var showInfo by remember { mutableStateOf(false) }
 
@@ -592,7 +596,7 @@ fun ConfigField(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = horizontalPadding, vertical = 14.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -651,7 +655,7 @@ fun ConfigField(
     if (showDivider) {
         HorizontalDivider(
             color = SeekerClawColors.CardBorder,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = horizontalPadding),
         )
     }
 
@@ -1161,7 +1165,7 @@ fun SeekerClawSearchField(
             cursorBrush = SolidColor(SeekerClawColors.Primary),
             modifier = Modifier
                 .weight(1f)
-                .padding(end = Spacing.lg),
+                .padding(end = Spacing.sm),
             decorationBox = { innerTextField ->
                 if (value.isEmpty()) {
                     Text(
@@ -1174,6 +1178,19 @@ fun SeekerClawSearchField(
                 innerTextField()
             },
         )
+        // Built-in clear affordance — appears whenever there is a query, on
+        // every search surface (parity with the pre-1247 Skills field).
+        if (value.isNotEmpty()) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Clear search",
+                tint = SeekerClawColors.TextDim,
+                modifier = Modifier
+                    .padding(end = Spacing.lg)
+                    .size(Sizing.iconMd)
+                    .clickable { onValueChange("") },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
@@ -1231,23 +1231,29 @@ fun EmptyState(
                 color = SeekerClawColors.TextSecondary,
             )
         }
-        if (primaryLabel != null && onPrimary != null) {
+        // CodeRabbit #449 R1: actions render independently — a secondary-only
+        // caller must still get its action.
+        val hasPrimary = primaryLabel != null && onPrimary != null
+        val hasSecondary = secondaryLabel != null && onSecondary != null
+        if (hasPrimary || hasSecondary) {
             Spacer(Modifier.height(Spacing.lg))
             Row(verticalAlignment = Alignment.CenterVertically) {
-                PrimaryButton(
-                    onClick = onPrimary,
-                    label = primaryLabel,
-                    height = Sizing.buttonSecondaryHeight,
-                )
-                if (secondaryLabel != null && onSecondary != null) {
-                    Spacer(Modifier.width(Spacing.lg))
+                if (hasPrimary) {
+                    PrimaryButton(
+                        onClick = onPrimary!!,
+                        label = primaryLabel!!,
+                        height = Sizing.buttonSecondaryHeight,
+                    )
+                }
+                if (hasSecondary) {
+                    if (hasPrimary) Spacer(Modifier.width(Spacing.lg))
                     Text(
-                        text = secondaryLabel,
+                        text = secondaryLabel!!,
                         fontFamily = RethinkSans,
                         fontSize = TypeScale.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = SeekerClawColors.TextSecondary,
-                        modifier = Modifier.clickable(onClick = onSecondary),
+                        modifier = Modifier.clickable(onClick = onSecondary!!),
                     )
                 }
             }
@@ -1266,6 +1272,9 @@ fun StatusIndicator(
     word: String,
     color: Color,
     modifier: Modifier = Modifier,
+    // CodeRabbit #449 R1: pulse animations should breathe the DOT, not the
+    // word — a label fading to 40% is illegible. 1f = static.
+    dotAlpha: Float = 1f,
 ) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Text(
@@ -1280,7 +1289,7 @@ fun StatusIndicator(
             modifier = Modifier
                 .size(10.dp)
                 .clip(CircleShape)
-                .background(color),
+                .background(color.copy(alpha = dotAlpha)),
         )
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -469,7 +470,12 @@ fun CardSurface(
 
 /**
  * Label/value row with optional status dot and divider.
- * Monospace font for both label and value. Used in SystemScreen, SettingsScreen, etc.
+ *
+ * BAT-1247 (audit: "Monospace used for plain-English labels"): labels are now
+ * RethinkSans — monospace is reserved for TECHNICAL values (versions, hashes,
+ * sizes, counts, ms), per the design system's own rule. Values default to
+ * monospace; pass [monospaceValue] = false for human-readable values
+ * ("Charging", agent names) so they render in RethinkSans too.
  */
 @Composable
 fun InfoRow(
@@ -477,6 +483,7 @@ fun InfoRow(
     value: String,
     dotColor: Color? = null,
     isLast: Boolean = false,
+    monospaceValue: Boolean = true,
 ) {
     Row(
         modifier = Modifier
@@ -487,20 +494,20 @@ fun InfoRow(
     ) {
         Text(
             text = label,
-            fontFamily = FontFamily.Monospace,
-            fontSize = 13.sp,
+            fontFamily = RethinkSans,
+            fontSize = TypeScale.bodySmall,
             color = SeekerClawColors.TextSecondary,
         )
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = value,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
+                fontFamily = if (monospaceValue) FontFamily.Monospace else RethinkSans,
+                fontSize = TypeScale.bodySmall,
                 fontWeight = FontWeight.Medium,
                 color = SeekerClawColors.TextPrimary,
             )
             if (dotColor != null) {
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(Spacing.sm))
                 Box(
                     modifier = Modifier
                         .size(10.dp)
@@ -1063,4 +1070,219 @@ fun InputWithActionButton(
             }
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BAT-1247 shared primitives — ONE style per pattern, applied app-wide.
+// Audit findings M4 (three competing section-header styles), M5 (add-item
+// affordance drift), search-field divergence, empty-state divergence,
+// color-only status dots, and the four-way interactive-text drift all trace
+// to screens hand-rolling these. New screens MUST use these instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Page-level section header — THE one style for sections on any screen
+ * (Home "Status", Settings "Configuration", System "Activity", …): small,
+ * grey, letter-spaced. Replaces both the bold-white [SectionLabel] treatment
+ * and per-screen hand-rolled headers.
+ */
+@Composable
+fun PageSectionHeader(title: String, modifier: Modifier = Modifier) {
+    Text(
+        text = title,
+        fontFamily = RethinkSans,
+        fontSize = TypeScale.bodySmall,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 1.sp,
+        color = SeekerClawColors.TextSecondary,
+        modifier = modifier,
+    )
+}
+
+/**
+ * In-card field label — ALL-CAPS, grey, small. For labels INSIDE a card
+ * (skill detail "TYPE" / "DESCRIPTION", wallet card field names). Visually
+ * distinct from [PageSectionHeader] so page structure and card fields never
+ * blur (PM: no hierarchy flattening).
+ */
+@Composable
+fun InCardLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        fontFamily = RethinkSans,
+        fontSize = TypeScale.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 1.sp,
+        color = SeekerClawColors.TextDim,
+        modifier = modifier,
+    )
+}
+
+/**
+ * THE app search field (audit: Logs and Skills shipped two different search
+ * treatments). Filled Surface, standard corner radius, RethinkSans
+ * placeholder, monospace INPUT only when [monospaceInput] (log queries are
+ * technical; skill names are prose).
+ */
+@Composable
+fun SeekerClawSearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    monospaceInput: Boolean = false,
+) {
+    val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(Sizing.buttonSecondaryHeight)
+            .background(SeekerClawColors.Surface, shape)
+            .border(BorderStroke(Sizing.borderThin, SeekerClawColors.CardBorder), shape),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = null,
+            tint = SeekerClawColors.TextDim,
+            modifier = Modifier
+                .padding(start = Spacing.lg, end = Spacing.sm)
+                .size(Sizing.iconMd),
+        )
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = TextStyle(
+                color = SeekerClawColors.TextPrimary,
+                fontSize = TypeScale.bodyMedium.value.sp,
+                fontFamily = if (monospaceInput) FontFamily.Monospace else RethinkSans,
+            ),
+            cursorBrush = SolidColor(SeekerClawColors.Primary),
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = Spacing.lg),
+            decorationBox = { innerTextField ->
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        color = SeekerClawColors.TextDim,
+                        fontSize = TypeScale.bodyMedium,
+                        fontFamily = RethinkSans,
+                    )
+                }
+                innerTextField()
+            },
+        )
+    }
+}
+
+/**
+ * THE empty-state template (audit: MCP folded an italic line into its
+ * explainer while Env Vars used a separate headline card). Centered headline
+ * + optional one-line hint + optional primary action + optional secondary
+ * text action, with parallel copy across screens ("No MCP servers yet." /
+ * "No env vars yet.").
+ */
+@Composable
+fun EmptyState(
+    headline: String,
+    modifier: Modifier = Modifier,
+    hint: String? = null,
+    primaryLabel: String? = null,
+    onPrimary: (() -> Unit)? = null,
+    secondaryLabel: String? = null,
+    onSecondary: (() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth().padding(vertical = Spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = headline,
+            fontFamily = RethinkSans,
+            fontSize = TypeScale.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = SeekerClawColors.TextPrimary,
+        )
+        if (hint != null) {
+            Spacer(Modifier.height(Spacing.sm))
+            Text(
+                text = hint,
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.bodySmall,
+                color = SeekerClawColors.TextSecondary,
+            )
+        }
+        if (primaryLabel != null && onPrimary != null) {
+            Spacer(Modifier.height(Spacing.lg))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                PrimaryButton(
+                    onClick = onPrimary,
+                    label = primaryLabel,
+                    height = Sizing.buttonSecondaryHeight,
+                )
+                if (secondaryLabel != null && onSecondary != null) {
+                    Spacer(Modifier.width(Spacing.lg))
+                    Text(
+                        text = secondaryLabel,
+                        fontFamily = RethinkSans,
+                        fontSize = TypeScale.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = SeekerClawColors.TextSecondary,
+                        modifier = Modifier.clickable(onClick = onSecondary),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Status dot + VISIBLE status word (audit a11y: Home conveyed service health
+ * by hue alone; PM: contentDescription alone is insufficient). Word inherits
+ * the dot color so the pair reads as one unit; state is carried by TEXT, not
+ * only color.
+ */
+@Composable
+fun StatusIndicator(
+    word: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = word,
+            fontFamily = RethinkSans,
+            fontSize = TypeScale.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+        Spacer(Modifier.width(Spacing.sm))
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+    }
+}
+
+/**
+ * Green screen-level text action ("Import", "Export All", header "+ Add").
+ * One of the three sanctioned interactive-text affordances:
+ *   green [ScreenActionLink] (ActionPrimary) = screen-level action,
+ *   white "Edit" (ConfigField/TextInteractive) = row edit,
+ *   grey text + chevron = navigation drill-in.
+ */
+@Composable
+fun ScreenActionLink(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Text(
+        text = label,
+        fontFamily = RethinkSans,
+        fontSize = TypeScale.bodyMedium,
+        fontWeight = FontWeight.Bold,
+        color = SeekerClawColors.ActionPrimary,
+        modifier = modifier.clickable(onClick = onClick),
+    )
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
@@ -582,6 +582,9 @@ fun ConfigField(
     showDivider: Boolean = true,
     info: String? = null,
     isRequired: Boolean = false,
+    // BAT-1247: incomplete/attention states render the value in Warning amber
+    // ("Brave Search (not configured)") instead of masquerading as configured.
+    valueColor: Color = SeekerClawColors.TextPrimary,
 ) {
     var showInfo by remember { mutableStateOf(false) }
 
@@ -642,7 +645,7 @@ fun ConfigField(
             text = value,
             fontFamily = RethinkSans,
             fontSize = 14.sp,
-            color = SeekerClawColors.TextPrimary,
+            color = valueColor,
         )
     }
     if (showDivider) {

--- a/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/components/SharedComponents.kt
@@ -560,18 +560,15 @@ fun SeekerClawTopAppBar(title: String, onBack: () -> Unit) {
 
 /**
  * Section label used across settings, setup, and system screens.
- * RethinkSans, ExtraBold, white. Callers are responsible for adding
- * their own bottom spacing.
+ *
+ * BAT-1247 (M4 — three competing section-header styles): now delegates to
+ * [PageSectionHeader], so every existing call site inherits THE page-level
+ * style (grey, letter-spaced) without per-screen edits. Callers are still
+ * responsible for their own bottom spacing.
  */
 @Composable
 fun SectionLabel(title: String) {
-    Text(
-        text = title,
-        fontFamily = RethinkSans,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.ExtraBold,
-        color = SeekerClawColors.TextPrimary,
-    )
+    PageSectionHeader(title)
 }
 
 /**

--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -888,10 +888,12 @@ private fun UplinkCard(
             )
         }
 
+        // CodeRabbit #449 R1: pulse only the dot — fading the whole row made
+        // the status word breathe to 40% opacity.
         StatusIndicator(
             word = statusWord,
             color = dotColor,
-            modifier = Modifier.alpha(dotAlpha),
+            dotAlpha = dotAlpha,
         )
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/dashboard/DashboardScreen.kt
@@ -56,12 +56,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.seekerclaw.app.BuildConfig
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.modelDisplayName
 import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.service.SeekerClawService
 import com.seekerclaw.app.ui.components.DashboardActionButton
 import com.seekerclaw.app.ui.components.DashboardActionState
+import com.seekerclaw.app.ui.components.InCardLabel
+import com.seekerclaw.app.ui.components.PageSectionHeader
+import com.seekerclaw.app.ui.components.StatusIndicator
 import com.seekerclaw.app.ui.components.WarningButton
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 import com.seekerclaw.app.ui.theme.SeekerClawColors
@@ -71,6 +75,7 @@ import com.seekerclaw.app.util.LogLevel
 import com.seekerclaw.app.util.AgentHealth
 import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
+import com.seekerclaw.app.util.UptimeFormat
 import com.seekerclaw.app.util.rememberUptime
 import android.content.Context
 import android.net.ConnectivityManager
@@ -607,17 +612,10 @@ fun DashboardScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text(
-                text = "Uptime",
-                fontFamily = RethinkSans,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Medium,
-                color = SeekerClawColors.TextDim,
-                letterSpacing = 1.sp,
-            )
+            InCardLabel(text = "Uptime")
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = formatUptime(uptime),
+                text = UptimeFormat.format(uptime),
                 fontFamily = FontFamily.Monospace,
                 fontSize = 32.sp,
                 fontWeight = FontWeight.Bold,
@@ -639,14 +637,7 @@ fun DashboardScreen(
         Spacer(modifier = Modifier.height(24.dp))
 
         // Uplinks
-        Text(
-            text = "Status",
-            fontFamily = RethinkSans,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Medium,
-            color = SeekerClawColors.TextDim,
-            letterSpacing = 1.sp,
-        )
+        PageSectionHeader(title = "Status")
 
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -659,7 +650,7 @@ fun DashboardScreen(
                     "degraded" -> "Engine retrying"
                     "error" -> "Engine error"
                     "stale" -> "Engine unresponsive"
-                    else -> "Claw Engine"
+                    else -> "Gateway " + BuildConfig.OPENCLAW_VERSION
                 }
                 ServiceStatus.STARTING -> "Starting..."
                 ServiceStatus.STOPPED -> "Offline"
@@ -678,6 +669,18 @@ fun DashboardScreen(
                 ServiceStatus.STOPPED -> SeekerClawColors.TextDim
                 ServiceStatus.ERROR -> SeekerClawColors.Error
             }
+            // Status word mirrors gatewayDotColor branch-for-branch (a11y:
+            // state must be carried by text, not hue alone).
+            val gatewayWord = when (status) {
+                ServiceStatus.RUNNING -> when (health.apiStatus) {
+                    "degraded", "stale" -> "Degraded"
+                    "error" -> "Down"
+                    else -> "Running"
+                }
+                ServiceStatus.STARTING -> "Starting"
+                ServiceStatus.STOPPED -> "Offline"
+                ServiceStatus.ERROR -> "Down"
+            }
 
             val channelSubtitle = if (!hasBotToken) "Bot token missing" else when (status) {
                 ServiceStatus.RUNNING -> "Message relay"
@@ -690,6 +693,12 @@ fun DashboardScreen(
                 ServiceStatus.STARTING -> SeekerClawColors.Warning
                 ServiceStatus.ERROR -> SeekerClawColors.Error
                 ServiceStatus.STOPPED -> SeekerClawColors.TextDim
+            }
+            val channelWord = if (!hasBotToken) "Down" else when (status) {
+                ServiceStatus.RUNNING -> "Connected"
+                ServiceStatus.STARTING -> "Starting"
+                ServiceStatus.ERROR -> "Down"
+                ServiceStatus.STOPPED -> "Offline"
             }
 
             val aiSubtitle = if (!hasCredential) "Credential missing" else when (status) {
@@ -718,20 +727,32 @@ fun DashboardScreen(
                 ServiceStatus.ERROR -> SeekerClawColors.Error
                 ServiceStatus.STOPPED -> SeekerClawColors.TextDim
             }
+            val aiWord = if (!hasCredential) "Down" else when (status) {
+                ServiceStatus.RUNNING -> when (health.apiStatus) {
+                    "degraded", "stale" -> "Degraded"
+                    "error" -> "Down"
+                    else -> "Ready"
+                }
+                ServiceStatus.STARTING -> "Starting"
+                ServiceStatus.ERROR -> "Down"
+                ServiceStatus.STOPPED -> "Offline"
+            }
 
             val isDiscord = config?.channel == "discord"
             UplinkCard(
                 icon = if (isDiscord) "//DC" else "//TG",
                 name = if (isDiscord) "Discord" else "Telegram",
                 subtitle = channelSubtitle,
+                statusWord = channelWord,
                 dotColor = channelDotColor,
                 shape = shape,
                 dotAlpha = if (isRunning) pulseAlpha else 1f,
             )
             UplinkCard(
                 icon = "//GW",
-                name = "Engine",
+                name = "Claw Engine",
                 subtitle = gatewaySubtitle,
+                statusWord = gatewayWord,
                 dotColor = gatewayDotColor,
                 shape = shape,
                 dotAlpha = if (isRunning) pulseAlpha else 1f,
@@ -740,6 +761,7 @@ fun DashboardScreen(
                 icon = "//AI",
                 name = "AI Provider",
                 subtitle = aiSubtitle,
+                statusWord = aiWord,
                 dotColor = aiDotColor,
                 shape = shape,
                 dotAlpha = if (isRunning) pulseAlpha else 1f,
@@ -828,6 +850,7 @@ private fun UplinkCard(
     icon: String,
     name: String,
     subtitle: String,
+    statusWord: String,
     dotColor: Color,
     shape: RoundedCornerShape,
     dotAlpha: Float = 1f,
@@ -865,26 +888,12 @@ private fun UplinkCard(
             )
         }
 
-        Box(
-            modifier = Modifier
-                .size(10.dp)
-                .clip(CircleShape)
-                .background(dotColor)
-                .alpha(dotAlpha),
+        StatusIndicator(
+            word = statusWord,
+            color = dotColor,
+            modifier = Modifier.alpha(dotAlpha),
         )
     }
-}
-
-private fun formatUptime(millis: Long): String {
-    if (millis <= 0) return "00h 00m 00s"
-    val seconds = millis / 1000
-    val minutes = seconds / 60
-    val hours = minutes / 60
-    val days = hours / 24
-    return buildString {
-        if (days > 0) append("${days}d ")
-        append("%02dh %02dm %02ds".format(hours % 24, minutes % 60, seconds % 60))
-    }.trimEnd()
 }
 
 private fun formatLastActivity(timestamp: Long, context: Context): String {

--- a/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
@@ -18,18 +18,17 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Terminal
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,15 +37,20 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
+import com.seekerclaw.app.ui.components.SeekerClawSearchField
 import com.seekerclaw.app.ui.components.SeekerClawSwitch
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 import com.seekerclaw.app.ui.theme.RethinkSans
+import com.seekerclaw.app.ui.theme.Sizing
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,7 +60,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import com.seekerclaw.app.ui.theme.SeekerClawColors
 import com.seekerclaw.app.util.LogCollector
 import com.seekerclaw.app.util.LogLevel
-import com.seekerclaw.app.util.LogRedactor
+import com.seekerclaw.app.util.LogShareSanitizer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.Date
 
 @Composable
@@ -67,8 +74,10 @@ fun LogsScreen() {
     val listState = rememberLazyListState()
     var autoScroll by rememberSaveable { mutableStateOf(true) }
 
-    var showClearDialog by remember { mutableStateOf(false) }
     var searchQuery by rememberSaveable { mutableStateOf("") }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     // Filter toggles — rememberSaveable so they survive tab switches and config changes
     var showDebug by rememberSaveable { mutableStateOf(false) }
@@ -135,388 +144,334 @@ fun LogsScreen() {
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SeekerClawColors.Background)
-            .padding(20.dp),
-    ) {
-        // Header — icon + title + share/trash buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SeekerClawColors.Background)
+                .padding(20.dp),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    Icons.Default.Terminal,
-                    contentDescription = null,
-                    tint = SeekerClawColors.Primary,
-                    modifier = Modifier.size(24.dp),
-                )
-                Spacer(modifier = Modifier.width(10.dp))
+            // Header — bare title + share/clear actions (matches Skills/Settings tab pattern)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text = "Logs",
                     fontFamily = RethinkSans,
-                    fontSize = 20.sp,
+                    fontSize = TypeScale.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = SeekerClawColors.TextPrimary,
                 )
-            }
-            Row {
-                IconButton(onClick = {
-                    val logText = buildString {
-                        appendLine("SeekerClaw Logs — ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US).format(Date())}")
-                        appendLine("─".repeat(40))
-                        filteredLogs.forEach { entry ->
-                            val timeStr = android.text.format.DateFormat.format(timePattern, Date(entry.timestamp))
-                            appendLine("[${entry.level.name}] [$timeStr] ${entry.message}")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = {
+                        val logText = buildString {
+                            appendLine("SeekerClaw Logs — ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US).format(Date())}")
+                            appendLine("─".repeat(40))
+                            filteredLogs.forEach { entry ->
+                                val timeStr = android.text.format.DateFormat.format(timePattern, Date(entry.timestamp))
+                                appendLine("[${entry.level.name}] [$timeStr] ${entry.message}")
+                            }
                         }
-                    }
-                    // BAT-1161 P1A gate 6: Share second pass, defense-in-depth over the redaction
-                    // already applied at LogCollector ingress (append + the parseLine restore path).
-                    // Secrecy-fail-CLOSED: if the redactor throws we must NOT fall back to the
-                    // unmasked text. It is tempting to reason "the entries were already redacted,
-                    // so logText is safe" — but the same redactor is what masked them, so a throw
-                    // here is evidence it may have failed there too. Share is a one-tap path OFF
-                    // the device; a useless export is recoverable, a leaked token is not.
-                    val shareText = try { LogRedactor.redact(logText) } catch (_: Throwable) { "[[redaction-error]]" }
-                    val sendIntent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(android.content.Intent.EXTRA_TEXT, shareText)
-                        putExtra(android.content.Intent.EXTRA_SUBJECT, "SeekerClaw Logs")
-                    }
-                    context.startActivity(android.content.Intent.createChooser(sendIntent, "Share Logs"))
-                }) {
-                    Icon(
-                        Icons.Default.Share,
-                        contentDescription = "Share logs",
-                        tint = SeekerClawColors.TextDim,
-                    )
-                }
-                // BAT-1161 P1A: "Clear console" — this only clears the service_logs mirror +
-                // in-memory ring, NOT Node's node_debug.log (which keeps recording and re-forwards).
-                TextButton(onClick = { showClearDialog = true }) {
-                    Icon(
-                        Icons.Default.Delete,
-                        contentDescription = "Clear console",
-                        tint = SeekerClawColors.TextDim,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = "Clear console",
-                        fontFamily = RethinkSans,
-                        fontSize = 13.sp,
-                        color = SeekerClawColors.TextDim,
-                    )
-                }
-            }
-        }
-
-        Text(
-            text = "System logs and diagnostics",
-            fontFamily = RethinkSans,
-            fontSize = 13.sp,
-            color = SeekerClawColors.TextDim,
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Search bar
-        OutlinedTextField(
-            value = searchQuery,
-            onValueChange = { searchQuery = it },
-            placeholder = {
-                Text(
-                    "Search logs\u2026",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 13.sp,
-                )
-            },
-            leadingIcon = {
-                Icon(
-                    Icons.Default.Search,
-                    contentDescription = "Search",
-                    tint = SeekerClawColors.TextDim,
-                    modifier = Modifier.size(18.dp),
-                )
-            },
-            trailingIcon = {
-                if (searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { searchQuery = "" }) {
+                        // Share second pass, defense-in-depth over the redaction already applied
+                        // at LogCollector ingress (append + the parseLine restore path).
+                        // LogShareSanitizer = Message-marker scrub + LogRedactor, share-only —
+                        // console rendering is untouched. Secrecy-fail-CLOSED: if the sanitizer
+                        // throws we must NOT fall back to the unmasked text. It is tempting to
+                        // reason "the entries were already redacted, so logText is safe" — but
+                        // the same redactor is what masked them, so a throw here is evidence it
+                        // may have failed there too. Share is a one-tap path OFF the device; a
+                        // useless export is recoverable, a leaked token is not.
+                        val shareText = try { LogShareSanitizer.sanitize(logText) } catch (_: Throwable) { "[[redaction-error]]" }
+                        val sendIntent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(android.content.Intent.EXTRA_TEXT, shareText)
+                            putExtra(android.content.Intent.EXTRA_SUBJECT, "SeekerClaw Logs")
+                        }
+                        context.startActivity(android.content.Intent.createChooser(sendIntent, "Share Logs"))
+                    }) {
                         Icon(
-                            Icons.Default.Close,
-                            contentDescription = "Clear search",
+                            Icons.Default.Share,
+                            contentDescription = "Share logs",
                             tint = SeekerClawColors.TextDim,
-                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                    // BAT-1161 P1A: "Clear console" — this only clears the service_logs mirror +
+                    // in-memory ring, NOT Node's node_debug.log (which keeps recording and
+                    // re-forwards). Destructive → Error tint. Undo path: the cleared entries are
+                    // stashed in a local variable (no persistence) and replayed through
+                    // LogCollector.append() — original timestamps preserved via eventTimeMs —
+                    // which restores both the in-memory ring and the service_logs mirror, so the
+                    // 1.5s refreshFromFile loop doesn't wipe the restore.
+                    TextButton(onClick = {
+                        val stash = logs
+                        LogCollector.clear()
+                        scope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = "Console cleared",
+                                actionLabel = "Undo",
+                                duration = SnackbarDuration.Long,
+                            )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                withContext(Dispatchers.IO) {
+                                    stash.forEach { entry ->
+                                        LogCollector.append(entry.message, entry.level, eventTimeMs = entry.timestamp)
+                                    }
+                                }
+                            }
+                        }
+                    }) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Clear console",
+                            tint = SeekerClawColors.Error,
+                            modifier = Modifier.size(Sizing.iconMd),
+                        )
+                        Spacer(modifier = Modifier.width(Spacing.xs))
+                        Text(
+                            text = "Clear console",
+                            fontFamily = RethinkSans,
+                            fontSize = TypeScale.bodySmall,
+                            color = SeekerClawColors.Error,
                         )
                     }
                 }
-            },
-            singleLine = true,
-            textStyle = androidx.compose.ui.text.TextStyle(
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
-                color = SeekerClawColors.TextPrimary,
-            ),
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = SeekerClawColors.Primary,
-                unfocusedBorderColor = SeekerClawColors.TextDim.copy(alpha = 0.3f),
-                cursorColor = SeekerClawColors.Primary,
-            ),
-            shape = shape,
-            modifier = Modifier.fillMaxWidth(),
-        )
+            }
 
-        Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(Spacing.md))
 
-        // Terminal window
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .background(SeekerClawColors.Surface, shape)
-                .cornerGlowBorder(),
-        ) {
-            if (filteredLogs.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    if (logs.isEmpty()) {
-                        // Genuine empty — no logs at all
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = "$ _",
-                                fontFamily = FontFamily.Monospace,
-                                fontSize = 24.sp,
-                                color = SeekerClawColors.TextDim.copy(alpha = 0.4f),
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = "No logs yet.",
-                                fontFamily = FontFamily.Monospace,
-                                fontSize = 13.sp,
-                                color = SeekerClawColors.TextDim,
-                            )
-                        }
-                    } else {
-                        // Logs exist but are all filtered out
-                        val hasSearchFilter = searchQuery.isNotBlank()
-                        val reasonText = when {
-                            hasSearchFilter -> "No logs match your search."
-                            else -> "No logs for selected levels."
-                        }
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = "\u2205",
-                                fontSize = 28.sp,
-                                color = SeekerClawColors.TextDim.copy(alpha = 0.4f),
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = reasonText,
-                                fontFamily = FontFamily.Monospace,
-                                fontSize = 13.sp,
-                                color = SeekerClawColors.TextDim,
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = "${logs.size} entries hidden.",
-                                fontFamily = FontFamily.Monospace,
-                                fontSize = 12.sp,
-                                color = SeekerClawColors.TextDim.copy(alpha = 0.6f),
-                            )
-                            Spacer(modifier = Modifier.height(12.dp))
-                            TextButton(onClick = {
-                                showDebug = true
-                                showInfo = true
-                                showWarn = true
-                                showError = true
-                                searchQuery = ""
-                            }) {
+            // Search bar — THE app search field; monospace input (log queries are technical)
+            SeekerClawSearchField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = "Search logs…",
+                monospaceInput = true,
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.md))
+
+            // Terminal window
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .background(SeekerClawColors.Surface, shape)
+                    .cornerGlowBorder(),
+            ) {
+                if (filteredLogs.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (logs.isEmpty()) {
+                            // Genuine empty — no logs at all
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Text(
-                                    text = "Show all",
-                                    fontFamily = RethinkSans,
-                                    fontSize = 13.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = SeekerClawColors.Primary,
+                                    text = "$ _",
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 24.sp,
+                                    color = SeekerClawColors.TextDim.copy(alpha = 0.4f),
                                 )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = "No logs yet.",
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 13.sp,
+                                    color = SeekerClawColors.TextDim,
+                                )
+                            }
+                        } else {
+                            // Logs exist but are all filtered out
+                            val hasSearchFilter = searchQuery.isNotBlank()
+                            val reasonText = when {
+                                hasSearchFilter -> "No logs match your search."
+                                else -> "No logs for selected levels."
+                            }
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    text = "∅",
+                                    fontSize = 28.sp,
+                                    color = SeekerClawColors.TextDim.copy(alpha = 0.4f),
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = reasonText,
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 13.sp,
+                                    color = SeekerClawColors.TextDim,
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "${logs.size} entries hidden.",
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 12.sp,
+                                    color = SeekerClawColors.TextDim.copy(alpha = 0.6f),
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                TextButton(onClick = {
+                                    showDebug = true
+                                    showInfo = true
+                                    showWarn = true
+                                    showError = true
+                                    searchQuery = ""
+                                }) {
+                                    Text(
+                                        text = "Show all",
+                                        fontFamily = RethinkSans,
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        // BAT-1247: screen-level action = green;
+                                        // red stays destructive/brand.
+                                        color = SeekerClawColors.ActionPrimary,
+                                    )
+                                }
                             }
                         }
                     }
-                }
-            } else {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 14.dp, vertical = 10.dp),
-                ) {
-                    itemsIndexed(
-                        filteredLogs,
-                        key = { index, entry -> entry.timestamp to index },
-                    ) { index, entry ->
-                        val color = when (entry.level) {
-                            LogLevel.DEBUG -> SeekerClawColors.LogDebug
-                            LogLevel.INFO -> SeekerClawColors.LogInfo
-                            LogLevel.WARN -> SeekerClawColors.Warning
-                            LogLevel.ERROR -> SeekerClawColors.Error
+                } else {
+                    // contentPadding (not a modifier padding) so the first line rests
+                    // Spacing.sm below the card's top edge instead of clipping against
+                    // it, while scrolled content still slides through the inset.
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = Spacing.md,
+                            top = Spacing.sm,
+                            end = Spacing.md,
+                            bottom = Spacing.sm,
+                        ),
+                    ) {
+                        itemsIndexed(
+                            filteredLogs,
+                            key = { index, entry -> entry.timestamp to index },
+                        ) { index, entry ->
+                            val timeStr = android.text.format.DateFormat.format(timePattern, Date(entry.timestamp))
+                            Text(
+                                text = "[$timeStr] ${entry.message}",
+                                color = logLevelColor(entry.level),
+                                fontSize = TypeScale.labelSmall,
+                                fontFamily = FontFamily.Monospace,
+                                lineHeight = 18.sp,
+                                modifier = Modifier.padding(vertical = 1.dp),
+                            )
                         }
-                        val timeStr = android.text.format.DateFormat.format(timePattern, Date(entry.timestamp))
-                        Text(
-                            text = "[$timeStr] ${entry.message}",
-                            color = color,
-                            fontSize = 12.sp,
-                            fontFamily = FontFamily.Monospace,
-                            lineHeight = 18.sp,
-                            modifier = Modifier.padding(vertical = 1.dp),
-                        )
                     }
                 }
             }
-        }
 
-        // Diagnostic status line — non-spammy, always visible
-        if (logs.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(6.dp))
-            val hiddenCount = logs.size - filteredLogs.size
-            val statusText = buildString {
-                append("${filteredLogs.size}/${logs.size} entries")
-                if (hiddenCount > 0) append(" \u00b7 $hiddenCount filtered")
+            // Diagnostic status line — non-spammy, always visible
+            if (logs.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                val hiddenCount = logs.size - filteredLogs.size
+                val statusText = buildString {
+                    append("${filteredLogs.size}/${logs.size} entries")
+                    if (hiddenCount > 0) append(" · $hiddenCount filtered")
+                }
+                Text(
+                    text = statusText,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 11.sp,
+                    color = SeekerClawColors.TextDim.copy(alpha = 0.5f),
+                )
             }
-            Text(
-                text = statusText,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 11.sp,
-                color = SeekerClawColors.TextDim.copy(alpha = 0.5f),
-            )
-        }
 
-        Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(6.dp))
 
-        // Auto-scroll toggle
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "Auto-scroll",
-                fontFamily = RethinkSans,
-                fontSize = 14.sp,
-                color = SeekerClawColors.TextSecondary,
-            )
-            SeekerClawSwitch(
-                checked = autoScroll,
-                onCheckedChange = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    autoScroll = it
-                },
-            )
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Log level filters
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            FilterChip(
-                label = "Debug",
-                active = showDebug,
-                activeColor = SeekerClawColors.LogDebug,
-                shape = shape,
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    showDebug = !showDebug
-                },
-            )
-            FilterChip(
-                label = "Info",
-                active = showInfo,
-                activeColor = SeekerClawColors.LogInfo,
-                shape = shape,
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    showInfo = !showInfo
-                },
-            )
-            FilterChip(
-                label = "Warn",
-                active = showWarn,
-                activeColor = SeekerClawColors.Warning,
-                shape = shape,
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    showWarn = !showWarn
-                },
-            )
-            FilterChip(
-                label = "Error",
-                active = showError,
-                activeColor = SeekerClawColors.Error,
-                shape = shape,
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    showError = !showError
-                },
-            )
-        }
-    }
-
-    if (showClearDialog) {
-        AlertDialog(
-            onDismissRequest = { showClearDialog = false },
-            title = {
+            // Auto-scroll toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
-                    "Clear console",
+                    text = "Auto-scroll",
                     fontFamily = RethinkSans,
-                    fontWeight = FontWeight.Bold,
-                    color = SeekerClawColors.TextPrimary,
-                )
-            },
-            text = {
-                Text(
-                    "This clears the on-screen console and its mirror. Node's own debug log keeps recording, so new entries will appear again.",
-                    fontFamily = RethinkSans,
-                    fontSize = 13.sp,
+                    fontSize = 14.sp,
                     color = SeekerClawColors.TextSecondary,
-                    lineHeight = 20.sp,
                 )
-            },
-            confirmButton = {
-                TextButton(onClick = {
-                    LogCollector.clear()
-                    showClearDialog = false
-                }) {
-                    Text(
-                        "Clear",
-                        fontFamily = RethinkSans,
-                        fontWeight = FontWeight.Bold,
-                        color = SeekerClawColors.Error,
-                    )
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showClearDialog = false }) {
-                    Text(
-                        "Cancel",
-                        fontFamily = RethinkSans,
-                        color = SeekerClawColors.TextDim,
-                    )
-                }
-            },
-            containerColor = SeekerClawColors.Surface,
-            shape = shape,
+                SeekerClawSwitch(
+                    checked = autoScroll,
+                    onCheckedChange = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        autoScroll = it
+                    },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Log level filters — active color matches the console line color per level
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    label = "Debug",
+                    active = showDebug,
+                    activeColor = logLevelColor(LogLevel.DEBUG),
+                    shape = shape,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        showDebug = !showDebug
+                    },
+                )
+                FilterChip(
+                    label = "Info",
+                    active = showInfo,
+                    activeColor = logLevelColor(LogLevel.INFO),
+                    shape = shape,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        showInfo = !showInfo
+                    },
+                )
+                FilterChip(
+                    label = "Warn",
+                    active = showWarn,
+                    activeColor = logLevelColor(LogLevel.WARN),
+                    shape = shape,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        showWarn = !showWarn
+                    },
+                )
+                FilterChip(
+                    label = "Error",
+                    active = showError,
+                    activeColor = logLevelColor(LogLevel.ERROR),
+                    shape = shape,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        showError = !showError
+                    },
+                )
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
+}
+
+/**
+ * Single source of the level → color mapping, shared by console lines and
+ * filter chips. Palette roles only: INFO reads as primary prose, DEBUG is
+ * de-emphasized, WARN/ERROR use the semantic roles. (Replaced the old
+ * off-palette LogInfo blue.)
+ */
+private fun logLevelColor(level: LogLevel): Color = when (level) {
+    LogLevel.DEBUG -> SeekerClawColors.TextSecondary
+    LogLevel.INFO -> SeekerClawColors.TextPrimary
+    LogLevel.WARN -> SeekerClawColors.Warning
+    LogLevel.ERROR -> SeekerClawColors.Error
 }
 
 @Composable
@@ -532,12 +487,22 @@ private fun FilterChip(
         onClick = onClick,
         modifier = modifier,
         shape = shape,
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+        contentPadding = PaddingValues(horizontal = Spacing.sm, vertical = Spacing.sm),
         colors = ButtonDefaults.buttonColors(
             containerColor = if (active) activeColor.copy(alpha = 0.2f) else SeekerClawColors.Surface,
             contentColor = if (active) activeColor else SeekerClawColors.TextDim,
         ),
     ) {
-        Text(text = label, fontFamily = RethinkSans, fontSize = 12.sp, maxLines = 1, softWrap = false)
+        // Non-color selected cue (a11y): leading checkmark on active chips,
+        // so selection survives color-vision differences. Inherits contentColor.
+        if (active) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = null,
+                modifier = Modifier.size(Sizing.iconSm),
+            )
+            Spacer(modifier = Modifier.width(Spacing.xs))
+        }
+        Text(text = label, fontFamily = RethinkSans, fontSize = TypeScale.labelSmall, maxLines = 1, softWrap = false)
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/logs/LogsScreen.kt
@@ -25,10 +25,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,9 +61,7 @@ import com.seekerclaw.app.ui.theme.SeekerClawColors
 import com.seekerclaw.app.util.LogCollector
 import com.seekerclaw.app.util.LogLevel
 import com.seekerclaw.app.util.LogShareSanitizer
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.Date
 
 @Composable
@@ -78,6 +76,7 @@ fun LogsScreen() {
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    var showClearConfirm by remember { mutableStateOf(false) }
 
     // Filter toggles — rememberSaveable so they survive tab switches and config changes
     var showDebug by rememberSaveable { mutableStateOf(false) }
@@ -199,32 +198,16 @@ fun LogsScreen() {
                     }
                     // BAT-1161 P1A: "Clear console" — this only clears the service_logs mirror +
                     // in-memory ring, NOT Node's node_debug.log (which keeps recording and
-                    // re-forwards). Destructive → Error tint. Undo path: the cleared entries are
-                    // stashed in a local variable (no persistence) and replayed through
-                    // LogCollector.append() — original timestamps preserved via eventTimeMs —
-                    // which restores both the in-memory ring and the service_logs mirror, so the
-                    // 1.5s refreshFromFile loop doesn't wipe the restore.
-                    TextButton(onClick = {
-                        val stash = logs
-                        LogCollector.clear()
-                        scope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = "Console cleared",
-                                actionLabel = "Undo",
-                                duration = SnackbarDuration.Long,
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                withContext(Dispatchers.IO) {
-                                    stash.forEach { entry ->
-                                        LogCollector.append(entry.message, entry.level, eventTimeMs = entry.timestamp)
-                                    }
-                                }
-                            }
-                        }
-                    }) {
+                    // re-forwards). Destructive → Error tint. CodeRabbit #449 R1: the in-memory
+                    // Undo stash died with the composable (leave screen → Undo gone) and replay
+                    // could reorder entries — per the PM contract's fallback ("otherwise use
+                    // confirmation"), clearing now confirms via dialog instead.
+                    TextButton(onClick = { showClearConfirm = true }) {
                         Icon(
                             Icons.Default.Delete,
-                            contentDescription = "Clear console",
+                            // Visible text right beside this already labels the action —
+                            // a second identical description made TalkBack announce it twice.
+                            contentDescription = null,
                             tint = SeekerClawColors.Error,
                             modifier = Modifier.size(Sizing.iconMd),
                         )
@@ -234,6 +217,49 @@ fun LogsScreen() {
                             fontFamily = RethinkSans,
                             fontSize = TypeScale.bodySmall,
                             color = SeekerClawColors.Error,
+                        )
+                    }
+                    if (showClearConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showClearConfirm = false },
+                            containerColor = SeekerClawColors.Surface,
+                            shape = shape,
+                            title = {
+                                Text(
+                                    "Clear console?",
+                                    fontFamily = RethinkSans,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = TypeScale.titleMedium,
+                                    color = SeekerClawColors.TextPrimary,
+                                )
+                            },
+                            text = {
+                                Text(
+                                    "Clears the on-screen console and its mirror. The full node_debug.log keeps recording.",
+                                    fontFamily = RethinkSans,
+                                    fontSize = TypeScale.bodySmall,
+                                    color = SeekerClawColors.TextSecondary,
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showClearConfirm = false
+                                    LogCollector.clear()
+                                    scope.launch {
+                                        snackbarHostState.showSnackbar(
+                                            message = "Console cleared",
+                                            duration = SnackbarDuration.Short,
+                                        )
+                                    }
+                                }) {
+                                    Text("Clear", fontFamily = RethinkSans, fontWeight = FontWeight.Bold, color = SeekerClawColors.Error)
+                                }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showClearConfirm = false }) {
+                                    Text("Cancel", fontFamily = RethinkSans, color = SeekerClawColors.TextSecondary)
+                                }
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/EnvVarsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/EnvVarsScreen.kt
@@ -125,6 +125,10 @@ fun EnvVarsScreen(
             else -> envVars + newVar
         }
         ConfigManager.saveEnvVars(context, updated)
+        // CodeRabbit #449 R1: re-gate writes until the async configVersion
+        // reload lands — a second save built on the stale `envVars` snapshot
+        // could silently drop the first one. The reload effect flips this back.
+        isLoaded = false
         editsThisSession = true
         dialogState = EnvVarDialogState.Hidden
     }
@@ -390,6 +394,7 @@ fun EnvVarsScreen(
                 // Raw editor returns the COMPLETE intended list — replace outright,
                 // not merge. This is how rename/delete/edit-in-place work.
                 ConfigManager.saveEnvVars(context, finalList)
+                isLoaded = false // re-gate until reload (see onSave)
                 editsThisSession = true
                 showRawEditor = false
             },
@@ -428,6 +433,7 @@ fun EnvVarsScreen(
             confirmButton = {
                 TextButton(onClick = {
                     ConfigManager.saveEnvVars(context, envVars.filterNot { it.name == target.name })
+                    isLoaded = false // re-gate until reload (see onSave)
                     editsThisSession = true
                     deleteTarget = null
                 }) {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/EnvVarsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/EnvVarsScreen.kt
@@ -2,27 +2,22 @@ package com.seekerclaw.app.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -41,10 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -53,9 +46,11 @@ import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.EnvVar
 import com.seekerclaw.app.config.EnvVarRegistry
 import com.seekerclaw.app.ui.components.CardSurface
-import com.seekerclaw.app.ui.components.SectionLabel
+import com.seekerclaw.app.ui.components.EmptyState
+import com.seekerclaw.app.ui.components.ScreenActionLink
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.ui.theme.Spacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -156,16 +151,15 @@ fun EnvVarsScreen(
                     }
                 },
                 actions = {
-                    IconButton(
-                        onClick = { dialogState = EnvVarDialogState.Add() },
-                        enabled = isLoaded,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Add,
-                            contentDescription = "Add env var",
-                            tint = if (isLoaded) SeekerClawColors.TextPrimary else SeekerClawColors.TextDim,
-                        )
-                    }
+                    // BAT-1247 M5: unified add affordance — green "+ Add"
+                    // ScreenActionLink instead of a bare "+" icon. The
+                    // isLoaded gate moves into onClick: saves must never
+                    // build on the not-yet-loaded (empty) list.
+                    ScreenActionLink(
+                        label = "+ Add",
+                        onClick = { if (isLoaded) dialogState = EnvVarDialogState.Add() },
+                        modifier = Modifier.padding(end = Spacing.lg),
+                    )
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = SeekerClawColors.Background,
@@ -181,11 +175,10 @@ fun EnvVarsScreen(
                 .padding(horizontal = 20.dp, vertical = 8.dp)
                 .verticalScroll(rememberScrollState()),
         ) {
-            SectionLabel("Environment Variables")
-            Spacer(modifier = Modifier.height(10.dp))
-
-            // Combined header card: security disclosure + summary + raw editor action.
-            // Three sections of related meta-info, one surface — less card noise.
+            // BAT-1247 M5 nit: no page section header — the top bar already
+            // titles this single-section screen.
+            // Combined header card: security disclosure + summary, plus the
+            // raw-editor link while vars exist. One surface — less card noise.
             CardSurface {
                 // Security disclosure — values are readable by agent tools / skills
                 Row(verticalAlignment = Alignment.Top) {
@@ -232,17 +225,14 @@ fun EnvVarsScreen(
                         color = SeekerClawColors.TextSecondary,
                     )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                TextButton(
-                    onClick = { showRawEditor = true },
-                    enabled = isLoaded,
-                    contentPadding = PaddingValues(0.dp),
-                ) {
-                    Text(
-                        text = "{ }  Raw editor",
-                        fontFamily = RethinkSans,
-                        fontSize = 13.sp,
-                        color = SeekerClawColors.TextInteractive,
+                if (envVars.isNotEmpty()) {
+                    // BAT-1247 M5: THE single raw-editor affordance while vars
+                    // exist, kept near the list header. When the list is empty
+                    // the EmptyState's secondary action covers it instead.
+                    Spacer(modifier = Modifier.height(Spacing.sm))
+                    ScreenActionLink(
+                        label = "{ } Raw editor",
+                        onClick = { if (isLoaded) showRawEditor = true },
                     )
                 }
             }
@@ -250,66 +240,18 @@ fun EnvVarsScreen(
             Spacer(modifier = Modifier.height(12.dp))
 
             if (envVars.isEmpty()) {
-                // Empty state
-                CardSurface {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            text = "No env vars yet.",
-                            fontFamily = RethinkSans,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Medium,
-                            color = SeekerClawColors.TextPrimary,
-                        )
-                        Text(
-                            text = "Tap + to add your first, or use the raw editor for bulk paste.",
-                            fontFamily = RethinkSans,
-                            fontSize = 13.sp,
-                            color = SeekerClawColors.TextDim,
-                            fontStyle = FontStyle.Italic,
-                            modifier = Modifier.padding(top = 4.dp),
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        ) {
-                            Button(
-                                onClick = { dialogState = EnvVarDialogState.Add() },
-                                shape = shape,
-                                enabled = isLoaded,
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = SeekerClawColors.ActionPrimary,
-                                    contentColor = Color.White,
-                                ),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
-                                )
-                                Text(
-                                    text = "Add",
-                                    fontFamily = RethinkSans,
-                                    fontSize = 14.sp,
-                                    modifier = Modifier.padding(start = 4.dp),
-                                )
-                            }
-                            TextButton(
-                                onClick = { showRawEditor = true },
-                                enabled = isLoaded,
-                            ) {
-                                Text(
-                                    text = "{ }  Raw editor",
-                                    fontFamily = RethinkSans,
-                                    fontSize = 14.sp,
-                                    color = SeekerClawColors.TextInteractive,
-                                )
-                            }
-                        }
-                    }
-                }
+                // BAT-1247 M5: shared EmptyState template. Copy must not
+                // point at the top bar; both actions carry the isLoaded gate
+                // in their handlers (saves must never build on the
+                // not-yet-loaded list).
+                EmptyState(
+                    headline = "No env vars yet.",
+                    hint = "Add your first variable, or use the raw editor for bulk paste.",
+                    primaryLabel = "+ Add",
+                    onPrimary = { if (isLoaded) dialogState = EnvVarDialogState.Add() },
+                    secondaryLabel = "{ } Raw editor",
+                    onSecondary = { if (isLoaded) showRawEditor = true },
+                )
             } else {
                 // Env var list
                 CardSurface {

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/McpConfigScreen.kt
@@ -14,17 +14,20 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,10 +40,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
@@ -50,12 +51,15 @@ import androidx.compose.runtime.collectAsState
 import com.seekerclaw.app.state.McpServer
 import com.seekerclaw.app.state.McpServersStore
 import com.seekerclaw.app.ui.components.CardSurface
-import com.seekerclaw.app.ui.components.SectionLabel
-import com.seekerclaw.app.ui.components.SeekerClawScaffold
+import com.seekerclaw.app.ui.components.EmptyState
+import com.seekerclaw.app.ui.components.ScreenActionLink
 import com.seekerclaw.app.ui.components.SeekerClawSwitch
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun McpConfigScreen(onBack: () -> Unit) {
     val context = LocalContext.current
@@ -88,7 +92,49 @@ fun McpConfigScreen(onBack: () -> Unit) {
 
     val shape = RoundedCornerShape(SeekerClawColors.CornerRadius)
 
-    SeekerClawScaffold(title = "MCP Servers", onBack = onBack) { padding ->
+    Scaffold(
+        topBar = {
+            // BAT-1247 M5: SeekerClawScaffold has no actions slot, so this
+            // bar mirrors SeekerClawTopAppBar 1:1 (18.sp bold RethinkSans
+            // title, white back arrow, Background container — the one place
+            // that size is sanctioned) and adds the unified green "+ Add"
+            // screen action.
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "MCP Servers",
+                        fontFamily = RethinkSans,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = SeekerClawColors.TextPrimary,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = SeekerClawColors.TextPrimary,
+                        )
+                    }
+                },
+                actions = {
+                    ScreenActionLink(
+                        label = "+ Add",
+                        onClick = {
+                            editingMcpServer = null
+                            showMcpDialog = true
+                        },
+                        modifier = Modifier.padding(end = Spacing.lg),
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = SeekerClawColors.Background,
+                ),
+            )
+        },
+        containerColor = SeekerClawColors.Background,
+    ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -96,28 +142,32 @@ fun McpConfigScreen(onBack: () -> Unit) {
                 .padding(horizontal = 20.dp, vertical = 8.dp)
                 .verticalScroll(rememberScrollState()),
         ) {
-            SectionLabel("MCP Servers")
-            Spacer(modifier = Modifier.height(10.dp))
-
+            // Explainer card — prose only. M5: the embedded add button and
+            // italic "No servers configured" line are gone; adding lives in
+            // the top bar and the shared EmptyState below.
             CardSurface {
                 Text(
                     text = SettingsHelpTexts.MCP_SERVERS,
                     fontFamily = RethinkSans,
-                    fontSize = 13.sp,
+                    fontSize = TypeScale.bodySmall,
                     color = SeekerClawColors.TextDim,
                 )
+            }
 
-                Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(Spacing.md))
 
-                if (mcpServers.isEmpty()) {
-                    Text(
-                        text = "No servers configured",
-                        fontFamily = RethinkSans,
-                        fontSize = 13.sp,
-                        color = SeekerClawColors.TextDim,
-                        fontStyle = FontStyle.Italic,
-                    )
-                } else {
+            if (mcpServers.isEmpty()) {
+                EmptyState(
+                    headline = "No MCP servers yet.",
+                    hint = "Add a server URL and your agent discovers its tools live.",
+                    primaryLabel = "Add MCP Server",
+                    onPrimary = {
+                        editingMcpServer = null
+                        showMcpDialog = true
+                    },
+                )
+            } else {
+                CardSurface {
                     for (server in mcpServers) {
                         Row(
                             modifier = Modifier
@@ -206,23 +256,6 @@ fun McpConfigScreen(onBack: () -> Unit) {
                             }
                         }
                     }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Button(
-                    onClick = {
-                        editingMcpServer = null
-                        showMcpDialog = true
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = shape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = SeekerClawColors.ActionPrimary,
-                        contentColor = Color.White,
-                    ),
-                ) {
-                    Text("Add MCP Server", fontFamily = RethinkSans, fontSize = 14.sp)
                 }
             }
 

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/ProviderConfigScreen.kt
@@ -15,7 +15,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import com.seekerclaw.app.ui.components.InfoDialog
 import com.seekerclaw.app.ui.components.SeekerClawScaffold
 import com.seekerclaw.app.ui.components.SeekerClawSwitch
 import com.seekerclaw.app.state.RuntimeStateStore
@@ -36,6 +41,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -52,7 +59,10 @@ import com.seekerclaw.app.ui.components.ActionResult
 import com.seekerclaw.app.ui.components.MorphActionButton
 import com.seekerclaw.app.ui.components.rememberOpenAIOAuthController
 import com.seekerclaw.app.ui.components.rememberXaiOAuthController
+import com.seekerclaw.app.ui.theme.BrandAlpha
 import com.seekerclaw.app.ui.theme.Sizing
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.ModelRegistry
 import com.seekerclaw.app.config.availableModels
@@ -398,8 +408,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             onClick = { showAuthTypePicker = true },
                             info = SettingsHelpTexts.AUTH_TYPE,
                         )
-                        ConfigField(
-                            label = if (config?.authType == "api_key") "API Key (active)" else "API Key",
+                        // BAT-1247: the in-use credential is marked with a green
+                        // "Active" chip — no "(active)" label suffix, no ambiguous
+                        // red required-asterisk on the active row.
+                        CredentialField(
+                            label = "API Key",
                             value = maskKey(config?.anthropicApiKey),
                             onClick = {
                                 editField = "anthropicApiKey"
@@ -407,10 +420,11 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 editValue = config?.anthropicApiKey ?: ""
                             },
                             info = SettingsHelpTexts.API_KEY,
-                            isRequired = config?.authType == "api_key",
+                            isActive = config?.authType == "api_key",
+                            monospaceValue = !(config?.anthropicApiKey.isNullOrBlank()),
                         )
-                        ConfigField(
-                            label = if (config?.authType == "setup_token") "Setup Token (active)" else "Setup Token",
+                        CredentialField(
+                            label = "Setup Token",
                             value = maskKey(config?.setupToken),
                             onClick = {
                                 editField = "setupToken"
@@ -418,7 +432,8 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 editValue = config?.setupToken ?: ""
                             },
                             info = SettingsHelpTexts.SETUP_TOKEN,
-                            isRequired = config?.authType == "setup_token",
+                            isActive = config?.authType == "setup_token",
+                            monospaceValue = !(config?.setupToken.isNullOrBlank()),
                             showDivider = false,
                         )
                     }
@@ -453,7 +468,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         val oauthState = oauthController.state
                         val showOAuthSection = openaiAuthType == "oauth" || oauthState.isPolling || oauthState.error != null
                         if (!showOAuthSection) {
-                            ConfigField(
+                            CredentialField(
                                 label = "API Key",
                                 value = maskKey(config?.openaiApiKey),
                                 onClick = {
@@ -463,6 +478,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 },
                                 info = SettingsHelpTexts.OPENAI_API_KEY,
                                 isRequired = true,
+                                monospaceValue = !(config?.openaiApiKey.isNullOrBlank()),
                                 showDivider = false,
                             )
                         } else {
@@ -504,7 +520,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                         val xaiOAuthState = xaiOAuthController.state
                         val showXaiOAuthSection = xaiAuthType == "oauth" || xaiOAuthState.isPolling || xaiOAuthState.error != null
                         if (!showXaiOAuthSection) {
-                            ConfigField(
+                            CredentialField(
                                 label = "API Key",
                                 value = maskKey(config?.xaiApiKey),
                                 onClick = {
@@ -514,6 +530,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 },
                                 info = "Get your key at console.x.ai",
                                 isRequired = true,
+                                monospaceValue = !(config?.xaiApiKey.isNullOrBlank()),
                                 showDivider = false,
                             )
                         } else {
@@ -555,7 +572,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             },
                             info = "Auto-switches if primary model is down (e.g. google/gemini-2.5-pro)",
                         )
-                        ConfigField(
+                        CredentialField(
                             label = "API Key",
                             value = maskKey(config?.openrouterApiKey),
                             onClick = {
@@ -565,6 +582,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             },
                             info = "Get your key at openrouter.ai/keys",
                             isRequired = true,
+                            monospaceValue = !(config?.openrouterApiKey.isNullOrBlank()),
                             showDivider = false,
                         )
                     }
@@ -604,12 +622,13 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             onClick = { editField = "customHeaders"; editLabel = "Extra Headers (JSON)"; editValue = config?.customHeaders ?: "" },
                             info = "Optional JSON object. Example: {\"X-API-Key\":\"...\"}",
                         )
-                        ConfigField(
+                        CredentialField(
                             label = "API Key",
                             value = maskKey(config?.customApiKey),
                             onClick = { editField = "customApiKey"; editLabel = "API Key"; editValue = config?.customApiKey ?: "" },
                             info = "Used as Bearer auth unless Authorization is in Extra Headers.",
                             isRequired = true,
+                            monospaceValue = !(config?.customApiKey.isNullOrBlank()),
                             showDivider = false,
                         )
                     }
@@ -890,7 +909,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 selected = selectedModel == model.id,
                                 onClick = { selectedModel = model.id },
                                 colors = RadioButtonDefaults.colors(
-                                    selectedColor = SeekerClawColors.Primary,
+                                    selectedColor = SeekerClawColors.ActionPrimary,
                                     unselectedColor = SeekerClawColors.TextDim,
                                 ),
                             )
@@ -922,7 +941,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             selected = isCustomSelected || selectedModel == CUSTOM_MODEL_SENTINEL,
                             onClick = { selectedModel = customModelId.ifBlank { CUSTOM_MODEL_SENTINEL } },
                             colors = RadioButtonDefaults.colors(
-                                selectedColor = SeekerClawColors.Primary,
+                                selectedColor = SeekerClawColors.ActionPrimary,
                                 unselectedColor = SeekerClawColors.TextDim,
                             ),
                         )
@@ -1034,7 +1053,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                                 selected = selectedAuth == typeId,
                                 onClick = { selectedAuth = typeId },
                                 colors = RadioButtonDefaults.colors(
-                                    selectedColor = SeekerClawColors.Primary,
+                                    selectedColor = SeekerClawColors.ActionPrimary,
                                     unselectedColor = SeekerClawColors.TextDim,
                                 ),
                             )
@@ -1156,7 +1175,7 @@ fun ProviderConfigScreen(onBack: () -> Unit) {
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             RadioButton(selected = selectedFormat == formatId, onClick = { selectedFormat = formatId },
-                                colors = RadioButtonDefaults.colors(selectedColor = SeekerClawColors.Primary, unselectedColor = SeekerClawColors.TextDim))
+                                colors = RadioButtonDefaults.colors(selectedColor = SeekerClawColors.ActionPrimary, unselectedColor = SeekerClawColors.TextDim))
                             Column(modifier = Modifier.padding(start = 8.dp)) {
                                 Text(label, fontFamily = RethinkSans, fontSize = 14.sp, color = SeekerClawColors.TextPrimary)
                                 Text(if (formatId == "responses") "OpenAI Responses API format" else "Standard /v1/chat/completions format",
@@ -1813,4 +1832,122 @@ private fun CustomEchoReasoningRow() {
             },
         )
     }
+}
+
+/**
+ * BAT-1247: credential row for API keys / setup tokens. Mirrors the shared
+ * [ConfigField] layout exactly (row paddings, label/value scale, Edit
+ * affordance, info dialog, divider) with two credential-specific upgrades:
+ *  - masked key/token values render in monospace (technical values), and
+ *  - the credential currently in use is marked with a green [ActiveChip]
+ *    instead of an "(active)" label suffix + ambiguous red asterisk.
+ * [isRequired] keeps ConfigField's red asterisk + a11y semantics for
+ * providers whose single credential is mandatory.
+ */
+@Composable
+private fun CredentialField(
+    label: String,
+    value: String,
+    onClick: () -> Unit,
+    info: String? = null,
+    isActive: Boolean = false,
+    isRequired: Boolean = false,
+    monospaceValue: Boolean = true,
+    showDivider: Boolean = true,
+) {
+    var showInfo by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            // md + xxs = 14dp vertical — matches ConfigField's row padding.
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md + Spacing.xxs),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = if (isRequired) Modifier.semantics(mergeDescendants = true) {
+                    contentDescription = "$label, required"
+                } else Modifier,
+            ) {
+                Text(
+                    text = label,
+                    fontFamily = RethinkSans,
+                    fontSize = TypeScale.labelSmall,
+                    color = SeekerClawColors.TextDim,
+                )
+                if (isRequired) {
+                    Text(
+                        text = " *",
+                        fontSize = TypeScale.labelSmall,
+                        color = SeekerClawColors.Error,
+                    )
+                }
+                if (isActive) {
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    ActiveChip()
+                }
+                if (info != null) {
+                    IconButton(onClick = { showInfo = true }) {
+                        Icon(
+                            Icons.Outlined.Info,
+                            contentDescription = "More info about $label",
+                            tint = SeekerClawColors.TextDim,
+                            // md + xxs = 14dp — matches ConfigField's info-icon size.
+                            modifier = Modifier.size(Spacing.md + Spacing.xxs),
+                        )
+                    }
+                }
+            }
+            Text(
+                text = "Edit",
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.labelSmall,
+                color = SeekerClawColors.TextInteractive,
+            )
+        }
+        Spacer(modifier = Modifier.height(Spacing.xxs))
+        Text(
+            text = value,
+            fontFamily = if (monospaceValue) FontFamily.Monospace else RethinkSans,
+            fontSize = TypeScale.bodyMedium,
+            color = SeekerClawColors.TextPrimary,
+        )
+    }
+    if (showDivider) {
+        HorizontalDivider(
+            color = SeekerClawColors.CardBorder,
+            modifier = Modifier.padding(horizontal = Spacing.lg),
+        )
+    }
+    if (showInfo && info != null) {
+        InfoDialog(title = label, message = info, onDismiss = { showInfo = false })
+    }
+}
+
+/**
+ * Small green "Active" chip — marks which stored credential the provider
+ * is currently using (Q5: green = the one active-control accent; red is
+ * reserved for destructive/warning emphasis).
+ */
+@Composable
+private fun ActiveChip() {
+    Text(
+        text = "Active",
+        fontFamily = RethinkSans,
+        fontSize = TypeScale.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = SeekerClawColors.ActionPrimary,
+        modifier = Modifier
+            .background(
+                SeekerClawColors.ActionPrimary.copy(alpha = BrandAlpha.errorBackground),
+                RoundedCornerShape(SeekerClawColors.CornerRadius),
+            )
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
+    )
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/SettingsScreen.kt
@@ -89,7 +89,9 @@ import androidx.compose.material3.IconButton
 import com.seekerclaw.app.config.ConfigClaimImport
 import com.seekerclaw.app.config.ConfigClaimImporter
 import com.seekerclaw.app.config.ConfigManager
+import com.seekerclaw.app.config.ModelRegistry
 import com.seekerclaw.app.config.availableModels
+import com.seekerclaw.app.config.providerById
 import com.seekerclaw.app.config.searchProviderById
 import com.seekerclaw.app.qr.QrScannerActivity
 import com.seekerclaw.app.service.SeekerClawService
@@ -111,9 +113,11 @@ import com.seekerclaw.app.ui.components.SectionLabel
 import com.seekerclaw.app.ui.components.ConfigField
 import com.seekerclaw.app.ui.components.InfoDialog
 import com.seekerclaw.app.ui.components.InfoRow
+import com.seekerclaw.app.ui.components.PageSectionHeader
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 import com.seekerclaw.app.ui.theme.Sizing
 import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -495,9 +499,23 @@ fun SettingsScreen(
                     .background(SeekerClawColors.Surface, shape)
                     .cornerGlowBorder(),
             ) {
+                // BAT-1247: show the live provider/model/auth summary instead of
+                // the static "Provider, Model, Keys" placeholder. Composed from
+                // config state this screen already loads — display names only,
+                // never key material. Falls back to the old string when config
+                // is absent (fresh install / pre-setup).
                 ConfigField(
                     label = "AI Configuration",
-                    value = "Provider, Model, Keys",
+                    value = config?.let { cfg ->
+                        val providerName = providerById(cfg.provider).displayName
+                        val modelName = ModelRegistry.modelDisplayName(cfg.model)
+                        val aiAuthLabel = when (cfg.provider) {
+                            "claude" -> if (cfg.authType == "setup_token") "Setup token" else "API key"
+                            "openai", "xai" -> if (cfg.authType == "oauth") "OAuth" else "API key"
+                            else -> "API key"
+                        }
+                        "$providerName · $modelName · $aiAuthLabel"
+                    } ?: "Provider, Model, Keys",
                     onClick = onNavigateToAiConfig,
                     info = "Select AI provider, configure model and API credentials.",
                 )
@@ -522,7 +540,11 @@ fun SettingsScreen(
                     value = "Every ${config?.heartbeatIntervalMinutes ?: 30} minutes",
                     onClick = {
                         editField = "heartbeatIntervalMinutes"
-                        editLabel = "Heartbeat Interval (minutes, 5–120)"
+                        // BAT-1247: dialog title becomes "Edit Heartbeat Interval";
+                        // the field itself is labeled "Minutes" with "5–120" as
+                        // supporting text (see the edit dialog below) so title and
+                        // field label no longer repeat word-for-word.
+                        editLabel = "Heartbeat Interval"
                         editValue = (config?.heartbeatIntervalMinutes ?: 30).toString()
                     },
                     info = SettingsHelpTexts.HEARTBEAT_INTERVAL,
@@ -537,13 +559,17 @@ fun SettingsScreen(
                     },
                     info = SettingsHelpTexts.MAX_STEPS_PER_TURN,
                 )
+                // BAT-1247: a not-configured provider renders its value in
+                // Warning amber instead of masquerading as configured.
+                val searchConfigured = (config?.activeSearchApiKey ?: "").isNotBlank()
                 ConfigField(
                     label = "Search Provider",
                     value = searchProviderById(config?.searchProvider ?: "brave").displayName +
-                        if ((config?.activeSearchApiKey ?: "").isBlank()) " (not configured)" else "",
+                        if (!searchConfigured) " (not configured)" else "",
                     onClick = onNavigateToSearchConfig,
                     info = SettingsHelpTexts.SEARCH_PROVIDER,
                     showDivider = true,
+                    valueColor = if (searchConfigured) SeekerClawColors.TextPrimary else SeekerClawColors.Warning,
                 )
                 ConfigField(
                     label = "MCP Servers",
@@ -552,10 +578,15 @@ fun SettingsScreen(
                     info = SettingsHelpTexts.MCP_SERVERS,
                     showDivider = true,
                 )
+                // BAT-1247: standard info dialog like the sibling rows. The info
+                // icon also equalizes the label-row height with the MCP row above
+                // (the IconButton's touch target set the two rows' label-to-value
+                // spacing apart when only one row had it).
                 ConfigField(
                     label = "Env Vars",
                     value = "$envVarCount var${if (envVarCount != 1) "s" else ""} set",
                     onClick = onNavigateToEnvVars,
+                    info = "Environment variables are injected into the agent's Node.js process at startup — API keys for skills, etc.",
                     showDivider = false,
                 )
             }
@@ -699,7 +730,9 @@ fun SettingsScreen(
                     }
 
                     Spacer(modifier = Modifier.height(12.dp))
-                    OutlinedButton(
+                    // BAT-1247 (audit: soft-destructive actions use the red-outline
+                    // variant): Disconnect is reversible-destructive — DangerOutlineButton.
+                    DangerOutlineButton(
                         onClick = {
                             // BAT-1021: clear the process-local MWA auth-token cache in
                             // lockstep with the persisted wallet address so the next
@@ -712,14 +745,8 @@ fun SettingsScreen(
                             walletError = null
                             Analytics.featureUsed("wallet_disconnected")
                         },
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = shape,
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = SeekerClawColors.Error,
-                        ),
-                    ) {
-                        Text("Disconnect Wallet", fontFamily = RethinkSans, fontSize = 14.sp)
-                    }
+                        label = "Disconnect Wallet",
+                    )
                 } else {
                     // Not connected — show Connect button
                     if (walletError != null) {
@@ -884,6 +911,8 @@ fun SettingsScreen(
                     },
                     showDivider = true,
                     info = SettingsHelpTexts.JUPITER_API_KEY,
+                    // BAT-1247: inside CardSurface (16dp) — align with siblings.
+                    horizontalPadding = 0.dp,
                 )
 
                 // ── Helius API Key (Solana RPC + NFT holdings — BAT-1000) ─────
@@ -907,6 +936,8 @@ fun SettingsScreen(
                     },
                     showDivider = false,
                     info = SettingsHelpTexts.HELIUS_API_KEY,
+                    // BAT-1247: inside CardSurface (16dp) — align with siblings.
+                    horizontalPadding = 0.dp,
                 )
             }
         }
@@ -1062,7 +1093,14 @@ fun SettingsScreen(
         Spacer(modifier = Modifier.height(10.dp))
 
         CardSurface {
-            InfoRow("Version", "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+            // BAT-1247: value formats kept IDENTICAL to the System screen's
+            // Status card (same buildString incl. the debug-only git SHA) so
+            // the two surfaces never show diverging version strings. InfoRow
+            // renders values monospace by default — matching System.
+            InfoRow("Version", buildString {
+                append("${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                if (BuildConfig.DEBUG) append(" · ${BuildConfig.GIT_SHA}")
+            })
             InfoRow("Claw Engine", BuildConfig.OPENCLAW_VERSION)
             InfoRow("Node.js", BuildConfig.NODEJS_VERSION, isLast = true)
         }
@@ -1077,11 +1115,30 @@ fun SettingsScreen(
                     label = "Reset Config",
                 )
 
+                // BAT-1247: one-line consequence caption under each destructive
+                // action so users can tell each action's blast radius before
+                // tapping. Buttons and dialogs unchanged.
+                Spacer(modifier = Modifier.height(Spacing.xs))
+                Text(
+                    text = "Clears settings — agent memory is kept.",
+                    fontFamily = RethinkSans,
+                    fontSize = TypeScale.bodySmall,
+                    color = SeekerClawColors.TextSecondary,
+                )
+
                 Spacer(modifier = Modifier.height(Spacing.md))
 
                 DangerButton(
                     onClick = { showClearMemoryDialog = true },
                     label = "Wipe Memory",
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.xs))
+                Text(
+                    text = "Permanently erases the agent's memory and personality.",
+                    fontFamily = RethinkSans,
+                    fontSize = TypeScale.bodySmall,
+                    color = SeekerClawColors.TextSecondary,
                 )
             }
         }
@@ -1112,10 +1169,30 @@ fun SettingsScreen(
                             modifier = Modifier.padding(bottom = 12.dp),
                         )
                     }
+                    // BAT-1247: heartbeat gets a distinct field label ("Minutes")
+                    // plus M3 supportingText for the valid range, instead of
+                    // repeating the dialog title verbatim. Validation unchanged.
+                    val isHeartbeatField = editField == "heartbeatIntervalMinutes"
                     OutlinedTextField(
                         value = editValue,
                         onValueChange = { editValue = it },
-                        label = { Text(editLabel, fontFamily = RethinkSans, fontSize = 12.sp) },
+                        label = {
+                            Text(
+                                if (isHeartbeatField) "Minutes" else editLabel,
+                                fontFamily = RethinkSans,
+                                fontSize = 12.sp,
+                            )
+                        },
+                        supportingText = if (isHeartbeatField) {
+                            {
+                                Text(
+                                    "5–120",
+                                    fontFamily = RethinkSans,
+                                    fontSize = TypeScale.labelSmall,
+                                    color = SeekerClawColors.TextDim,
+                                )
+                            }
+                        } else null,
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         textStyle = androidx.compose.ui.text.TextStyle(
@@ -1595,14 +1672,11 @@ private fun CollapsibleSection(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = title,
-            fontFamily = RethinkSans,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Medium,
-            color = SeekerClawColors.TextSecondary,
-            letterSpacing = 1.sp,
-        )
+        // BAT-1247: hand-rolled header replaced with PageSectionHeader so
+        // collapsible sections match the standalone "System" header (which
+        // goes through SectionLabel → PageSectionHeader) — ONE page-level
+        // section-header style everywhere.
+        PageSectionHeader(title)
         Icon(
             imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
             contentDescription = if (expanded) "Collapse $title" else "Expand $title",

--- a/app/src/main/java/com/seekerclaw/app/ui/settings/wallet/BurnerWalletScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/settings/wallet/BurnerWalletScreen.kt
@@ -42,8 +42,8 @@ import com.seekerclaw.app.ui.components.CardSurface
 import com.seekerclaw.app.ui.components.MorphActionButton
 import com.seekerclaw.app.ui.components.PrimaryButton
 import com.seekerclaw.app.ui.components.SecondaryButton
+import com.seekerclaw.app.ui.components.InCardLabel
 import com.seekerclaw.app.ui.components.SeekerClawScaffold
-import com.seekerclaw.app.ui.components.SectionLabel
 import com.seekerclaw.app.ui.settings.wallet.components.BurnerCaps
 import com.seekerclaw.app.ui.settings.wallet.components.CapsConfigSection
 import com.seekerclaw.app.ui.settings.wallet.components.DangerZoneSection
@@ -336,13 +336,9 @@ private fun EmptyStateSection(
     }
 
     CardSurface {
-        Text(
-            text = "Set up burner",
-            fontFamily = RethinkSans,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.ExtraBold,
-            color = SeekerClawColors.TextPrimary,
-        )
+        // BAT-1247 M4: shared in-card label instead of a hand-rolled
+        // bold-white header.
+        InCardLabel("Set up burner")
         Spacer(Modifier.height(Spacing.sm))
         Text(
             text = "Paste a base58 private key or a Solana CLI JSON byte array. The key is encrypted on this device — Node never sees it.",
@@ -517,7 +513,9 @@ private fun ConfiguredStateSection(
     val fundingContext = LocalContext.current
     val fundingHaptic = LocalHapticFeedback.current
     CardSurface {
-        SectionLabel("Funding")
+        // BAT-1247 M4: label INSIDE a card is InCardLabel, not the
+        // page-level section header.
+        InCardLabel("Funding")
         Spacer(Modifier.height(Spacing.sm))
         Text(
             text = "Send SOL or USDC from your main wallet to the address below. Tap to copy.",

--- a/app/src/main/java/com/seekerclaw/app/ui/skills/SkillDetailScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/skills/SkillDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.seekerclaw.app.ui.skills
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,8 +25,22 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.seekerclaw.app.ui.components.CardSurface
+import com.seekerclaw.app.ui.components.InCardLabel
+import com.seekerclaw.app.ui.components.ScreenActionLink
+import com.seekerclaw.app.ui.components.SeekerClawScaffold
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
+
+/**
+ * BAT-1247: the bare `missing "version"` diagnostic from SkillsRepository is
+ * mapped to an actionable one-liner AT RENDER — the repository string (and
+ * every other diagnostic) stays untouched.
+ */
+private const val MISSING_VERSION_RAW = "missing \"version\""
+private const val MISSING_VERSION_FRIENDLY =
+    "Missing \"version\" in SKILL.md frontmatter — the skill still works; add version: \"1.0.0\" to silence this."
 
 @Composable
 fun SkillDetailScreen(
@@ -36,72 +48,43 @@ fun SkillDetailScreen(
     onBack: () -> Unit,
     onExport: (() -> Unit)? = null,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SeekerClawColors.Background)
-            .verticalScroll(rememberScrollState()),
-    ) {
-        // Top bar
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = "← Skills",
-                fontFamily = RethinkSans,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Medium,
-                color = SeekerClawColors.Primary,
-                modifier = Modifier.clickable(onClickLabel = "Back to skills list", onClick = onBack),
-            )
-            if (onExport != null) {
-                Text(
-                    text = "Export",
-                    fontFamily = RethinkSans,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = SeekerClawColors.Accent,
-                    modifier = Modifier
-                        .clickable(onClickLabel = "Export skill", onClick = onExport)
-                        .padding(4.dp),
-                )
-            }
-        }
-
-        HorizontalDivider(
-            thickness = 1.dp,
-            color = SeekerClawColors.CardBorder,
-        )
-
+    SeekerClawScaffold(title = skill.name, onBack = onBack) { padding ->
         Column(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
         ) {
-            // Header: avatar + name + version
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            // Header row: avatar + name + version, with the green screen-level Export action
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 SkillAvatar(skill = skill, size = 56, emojiFontSize = 32)
-                Spacer(Modifier.width(16.dp))
-                Column {
+                Spacer(Modifier.width(Spacing.lg))
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = skill.name,
                         fontFamily = RethinkSans,
-                        fontSize = 22.sp,
+                        fontSize = TypeScale.titleLarge,
                         fontWeight = FontWeight.Bold,
                         color = SeekerClawColors.TextPrimary,
                     )
                     if (skill.version.isNotEmpty()) {
-                        Spacer(Modifier.height(2.dp))
+                        Spacer(Modifier.height(Spacing.xxs))
                         Text(
                             text = "v${skill.version.removePrefix("v").removePrefix("V")}",
                             fontFamily = FontFamily.Monospace,
-                            fontSize = 12.sp,
+                            fontSize = TypeScale.labelSmall,
                             color = SeekerClawColors.TextDim,
                         )
                     }
+                }
+                if (onExport != null) {
+                    Spacer(Modifier.width(Spacing.md))
+                    ScreenActionLink(label = "Export", onClick = onExport)
                 }
             }
 
@@ -173,7 +156,7 @@ fun SkillDetailScreen(
                                 )
                                 Spacer(Modifier.width(8.dp))
                                 Text(
-                                    text = warning,
+                                    text = if (warning == MISSING_VERSION_RAW) MISSING_VERSION_FRIENDLY else warning,
                                     fontFamily = RethinkSans,
                                     fontSize = 13.sp,
                                     color = SeekerClawColors.Warning,
@@ -205,15 +188,8 @@ private fun InfoSection(
     content: @Composable () -> Unit,
 ) {
     CardSurface {
-        Text(
-            text = label,
-            fontFamily = RethinkSans,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Bold,
-            color = SeekerClawColors.TextDim,
-            letterSpacing = 1.sp,
-        )
-        Spacer(Modifier.height(10.dp))
+        InCardLabel(text = label)
+        Spacer(Modifier.height(Spacing.sm))
         content()
     }
 }

--- a/app/src/main/java/com/seekerclaw/app/ui/skills/SkillDetailScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/skills/SkillDetailScreen.kt
@@ -40,7 +40,7 @@ import com.seekerclaw.app.ui.theme.TypeScale
  */
 private const val MISSING_VERSION_RAW = "missing \"version\""
 private const val MISSING_VERSION_FRIENDLY =
-    "Missing \"version\" in SKILL.md frontmatter — the skill still works; add version: \"1.0.0\" to silence this."
+    "Missing \"version\" in SKILL.md frontmatter — the skill still works; add a version field to silence this."
 
 @Composable
 fun SkillDetailScreen(

--- a/app/src/main/java/com/seekerclaw/app/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/skills/SkillsScreen.kt
@@ -4,7 +4,9 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -40,6 +42,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.SubcomposeAsyncImage
@@ -48,10 +51,17 @@ import androidx.compose.runtime.collectAsState
 import androidx.navigation.NavHostController
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.EnvVarRegistry
+import com.seekerclaw.app.ui.components.CardSurface
+import com.seekerclaw.app.ui.components.PageSectionHeader
+import com.seekerclaw.app.ui.components.ScreenActionLink
+import com.seekerclaw.app.ui.components.SeekerClawSearchField
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 import com.seekerclaw.app.ui.navigation.EnvVarsRoute
 import com.seekerclaw.app.ui.theme.RethinkSans
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.ui.theme.Sizing
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 import com.seekerclaw.app.util.Analytics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -213,32 +223,23 @@ private fun SkillsListContent(
                         fontWeight = FontWeight.Bold,
                         color = SeekerClawColors.TextPrimary,
                     )
-                    Text(
-                        text = "Import",
-                        fontFamily = RethinkSans,
-                        fontSize = 13.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = SeekerClawColors.Accent,
-                        modifier = Modifier
-                            .clickable(onClickLabel = "Import skills") {
-                                importSkillsLauncher.launch(arrayOf("application/zip", "text/markdown", "text/plain"))
-                            }
-                            .padding(4.dp),
+                    ScreenActionLink(
+                        label = "Import",
+                        onClick = {
+                            importSkillsLauncher.launch(arrayOf("application/zip", "text/markdown", "text/plain"))
+                        },
                     )
                 }
             }
 
             item {
                 Spacer(Modifier.height(4.dp))
-                SearchField(
-                    query = searchQuery,
-                    onQueryChange = { searchQuery = it },
-                    shape = shape,
+                // BAT-1247 (audit: two search-field styles) — the ONE shared field.
+                SeekerClawSearchField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = "Search skills...",
                 )
-            }
-
-            item {
-                MarketplaceTeaserCard(shape = shape)
             }
 
             if (filtered.isEmpty()) {
@@ -275,6 +276,10 @@ private fun SkillsListContent(
                     }
                 }
             }
+
+            item {
+                MarketplaceTeaserCard()
+            }
         }
     }
 }
@@ -288,133 +293,53 @@ private fun SectionHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 8.dp, bottom = 4.dp),
+            .padding(top = Spacing.sm, bottom = Spacing.xs),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = title,
-            fontFamily = RethinkSans,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Bold,
-            color = SeekerClawColors.TextDim,
-            letterSpacing = 0.5.sp,
-        )
+        PageSectionHeader(title = title)
         if (actionLabel != null && onAction != null) {
-            Text(
-                text = actionLabel,
-                fontFamily = RethinkSans,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Medium,
-                color = SeekerClawColors.Accent,
-                modifier = Modifier
-                    .clickable(onClickLabel = actionLabel, onClick = onAction)
-                    .padding(4.dp),
-            )
+            ScreenActionLink(label = actionLabel, onClick = onAction)
         }
     }
 }
 
 @Composable
-private fun SearchField(
-    query: String,
-    onQueryChange: (String) -> Unit,
-    shape: RoundedCornerShape,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SeekerClawColors.Surface, shape)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+private fun MarketplaceTeaserCard() {
+    val chipShape = RoundedCornerShape(Spacing.xs)
+    CardSurface {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top,
+        ) {
+            Text(
+                text = "Skill Marketplace",
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = SeekerClawColors.TextPrimary,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "COMING SOON",
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = SeekerClawColors.TextSecondary,
+                modifier = Modifier
+                    .background(SeekerClawColors.Surface, chipShape)
+                    .border(BorderStroke(Sizing.borderThin, SeekerClawColors.BorderSubtle), chipShape)
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+            )
+        }
+        Spacer(Modifier.height(Spacing.sm))
         Text(
-            text = "⌕",
-            fontFamily = FontFamily.Monospace,
-            fontSize = 18.sp,
+            text = "Discover and install skills created by the community.",
+            fontFamily = RethinkSans,
+            fontSize = TypeScale.bodySmall,
             color = SeekerClawColors.TextDim,
         )
-        Spacer(Modifier.width(10.dp))
-        Box(modifier = Modifier.weight(1f)) {
-            if (query.isEmpty()) {
-                Text(
-                    text = "Search skills...",
-                    fontFamily = RethinkSans,
-                    fontSize = 14.sp,
-                    color = SeekerClawColors.TextDim,
-                )
-            }
-            BasicTextField(
-                value = query,
-                onValueChange = onQueryChange,
-                singleLine = true,
-                cursorBrush = SolidColor(SeekerClawColors.Accent),
-                textStyle = TextStyle(
-                    fontFamily = RethinkSans,
-                    fontSize = 14.sp,
-                    color = SeekerClawColors.TextPrimary,
-                ),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        if (query.isNotEmpty()) {
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = "✕",
-                fontFamily = FontFamily.Monospace,
-                fontSize = 14.sp,
-                color = SeekerClawColors.TextDim,
-                modifier = Modifier.clickable(onClickLabel = "Clear search") { onQueryChange("") },
-            )
-        }
-    }
-}
-
-@Composable
-private fun MarketplaceTeaserCard(shape: RoundedCornerShape) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SeekerClawColors.Surface, shape)
-            .cornerGlowBorder()
-            .padding(20.dp),
-    ) {
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top,
-            ) {
-                Text(
-                    text = "Skill Marketplace",
-                    fontFamily = RethinkSans,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = SeekerClawColors.TextPrimary,
-                    modifier = Modifier.weight(1f),
-                )
-                Text(
-                    text = "COMING SOON",
-                    fontFamily = RethinkSans,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = SeekerClawColors.Primary,
-                    modifier = Modifier
-                        .background(
-                            SeekerClawColors.Primary.copy(alpha = 0.12f),
-                            RoundedCornerShape(4.dp),
-                        )
-                        .padding(horizontal = 8.dp, vertical = 4.dp),
-                )
-            }
-            Spacer(Modifier.height(6.dp))
-            Text(
-                text = "Discover and install skills created by the community.",
-                fontFamily = RethinkSans,
-                fontSize = 13.sp,
-                color = SeekerClawColors.TextDim,
-            )
-        }
     }
 }
 
@@ -545,6 +470,7 @@ private fun SkillCard(
                     fontSize = 13.sp,
                     color = SeekerClawColors.TextDim,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
             if (skill.triggers.isNotEmpty()) {

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -305,7 +305,10 @@ fun SystemScreen(onBack: () -> Unit) {
         CardSurface {
             val showLastMessage = status == ServiceStatus.RUNNING && lastActivity > 0L
             InfoRow(
-                label = "Telegram",
+                // CodeRabbit #449 R1: label the configured channel, not a
+                // hardcoded "Telegram" (Discord configs exist — Dashboard
+                // already branches on config?.channel).
+                label = if (config?.channel == "discord") "Discord" else "Telegram",
                 value = if (status == ServiceStatus.RUNNING) "Connected" else "Disconnected",
                 dotColor = if (status == ServiceStatus.RUNNING) SeekerClawColors.Accent else SeekerClawColors.TextDim,
                 isLast = !showLastMessage,
@@ -334,7 +337,10 @@ fun SystemScreen(onBack: () -> Unit) {
                     is ApiUsageData.OAuthUsage ->
                         usage.error == null || usage.fiveHourUtilization > 0f || usage.sevenDayUtilization > 0f
                     is ApiUsageData.ApiKeyUsage ->
-                        usage.error == null || usage.requestsLimit > 0
+                        // CodeRabbit #449 R1: accept token-only partial data —
+                        // a valid tokensLimit must render even when the
+                        // requests side errored.
+                        usage.error == null || usage.requestsLimit > 0 || usage.tokensLimit > 0
                 }
                 // BAT-1247 M1: did the provider actually return quota data?
                 // Zero/absent limit totals must never be turned into a
@@ -701,10 +707,13 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }
     }
 
-    // All-time total across every day the query returned (database.js caps at
-    // 13 months, which comfortably covers SeekerClaw's entire install history).
-    val totalMessages = remember(dailyActivity) {
-        dailyActivity.sumOf { it.count.toLong() }
+    // CodeRabbit #449 R1: the caption says "last N weeks", so the total must
+    // cover exactly the grid window — the query itself can return up to 13
+    // months of rows, which previously inflated the number vs its label.
+    val totalMessages = remember(dateCountMap, gridStart, gridEnd) {
+        dateCountMap.entries.sumOf { (date, count) ->
+            if (!date.isBefore(gridStart) && !date.isAfter(gridEnd)) count.toLong() else 0L
+        }
     }
 
     CardSurface(

--- a/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/seekerclaw/app/ui/system/SystemScreen.kt
@@ -3,8 +3,8 @@ package com.seekerclaw.app.ui.system
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -37,6 +38,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import com.seekerclaw.app.ui.theme.RethinkSans
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -45,10 +47,13 @@ import com.seekerclaw.app.ui.components.CardSurface
 import com.seekerclaw.app.ui.components.InfoRow
 import com.seekerclaw.app.ui.components.cornerGlowBorder
 
-import com.seekerclaw.app.ui.components.SectionLabel
+import com.seekerclaw.app.ui.components.InCardLabel
+import com.seekerclaw.app.ui.components.PageSectionHeader
 import com.seekerclaw.app.config.ConfigManager
 import com.seekerclaw.app.config.modelDisplayName
 import com.seekerclaw.app.ui.theme.SeekerClawColors
+import com.seekerclaw.app.ui.theme.Spacing
+import com.seekerclaw.app.ui.theme.TypeScale
 import com.seekerclaw.app.util.AppStorageInfo
 import com.seekerclaw.app.util.DeviceInfo
 import com.seekerclaw.app.util.DeviceInfoProvider
@@ -57,10 +62,12 @@ import com.seekerclaw.app.util.DayActivity
 import com.seekerclaw.app.util.DbSummary
 import com.seekerclaw.app.util.ServiceState
 import com.seekerclaw.app.util.ServiceStatus
+import com.seekerclaw.app.util.UptimeFormat
 import com.seekerclaw.app.util.fetchDbSummary
 import com.seekerclaw.app.util.rememberUptime
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -165,7 +172,7 @@ fun SystemScreen(onBack: () -> Unit) {
     ) {
 
         // ==================== STATUS ====================
-        SectionLabel("Status")
+        PageSectionHeader("Status")
         Spacer(modifier = Modifier.height(8.dp))
 
         CardSurface {
@@ -188,15 +195,17 @@ fun SystemScreen(onBack: () -> Unit) {
                     ServiceStatus.STOPPED -> SeekerClawColors.TextDim
                     ServiceStatus.ERROR -> SeekerClawColors.Error
                 },
+                monospaceValue = false,
             )
-            InfoRow("Agent", agentName)
-            InfoRow("Uptime", formatUptime(uptime), isLast = true)
+            InfoRow("Model", modelName, monospaceValue = false)
+            InfoRow("Agent", agentName, monospaceValue = false)
+            InfoRow("Uptime", UptimeFormat.format(uptime), isLast = true)
         }
 
         Spacer(modifier = Modifier.height(24.dp))
 
         // ==================== ACTIVITY ====================
-        SectionLabel("Activity")
+        PageSectionHeader("Activity")
         Spacer(modifier = Modifier.height(8.dp))
 
         // Preserve last known activity data even when service stops
@@ -215,7 +224,7 @@ fun SystemScreen(onBack: () -> Unit) {
         Spacer(modifier = Modifier.height(24.dp))
 
         // ==================== DEVICE ====================
-        SectionLabel("Device")
+        PageSectionHeader("Device")
         Spacer(modifier = Modifier.height(8.dp))
 
         CardSurface {
@@ -260,8 +269,8 @@ fun SystemScreen(onBack: () -> Unit) {
             } else {
                 Text(
                     text = "Loading\u2026",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 13.sp,
+                    fontFamily = RethinkSans,
+                    fontSize = TypeScale.bodySmall,
                     color = SeekerClawColors.TextDim,
                 )
             }
@@ -277,14 +286,7 @@ fun SystemScreen(onBack: () -> Unit) {
                         .background(SeekerClawColors.TextDim.copy(alpha = 0.15f)),
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    text = "APP STORAGE",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = SeekerClawColors.TextDim,
-                    letterSpacing = 1.sp,
-                )
+                InCardLabel("App Storage")
                 Spacer(modifier = Modifier.height(8.dp))
                 InfoRow("Workspace", "%.1f MB".format(appInfo.workspaceMb))
                 InfoRow("Database", "%.1f MB".format(appInfo.databaseMb))
@@ -297,22 +299,25 @@ fun SystemScreen(onBack: () -> Unit) {
         Spacer(modifier = Modifier.height(24.dp))
 
         // ==================== CONNECTION ====================
-        SectionLabel("Connection")
+        PageSectionHeader("Connection")
         Spacer(modifier = Modifier.height(8.dp))
 
         CardSurface {
+            val showLastMessage = status == ServiceStatus.RUNNING && lastActivity > 0L
             InfoRow(
                 label = "Telegram",
                 value = if (status == ServiceStatus.RUNNING) "Connected" else "Disconnected",
                 dotColor = if (status == ServiceStatus.RUNNING) SeekerClawColors.Accent else SeekerClawColors.TextDim,
+                isLast = !showLastMessage,
+                monospaceValue = false,
             )
-            if (status == ServiceStatus.RUNNING && lastActivity > 0L) {
+            if (showLastMessage) {
                 InfoRow(
                     label = "Last message",
                     value = formatTimeAgo(lastActivity),
+                    isLast = true,
                 )
             }
-            InfoRow("Model", modelName, isLast = true)
         }
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -320,7 +325,7 @@ fun SystemScreen(onBack: () -> Unit) {
         // ==================== API LIMITS ====================
         val usage = apiUsage
         if (usage != null) {
-            SectionLabel("API Limits")
+            PageSectionHeader("API Limits")
             Spacer(modifier = Modifier.height(8.dp))
 
             CardSurface {
@@ -330,6 +335,13 @@ fun SystemScreen(onBack: () -> Unit) {
                         usage.error == null || usage.fiveHourUtilization > 0f || usage.sevenDayUtilization > 0f
                     is ApiUsageData.ApiKeyUsage ->
                         usage.error == null || usage.requestsLimit > 0
+                }
+                // BAT-1247 M1: did the provider actually return quota data?
+                // Zero/absent limit totals must never be turned into a
+                // percentage — a zero denominator is "no data", not "100% left".
+                val hasRealData = when (usage) {
+                    is ApiUsageData.OAuthUsage -> hasValidData
+                    is ApiUsageData.ApiKeyUsage -> usage.requestsLimit > 0 || usage.tokensLimit > 0
                 }
 
                 if (hasValidData) {
@@ -348,23 +360,38 @@ fun SystemScreen(onBack: () -> Unit) {
                             )
                         }
                         is ApiUsageData.ApiKeyUsage -> {
-                            val reqProgress = if (usage.requestsLimit > 0)
-                                (usage.requestsLimit - usage.requestsRemaining).toFloat() / usage.requestsLimit else 0f
-                            UsageLimitBar(
-                                label = "Requests",
-                                utilization = reqProgress,
-                                detailText = "${usage.requestsRemaining} / ${usage.requestsLimit}",
-                                resetsAt = usage.requestsReset,
-                            )
-                            Spacer(modifier = Modifier.height(16.dp))
-                            val tokProgress = if (usage.tokensLimit > 0)
-                                (usage.tokensLimit - usage.tokensRemaining).toFloat() / usage.tokensLimit else 0f
-                            UsageLimitBar(
-                                label = "Tokens",
-                                utilization = tokProgress,
-                                detailText = "${formatTokens(usage.tokensRemaining)} / ${formatTokens(usage.tokensLimit)}",
-                                resetsAt = usage.tokensReset,
-                            )
+                            if (!hasRealData) {
+                                Text(
+                                    text = "No limit data",
+                                    fontFamily = RethinkSans,
+                                    fontSize = TypeScale.bodySmall,
+                                    color = SeekerClawColors.TextSecondary,
+                                )
+                            } else {
+                                if (usage.requestsLimit > 0) {
+                                    val reqProgress =
+                                        (usage.requestsLimit - usage.requestsRemaining).toFloat() / usage.requestsLimit
+                                    UsageLimitBar(
+                                        label = "Requests",
+                                        utilization = reqProgress,
+                                        detailText = "${usage.requestsRemaining} / ${usage.requestsLimit}",
+                                        resetsAt = usage.requestsReset,
+                                    )
+                                }
+                                if (usage.requestsLimit > 0 && usage.tokensLimit > 0) {
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                }
+                                if (usage.tokensLimit > 0) {
+                                    val tokProgress =
+                                        (usage.tokensLimit - usage.tokensRemaining).toFloat() / usage.tokensLimit
+                                    UsageLimitBar(
+                                        label = "Tokens",
+                                        utilization = tokProgress,
+                                        detailText = "${formatTokens(usage.tokensRemaining)} / ${formatTokens(usage.tokensLimit)}",
+                                        resetsAt = usage.tokensReset,
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -379,20 +406,24 @@ fun SystemScreen(onBack: () -> Unit) {
                     )
                 }
 
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "Updated ${formatTimeAgo(usage.updatedAt)}",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 10.sp,
-                    color = SeekerClawColors.TextDim,
-                )
+                // "Updated Xm ago" only makes sense when real quota data was
+                // actually fetched (BAT-1247 M1).
+                if (hasRealData) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Updated ${formatTimeAgo(usage.updatedAt)}",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 10.sp,
+                        color = SeekerClawColors.TextDim,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))
         }
 
         // ==================== USAGE ====================
-        SectionLabel("Usage")
+        PageSectionHeader("Usage")
         Spacer(modifier = Modifier.height(8.dp))
 
         Row(
@@ -438,7 +469,7 @@ fun SystemScreen(onBack: () -> Unit) {
         if (status == ServiceStatus.RUNNING || status == ServiceStatus.STARTING) {
             Spacer(modifier = Modifier.height(24.dp))
 
-            SectionLabel("API Analytics")
+            PageSectionHeader("API Analytics")
             Spacer(modifier = Modifier.height(8.dp))
 
             CardSurface {
@@ -480,7 +511,7 @@ fun SystemScreen(onBack: () -> Unit) {
             // ==================== MEMORY INDEX (BAT-33) ====================
             Spacer(modifier = Modifier.height(24.dp))
 
-            SectionLabel("Memory Index")
+            PageSectionHeader("Memory Index")
             Spacer(modifier = Modifier.height(8.dp))
 
             CardSurface {
@@ -525,8 +556,8 @@ private fun ResourceBar(
         ) {
             Text(
                 text = label,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.bodySmall,
                 fontWeight = FontWeight.Medium,
                 color = SeekerClawColors.TextPrimary,
             )
@@ -534,14 +565,14 @@ private fun ResourceBar(
                 Text(
                     text = value,
                     fontFamily = FontFamily.Monospace,
-                    fontSize = 12.sp,
+                    fontSize = TypeScale.labelSmall,
                     color = SeekerClawColors.TextSecondary,
                 )
                 if (suffix.isNotEmpty()) {
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = suffix,
-                        fontFamily = FontFamily.Monospace,
+                        fontFamily = RethinkSans,
                         fontSize = 10.sp,
                         color = SeekerClawColors.Accent,
                     )
@@ -578,7 +609,7 @@ private fun StatCard(
     ) {
         Text(
             text = label,
-            fontFamily = FontFamily.Monospace,
+            fontFamily = RethinkSans,
             fontSize = 11.sp,
             color = SeekerClawColors.TextDim,
         )
@@ -633,6 +664,25 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         }
     }
 
+    // Sparse month labels above the grid (GitHub idiom), derived from the
+    // dates the cells already represent: label a column whose Monday enters a
+    // new month. Column 0 is labeled too, unless a month boundary lands in
+    // the next couple of columns (would overlap).
+    val monthLabels = remember(weeks) {
+        val labels = mutableMapOf<Int, String>()
+        for (weekIndex in weeks.indices) {
+            val monday = weeks[weekIndex][0]
+            if (weekIndex == 0 || monday.month != weeks[weekIndex - 1][0].month) {
+                labels[weekIndex] = monday.month.getDisplayName(
+                    java.time.format.TextStyle.SHORT,
+                    Locale.getDefault(),
+                )
+            }
+        }
+        if (labels.keys.any { it in 1..2 }) labels.remove(0)
+        labels
+    }
+
     // Percentile thresholds from non-zero counts
     val thresholds = remember(dateCountMap) {
         val nonZero = dateCountMap.values.filter { it > 0 }.sorted()
@@ -665,38 +715,88 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
         if (dailyActivity.isEmpty() || totalMessages == 0L) {
             Text(
                 text = "No message data yet",
-                fontFamily = FontFamily.Monospace,
+                fontFamily = RethinkSans,
                 fontSize = 11.sp,
                 color = SeekerClawColors.TextDim,
             )
         } else {
-            // Fixed 26-week window — no horizontal scroll. Cells size responsively
-            // within a 6–16dp range; at typical phone widths they land around 10–12dp.
-            // Grid: 7 rows × 26 weeks. Weighted cells + spacedBy arrangement let
-            // Compose distribute the exact available width — no manual rounding,
-            // no right-edge clipping. aspectRatio(1f) keeps cells square.
-            Column(verticalArrangement = Arrangement.spacedBy(cellGap)) {
-                for (dayOfWeek in 0..6) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(cellGap),
-                    ) {
+            // Fixed 26-week window — no horizontal scroll. Cell size is computed
+            // from the available width minus the weekday gutter, so cells stay
+            // square and the month-label row aligns exactly with the grid columns.
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                val gutterWidth = Spacing.xxl
+                val cellSize = ((maxWidth - gutterWidth - cellGap * weeks.size) / weeks.size)
+                    .coerceAtLeast(Spacing.xs)
+                Column {
+                    // Month axis (sparse labels, derived from cell dates)
+                    Row(horizontalArrangement = Arrangement.spacedBy(cellGap)) {
+                        Spacer(modifier = Modifier.width(gutterWidth))
                         for (weekIndex in weeks.indices) {
-                            val date = weeks[weekIndex][dayOfWeek]
-                            // Past + today → normal heatmap color; future days in the
-                            // current week stay blank so "today" is visually the last
-                            // filled cell.
-                            val color = if (date <= today) {
-                                heatmapColorForCount(dateCountMap[date] ?: 0, thresholds)
-                            } else {
-                                Color.Transparent
+                            Box(modifier = Modifier.width(cellSize)) {
+                                val monthLabel = monthLabels[weekIndex]
+                                if (monthLabel != null) {
+                                    Text(
+                                        text = monthLabel,
+                                        fontFamily = RethinkSans,
+                                        fontSize = TypeScale.labelSmall,
+                                        color = SeekerClawColors.TextDim,
+                                        maxLines = 1,
+                                        softWrap = false,
+                                        overflow = TextOverflow.Visible,
+                                    )
+                                }
                             }
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .aspectRatio(1f)
-                                    .background(color, cellShape),
-                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(Spacing.xs))
+                    Column(verticalArrangement = Arrangement.spacedBy(cellGap)) {
+                        for (dayOfWeek in 0..6) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(cellGap)) {
+                                // Weekday axis — Mon/Wed/Fri only (GitHub idiom).
+                                // The label overflows its cell-height box
+                                // vertically (unbounded) so labeled rows keep
+                                // the same pitch as unlabeled ones.
+                                Box(
+                                    modifier = Modifier
+                                        .width(gutterWidth)
+                                        .height(cellSize),
+                                    contentAlignment = Alignment.CenterStart,
+                                ) {
+                                    val dayLabel = when (dayOfWeek) {
+                                        0 -> "Mon"
+                                        2 -> "Wed"
+                                        4 -> "Fri"
+                                        else -> null
+                                    }
+                                    if (dayLabel != null) {
+                                        Text(
+                                            text = dayLabel,
+                                            modifier = Modifier.wrapContentHeight(unbounded = true),
+                                            fontFamily = RethinkSans,
+                                            fontSize = TypeScale.labelSmall,
+                                            color = SeekerClawColors.TextDim,
+                                            maxLines = 1,
+                                            softWrap = false,
+                                        )
+                                    }
+                                }
+                                for (weekIndex in weeks.indices) {
+                                    val date = weeks[weekIndex][dayOfWeek]
+                                    // Past + today → normal heatmap color; future days in the
+                                    // current week stay blank so "today" is visually the last
+                                    // filled cell.
+                                    val color = if (date <= today) {
+                                        heatmapColorForCount(dateCountMap[date] ?: 0, thresholds)
+                                    } else {
+                                        Color.Transparent
+                                    }
+                                    Box(
+                                        modifier = Modifier
+                                            .size(cellSize)
+                                            .background(color, cellShape),
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -716,8 +816,8 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                     else -> "%,d".format(totalMessages)
                 }
                 Text(
-                    text = "$countText requests",
-                    fontFamily = FontFamily.Monospace,
+                    text = "$countText requests · last ${weeks.size} weeks",
+                    fontFamily = RethinkSans,
                     fontSize = 11.sp,
                     color = SeekerClawColors.TextDim,
                 )
@@ -726,7 +826,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         text = "Less",
-                        fontFamily = FontFamily.Monospace,
+                        fontFamily = RethinkSans,
                         fontSize = 11.sp,
                         color = SeekerClawColors.TextDim,
                     )
@@ -745,7 +845,7 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
                         text = "More",
-                        fontFamily = FontFamily.Monospace,
+                        fontFamily = RethinkSans,
                         fontSize = 11.sp,
                         color = SeekerClawColors.TextDim,
                     )
@@ -753,19 +853,6 @@ private fun MessageActivityHeatmap(dailyActivity: List<DayActivity>) {
             }
         }
     }
-}
-
-private fun formatUptime(millis: Long): String {
-    if (millis <= 0) return "0m"
-    val seconds = millis / 1000
-    val minutes = seconds / 60
-    val hours = minutes / 60
-    val days = hours / 24
-    return buildString {
-        if (days > 0) append("${days}d ")
-        if (hours % 24 > 0) append("${hours % 24}h ")
-        append("${minutes % 60}m")
-    }.trim()
 }
 
 @Composable
@@ -792,15 +879,15 @@ private fun UsageLimitBar(
         ) {
             Text(
                 text = label,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
+                fontFamily = RethinkSans,
+                fontSize = TypeScale.bodySmall,
                 fontWeight = FontWeight.Medium,
                 color = SeekerClawColors.TextPrimary,
             )
             Text(
                 text = "${remaining}% left",
                 fontFamily = FontFamily.Monospace,
-                fontSize = 12.sp,
+                fontSize = TypeScale.labelSmall,
                 fontWeight = FontWeight.Bold,
                 color = barColor,
             )

--- a/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
@@ -26,6 +26,12 @@ object LogShareSanitizer {
     // "Message:" mid-sentence is left alone only when it IS the marker.
     private val messageMarker = Regex("""(^|.*?\s)Message: (.*)$""")
 
+    // A console ENTRY starts with a bracketed prefix ("[11:42:23 PM] …",
+    // "[Node] …"). A chat body that itself contained newlines renders as
+    // continuation lines WITHOUT that prefix — those must be scrubbed too
+    // (CodeRabbit #449 R1: single-line scrubbing let multiline bodies leak).
+    private val entryStart = Regex("""^\[""")
+
     /** Sanitize one already-formatted console line for the Share payload. */
     fun sanitizeLine(line: String): String {
         val scrubbed = messageMarker.replace(line) { m ->
@@ -36,7 +42,28 @@ object LogShareSanitizer {
         return LogRedactor.redact(scrubbed)
     }
 
-    /** Sanitize the full multi-line share payload. */
-    fun sanitize(text: String): String =
-        text.lineSequence().joinToString("\n") { sanitizeLine(it) }
+    /**
+     * Sanitize the full multi-line share payload. Stateful: once a line hits
+     * the message marker, every following line that does NOT start a new
+     * console entry is treated as body continuation and fully replaced —
+     * conservative by design (over-scrubbing a stray continuation beats
+     * leaking one line of a user's chat).
+     */
+    fun sanitize(text: String): String {
+        var inMessage = false
+        return text.lineSequence().joinToString("\n") { line ->
+            when {
+                messageMarker.matches(line) -> {
+                    inMessage = true
+                    sanitizeLine(line)
+                }
+                inMessage && !entryStart.containsMatchIn(line) ->
+                    "[redacted continuation]"
+                else -> {
+                    inMessage = false
+                    sanitizeLine(line)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
@@ -26,11 +26,31 @@ object LogShareSanitizer {
     // "Message:" mid-sentence is left alone only when it IS the marker.
     private val messageMarker = Regex("""(^|.*?\s)Message: (.*)$""")
 
-    // A console ENTRY starts with a bracketed prefix ("[11:42:23 PM] …",
-    // "[Node] …"). A chat body that itself contained newlines renders as
-    // continuation lines WITHOUT that prefix — those must be scrubbed too
-    // (CodeRabbit #449 R1: single-line scrubbing let multiline bodies leak).
-    private val entryStart = Regex("""^\[""")
+    // A console ENTRY is emitted by LogsScreen as EXACTLY
+    //     "[${'$'}{entry.level.name}] [${'$'}timeStr] ${'$'}{entry.message}"
+    // i.e. a level token from [LogLevel] followed by a bracketed time
+    // ("[INFO] [11:42:23 PM] …" / 24h "[WARN] [23:42:23] …").
+    //
+    // This MUST be strict. An earlier version matched any line starting with
+    // "[", which let a message body leak: a multiline chat message whose
+    // continuation line began with "[" — a pasted config section "[database]",
+    // a markdown link, a bracketed log paste — looked like a new entry, flipped
+    // `inMessage` off, and every following body line escaped the message scrub
+    // with only [LogRedactor.redact] (static token shapes) standing between it
+    // and the Share payload. Pasting logs/config into the agent is exactly when
+    // secrets are in the message, so that was a live leak path
+    // (CodeRabbit #449 R2 — Major).
+    //
+    // Anchored on the real emission format: only a genuine level+time header
+    // ends redaction mode. Anything else is treated as body continuation.
+    //
+    // Built FROM [LogLevel] rather than hardcoding "DEBUG|INFO|WARN|ERROR", so
+    // adding a level can't silently turn its entries into "continuation" and
+    // erase them from the export. Enum names are Kotlin identifiers, so they
+    // cannot contain regex metacharacters — no escaping needed.
+    private val entryStart = Regex(
+        LogLevel.entries.joinToString("|", prefix = """^\[(?:""", postfix = """)] \[""")
+    )
 
     /** Sanitize one already-formatted console line for the Share payload. */
     fun sanitizeLine(line: String): String {

--- a/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/LogShareSanitizer.kt
@@ -1,0 +1,42 @@
+package com.seekerclaw.app.util
+
+/**
+ * BAT-1247 (PM Q2): sanitize the log text handed to the Share sheet.
+ *
+ * The on-device console keeps full fidelity — this runs ONLY on the Share
+ * payload, the one-tap path OFF the device. Two passes:
+ *
+ *  1. **Message-body scrub.** The Node runtime logs inbound chat messages as
+ *     `… Message: <first 100 chars>` (message-handler.js). Everything after
+ *     the `Message: ` marker is replaced with a deterministic
+ *     `[redacted, N chars]` marker. Timestamp, level, and source prefix are
+ *     preserved (PM: retain useful metadata), so support can still see WHEN
+ *     messages flowed without seeing WHAT was said.
+ *  2. **Secret backstop.** [LogRedactor.redact] over every line — the same
+ *     static token shapes (sk-ant-/bot tokens/JWTs/…) applied to the mirror
+ *     and console, re-applied here as defense in depth.
+ *
+ * Pure and allocation-light; callers wrap fail-open like the existing share
+ * redaction (a sanitizer crash must not open an unredacted escape hatch).
+ */
+object LogShareSanitizer {
+
+    // `Message: ` preceded by start-of-line or whitespace/bracket — anchored on
+    // the exact emission format so arbitrary prose containing the word
+    // "Message:" mid-sentence is left alone only when it IS the marker.
+    private val messageMarker = Regex("""(^|.*?\s)Message: (.*)$""")
+
+    /** Sanitize one already-formatted console line for the Share payload. */
+    fun sanitizeLine(line: String): String {
+        val scrubbed = messageMarker.replace(line) { m ->
+            val prefix = m.groupValues[1]
+            val body = m.groupValues[2]
+            "${prefix}Message: [redacted, ${body.length} chars]"
+        }
+        return LogRedactor.redact(scrubbed)
+    }
+
+    /** Sanitize the full multi-line share payload. */
+    fun sanitize(text: String): String =
+        text.lineSequence().joinToString("\n") { sanitizeLine(it) }
+}

--- a/app/src/main/java/com/seekerclaw/app/util/UptimeFormat.kt
+++ b/app/src/main/java/com/seekerclaw/app/util/UptimeFormat.kt
@@ -1,0 +1,32 @@
+package com.seekerclaw.app.util
+
+/**
+ * BAT-1247: the ONE uptime formatter for every screen.
+ *
+ * Pre-1247 the Dashboard rendered zero-padded "00h 03m 36s" while the System
+ * screen rendered a bare "7m" for the same value one navigation hop away
+ * (audit finding: "Uptime rendered in two different formats"). Both screens
+ * now call this. Zero units are dropped from the left; the two most
+ * significant units are shown so a live counter still ticks visibly:
+ *
+ *   42s            (under a minute)
+ *   3m 36s         (under an hour)
+ *   1h 03m         (under a day — minutes zero-padded so width is stable)
+ *   2d 05h         (a day or more)
+ */
+object UptimeFormat {
+    fun format(millis: Long): String {
+        if (millis <= 0L) return "0s"
+        val totalSeconds = millis / 1000
+        val seconds = totalSeconds % 60
+        val minutes = (totalSeconds / 60) % 60
+        val hours = (totalSeconds / 3600) % 24
+        val days = totalSeconds / 86400
+        return when {
+            days > 0 -> "${days}d %02dh".format(hours)
+            hours > 0 -> "${hours}h %02dm".format(minutes)
+            minutes > 0 -> "${minutes}m %02ds".format(seconds)
+            else -> "${seconds}s"
+        }
+    }
+}

--- a/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
@@ -1,0 +1,88 @@
+package com.seekerclaw.app.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * BAT-1247 (PM Q2) acceptance criteria: the Share payload must contain
+ * (a) NO raw Telegram message bodies and (b) NO known secret/token forms —
+ * while retaining timestamp / level / source metadata.
+ */
+class LogShareSanitizerTest {
+
+    // ── (a) message bodies absent ───────────────────────────────────────────
+
+    @Test
+    fun `message body is replaced with deterministic marker`() {
+        val line = "[11:42:23 PM] [Node] Message: Hey girl"
+        val out = LogShareSanitizer.sanitizeLine(line)
+        assertFalse("body must not survive", out.contains("Hey girl"))
+        assertEquals("[11:42:23 PM] [Node] Message: [redacted, 8 chars]", out)
+    }
+
+    @Test
+    fun `metadata before the marker is preserved`() {
+        val out = LogShareSanitizer.sanitizeLine("[11:42:32 PM] [Node] Message: How are you?")
+        assertTrue(out.startsWith("[11:42:32 PM] [Node] "))
+        assertFalse(out.contains("How are you?"))
+    }
+
+    @Test
+    fun `media and reply suffixes are scrubbed with the body`() {
+        // message-handler.js appends " [photo]" / " [reply]" AFTER the body —
+        // they are part of the post-marker segment and go with it.
+        val out = LogShareSanitizer.sanitizeLine("[1:00:00 AM] [Node] Message: secret plan [photo] [reply]")
+        assertFalse(out.contains("secret plan"))
+        assertTrue(out.contains("[redacted,"))
+    }
+
+    @Test
+    fun `multi-line payload scrubs every message line`() {
+        val text = listOf(
+            "[11:41:23 PM] [Node] [DB] Loaded existing database",
+            "[11:42:23 PM] [Node] Message: Hey girl",
+            "[11:42:32 PM] [Node] Message: How are you?",
+        ).joinToString("\n")
+        val out = LogShareSanitizer.sanitize(text)
+        assertFalse(out.contains("Hey girl"))
+        assertFalse(out.contains("How are you?"))
+        assertTrue("non-message lines untouched", out.contains("[DB] Loaded existing database"))
+    }
+
+    @Test
+    fun `lines without the marker are unchanged`() {
+        val line = "[11:41:24 PM] [Node] [ControlServer] Listening on 127.0.0.1:8766"
+        assertEquals(line, LogShareSanitizer.sanitizeLine(line))
+    }
+
+    // ── (b) known secret forms absent ───────────────────────────────────────
+
+    @Test
+    fun `anthropic key form is masked in share payload`() {
+        val out = LogShareSanitizer.sanitizeLine("[E] auth failed for sk-ant-api03-AbCdEfGhIjKlMnOp")
+        assertFalse(out.contains("sk-ant-api03-AbCdEfGhIjKlMnOp"))
+        assertTrue(out.contains("sk-ant-***"))
+    }
+
+    @Test
+    fun `telegram bot token form is masked in share payload`() {
+        val out = LogShareSanitizer.sanitizeLine("[E] polling 12345678:AAAbbbCCCdddEEEfffGGGhh failed")
+        assertFalse(out.contains("12345678:AAAbbbCCCdddEEEfffGGGhh"))
+    }
+
+    @Test
+    fun `jwt form is masked in share payload`() {
+        val out = LogShareSanitizer.sanitizeLine("bearer eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM rejected")
+        assertFalse(out.contains("eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM"))
+        assertTrue(out.contains("eyJ***"))
+    }
+
+    @Test
+    fun `secret inside a message body is doubly covered`() {
+        val out = LogShareSanitizer.sanitizeLine("[N] Message: my key is sk-ant-api03-AbCdEfGhIjKlMnOp")
+        assertFalse(out.contains("sk-ant-api03"))
+        assertFalse(out.contains("my key is"))
+    }
+}

--- a/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
@@ -88,13 +88,20 @@ class LogShareSanitizerTest {
 
     // ── multiline bodies (CodeRabbit #449 R1 regression) ────────────────────
 
+    // NOTE ON FIXTURES: multi-line tests below use the REAL emission format from
+    // LogsScreen.kt — `"[${'$'}{entry.level.name}] [${'$'}timeStr] ${'$'}{entry.message}"`, i.e.
+    // "[INFO] [11:42:23 PM] [Node] …". Earlier fixtures omitted the level token
+    // and so exercised a shape the app never produces; since `entryStart` is now
+    // anchored on the real header, fixtures must match production or these tests
+    // prove nothing.
+
     @Test
     fun `multiline message body is fully scrubbed, not just the first line`() {
         val text = listOf(
-            "[11:42:23 PM] [Node] Message: first secret line",
+            "[INFO] [11:42:23 PM] [Node] Message: first secret line",
             "second secret line without prefix",
             "third secret line",
-            "[11:43:00 PM] [Node] [DB] Loaded existing database",
+            "[DEBUG] [11:43:00 PM] [Node] [DB] Loaded existing database",
         ).joinToString("\n")
         val out = LogShareSanitizer.sanitize(text)
         assertFalse(out.contains("first secret line"))
@@ -107,14 +114,65 @@ class LogShareSanitizerTest {
     @Test
     fun `continuation state resets at the next bracketed entry`() {
         val text = listOf(
-            "[1:00 AM] [Node] Message: body",
+            "[INFO] [1:00 AM] [Node] Message: body",
             "body continues",
-            "[1:01 AM] [Node] [ControlServer] Listening on 127.0.0.1:8766",
-            "[1:02 AM] [Node] [Skills] 35 skills loaded",
+            "[INFO] [1:01 AM] [Node] [ControlServer] Listening on 127.0.0.1:8766",
+            "[INFO] [1:02 AM] [Node] [Skills] 35 skills loaded",
         ).joinToString("\n")
         val out = LogShareSanitizer.sanitize(text)
         assertFalse(out.contains("body continues"))
         assertTrue(out.contains("Listening on 127.0.0.1:8766"))
         assertTrue(out.contains("35 skills loaded"))
+    }
+
+    // ── bracket-prefixed continuation (CodeRabbit #449 R2 — Major) ──────────
+    // A multiline chat body whose continuation line STARTS WITH "[" — a pasted
+    // config section, a markdown link, a bracketed log paste — must not be
+    // mistaken for a new console entry. The old `^\[` rule flipped redaction
+    // OFF there, so every following body line reached the Share payload with
+    // only LogRedactor's static token shapes protecting it. Pasting logs or
+    // config into the agent is precisely when secrets are in the message.
+
+    @Test
+    fun `bracketed continuation line does not end redaction`() {
+        val text = listOf(
+            "[INFO] [2:00 PM] [Node] Message: here is my config",
+            "[database]",
+            "host=admin:hunter2@internal.db",
+            "[INFO] [2:01 PM] [Node] [Skills] 29 loaded",
+        ).joinToString("\n")
+        val out = LogShareSanitizer.sanitize(text)
+        assertFalse("bracketed continuation must not leak", out.contains("[database]"))
+        assertFalse("line AFTER it must not leak", out.contains("hunter2"))
+        assertFalse(out.contains("internal.db"))
+        assertTrue("real next entry still recognised", out.contains("29 loaded"))
+    }
+
+    @Test
+    fun `markdown-link continuation does not end redaction`() {
+        val text = listOf(
+            "[WARN] [3:00 PM] [Node] Message: check this",
+            "[my private doc](https://internal.example.com/secret-token-abc)",
+            "[ERROR] [3:01 PM] [Node] [DB] ok",
+        ).joinToString("\n")
+        val out = LogShareSanitizer.sanitize(text)
+        assertFalse(out.contains("secret-token-abc"))
+        assertFalse(out.contains("my private doc"))
+        assertTrue(out.contains("[DB] ok"))
+    }
+
+    @Test
+    fun `every log level is recognised as an entry header`() {
+        // If a level were missing from the pattern, entries at that level would
+        // be swallowed as "continuation" after any Message: line — silently
+        // destroying diagnostics in the export.
+        for (level in LogLevel.entries) {
+            val text = listOf(
+                "[INFO] [4:00 PM] [Node] Message: body",
+                "[${level.name}] [4:01 PM] [Node] [DB] marker-$level",
+            ).joinToString("\n")
+            val out = LogShareSanitizer.sanitize(text)
+            assertTrue("$level entry must survive", out.contains("marker-$level"))
+        }
     }
 }

--- a/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
+++ b/app/src/test/java/com/seekerclaw/app/util/LogShareSanitizerTest.kt
@@ -85,4 +85,36 @@ class LogShareSanitizerTest {
         assertFalse(out.contains("sk-ant-api03"))
         assertFalse(out.contains("my key is"))
     }
+
+    // ── multiline bodies (CodeRabbit #449 R1 regression) ────────────────────
+
+    @Test
+    fun `multiline message body is fully scrubbed, not just the first line`() {
+        val text = listOf(
+            "[11:42:23 PM] [Node] Message: first secret line",
+            "second secret line without prefix",
+            "third secret line",
+            "[11:43:00 PM] [Node] [DB] Loaded existing database",
+        ).joinToString("\n")
+        val out = LogShareSanitizer.sanitize(text)
+        assertFalse(out.contains("first secret line"))
+        assertFalse(out.contains("second secret line"))
+        assertFalse(out.contains("third secret line"))
+        assertTrue("continuation replaced", out.contains("[redacted continuation]"))
+        assertTrue("next entry intact", out.contains("[DB] Loaded existing database"))
+    }
+
+    @Test
+    fun `continuation state resets at the next bracketed entry`() {
+        val text = listOf(
+            "[1:00 AM] [Node] Message: body",
+            "body continues",
+            "[1:01 AM] [Node] [ControlServer] Listening on 127.0.0.1:8766",
+            "[1:02 AM] [Node] [Skills] 35 skills loaded",
+        ).joinToString("\n")
+        val out = LogShareSanitizer.sanitize(text)
+        assertFalse(out.contains("body continues"))
+        assertTrue(out.contains("Listening on 127.0.0.1:8766"))
+        assertTrue(out.contains("35 skills loaded"))
+    }
 }


### PR DESCRIPTION
## Summary

Implements **BAT-1247 Contract v1.1** (PM-signed): the 42 IN-SCOPE findings from the 43-finding device UX audit (5-agent audit over 14 live API-36 screenshots). ~~**Compose/Kotlin only — zero Node/JS … changes.**~~ — **NO LONGER TRUE, see “Contract boundary crossing” below.** The UX pass itself is still Compose-only; a security fix added later touches Node. No dependency, targetSdk, data-model, storage, or navigation-graph changes. All behavior preserved (navigation, dialogs, save flows, share/clear, skill export).

Delivered per the contract's commit clusters:

**C1 — shared primitives** (`6d8e44c`, `38eac48`, `f64b17b`, `e199433`)
- `PageSectionHeader` / `InCardLabel` — M4's one-style-per-context (page vs in-card), with `SectionLabel` delegating so all 10 legacy call sites migrate at once
- `SeekerClawSearchField` (with built-in clear ✕), `EmptyState` template, `StatusIndicator` (dot + visible word), `ScreenActionLink` (green)
- `InfoRow` labels de-monospaced (mono = technical values only); `ConfigField` `valueColor` + `horizontalPadding`
- `util/UptimeFormat` — the one formatter; `util/LogShareSanitizer` + **9 unit tests** (PM Q2)

**C2/C3 — per-screen** (one commit per cluster for the evidence ledger)
- `3a14da7` Dashboard — status **words** on the three service cards (a11y), shared uptime, Engine card copy
- `5c5a7e9` System — **M1 honest "No limit data"** (no % from a 0 denominator), heatmap month/weekday axes + scoped total, monospace re-scope, Model row → Status
- `ce5949c` Logs — per-level colors, chip selected cues, **Clear = red + Undo snackbar**, shared search, **Q2 share scrub** (bodies → `[redacted, N chars]`, metadata kept, secret backstop) — *see the security section below: the Kotlin scrub alone did NOT close the leak*, top-clip fix, bare-title header
- `c9c340e` Skills — **M3 standard back header** (red "← Skills" gone), ellipsis, **Q3 teaser demoted + de-redded**, actionable version diagnostic, `InCardLabel`s
- `6a154e1` Settings — live "Provider · Model · Auth" value, Danger-Zone scope captions, Env-Vars info + spacing, **amber "(not configured)"**, heartbeat-dialog dedup + supporting text, Disconnect Wallet → `DangerOutlineButton`, Jupiter/Helius indent fix
- `75106cc` Provider/Wallet — asterisk → green **Active chip**, monospace keys/addresses, **Q5 green radios** (`ProviderPicker`)
- `2ca8250` MCP + Env Vars — **M5 one add pattern** + shared `EmptyState`s, duplicate affordances/titles removed, security warning untouched

## Disposition
42 IN SCOPE implemented · 1 FOLLOW-UP (M2 Remove-skill → **BAT-1248**) · 0 WONTFIX. ~~Boundary crossers: none.~~ → **one, declared below.**

## ⚠️ Contract boundary crossing — security fix (declared)

**The BAT-1247 v1.1 contract says “Compose/Kotlin only — zero Node/JS changes”. This PR now touches Node.** The maintainer authorised the crossing explicitly rather than splitting it out, because **the Kotlin half alone does not close the leak** and shipping it as a security fix would misrepresent what it does. Flagging for PM.

### What was actually wrong

Commit `9aecbcbf` anchored `entryStart` on the real console-entry header. That change is correct, but it hardened **a shape production never emits**, and its claim that the fixtures “match production” was wrong — the *header* format was verified against `LogsScreen.kt`; the *continuation* shape was verified against nothing.

Traced end to end:

| stage | behaviour |
|---|---|
| `config.js log()` | `text.split('
')` — **one wire record per physical line** |
| `SeekerClawService.kt` | `LogCollector.append()` once per record |
| `LogsScreen.kt:173` | renders each as `[LEVEL] [time] [Node] …` |

So a multiline chat body never arrives as the un-prefixed continuation lines the sanitizer targets. Every body line wears a genuine header, matches `entryStart`, flips `inMessage` off, and ships verbatim:

```
in   [INFO] [2:00:00 PM] [Node] Message: here is my config
     [INFO] [2:00:00 PM] [Node] [database]
     [INFO] [2:00:00 PM] [Node] host=admin:hunter2@internal.db

out  [INFO] [2:00:00 PM] [Node] Message: [redacted, 17 chars]
     [INFO] [2:00:00 PM] [Node] [database]
     [INFO] [2:00:00 PM] [Node] host=admin:hunter2@internal.db
```

The credential reaches the Share sheet — a one-tap path off the device. **This predates the PR:** the raw `Message: ${combinedText.slice(0,100)}` site is on `origin/main` today, and `docs/internal/audits/LOG-AUDIT.md` already flagged it.

### The fix (`9b5849e9`)

- **NEW `log-safe.js`** — pure `flattenForLog(text, maxChars)`: truncate first (so the budget still measures what the user typed), then collapse `/[
]+/` to `' ⏎ '`. Guarantees no newline survives. Pure + dependency-free so the invariant is testable without message-handler's dependency graph (`history-trim.js` precedent).
- **`message-handler.js`** — the `Message: ` preview goes through `flattenForLog`, keeping the whole body in ONE record behind the marker where the scrub covers it.
- **Sites logging raw user text with no `Message: ` marker** (invisible to the sanitizer by construction) now log length + 8-hex sha256, matching ai.js's existing `msgLen=`/`msgFp=` convention: `message-handler.js` ~378 and `main.js` ~405 and `ai.js` ~2707 (`goalLen=`/`goalFp=`), `main.js` ~595 (`msgLen=`/`msgFp=`; `buttonData` kept — app-generated and the useful diagnostic). Correlation across resume attempts is preserved; the text is not.

**Deliberately NOT changed** — verified non-leaks, not oversights: `main.js` ~322/~547 `[Confirm] User replied "…"` is reached only inside `if (isApprove || isDeny)`, so the value is provably a yes/no//approve//deny variant; `main.js` ~579 `[QuickAction]` logs app-generated `cb.data`.

**Severity calibration:** `showDebug` defaults to `false`, so the two DEBUG sites only enter the Share payload when the user enables DEBUG — which is exactly what someone collecting support logs does. The INFO sites were the live default exposure.

### Negative controls (all three run)

| revert | expected | result |
|---|---|---|
| the flatten call site | call-site drift guard fails | ✅ |
| a `goal=` site | goal drift guard fails | ✅ |
| the Kotlin `entryStart` regex | the two leak tests fail | ✅ |

The call-site guard **did not fail on the first attempt** — it inspected the `deps.log()` line while the raw slice lived in the assignment above it. Rewritten to assert on where the value is *built*, then re-verified red-then-green. Recorded here because a drift guard that cannot fail is worse than none.

## Test plan
- [x] `compileDappStoreDebugKotlin` — green
- [x] `testDappStoreDebugUnitTest` — full Kotlin suite **33 classes / 529 tests / 0 failures** (incl. `LogShareSanitizerTest`, now 16 tests)
- [x] `node tests/nodejs-project/log-safe.test.js` — **11 assertions**, all three negative controls verified red-then-green
- [x] Node suite: **88 run, 87 pass**. `shutdown-flush.test.js` fails identically (`14 passed, 2 failed`) on untouched `origin/main` and is CI-skipped as *“fixture-only — needs workDir + timer scaffold”* — pre-existing, not a regression, not addressed here
- [x] `scripts/pre-push-check.sh` — ALL CHECKS PASSED
- [ ] **Evidence ledger (finding → commit → before/after screenshots)** — pending device: this machine has no hypervisor for an emulator; S24 not attached; Seeker is **locked in the BAT-1187 24 h soak** (contract forbids touching it). Will be posted before review is requested.
- [ ] Post-soak Seeker visual pass (contract gate)

## Known limitations
- DRAFT until the evidence ledger lands (PM gate: evidence before review).
- Minor deferred nits recorded in the workflow output (pre-existing inline tokens on untouched lines; flagged for a future token sweep — out of contract scope).

## Self-Awareness Checklist
- [x] **SAB-relevant, assessed.** ~~N/A — no JS log-site changes~~ is no longer accurate: this PR now **modifies** JS log sites (`message-handler.js`, `main.js`, `ai.js`). It adds **no new ERROR/WARN sites**, does not touch `buildSystemBlocks()`, and does not change DIAGNOSTICS.md or any agent capability — so the SAB pre-merge trigger does not fire. Checked `DIAGNOSTICS.md` for drift against the changed log lines: none references their shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared search, empty-state, status, and action components.
  - Settings now shows live provider, model, authentication, and environment-variable details.
  - System status includes expanded connection, uptime, quota, and activity information.
  - Added clearer setup actions for wallets, skills, MCP, and environment variables.

- **Bug Fixes**
  - Log sharing now protects sensitive message content.
  - Improved unavailable quota and missing skill-version handling.

- **UI Improvements**
  - Refreshed dashboard, logs, settings, skills, wallet, and system layouts, typography, spacing, and accessibility.
  - Logs now offer clearer filters, status text, and clearing feedback.
  - Active credentials are clearly identified, with improved API-key readability and safer destructive-action messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
